### PR TITLE
U5: implement scoped BM25 retrieval

### DIFF
--- a/kernel/bm25/bm25.go
+++ b/kernel/bm25/bm25.go
@@ -1,24 +1,256 @@
 package bm25
 
-import "semantix/kernel/slice"
+import (
+	"errors"
+	"math"
+	"sort"
+	"sync"
 
-// Index is a BM25 retrieval index over slices (implementation lands in U5).
-// Parameters follow the reference: k1=1.2, b=0.75, CJK split per rune.
+	"semantix/kernel/slice"
+)
+
+const (
+	defaultK1 = 1.2
+	defaultB  = 0.75
+)
+
+type document struct {
+	value  *slice.Slice
+	terms  map[string]int
+	length int
+}
+
+// Index is an in-memory BM25 retrieval index over slices.
 type Index struct {
+	mu sync.RWMutex
+
 	k1 float64
 	b  float64
+
+	docs             map[string]*document
+	postings         map[string]map[string]int
+	scopeDocs        map[slice.Scope]map[string]struct{}
+	scopeDF          map[slice.Scope]map[string]int
+	scopeTotalLength map[slice.Scope]int
 }
 
 // New returns an Index with the reference parameters.
-func New() *Index { return &Index{k1: 1.2, b: 0.75} } // U5 wires the implementation
+func New() *Index {
+	return &Index{
+		k1:               defaultK1,
+		b:                defaultB,
+		docs:             make(map[string]*document),
+		postings:         make(map[string]map[string]int),
+		scopeDocs:        make(map[slice.Scope]map[string]struct{}),
+		scopeDF:          make(map[slice.Scope]map[string]int),
+		scopeTotalLength: make(map[slice.Scope]int),
+	}
+}
 
 // Search returns the top-k matches for query within scope.
 func (ix *Index) Search(query string, k int, scope slice.Scope) ([]slice.Hit, error) {
-	return nil, nil // placeholder until U5
+	if ix == nil {
+		return nil, errors.New("bm25: nil index")
+	}
+	if k <= 0 {
+		return []slice.Hit{}, nil
+	}
+
+	queryTerms := uniqueTerms(tokenize(query))
+	if len(queryTerms) == 0 {
+		return nil, errors.New("bm25: query must contain at least one letter or number")
+	}
+
+	ix.mu.RLock()
+	defer ix.mu.RUnlock()
+
+	docIDs := ix.scopeDocs[scope]
+	totalDocs := len(docIDs)
+	if totalDocs == 0 {
+		return []slice.Hit{}, nil
+	}
+
+	avgLength := float64(ix.scopeTotalLength[scope]) / float64(totalDocs)
+	if avgLength <= 0 {
+		return []slice.Hit{}, nil
+	}
+
+	candidates := make(map[string]struct{})
+	for _, term := range queryTerms {
+		for id := range ix.postings[term] {
+			if _, ok := docIDs[id]; ok {
+				candidates[id] = struct{}{}
+			}
+		}
+	}
+
+	hits := make([]slice.Hit, 0, len(candidates))
+	for id := range candidates {
+		doc := ix.docs[id]
+		score := ix.score(doc, queryTerms, scope, totalDocs, avgLength)
+		if score <= 0 {
+			continue
+		}
+		hits = append(hits, slice.Hit{Slice: cloneSlice(doc.value), Score: score})
+	}
+
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score == hits[j].Score {
+			return hits[i].Slice.ID < hits[j].Slice.ID
+		}
+		return hits[i].Score > hits[j].Score
+	})
+	if len(hits) > k {
+		hits = hits[:k]
+	}
+	return hits, nil
 }
 
-// Insert adds s to the index.
-func (ix *Index) Insert(s *slice.Slice) error { return nil } // placeholder until U5
+func (ix *Index) score(doc *document, queryTerms []string, scope slice.Scope, totalDocs int, avgLength float64) float64 {
+	if doc == nil || doc.length == 0 {
+		return 0
+	}
 
-// Remove deletes s from the index.
-func (ix *Index) Remove(id string) error { return nil } // placeholder until U5
+	var score float64
+	docLength := float64(doc.length)
+	for _, term := range queryTerms {
+		tf := doc.terms[term]
+		df := ix.scopeDF[scope][term]
+		if tf == 0 || df == 0 {
+			continue
+		}
+
+		idf := math.Log(1 + (float64(totalDocs)-float64(df)+0.5)/(float64(df)+0.5))
+		frequency := float64(tf)
+		numerator := frequency * (ix.k1 + 1)
+		denominator := frequency + ix.k1*(1-ix.b+ix.b*docLength/avgLength)
+		score += idf * numerator / denominator
+	}
+	return score
+}
+
+// Insert adds s to the index. An existing slice with the same ID is replaced.
+func (ix *Index) Insert(s *slice.Slice) error {
+	if ix == nil {
+		return errors.New("bm25: nil index")
+	}
+	if s == nil {
+		return errors.New("bm25: nil slice")
+	}
+	if s.ID == "" {
+		return errors.New("bm25: empty slice ID")
+	}
+
+	terms := tokenize(string(s.Content))
+	if len(terms) == 0 {
+		return errors.New("bm25: slice content must contain at least one letter or number")
+	}
+	doc := &document{
+		value:  cloneSlice(s),
+		terms:  countTerms(terms),
+		length: len(terms),
+	}
+
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	ix.initLocked()
+
+	if old := ix.docs[s.ID]; old != nil {
+		ix.removeLocked(s.ID, old)
+	}
+
+	ix.docs[s.ID] = doc
+	scope := doc.value.Scope
+	if ix.scopeDocs[scope] == nil {
+		ix.scopeDocs[scope] = make(map[string]struct{})
+	}
+	if ix.scopeDF[scope] == nil {
+		ix.scopeDF[scope] = make(map[string]int)
+	}
+	ix.scopeDocs[scope][s.ID] = struct{}{}
+	ix.scopeTotalLength[scope] += doc.length
+
+	for term, frequency := range doc.terms {
+		if ix.postings[term] == nil {
+			ix.postings[term] = make(map[string]int)
+		}
+		ix.postings[term][s.ID] = frequency
+		ix.scopeDF[scope][term]++
+	}
+	return nil
+}
+
+// Remove deletes s from the index. Removing an unknown ID is a no-op.
+func (ix *Index) Remove(id string) error {
+	if ix == nil {
+		return errors.New("bm25: nil index")
+	}
+	if id == "" {
+		return errors.New("bm25: empty slice ID")
+	}
+
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	if doc := ix.docs[id]; doc != nil {
+		ix.removeLocked(id, doc)
+	}
+	return nil
+}
+
+func (ix *Index) initLocked() {
+	if ix.k1 == 0 {
+		ix.k1 = defaultK1
+	}
+	if ix.b == 0 {
+		ix.b = defaultB
+	}
+	if ix.docs == nil {
+		ix.docs = make(map[string]*document)
+	}
+	if ix.postings == nil {
+		ix.postings = make(map[string]map[string]int)
+	}
+	if ix.scopeDocs == nil {
+		ix.scopeDocs = make(map[slice.Scope]map[string]struct{})
+	}
+	if ix.scopeDF == nil {
+		ix.scopeDF = make(map[slice.Scope]map[string]int)
+	}
+	if ix.scopeTotalLength == nil {
+		ix.scopeTotalLength = make(map[slice.Scope]int)
+	}
+}
+
+func (ix *Index) removeLocked(id string, doc *document) {
+	delete(ix.docs, id)
+	scope := doc.value.Scope
+	delete(ix.scopeDocs[scope], id)
+	ix.scopeTotalLength[scope] -= doc.length
+
+	for term := range doc.terms {
+		delete(ix.postings[term], id)
+		if len(ix.postings[term]) == 0 {
+			delete(ix.postings, term)
+		}
+
+		ix.scopeDF[scope][term]--
+		if ix.scopeDF[scope][term] == 0 {
+			delete(ix.scopeDF[scope], term)
+		}
+	}
+	if len(ix.scopeDocs[scope]) == 0 {
+		delete(ix.scopeDocs, scope)
+		delete(ix.scopeDF, scope)
+		delete(ix.scopeTotalLength, scope)
+	}
+}
+
+func cloneSlice(s *slice.Slice) *slice.Slice {
+	if s == nil {
+		return nil
+	}
+	cloned := *s
+	cloned.Content = append([]byte(nil), s.Content...)
+	cloned.Embedding = append([]float32(nil), s.Embedding...)
+	return &cloned
+}

--- a/kernel/bm25/bm25_test.go
+++ b/kernel/bm25/bm25_test.go
@@ -1,0 +1,194 @@
+package bm25
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+func TestSearchRanksMatchingDocument(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "relevant", Scope: slice.Project, Content: []byte("prompt cache cache stability")})
+	mustInsert(t, ix, &slice.Slice{ID: "unrelated", Scope: slice.Project, Content: []byte("dashboard colors")})
+
+	hits := mustSearch(t, ix, "prompt cache", 5, slice.Project)
+	if len(hits) != 1 || hits[0].Slice.ID != "relevant" {
+		t.Fatalf("Search() = %#v, want relevant document", hitIDs(hits))
+	}
+}
+
+func TestSearchRanksCJKDocument(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "retrieval", Scope: slice.Project, Content: []byte("使用 BM25 实现中文检索")})
+	mustInsert(t, ix, &slice.Slice{ID: "frontend", Scope: slice.Project, Content: []byte("修改网页背景颜色")})
+
+	hits := mustSearch(t, ix, "中文检索", 5, slice.Project)
+	if len(hits) == 0 || hits[0].Slice.ID != "retrieval" {
+		t.Fatalf("top hit = %#v, want retrieval", hitIDs(hits))
+	}
+}
+
+func TestSearchFiltersScope(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "project", Scope: slice.Project, Content: []byte("project test command")})
+	mustInsert(t, ix, &slice.Slice{ID: "user", Scope: slice.User, Content: []byte("user test preference")})
+
+	projectHits := mustSearch(t, ix, "test", 10, slice.Project)
+	if got := hitIDs(projectHits); len(got) != 1 || got[0] != "project" {
+		t.Fatalf("project Search() = %#v, want [project]", got)
+	}
+	userHits := mustSearch(t, ix, "test", 10, slice.User)
+	if got := hitIDs(userHits); len(got) != 1 || got[0] != "user" {
+		t.Fatalf("user Search() = %#v, want [user]", got)
+	}
+}
+
+func TestInsertReplacesExistingDocument(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "doc", Scope: slice.Project, Content: []byte("cache")})
+	mustInsert(t, ix, &slice.Slice{ID: "doc", Scope: slice.User, Content: []byte("dashboard")})
+
+	if hits := mustSearch(t, ix, "cache", 10, slice.Project); len(hits) != 0 {
+		t.Fatalf("old document still searchable: %#v", hitIDs(hits))
+	}
+	hits := mustSearch(t, ix, "dashboard", 10, slice.User)
+	if got := hitIDs(hits); len(got) != 1 || got[0] != "doc" {
+		t.Fatalf("replacement Search() = %#v, want [doc]", got)
+	}
+}
+
+func TestInsertCopiesInput(t *testing.T) {
+	ix := New()
+	doc := &slice.Slice{ID: "doc", Scope: slice.Project, Content: []byte("stable cache")}
+	mustInsert(t, ix, doc)
+	doc.Scope = slice.User
+	copy(doc.Content, "broken")
+
+	hits := mustSearch(t, ix, "stable", 10, slice.Project)
+	if len(hits) != 1 || string(hits[0].Slice.Content) != "stable cache" {
+		t.Fatalf("indexed document changed through caller mutation: %#v", hits)
+	}
+}
+
+func TestRemoveIsCompleteAndIdempotent(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "doc", Scope: slice.Project, Content: []byte("cache cache")})
+	if err := ix.Remove("doc"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ix.Remove("doc"); err != nil {
+		t.Fatalf("second Remove() error = %v", err)
+	}
+	if hits := mustSearch(t, ix, "cache", 10, slice.Project); len(hits) != 0 {
+		t.Fatalf("removed document still searchable: %#v", hitIDs(hits))
+	}
+}
+
+func TestSearchLimitsAndStablySortsEqualScores(t *testing.T) {
+	ix := New()
+	for _, id := range []string{"c", "a", "b"} {
+		mustInsert(t, ix, &slice.Slice{ID: id, Scope: slice.Project, Content: []byte("same content")})
+	}
+
+	hits := mustSearch(t, ix, "same", 2, slice.Project)
+	got := hitIDs(hits)
+	want := []string{"a", "b"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("Search() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSearchUsesScopeLocalStatistics(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "short", Scope: slice.Project, Content: []byte("cache")})
+	mustInsert(t, ix, &slice.Slice{ID: "long", Scope: slice.Project, Content: []byte("cache filler filler filler filler")})
+	for i := 0; i < 20; i++ {
+		mustInsert(t, ix, &slice.Slice{ID: string(rune('A' + i)), Scope: slice.User, Content: []byte("cache user")})
+	}
+
+	hits := mustSearch(t, ix, "cache", 10, slice.Project)
+	if len(hits) != 2 || hits[0].Slice.ID != "short" {
+		t.Fatalf("Search() = %#v, want short document first", hitIDs(hits))
+	}
+
+	wantIDF := math.Log(1 + (2.0-2.0+0.5)/(2.0+0.5))
+	wantScore := wantIDF * (1 * (defaultK1 + 1)) / (1 + defaultK1*(1-defaultB+defaultB*1/3))
+	if math.Abs(hits[0].Score-wantScore) > 1e-12 {
+		t.Fatalf("score = %.12f, want %.12f", hits[0].Score, wantScore)
+	}
+}
+
+func TestInvalidInputs(t *testing.T) {
+	ix := New()
+	if err := ix.Insert(nil); err == nil {
+		t.Fatal("Insert(nil) succeeded, want error")
+	}
+	if err := ix.Insert(&slice.Slice{Content: []byte("content")}); err == nil {
+		t.Fatal("Insert(empty ID) succeeded, want error")
+	}
+	if err := ix.Insert(&slice.Slice{ID: "empty", Content: []byte("!!!")}); err == nil {
+		t.Fatal("Insert(empty content) succeeded, want error")
+	}
+	if err := ix.Remove(""); err == nil {
+		t.Fatal("Remove(empty ID) succeeded, want error")
+	}
+	if _, err := ix.Search("!!!", 5, slice.Project); err == nil {
+		t.Fatal("Search(punctuation) succeeded, want error")
+	}
+	if hits, err := ix.Search("valid", 0, slice.Project); err != nil || len(hits) != 0 {
+		t.Fatalf("Search(k=0) = %#v, %v; want empty result", hits, err)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	ix := New()
+	const workers = 20
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		id := string(rune('a' + i))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := 0; n < 50; n++ {
+				if err := ix.Insert(&slice.Slice{ID: id, Scope: slice.Project, Content: []byte("concurrent cache")}); err != nil {
+					t.Errorf("Insert() error = %v", err)
+					return
+				}
+				if _, err := ix.Search("cache", 5, slice.Project); err != nil {
+					t.Errorf("Search() error = %v", err)
+					return
+				}
+			}
+			if err := ix.Remove(id); err != nil {
+				t.Errorf("Remove() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func mustInsert(t *testing.T, ix *Index, s *slice.Slice) {
+	t.Helper()
+	if err := ix.Insert(s); err != nil {
+		t.Fatalf("Insert(%q) error = %v", s.ID, err)
+	}
+}
+
+func mustSearch(t *testing.T, ix *Index, query string, k int, scope slice.Scope) []slice.Hit {
+	t.Helper()
+	hits, err := ix.Search(query, k, scope)
+	if err != nil {
+		t.Fatalf("Search(%q) error = %v", query, err)
+	}
+	return hits
+}
+
+func hitIDs(hits []slice.Hit) []string {
+	ids := make([]string, len(hits))
+	for i, hit := range hits {
+		ids[i] = hit.Slice.ID
+	}
+	return ids
+}

--- a/kernel/bm25/tokenizer.go
+++ b/kernel/bm25/tokenizer.go
@@ -1,0 +1,58 @@
+package bm25
+
+import (
+	"strings"
+	"unicode"
+)
+
+// tokenize lowercases word tokens and emits each CJK rune as its own token.
+func tokenize(text string) []string {
+	var tokens []string
+	var word strings.Builder
+	flush := func() {
+		if word.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, word.String())
+		word.Reset()
+	}
+
+	for _, r := range text {
+		switch {
+		case isCJK(r):
+			flush()
+			tokens = append(tokens, string(r))
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_':
+			word.WriteRune(unicode.ToLower(r))
+		default:
+			flush()
+		}
+	}
+	flush()
+	return tokens
+}
+
+func isCJK(r rune) bool {
+	return unicode.In(r, unicode.Han, unicode.Hiragana, unicode.Katakana, unicode.Hangul)
+}
+
+func countTerms(terms []string) map[string]int {
+	counts := make(map[string]int, len(terms))
+	for _, term := range terms {
+		counts[term]++
+	}
+	return counts
+}
+
+func uniqueTerms(terms []string) []string {
+	seen := make(map[string]struct{}, len(terms))
+	unique := make([]string, 0, len(terms))
+	for _, term := range terms {
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		unique = append(unique, term)
+	}
+	return unique
+}

--- a/kernel/bm25/tokenizer_test.go
+++ b/kernel/bm25/tokenizer_test.go
@@ -1,0 +1,28 @@
+package bm25
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTokenizeLatinCJKAndPunctuation(t *testing.T) {
+	got := tokenize("BM25 检索 cache-first 日本語 한글 Cache_Key42")
+	want := []string{"bm25", "检", "索", "cache", "first", "日", "本", "語", "한", "글", "cache_key42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokenize() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTokenizeDropsOnlyPunctuation(t *testing.T) {
+	if got := tokenize(" !?，。--- "); len(got) != 0 {
+		t.Fatalf("tokenize() = %#v, want no tokens", got)
+	}
+}
+
+func TestUniqueTermsKeepsFirstSeenOrder(t *testing.T) {
+	got := uniqueTerms([]string{"cache", "测", "cache", "试", "测"})
+	want := []string{"cache", "测", "试"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("uniqueTerms() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the U5 BM25 retrieval work unit from #3 while keeping the change surface limited to `kernel/bm25/` so U4 can continue independently.

- adds an in-memory inverted index with `k1=1.2` and `b=0.75`
- tokenizes Latin words case-insensitively and splits CJK text per rune
- supports insert, idempotent remove, and same-ID replacement
- calculates document frequency and average length independently per slice scope
- provides deterministic top-k ordering and concurrent access protection
- adds focused tokenizer, ranking, scope, replacement, removal, validation, and concurrency tests

## Impact

U4 can produce and persist slices through the frozen `slice.Slice` contract. U6 can load those slices and insert them into this index without depending on BM25 internals.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./kernel/bm25`
- `go test -count=20 ./kernel/bm25`

Related to #3.