### PR TITLE
U6: add extract and search CLI

### DIFF
--- a/cmd/semantix/extract.go
+++ b/cmd/semantix/extract.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"semantix/kernel/slice"
+)
+
+func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	flags := flag.NewFlagSet("extract", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	input := flags.String("input", "", "session JSONL path, or - for stdin")
+	scopeValue := flags.String("scope", "project", "slice scope: session, project, or user")
+	dbOverride := flags.String("db", "", "database path override")
+	projectDB := flags.String("project-db", defaultProjectDB(), "project/session database path")
+	userDB := flags.String("user-db", defaultUserDB(), "user database path")
+	session := flags.String("session", "", "source session identifier")
+	project := flags.String("project", "", "project slug")
+	taskType := flags.String("task-type", "", "task type metadata")
+	language := flags.String("language", "", "language metadata")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *input == "" {
+		return errors.New("--input is required")
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %v", flags.Args())
+	}
+
+	scope, err := parseScope(*scopeValue)
+	if err != nil {
+		return err
+	}
+	data, err := readInput(*input)
+	if err != nil {
+		return err
+	}
+
+	extractor := deps.newExtractor()
+	if extractor == nil {
+		return errors.New("slice extractor is unavailable; merge the U4 implementation first")
+	}
+	items, err := extractor.Extract(data, slice.SliceMeta{
+		SourceSession: *session,
+		TaskType:      *taskType,
+		Language:      *language,
+		ProjectSlug:   *project,
+	})
+	if err != nil {
+		return fmt.Errorf("extract slices: %w", err)
+	}
+
+	dbPath := selectDB(scope, *dbOverride, *projectDB, *userDB)
+	if dir := filepath.Dir(dbPath); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create database directory: %w", err)
+		}
+	}
+	store, err := deps.openStore(dbPath)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	if store == nil {
+		return errors.New("slice store is unavailable; merge the U4 implementation first")
+	}
+	defer closeStore(store)
+
+	stored := 0
+	for i, item := range items {
+		if item == nil {
+			return fmt.Errorf("extractor returned nil slice at position %d", i)
+		}
+		item.Scope = scope
+		if err := store.Put(item); err != nil {
+			return fmt.Errorf("store slice %q: %w", item.ID, err)
+		}
+		stored++
+	}
+
+	fmt.Fprintf(stdout, "extracted=%d stored=%d scope=%s db=%s\n", len(items), stored, scopeName(scope), dbPath)
+	return nil
+}
+
+func readInput(path string) ([]byte, error) {
+	if path == "-" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return data, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read input %q: %w", path, err)
+	}
+	return data, nil
+}

--- a/cmd/semantix/flags.go
+++ b/cmd/semantix/flags.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"semantix/kernel/slice"
+)
+
+func parseScope(value string) (slice.Scope, error) {
+	switch value {
+	case "session":
+		return slice.Session, nil
+	case "project":
+		return slice.Project, nil
+	case "user":
+		return slice.User, nil
+	default:
+		return 0, fmt.Errorf("invalid scope %q (want session, project, or user)", value)
+	}
+}
+
+func scopeName(scope slice.Scope) string {
+	switch scope {
+	case slice.Session:
+		return "session"
+	case slice.Project:
+		return "project"
+	case slice.User:
+		return "user"
+	default:
+		return fmt.Sprintf("scope(%d)", scope)
+	}
+}
+
+func defaultProjectDB() string {
+	return filepath.Join(".semantix", "project.db")
+}
+
+func defaultUserDB() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.Join(".semantix", "user.db")
+	}
+	return filepath.Join(home, ".semantix", "user.db")
+}
+
+func selectDB(scope slice.Scope, override, projectDB, userDB string) string {
+	if override != "" {
+		return override
+	}
+	if scope == slice.User {
+		return userDB
+	}
+	return projectDB
+}

--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/slice"
+)
+
+type dependencies struct {
+	newExtractor func() slice.Extractor
+	openStore    func(string) (slice.Store, error)
+	newIndex     func() slice.Index
+}
+
+func productionDependencies() dependencies {
+	return dependencies{
+		newExtractor: slice.NewExtractor,
+		openStore:    slice.NewBboltStore,
+		newIndex: func() slice.Index {
+			return bm25.New()
+		},
+	}
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, productionDependencies()))
+}
+
+func run(args []string, stdout, stderr io.Writer, deps dependencies) int {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return 2
+	}
+
+	var err error
+	switch args[0] {
+	case "extract":
+		err = runExtract(args[1:], stdout, stderr, deps)
+	case "search":
+		err = runSearch(args[1:], stdout, stderr, deps)
+	case "help", "-h", "--help":
+		printUsage(stdout)
+		return 0
+	default:
+		fmt.Fprintf(stderr, "semantix: unknown command %q\n\n", args[0])
+		printUsage(stderr)
+		return 2
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "semantix %s: %v\n", args[0], err)
+		return 1
+	}
+	return 0
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  semantix extract --input <session.jsonl> [--scope project|user|session]")
+	fmt.Fprintln(w, "  semantix search [flags] <query>")
+}
+
+type storeCloser interface {
+	Close() error
+}
+
+func closeStore(store slice.Store) {
+	if closer, ok := store.(storeCloser); ok {
+		_ = closer.Close()
+	}
+}

--- a/cmd/semantix/main_test.go
+++ b/cmd/semantix/main_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/slice"
+)
+
+type fakeExtractor struct {
+	items []*slice.Slice
+	meta  slice.SliceMeta
+}
+
+func (f *fakeExtractor) Extract(_ []byte, meta slice.SliceMeta) ([]*slice.Slice, error) {
+	f.meta = meta
+	return f.items, nil
+}
+
+type fakeStore struct {
+	items  map[string]*slice.Slice
+	closed bool
+}
+
+func newFakeStore(items ...*slice.Slice) *fakeStore {
+	store := &fakeStore{items: make(map[string]*slice.Slice)}
+	for _, item := range items {
+		store.items[item.ID] = item
+	}
+	return store
+}
+
+func (f *fakeStore) Put(item *slice.Slice) error {
+	if item == nil {
+		return errors.New("nil slice")
+	}
+	f.items[item.ID] = item
+	return nil
+}
+
+func (f *fakeStore) Get(id string) (*slice.Slice, error) {
+	item := f.items[id]
+	if item == nil {
+		return nil, errors.New("not found")
+	}
+	return item, nil
+}
+
+func (f *fakeStore) List(scope slice.Scope) ([]*slice.Slice, error) {
+	var items []*slice.Slice
+	for _, item := range f.items {
+		if item.Scope == scope {
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
+func (f *fakeStore) UpdateStats(string, slice.SliceStats) error { return nil }
+
+func (f *fakeStore) Close() error {
+	f.closed = true
+	return nil
+}
+
+func TestExtractStoresSlicesInSelectedScope(t *testing.T) {
+	input := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(input, []byte("{\"role\":\"user\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	extractor := &fakeExtractor{items: []*slice.Slice{
+		{ID: "one", Scope: slice.Session, Content: []byte("first")},
+		{ID: "two", Scope: slice.Session, Content: []byte("second")},
+	}}
+	store := newFakeStore()
+	var openedPath string
+	deps := dependencies{
+		newExtractor: func() slice.Extractor { return extractor },
+		openStore: func(path string) (slice.Store, error) {
+			openedPath = path
+			return store, nil
+		},
+		newIndex: func() slice.Index { return bm25.New() },
+	}
+
+	var stdout, stderr bytes.Buffer
+	dbPath := filepath.Join(t.TempDir(), "user.db")
+	code := run([]string{
+		"extract", "--input", input, "--scope", "user", "--db", dbPath,
+		"--session", "session-1", "--project", "semantix", "--language", "zh-CN",
+	}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if openedPath != dbPath {
+		t.Fatalf("opened path = %q, want %q", openedPath, dbPath)
+	}
+	if extractor.meta.SourceSession != "session-1" || extractor.meta.ProjectSlug != "semantix" || extractor.meta.Language != "zh-CN" {
+		t.Fatalf("extractor meta = %#v", extractor.meta)
+	}
+	for _, id := range []string{"one", "two"} {
+		if store.items[id] == nil || store.items[id].Scope != slice.User {
+			t.Fatalf("stored slice %q = %#v, want user scope", id, store.items[id])
+		}
+	}
+	if !store.closed {
+		t.Fatal("store was not closed")
+	}
+	if !strings.Contains(stdout.String(), "extracted=2 stored=2 scope=user") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestSearchLoadsStoreAndRanksResults(t *testing.T) {
+	store := newFakeStore(
+		&slice.Slice{ID: "relevant", Scope: slice.Project, Content: []byte("BM25 cache retrieval")},
+		&slice.Slice{ID: "unrelated", Scope: slice.Project, Content: []byte("dashboard colors")},
+		&slice.Slice{ID: "user", Scope: slice.User, Content: []byte("cache preference")},
+	)
+	deps := dependencies{
+		newExtractor: func() slice.Extractor { return nil },
+		openStore:    func(string) (slice.Store, error) { return store, nil },
+		newIndex:     func() slice.Index { return bm25.New() },
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"search", "--db", "test.db", "--scope", "project", "--limit", "1", "cache retrieval"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "id=relevant") || strings.Contains(stdout.String(), "id=user") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if !store.closed {
+		t.Fatal("store was not closed")
+	}
+}
+
+func TestSearchJSONOutput(t *testing.T) {
+	store := newFakeStore(&slice.Slice{ID: "doc", Scope: slice.Project, Content: []byte("中文检索")})
+	deps := dependencies{
+		newExtractor: func() slice.Extractor { return nil },
+		openStore:    func(string) (slice.Store, error) { return store, nil },
+		newIndex:     func() slice.Index { return bm25.New() },
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"search", "--db", "test.db", "--json", "中文"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"id": "doc"`) || !strings.Contains(stdout.String(), `"content": "中文检索"`) {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestExtractReportsMissingU4Implementation(t *testing.T) {
+	input := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(input, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"extract", "--input", input}, &stdout, &stderr, productionDependencies())
+	if code != 1 {
+		t.Fatalf("run() code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "merge the U4 implementation first") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunRejectsUnknownCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"unknown"}, &stdout, &stderr, dependencies{})
+	if code != 2 || !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+}

--- a/cmd/semantix/search.go
+++ b/cmd/semantix/search.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type searchResult struct {
+	ID      string  `json:"id"`
+	Type    int     `json:"type"`
+	Scope   string  `json:"scope"`
+	Content string  `json:"content"`
+	Score   float64 `json:"score"`
+}
+
+func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	flags := flag.NewFlagSet("search", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	queryFlag := flags.String("query", "", "search query (alternatively pass it as positional text)")
+	scopeValue := flags.String("scope", "project", "slice scope: session, project, or user")
+	limit := flags.Int("limit", 10, "maximum number of results")
+	dbOverride := flags.String("db", "", "database path override")
+	projectDB := flags.String("project-db", defaultProjectDB(), "project/session database path")
+	userDB := flags.String("user-db", defaultUserDB(), "user database path")
+	jsonOutput := flags.Bool("json", false, "write JSON results")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *limit <= 0 {
+		return errors.New("--limit must be greater than zero")
+	}
+
+	query := strings.TrimSpace(*queryFlag)
+	if query == "" {
+		query = strings.TrimSpace(strings.Join(flags.Args(), " "))
+	} else if flags.NArg() != 0 {
+		return errors.New("use either --query or positional query text, not both")
+	}
+	if query == "" {
+		return errors.New("query is required")
+	}
+
+	scope, err := parseScope(*scopeValue)
+	if err != nil {
+		return err
+	}
+	dbPath := selectDB(scope, *dbOverride, *projectDB, *userDB)
+	store, err := deps.openStore(dbPath)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	if store == nil {
+		return errors.New("slice store is unavailable; merge the U4 implementation first")
+	}
+	defer closeStore(store)
+
+	items, err := store.List(scope)
+	if err != nil {
+		return fmt.Errorf("list %s slices: %w", scopeName(scope), err)
+	}
+	index := deps.newIndex()
+	if index == nil {
+		return errors.New("search index is unavailable")
+	}
+	for i, item := range items {
+		if item == nil {
+			return fmt.Errorf("store returned nil slice at position %d", i)
+		}
+		if err := index.Insert(item); err != nil {
+			return fmt.Errorf("index slice %q: %w", item.ID, err)
+		}
+	}
+
+	hits, err := index.Search(query, *limit, scope)
+	if err != nil {
+		return fmt.Errorf("search index: %w", err)
+	}
+	results := make([]searchResult, len(hits))
+	for i, hit := range hits {
+		results[i] = searchResult{
+			ID:      hit.Slice.ID,
+			Type:    int(hit.Slice.Type),
+			Scope:   scopeName(hit.Slice.Scope),
+			Content: string(hit.Slice.Content),
+			Score:   hit.Score,
+		}
+	}
+
+	if *jsonOutput {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(results)
+	}
+	for i, result := range results {
+		content := strings.Join(strings.Fields(result.Content), " ")
+		fmt.Fprintf(stdout, "%d. score=%.6f id=%s scope=%s\n   %s\n", i+1, result.Score, result.ID, result.Scope, content)
+	}
+	return nil
+}

--- a/kernel/bm25/bm25.go
+++ b/kernel/bm25/bm25.go
@@ -1,24 +1,256 @@
 package bm25
 
-import "semantix/kernel/slice"
+import (
+	"errors"
+	"math"
+	"sort"
+	"sync"
 
-// Index is a BM25 retrieval index over slices (implementation lands in U5).
-// Parameters follow the reference: k1=1.2, b=0.75, CJK split per rune.
+	"semantix/kernel/slice"
+)
+
+const (
+	defaultK1 = 1.2
+	defaultB  = 0.75
+)
+
+type document struct {
+	value  *slice.Slice
+	terms  map[string]int
+	length int
+}
+
+// Index is an in-memory BM25 retrieval index over slices.
 type Index struct {
+	mu sync.RWMutex
+
 	k1 float64
 	b  float64
+
+	docs             map[string]*document
+	postings         map[string]map[string]int
+	scopeDocs        map[slice.Scope]map[string]struct{}
+	scopeDF          map[slice.Scope]map[string]int
+	scopeTotalLength map[slice.Scope]int
 }
 
 // New returns an Index with the reference parameters.
-func New() *Index { return &Index{k1: 1.2, b: 0.75} } // U5 wires the implementation
+func New() *Index {
+	return &Index{
+		k1:               defaultK1,
+		b:                defaultB,
+		docs:             make(map[string]*document),
+		postings:         make(map[string]map[string]int),
+		scopeDocs:        make(map[slice.Scope]map[string]struct{}),
+		scopeDF:          make(map[slice.Scope]map[string]int),
+		scopeTotalLength: make(map[slice.Scope]int),
+	}
+}
 
 // Search returns the top-k matches for query within scope.
 func (ix *Index) Search(query string, k int, scope slice.Scope) ([]slice.Hit, error) {
-	return nil, nil // placeholder until U5
+	if ix == nil {
+		return nil, errors.New("bm25: nil index")
+	}
+	if k <= 0 {
+		return []slice.Hit{}, nil
+	}
+
+	queryTerms := uniqueTerms(tokenize(query))
+	if len(queryTerms) == 0 {
+		return nil, errors.New("bm25: query must contain at least one letter or number")
+	}
+
+	ix.mu.RLock()
+	defer ix.mu.RUnlock()
+
+	docIDs := ix.scopeDocs[scope]
+	totalDocs := len(docIDs)
+	if totalDocs == 0 {
+		return []slice.Hit{}, nil
+	}
+
+	avgLength := float64(ix.scopeTotalLength[scope]) / float64(totalDocs)
+	if avgLength <= 0 {
+		return []slice.Hit{}, nil
+	}
+
+	candidates := make(map[string]struct{})
+	for _, term := range queryTerms {
+		for id := range ix.postings[term] {
+			if _, ok := docIDs[id]; ok {
+				candidates[id] = struct{}{}
+			}
+		}
+	}
+
+	hits := make([]slice.Hit, 0, len(candidates))
+	for id := range candidates {
+		doc := ix.docs[id]
+		score := ix.score(doc, queryTerms, scope, totalDocs, avgLength)
+		if score <= 0 {
+			continue
+		}
+		hits = append(hits, slice.Hit{Slice: cloneSlice(doc.value), Score: score})
+	}
+
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score == hits[j].Score {
+			return hits[i].Slice.ID < hits[j].Slice.ID
+		}
+		return hits[i].Score > hits[j].Score
+	})
+	if len(hits) > k {
+		hits = hits[:k]
+	}
+	return hits, nil
 }
 
-// Insert adds s to the index.
-func (ix *Index) Insert(s *slice.Slice) error { return nil } // placeholder until U5
+func (ix *Index) score(doc *document, queryTerms []string, scope slice.Scope, totalDocs int, avgLength float64) float64 {
+	if doc == nil || doc.length == 0 {
+		return 0
+	}
 
-// Remove deletes s from the index.
-func (ix *Index) Remove(id string) error { return nil } // placeholder until U5
+	var score float64
+	docLength := float64(doc.length)
+	for _, term := range queryTerms {
+		tf := doc.terms[term]
+		df := ix.scopeDF[scope][term]
+		if tf == 0 || df == 0 {
+			continue
+		}
+
+		idf := math.Log(1 + (float64(totalDocs)-float64(df)+0.5)/(float64(df)+0.5))
+		frequency := float64(tf)
+		numerator := frequency * (ix.k1 + 1)
+		denominator := frequency + ix.k1*(1-ix.b+ix.b*docLength/avgLength)
+		score += idf * numerator / denominator
+	}
+	return score
+}
+
+// Insert adds s to the index. An existing slice with the same ID is replaced.
+func (ix *Index) Insert(s *slice.Slice) error {
+	if ix == nil {
+		return errors.New("bm25: nil index")
+	}
+	if s == nil {
+		return errors.New("bm25: nil slice")
+	}
+	if s.ID == "" {
+		return errors.New("bm25: empty slice ID")
+	}
+
+	terms := tokenize(string(s.Content))
+	if len(terms) == 0 {
+		return errors.New("bm25: slice content must contain at least one letter or number")
+	}
+	doc := &document{
+		value:  cloneSlice(s),
+		terms:  countTerms(terms),
+		length: len(terms),
+	}
+
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	ix.initLocked()
+
+	if old := ix.docs[s.ID]; old != nil {
+		ix.removeLocked(s.ID, old)
+	}
+
+	ix.docs[s.ID] = doc
+	scope := doc.value.Scope
+	if ix.scopeDocs[scope] == nil {
+		ix.scopeDocs[scope] = make(map[string]struct{})
+	}
+	if ix.scopeDF[scope] == nil {
+		ix.scopeDF[scope] = make(map[string]int)
+	}
+	ix.scopeDocs[scope][s.ID] = struct{}{}
+	ix.scopeTotalLength[scope] += doc.length
+
+	for term, frequency := range doc.terms {
+		if ix.postings[term] == nil {
+			ix.postings[term] = make(map[string]int)
+		}
+		ix.postings[term][s.ID] = frequency
+		ix.scopeDF[scope][term]++
+	}
+	return nil
+}
+
+// Remove deletes s from the index. Removing an unknown ID is a no-op.
+func (ix *Index) Remove(id string) error {
+	if ix == nil {
+		return errors.New("bm25: nil index")
+	}
+	if id == "" {
+		return errors.New("bm25: empty slice ID")
+	}
+
+	ix.mu.Lock()
+	defer ix.mu.Unlock()
+	if doc := ix.docs[id]; doc != nil {
+		ix.removeLocked(id, doc)
+	}
+	return nil
+}
+
+func (ix *Index) initLocked() {
+	if ix.k1 == 0 {
+		ix.k1 = defaultK1
+	}
+	if ix.b == 0 {
+		ix.b = defaultB
+	}
+	if ix.docs == nil {
+		ix.docs = make(map[string]*document)
+	}
+	if ix.postings == nil {
+		ix.postings = make(map[string]map[string]int)
+	}
+	if ix.scopeDocs == nil {
+		ix.scopeDocs = make(map[slice.Scope]map[string]struct{})
+	}
+	if ix.scopeDF == nil {
+		ix.scopeDF = make(map[slice.Scope]map[string]int)
+	}
+	if ix.scopeTotalLength == nil {
+		ix.scopeTotalLength = make(map[slice.Scope]int)
+	}
+}
+
+func (ix *Index) removeLocked(id string, doc *document) {
+	delete(ix.docs, id)
+	scope := doc.value.Scope
+	delete(ix.scopeDocs[scope], id)
+	ix.scopeTotalLength[scope] -= doc.length
+
+	for term := range doc.terms {
+		delete(ix.postings[term], id)
+		if len(ix.postings[term]) == 0 {
+			delete(ix.postings, term)
+		}
+
+		ix.scopeDF[scope][term]--
+		if ix.scopeDF[scope][term] == 0 {
+			delete(ix.scopeDF[scope], term)
+		}
+	}
+	if len(ix.scopeDocs[scope]) == 0 {
+		delete(ix.scopeDocs, scope)
+		delete(ix.scopeDF, scope)
+		delete(ix.scopeTotalLength, scope)
+	}
+}
+
+func cloneSlice(s *slice.Slice) *slice.Slice {
+	if s == nil {
+		return nil
+	}
+	cloned := *s
+	cloned.Content = append([]byte(nil), s.Content...)
+	cloned.Embedding = append([]float32(nil), s.Embedding...)
+	return &cloned
+}

--- a/kernel/bm25/bm25_test.go
+++ b/kernel/bm25/bm25_test.go
@@ -1,0 +1,194 @@
+package bm25
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+func TestSearchRanksMatchingDocument(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "relevant", Scope: slice.Project, Content: []byte("prompt cache cache stability")})
+	mustInsert(t, ix, &slice.Slice{ID: "unrelated", Scope: slice.Project, Content: []byte("dashboard colors")})
+
+	hits := mustSearch(t, ix, "prompt cache", 5, slice.Project)
+	if len(hits) != 1 || hits[0].Slice.ID != "relevant" {
+		t.Fatalf("Search() = %#v, want relevant document", hitIDs(hits))
+	}
+}
+
+func TestSearchRanksCJKDocument(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "retrieval", Scope: slice.Project, Content: []byte("使用 BM25 实现中文检索")})
+	mustInsert(t, ix, &slice.Slice{ID: "frontend", Scope: slice.Project, Content: []byte("修改网页背景颜色")})
+
+	hits := mustSearch(t, ix, "中文检索", 5, slice.Project)
+	if len(hits) == 0 || hits[0].Slice.ID != "retrieval" {
+		t.Fatalf("top hit = %#v, want retrieval", hitIDs(hits))
+	}
+}
+
+func TestSearchFiltersScope(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "project", Scope: slice.Project, Content: []byte("project test command")})
+	mustInsert(t, ix, &slice.Slice{ID: "user", Scope: slice.User, Content: []byte("user test preference")})
+
+	projectHits := mustSearch(t, ix, "test", 10, slice.Project)
+	if got := hitIDs(projectHits); len(got) != 1 || got[0] != "project" {
+		t.Fatalf("project Search() = %#v, want [project]", got)
+	}
+	userHits := mustSearch(t, ix, "test", 10, slice.User)
+	if got := hitIDs(userHits); len(got) != 1 || got[0] != "user" {
+		t.Fatalf("user Search() = %#v, want [user]", got)
+	}
+}
+
+func TestInsertReplacesExistingDocument(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "doc", Scope: slice.Project, Content: []byte("cache")})
+	mustInsert(t, ix, &slice.Slice{ID: "doc", Scope: slice.User, Content: []byte("dashboard")})
+
+	if hits := mustSearch(t, ix, "cache", 10, slice.Project); len(hits) != 0 {
+		t.Fatalf("old document still searchable: %#v", hitIDs(hits))
+	}
+	hits := mustSearch(t, ix, "dashboard", 10, slice.User)
+	if got := hitIDs(hits); len(got) != 1 || got[0] != "doc" {
+		t.Fatalf("replacement Search() = %#v, want [doc]", got)
+	}
+}
+
+func TestInsertCopiesInput(t *testing.T) {
+	ix := New()
+	doc := &slice.Slice{ID: "doc", Scope: slice.Project, Content: []byte("stable cache")}
+	mustInsert(t, ix, doc)
+	doc.Scope = slice.User
+	copy(doc.Content, "broken")
+
+	hits := mustSearch(t, ix, "stable", 10, slice.Project)
+	if len(hits) != 1 || string(hits[0].Slice.Content) != "stable cache" {
+		t.Fatalf("indexed document changed through caller mutation: %#v", hits)
+	}
+}
+
+func TestRemoveIsCompleteAndIdempotent(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "doc", Scope: slice.Project, Content: []byte("cache cache")})
+	if err := ix.Remove("doc"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ix.Remove("doc"); err != nil {
+		t.Fatalf("second Remove() error = %v", err)
+	}
+	if hits := mustSearch(t, ix, "cache", 10, slice.Project); len(hits) != 0 {
+		t.Fatalf("removed document still searchable: %#v", hitIDs(hits))
+	}
+}
+
+func TestSearchLimitsAndStablySortsEqualScores(t *testing.T) {
+	ix := New()
+	for _, id := range []string{"c", "a", "b"} {
+		mustInsert(t, ix, &slice.Slice{ID: id, Scope: slice.Project, Content: []byte("same content")})
+	}
+
+	hits := mustSearch(t, ix, "same", 2, slice.Project)
+	got := hitIDs(hits)
+	want := []string{"a", "b"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("Search() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSearchUsesScopeLocalStatistics(t *testing.T) {
+	ix := New()
+	mustInsert(t, ix, &slice.Slice{ID: "short", Scope: slice.Project, Content: []byte("cache")})
+	mustInsert(t, ix, &slice.Slice{ID: "long", Scope: slice.Project, Content: []byte("cache filler filler filler filler")})
+	for i := 0; i < 20; i++ {
+		mustInsert(t, ix, &slice.Slice{ID: string(rune('A' + i)), Scope: slice.User, Content: []byte("cache user")})
+	}
+
+	hits := mustSearch(t, ix, "cache", 10, slice.Project)
+	if len(hits) != 2 || hits[0].Slice.ID != "short" {
+		t.Fatalf("Search() = %#v, want short document first", hitIDs(hits))
+	}
+
+	wantIDF := math.Log(1 + (2.0-2.0+0.5)/(2.0+0.5))
+	wantScore := wantIDF * (1 * (defaultK1 + 1)) / (1 + defaultK1*(1-defaultB+defaultB*1/3))
+	if math.Abs(hits[0].Score-wantScore) > 1e-12 {
+		t.Fatalf("score = %.12f, want %.12f", hits[0].Score, wantScore)
+	}
+}
+
+func TestInvalidInputs(t *testing.T) {
+	ix := New()
+	if err := ix.Insert(nil); err == nil {
+		t.Fatal("Insert(nil) succeeded, want error")
+	}
+	if err := ix.Insert(&slice.Slice{Content: []byte("content")}); err == nil {
+		t.Fatal("Insert(empty ID) succeeded, want error")
+	}
+	if err := ix.Insert(&slice.Slice{ID: "empty", Content: []byte("!!!")}); err == nil {
+		t.Fatal("Insert(empty content) succeeded, want error")
+	}
+	if err := ix.Remove(""); err == nil {
+		t.Fatal("Remove(empty ID) succeeded, want error")
+	}
+	if _, err := ix.Search("!!!", 5, slice.Project); err == nil {
+		t.Fatal("Search(punctuation) succeeded, want error")
+	}
+	if hits, err := ix.Search("valid", 0, slice.Project); err != nil || len(hits) != 0 {
+		t.Fatalf("Search(k=0) = %#v, %v; want empty result", hits, err)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	ix := New()
+	const workers = 20
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		id := string(rune('a' + i))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := 0; n < 50; n++ {
+				if err := ix.Insert(&slice.Slice{ID: id, Scope: slice.Project, Content: []byte("concurrent cache")}); err != nil {
+					t.Errorf("Insert() error = %v", err)
+					return
+				}
+				if _, err := ix.Search("cache", 5, slice.Project); err != nil {
+					t.Errorf("Search() error = %v", err)
+					return
+				}
+			}
+			if err := ix.Remove(id); err != nil {
+				t.Errorf("Remove() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func mustInsert(t *testing.T, ix *Index, s *slice.Slice) {
+	t.Helper()
+	if err := ix.Insert(s); err != nil {
+		t.Fatalf("Insert(%q) error = %v", s.ID, err)
+	}
+}
+
+func mustSearch(t *testing.T, ix *Index, query string, k int, scope slice.Scope) []slice.Hit {
+	t.Helper()
+	hits, err := ix.Search(query, k, scope)
+	if err != nil {
+		t.Fatalf("Search(%q) error = %v", query, err)
+	}
+	return hits
+}
+
+func hitIDs(hits []slice.Hit) []string {
+	ids := make([]string, len(hits))
+	for i, hit := range hits {
+		ids[i] = hit.Slice.ID
+	}
+	return ids
+}

--- a/kernel/bm25/tokenizer.go
+++ b/kernel/bm25/tokenizer.go
@@ -1,0 +1,58 @@
+package bm25
+
+import (
+	"strings"
+	"unicode"
+)
+
+// tokenize lowercases word tokens and emits each CJK rune as its own token.
+func tokenize(text string) []string {
+	var tokens []string
+	var word strings.Builder
+	flush := func() {
+		if word.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, word.String())
+		word.Reset()
+	}
+
+	for _, r := range text {
+		switch {
+		case isCJK(r):
+			flush()
+			tokens = append(tokens, string(r))
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_':
+			word.WriteRune(unicode.ToLower(r))
+		default:
+			flush()
+		}
+	}
+	flush()
+	return tokens
+}
+
+func isCJK(r rune) bool {
+	return unicode.In(r, unicode.Han, unicode.Hiragana, unicode.Katakana, unicode.Hangul)
+}
+
+func countTerms(terms []string) map[string]int {
+	counts := make(map[string]int, len(terms))
+	for _, term := range terms {
+		counts[term]++
+	}
+	return counts
+}
+
+func uniqueTerms(terms []string) []string {
+	seen := make(map[string]struct{}, len(terms))
+	unique := make([]string, 0, len(terms))
+	for _, term := range terms {
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		unique = append(unique, term)
+	}
+	return unique
+}

--- a/kernel/bm25/tokenizer_test.go
+++ b/kernel/bm25/tokenizer_test.go
@@ -1,0 +1,28 @@
+package bm25
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTokenizeLatinCJKAndPunctuation(t *testing.T) {
+	got := tokenize("BM25 检索 cache-first 日本語 한글 Cache_Key42")
+	want := []string{"bm25", "检", "索", "cache", "first", "日", "本", "語", "한", "글", "cache_key42"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokenize() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTokenizeDropsOnlyPunctuation(t *testing.T) {
+	if got := tokenize(" !?，。--- "); len(got) != 0 {
+		t.Fatalf("tokenize() = %#v, want no tokens", got)
+	}
+}
+
+func TestUniqueTermsKeepsFirstSeenOrder(t *testing.T) {
+	got := uniqueTerms([]string{"cache", "测", "cache", "试", "测"})
+	want := []string{"cache", "测", "试"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("uniqueTerms() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the U6 CLI integration from #3.

- adds the `semantix extract` command for reading session JSONL, invoking the frozen U4 extractor contract, selecting project/user/session scope, and storing extracted slices
- adds the `semantix search` command for loading slices from the selected store, rebuilding the U5 BM25 index, and returning deterministic top-k results
- supports project and user database defaults, explicit `--db` overrides, metadata flags, positional or flagged queries, and JSON output
- closes concrete stores when they expose `Close()` without changing the frozen `slice.Store` interface
- reports a clear dependency error while the U4 extractor/store constructors are still placeholders
- adds CLI orchestration tests with fake U4 dependencies and the real U5 BM25 implementation

## Stacked dependency

This is a stacked draft PR and includes the U5 commit from #10. Merge #10 first; afterward this PR's effective diff against `feat/kernel-skeleton` will reduce to `cmd/semantix/`.

U4 is intentionally left untouched. Real JSONL-to-bbolt end-to-end acceptance remains blocked until `feat/u4-slice-core` provides non-placeholder `slice.NewExtractor` and `slice.NewBboltStore` implementations.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./cmd/semantix ./kernel/bm25`
- `go build ./cmd/semantix`

Related to #3.