### PR TITLE
GEO Week 2 #6: 改善 Features 证据与实现状态

### DIFF
--- a/site/src/components/Features.tsx
+++ b/site/src/components/Features.tsx
@@ -6,43 +6,61 @@ const features: Feature[] = [
     num: "01",
     titleEn: "Semantic Slice Library",
     title: "语义切片库",
-    body: "从历史会话提取可复用语义单元：任务模板 P、上下文块 C、工具调用模式 T、高频结果 R、记忆 M。向量索引并持久化到项目/用户双库。",
-    code: "type Slice struct { ID string; Type SliceType; Scope Scope; Content []byte }",
+    status: "已实现",
+    body: "会话 JSONL 可提取 P/T/R 切片，并按项目或用户 scope 持久化。提取和存储路径已有自动化测试。",
+    code: "extract -> P/T/R slices -> scoped store",
+    evidence: "https://github.com/Gnosil/semantix/blob/main/kernel/slice/slice_test.go",
+    evidenceLabel: "查看切片测试",
   },
   {
     num: "02",
     titleEn: "Semantic Cache L1·L2·L3",
     title: "三级语义缓存",
-    body: "L1 字节前缀缓存；L2 把跨会话稳定的切片原样注入前缀区，让语义命中变成厂商的字节命中；L3 带验证的只读结果复用。",
-    code: "L2: stable-slice injection → vendor byte cache",
+    status: "部分实现",
+    body: "BM25 检索和跨会话注入块已实现并有集成测试。L3 结果复用目前只有接口，真实数据命中率仍待验证。",
+    code: "BM25 + injection: implemented; L3: interface",
+    evidence: "https://github.com/Gnosil/semantix/blob/main/kernel/inject/inject_test.go#L245",
+    evidenceLabel: "查看跨会话测试",
   },
   {
     num: "03",
     titleEn: "Kernel Scheduler",
     title: "内核调度器",
-    body: "按任务 intent 联合决策：工具并发度、模型 tier、缓存注入、预取预算——从你的行为模式里学出来的调度策略。",
-    code: "decide(intent) → {concurrency, tier, inject, prefetch}",
+    status: "规划中",
+    body: "当前仅定义调度输入、计划与 Decider 接口。intent 学习、并发分组和模型 tier 决策尚未实现。",
+    code: "Decider interface: defined; implementation: pending",
+    evidence: "https://github.com/Gnosil/semantix/blob/main/kernel/sched/sched.go",
+    evidenceLabel: "查看调度接口",
   },
   {
     num: "04",
     titleEn: "Speculative Prefetch",
     title: "投机预取",
-    body: "把 LLM 流式输出的等待时间填满：预取下一轮的切片组装、embedding 计算。waste/hit 比例自我惩罚，越用越准。",
-    code: "waste/hit > 3:1 → signal-source weight ↓",
+    status: "规划中",
+    body: "当前仅定义只读 PrefetchTask 与 Prefetcher 接口。预取策略、预算控制和实际收益尚未实现或测量。",
+    code: "Prefetcher interface: defined; measurements: pending",
+    evidence: "https://github.com/Gnosil/semantix/blob/main/kernel/prefetch/prefetch.go",
+    evidenceLabel: "查看预取接口",
   },
   {
     num: "05",
     titleEn: "Self-Evolution",
     title: "自进化引擎",
-    body: "每轮回馈命中/污染/延迟/成本/成功率：在线 EWMA 调参（冻结期保护字节缓存）+ 离线重训。系统自己长出自己的最优参数。",
-    code: "online EWMA + freeze-period ≥1h + offline retrain",
+    status: "规划中",
+    body: "Signal、Params 与 Engine 接口已经定义；在线 EWMA 调参与离线重训仍是占位设计，没有效果曲线。",
+    code: "Engine interface: defined; tuning loop: pending",
+    evidence: "https://github.com/Gnosil/semantix/blob/main/kernel/evolve/evolve.go",
+    evidenceLabel: "查看进化接口",
   },
   {
     num: "06",
     titleEn: "Single Kernel, Many Harnesses",
-    title: "零侵入适配",
-    body: "不改造 harness 内核：适配层接入 DeepSeek-Reasonix、Claude Code 等任意 harness，上层能力原样复用。",
-    code: "adapter(harness) → kernel.emit(event)",
+    title: "Harness 接入",
+    status: "设计目标",
+    body: "通用事件、Source 与 lookup 契约已经存在；Reasonix、Claude Code 等生产级适配尚未完成兼容验证。",
+    code: "generic contracts: available; adapters: unverified",
+    evidence: "https://github.com/Gnosil/semantix/blob/main/docs/reports/harness-refactor-blueprint.md",
+    evidenceLabel: "查看接入蓝图",
   },
 ];
 
@@ -55,28 +73,23 @@ export default function Features() {
       <div className="relative wrap">
         <Reveal>
           <p className="font-mono text-sm font-medium text-accent">
-            Features 特性
+            Features 实现状态
           </p>
           <h2 className="mt-2 text-3xl font-bold tracking-tight md:text-4xl">
-            越用越好的能力。
+            机制、状态与证据。
           </h2>
-          <p className="mt-1 text-muted-foreground">
-            Autonomy you can actually audit.
-          </p>
           <p className="mt-4 max-w-2xl text-muted-foreground">
-            现有 harness 只做会话内的字节级前缀缓存——被动、会话绑定、调度静态。Semantix
-            把整个循环升级为跨会话的、主动的、自进化的闭环：每次交互都让下一次更便宜、更快。
+            以下状态以 main 分支代码和测试为准。已实现能力与路线图目标分别标注，限制条件直接写在功能说明中。
           </p>
         </Reveal>
 
         <div className="mt-12 grid gap-4 md:grid-cols-2">
           {features.map((f, i) => (
-            <Reveal key={f.num} delay={(i % 2) * 90}>
-              <article
-                className="rounded-lg border border-border bg-white p-6 transition hover:border-accent hover:shadow-sm"
-              >
-                <div className="font-mono text-sm font-semibold text-accent">
-                  {f.num}
+            <Reveal key={f.num} className="min-w-0" delay={(i % 2) * 90}>
+              <article className="flex h-full flex-col rounded-lg border border-border bg-white p-6 transition hover:border-accent hover:shadow-sm">
+                <div className="flex items-center justify-between gap-4 font-mono text-sm">
+                  <span className="font-semibold text-accent">{f.num}</span>
+                  <span className="text-xs text-muted-foreground">{f.status}</span>
                 </div>
                 <h3 className="mt-2 text-lg font-semibold">{f.titleEn}</h3>
                 <p className="text-sm text-muted-foreground">{f.title}</p>
@@ -86,6 +99,14 @@ export default function Features() {
                 <pre className="mt-4 overflow-x-auto rounded-md border border-border/60 bg-[oklch(0.976_0.005_165)] p-3 font-mono text-xs text-[oklch(0.45_0.02_260)]">
                   <code>{f.code}</code>
                 </pre>
+                <a
+                  href={f.evidence}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-4 w-fit text-sm font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent hover:decoration-accent"
+                >
+                  {f.evidenceLabel} <span aria-hidden="true">↗</span>
+                </a>
               </article>
             </Reveal>
           ))}

--- a/site/src/components/Hero.tsx
+++ b/site/src/components/Hero.tsx
@@ -40,9 +40,9 @@ export default function Hero() {
         {/* subheading */}
         <Reveal delay={160}>
           <p className="mx-auto mt-6 max-w-2xl text-muted-foreground">
-            Semantix 连接 Agent Harness 与资源层，负责并发调度、语义缓存和智能预取。
+            Semantix 连接 Agent Harness 与资源层，探索跨会话语义复用。
             <br className="hidden md:block" />
-            每次交互都会积累经验，让下一次响应更快、成本更低。
+            当前版本已实现会话切片、BM25 检索与跨会话注入；调度、预取和自进化闭环仍在开发中。
           </p>
         </Reveal>
 
@@ -90,7 +90,7 @@ export default function Hero() {
               <span className="h-3 w-3 rounded-full bg-[#FBBF24]" />
               <span className="h-3 w-3 rounded-full bg-[#4ADE80]" />
               <span className="ml-2 font-mono text-xs text-slate-400">
-                ~/semantix — extract &amp; search
+                ~/semantix - example output (not a benchmark)
               </span>
             </div>
             <div className="px-5 py-4 font-mono text-sm leading-relaxed text-slate-300">
@@ -125,7 +125,7 @@ export default function Hero() {
               </div>
               <div>&nbsp;</div>
               <div className="text-slate-500">
-                命中 3 slices · 0.4ms · 下次会话注入前缀，直接命中字节缓存
+                示例数据 · 实际结果取决于会话内容、数据规模与运行环境
               </div>
               <div>
                 <span className="blink inline-block h-4 w-2 bg-emerald-400 align-middle">

--- a/site/src/types/content.ts
+++ b/site/src/types/content.ts
@@ -10,8 +10,11 @@ export interface Feature {
   num: string;
   title: string;
   titleEn: string;
+  status: "已实现" | "部分实现" | "规划中" | "设计目标";
   body: string;
   code: string;
+  evidence: string;
+  evidenceLabel: string;
 }
 
 export interface Surface {


### PR DESCRIPTION
## What changed

- label every Features capability as implemented, partially implemented, planned, or a design target
- replace generalized marketing copy with concrete mechanisms, current limitations, and failure boundaries
- add first-party links to source code, tests, and the harness integration blueprint
- mark terminal numbers as example output and remove the unsupported `0.4ms` latency claim
- prevent long evidence snippets from clipping status labels on mobile

## Why

The Features section previously presented roadmap interfaces as completed capabilities and included precise or universal performance implications without reproducible context. This update makes the implementation state and evidence trail explicit for readers and automated audits.

## Validation

- `npm run lint` (passes with the existing `Nav.tsx` image optimization warning)
- `npm run typecheck`
- `npm run build`
- desktop and 390px responsive browser checks with no page-level horizontal overflow

Closes #34
