### PR TITLE
feat(site): 文档页改为左侧目录布局

### DIFF
--- a/site/src/app/docs/[slug]/page.tsx
+++ b/site/src/app/docs/[slug]/page.tsx
@@ -36,19 +36,18 @@ export default async function GeoDocumentPage({ params }: GeoPageProps) {
   const content = await readGeoDocument(document);
 
   return (
-    <main className="min-h-screen bg-background pt-16">
-      <div className="wrap py-10 md:py-16">
-        <div className="mb-10 flex flex-wrap items-center justify-between gap-4 border-b border-border pb-6">
-          <Link href="/docs" className="text-sm font-semibold text-muted-foreground hover:text-accent">
-            ← 返回文档
-          </Link>
-          <div className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
-            <span className="rounded-full bg-muted px-3 py-1">{document.language}</span>
-            <span className="rounded-full bg-muted px-3 py-1">{document.depth}</span>
+    <div className="px-6 py-10 md:px-10 md:py-14 lg:px-14">
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4 border-b border-border pb-5">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Link href="/docs" className="font-medium hover:text-accent">文档</Link>
+            <span aria-hidden="true">/</span>
+            <span>{document.depth}</span>
           </div>
+          <span className="font-mono text-xs text-muted-foreground">{document.language}</span>
         </div>
 
-        <article className="geo-prose mx-auto max-w-3xl">
+        <article className="geo-prose max-w-3xl">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
@@ -59,6 +58,6 @@ export default async function GeoDocumentPage({ params }: GeoPageProps) {
           </ReactMarkdown>
         </article>
       </div>
-    </main>
+    </div>
   );
 }

--- a/site/src/app/docs/layout.tsx
+++ b/site/src/app/docs/layout.tsx
@@ -1,14 +1,19 @@
-import Footer from "@/components/Footer";
+import DocsSidebar from "@/components/DocsSidebar";
 import GeoScrollReset from "@/components/GeoScrollReset";
 import Nav from "@/components/Nav";
+import { geoDocuments } from "@/lib/geo-docs";
 
 export default function GeoLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <>
       <Nav />
       <GeoScrollReset />
-      {children}
-      <Footer />
+      <main className="min-h-[100dvh] bg-background pt-16">
+        <div className="mx-auto grid min-h-[calc(100dvh-4rem)] w-full max-w-[1440px] lg:grid-cols-[280px_minmax(0,1fr)]">
+          <DocsSidebar documents={geoDocuments} />
+          <div className="min-w-0 lg:border-l lg:border-border">{children}</div>
+        </div>
+      </main>
     </>
   );
 }

--- a/site/src/app/docs/page.tsx
+++ b/site/src/app/docs/page.tsx
@@ -1,6 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { geoDocuments } from "@/lib/geo-docs";
 
 export const metadata: Metadata = {
   title: "文档 | Semantix",
@@ -9,46 +7,28 @@ export const metadata: Metadata = {
 
 export default function GeoIndexPage() {
   return (
-    <main className="min-h-screen bg-background pt-16">
-      <section className="border-b border-border bg-muted/40 py-20 md:py-28">
-        <div className="wrap">
-          <p className="mb-4 font-mono text-sm font-semibold uppercase tracking-[0.18em] text-accent">
-            Documentation · Project knowledge
-          </p>
-          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-foreground md:text-6xl">
-            Semantix 文档
-          </h1>
-          <p className="mt-6 max-w-2xl text-lg leading-8 text-muted-foreground">
-            从项目速览到架构深读，帮助开发者理解 Semantix 的定位、工作原理、边界与路线图。
-          </p>
-        </div>
-      </section>
+    <div className="px-6 py-10 md:px-10 md:py-14 lg:px-14">
+      <div className="mx-auto max-w-4xl">
+        <p className="font-mono text-xs font-semibold text-accent">SEMANTIX 文档</p>
+        <h1 className="mt-5 text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
+          从项目定位到核心机制。
+        </h1>
+        <p className="mt-5 max-w-2xl text-lg leading-8 text-muted-foreground">
+          文档已集中到左侧目录。建议先阅读项目速览，再根据语言和深度进入对应文档。
+        </p>
 
-      <section className="wrap py-14 md:py-20">
-        <div className="grid gap-4 md:grid-cols-2">
-          {geoDocuments.map((document) => (
-            <Link
-              key={document.slug}
-              href={`/docs/${document.slug}`}
-              className="group rounded-2xl border border-border bg-card p-6 transition-colors hover:border-accent md:p-8"
-            >
-              <div className="mb-8 flex items-center justify-between gap-4">
-                <span className="rounded-full bg-muted px-3 py-1 font-mono text-xs text-muted-foreground">
-                  {document.language}
-                </span>
-                <span className="font-mono text-xs text-accent">{document.depth}</span>
-              </div>
-              <h2 className="text-2xl font-semibold tracking-tight text-foreground">
-                {document.title}
-              </h2>
-              <p className="mt-3 leading-7 text-muted-foreground">{document.description}</p>
-              <span className="mt-8 inline-flex text-sm font-semibold text-foreground transition-colors group-hover:text-accent">
-                阅读文档 <span aria-hidden="true">→</span>
-              </span>
-            </Link>
-          ))}
-        </div>
-      </section>
-    </main>
+        <section className="mt-12 max-w-2xl border-t border-border pt-8">
+          <h2 className="text-xl font-semibold">阅读方式</h2>
+          <div className="mt-5 space-y-5 text-sm leading-7 text-muted-foreground">
+            <p>
+              桌面端从左侧目录选择文档，目录会保持在视口内并标记当前页面。正文在右侧独立阅读。
+            </p>
+            <p>
+              手机端点击正文上方的“文档目录”展开全部入口。中文与英文版本按速览和深入两组排列。
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
   );
 }

--- a/site/src/components/DocsSidebar.tsx
+++ b/site/src/components/DocsSidebar.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+type DocsNavDocument = {
+  slug: string;
+  title: string;
+  language: string;
+  depth: "速览" | "深入";
+};
+
+function DocumentLinks({
+  pathname,
+  documents,
+}: {
+  pathname: string;
+  documents: readonly DocsNavDocument[];
+}) {
+  const groups = [
+    {
+      title: "项目速览",
+      documents: documents.filter((document) => document.depth === "速览"),
+    },
+    {
+      title: "架构深读",
+      documents: documents.filter((document) => document.depth === "深入"),
+    },
+  ];
+
+  return (
+    <nav aria-label="文档目录" className="space-y-7">
+      <div>
+        <Link
+          href="/docs"
+          className={cn(
+            "block rounded-md px-3 py-2.5 text-sm transition-colors",
+            pathname === "/docs"
+              ? "bg-accent/10 font-semibold text-accent"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground",
+          )}
+        >
+          文档首页
+          <span className="mt-0.5 block text-xs font-normal opacity-75">全部文档与阅读说明</span>
+        </Link>
+      </div>
+
+      {groups.map((group) => (
+        <div key={group.title}>
+          <p className="mb-2 px-3 text-xs font-semibold text-foreground">{group.title}</p>
+          <div className="space-y-1">
+            {group.documents.map((document) => {
+              const href = `/docs/${document.slug}`;
+              const active = pathname === href;
+
+              return (
+                <Link
+                  key={document.slug}
+                  href={href}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "block rounded-md px-3 py-2.5 text-sm transition-colors",
+                    active
+                      ? "bg-accent/10 font-semibold text-accent"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  {document.title}
+                  <span className="mt-0.5 block font-mono text-[11px] font-normal opacity-70">
+                    {document.language}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      <div className="border-t border-border pt-5">
+        <a
+          href="https://github.com/Gnosil/semantix"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block px-3 text-sm font-medium text-muted-foreground transition-colors hover:text-accent"
+        >
+          GitHub 仓库 <span aria-hidden="true">↗</span>
+        </a>
+      </div>
+    </nav>
+  );
+}
+
+export default function DocsSidebar({ documents }: { documents: readonly DocsNavDocument[] }) {
+  const pathname = usePathname();
+
+  return (
+    <>
+      <div className="border-b border-border bg-white px-5 py-4 lg:hidden">
+        <details className="group">
+          <summary className="flex cursor-pointer list-none items-center justify-between font-semibold">
+            文档目录
+            <span aria-hidden="true" className="text-muted-foreground transition-transform group-open:rotate-180">
+              ↓
+            </span>
+          </summary>
+          <div className="pt-5">
+            <DocumentLinks pathname={pathname} documents={documents} />
+          </div>
+        </details>
+      </div>
+
+      <aside className="hidden bg-[oklch(0.992_0.002_165)] lg:sticky lg:top-16 lg:block lg:h-[calc(100dvh-4rem)] lg:overflow-y-auto">
+        <div className="px-5 py-8">
+          <p className="mb-7 px-3 font-mono text-xs font-semibold text-accent">SEMANTIX 文档</p>
+          <DocumentLinks pathname={pathname} documents={documents} />
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -43,7 +43,7 @@ export default function Nav() {
           : "border-transparent bg-transparent",
       )}
     >
-      <div className="wrap flex h-16 items-center justify-between">
+      <div className="mx-auto flex h-16 w-full max-w-[1360px] items-center justify-between px-5 sm:px-6">
         {/* Logo */}
         <Link href="/" aria-label="Semantix 首页" className="flex items-center gap-2.5">
           <img


### PR DESCRIPTION
## 改动内容

- 将文档入口集中到桌面端固定左侧目录，并标记当前文档
- 为移动端增加可折叠的文档目录
- 简化文档首页和详情页结构，正文统一在右侧阅读区展示
- 放宽桌面端顶部导航容器，让 Logo 更靠左并缓解导航拥挤

## 影响

文档浏览方式更接近完整的开发者文档站点，用户可以持续看到文档结构并快速切换中英文及不同阅读深度；主页正文宽度与移动端导航行为保持不变。

## 验证

- `npm run build`
- TypeScript 检查
- ESLint（无错误；保留现有 `<img>` 性能提示）
- `git diff --check`