### PR TITLE
docs(site): 补充主页维护者名单

### DIFF
--- a/site/src/components/Install.tsx
+++ b/site/src/components/Install.tsx
@@ -127,6 +127,33 @@ export default function Install() {
             >
               Gnosil
             </a>
+            {"、"}
+            <a
+              href="https://github.com/radianceded"
+              target="_blank"
+              rel="noopener"
+              className="text-accent hover:underline"
+            >
+              radianceded
+            </a>
+            {"、"}
+            <a
+              href="https://github.com/Allenli1233"
+              target="_blank"
+              rel="noopener"
+              className="text-accent hover:underline"
+            >
+              Allenli1233
+            </a>
+            {"、"}
+            <a
+              href="https://github.com/jh10724-dotcom"
+              target="_blank"
+              rel="noopener"
+              className="text-accent hover:underline"
+            >
+              jh10724-dotcom
+            </a>
             {" · "}© 2026 MIT License · 技术作者：Gnosil
           </p>
         </Reveal>


### PR DESCRIPTION
## 改动内容

- 在主页安装区底部的维护者名单中保留 `Gnosil`
- 追加 `radianceded`、`Allenli1233` 和 `jh10724-dotcom`
- 为每位维护者提供对应的 GitHub 主页链接
- 保持“技术作者：Gnosil”信息不变

## 用户影响

官网可以更完整地展示当前项目维护团队，并为访问者提供可验证的 GitHub 身份入口。

## 验证

- `npm run check`
- ESLint（无错误；保留现有 `<img>` 性能提示）
- TypeScript 检查
- 生产构建
- 内容测试（3/3 通过）
- `git diff --check`