### PR TITLE
feat(site): 新增 Blog 并将 FAQ 迁入文档

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -17,6 +17,15 @@
 - [Semantix Project Overview (EN)](https://semantix.ensureok.ai/docs/profile-en): Concise English overview of the project's purpose, terminology, and progress.
 - [Understanding Semantix from Scratch](https://semantix.ensureok.ai/docs/guide): Chinese deep dive from first principles — ecosystem, architecture, and the four components plus evolution engine.
 - [Understanding Semantix from Scratch (EN)](https://semantix.ensureok.ai/docs/guide-en): English deep dive covering the same architecture and mechanisms.
+- [Semantix FAQ](https://semantix.ensureok.ai/docs/faq): Project positioning, semantic cache levels, evolution mechanisms, and contribution requirements.
+
+## Blog
+
+- [Semantix Blog](https://semantix.ensureok.ai/blog/): Research and practical guides about persistent memory, semantic retrieval, and coding-agent infrastructure.
+- [Persistent Memory Open-Source Evaluation Guide](https://semantix.ensureok.ai/blog/persistent-memory-open-source-evaluation-guide): Criteria for evaluating persistent memory layers for coding agents.
+- [Open-Source Semantic Memory Shortlist](https://semantix.ensureok.ai/blog/open-source-semantic-memory-shortlist): A practical shortlist of open-source semantic memory options.
+- [Cross-Session Reuse Guide](https://semantix.ensureok.ai/blog/cross-session-reuse-guide): How reusable context moves between coding-agent sessions.
+- [Semantic Memory Comparison Guide](https://semantix.ensureok.ai/blog/open-source-semantic-memory-comparison-guide): A comparison framework for open-source semantic memory architectures.
 
 ## Site
 

--- a/site/scripts/blog.test.mjs
+++ b/site/scripts/blog.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const blogSlugs = [
+  "persistent-memory-open-source-evaluation-guide",
+  "open-source-semantic-memory-shortlist",
+  "cross-session-reuse-guide",
+  "open-source-semantic-memory-comparison-guide",
+];
+
+const blogIndex = await readFile(new URL("../out/blog/index.html", import.meta.url), "utf8");
+const sitemap = await readFile(new URL("../out/sitemap.xml", import.meta.url), "utf8");
+
+test("blog index links every published article", () => {
+  for (const slug of blogSlugs) {
+    assert.ok(blogIndex.includes(`/blog/${slug}/`), `blog index should link ${slug}`);
+  }
+});
+
+test("blog articles export with BlogPosting metadata", async () => {
+  for (const slug of blogSlugs) {
+    const html = await readFile(new URL(`../out/blog/${slug}/index.html`, import.meta.url), "utf8");
+    assert.ok(html.includes('"@type":"BlogPosting"'), `${slug} should expose BlogPosting JSON-LD`);
+    assert.ok(html.includes('Updated <!-- -->2026-08-10'), `${slug} should expose its update date`);
+  }
+});
+
+test("sitemap lists the blog index and every article", () => {
+  assert.ok(sitemap.includes("<loc>https://semantix.ensureok.ai/blog</loc>"));
+  for (const slug of blogSlugs) {
+    assert.ok(
+      sitemap.includes(`<loc>https://semantix.ensureok.ai/blog/${slug}</loc>`),
+      `sitemap should contain ${slug}`,
+    );
+  }
+});

--- a/site/scripts/week3-platform.test.mjs
+++ b/site/scripts/week3-platform.test.mjs
@@ -4,8 +4,9 @@ import test from "node:test";
 
 const llmsTxt = await readFile(new URL("../public/llms.txt", import.meta.url), "utf8");
 const llmsFullTxt = await readFile(new URL("../public/llms-full.txt", import.meta.url), "utf8");
-const robotsTxt = await readFile(new URL("../public/robots.txt", import.meta.url), "utf8");
+const robotsTxt = (await readFile(new URL("../public/robots.txt", import.meta.url), "utf8")).replaceAll("\r\n", "\n");
 const homepageHtml = await readFile(new URL("../out/index.html", import.meta.url), "utf8");
+const faqHtml = await readFile(new URL("../out/docs/faq/index.html", import.meta.url), "utf8");
 const sitemapXml = await readFile(new URL("../out/sitemap.xml", import.meta.url), "utf8");
 
 const jsonLdObjects = [...homepageHtml.matchAll(
@@ -66,20 +67,23 @@ test("homepage export ships WebSite and SoftwareApplication JSON-LD", () => {
   assert.equal(softwareApplication.codeRepository, "https://github.com/Gnosil/semantix");
 });
 
-test("homepage visible FAQ matches FAQPage JSON-LD", () => {
-  const faq = jsonLdObjects.find((value) => value["@type"] === "FAQPage");
+test("docs FAQ page visible content matches FAQPage JSON-LD", () => {
+  const faqJsonLdObjects = [...faqHtml.matchAll(
+    /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g,
+  )].map((match) => JSON.parse(match[1]));
+  const faq = faqJsonLdObjects.find((value) => value["@type"] === "FAQPage");
   assert.ok(faq, "expected FAQPage JSON-LD");
   assert.equal(faq.mainEntity.length, 5);
 
-  const visibleHtml = homepageHtml.replaceAll("<!-- -->", "");
+  const visibleHtml = faqHtml.replaceAll("<!-- -->", "");
   for (const question of faq.mainEntity) {
     assert.ok(
       visibleHtml.includes(question.name),
-      `visible homepage should contain the FAQ question "${question.name}"`,
+      `visible docs FAQ should contain the question "${question.name}"`,
     );
     assert.ok(
       visibleHtml.includes(question.acceptedAnswer.text),
-      `visible homepage should contain the FAQ answer for "${question.name}"`,
+      `visible docs FAQ should contain the answer for "${question.name}"`,
     );
   }
 });
@@ -105,4 +109,8 @@ test("sitemap lists all static docs pages", () => {
       `sitemap should contain /docs/${slug}`,
     );
   }
+  assert.ok(
+    sitemapXml.includes("<loc>https://semantix.ensureok.ai/docs/faq</loc>"),
+    "sitemap should contain /docs/faq",
+  );
 });

--- a/site/src/app/blog/[slug]/page.tsx
+++ b/site/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { getBlogPost, getBlogPosts } from "@/lib/blog-posts";
+import { siteIdentity } from "@/lib/site-identity";
+
+type BlogPostPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  const posts = await getBlogPosts();
+  return posts.map(({ slug }) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getBlogPost(slug);
+
+  if (!post) return {};
+
+  return {
+    title: `${post.title} | Semantix Blog`,
+    description: post.excerpt,
+    alternates: { canonical: `/blog/${post.slug}` },
+  };
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params;
+  const post = await getBlogPost(slug);
+
+  if (!post) notFound();
+
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "@id": `${siteIdentity.productUrl}/blog/${post.slug}#article`,
+    headline: post.title,
+    description: post.excerpt,
+    dateModified: post.updated,
+    datePublished: post.updated,
+    inLanguage: "en",
+    mainEntityOfPage: `${siteIdentity.productUrl}/blog/${post.slug}`,
+    author: { "@id": `${siteIdentity.operator.url}#organization` },
+    publisher: { "@id": `${siteIdentity.operator.url}#organization` },
+  };
+
+  return (
+    <div className="px-6 py-10 md:py-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(articleJsonLd).replace(/</g, "\\u003c"),
+        }}
+      />
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4 border-b border-border pb-5">
+          <Link href="/blog" className="text-sm font-medium text-muted-foreground hover:text-accent">
+            ← 返回 Blog
+          </Link>
+          <time dateTime={post.updated} className="font-mono text-xs text-muted-foreground">
+            Updated {post.updated}
+          </time>
+        </div>
+
+        <article className="geo-prose max-w-3xl">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              h1: () => <h1>{post.title}</h1>,
+            }}
+          >
+            {post.content}
+          </ReactMarkdown>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/site/src/app/blog/layout.tsx
+++ b/site/src/app/blog/layout.tsx
@@ -1,0 +1,12 @@
+import Footer from "@/components/Footer";
+import Nav from "@/components/Nav";
+
+export default function BlogLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <>
+      <Nav />
+      <main className="min-h-[calc(100dvh-4rem)] bg-background pt-16">{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/site/src/app/blog/page.tsx
+++ b/site/src/app/blog/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getBlogPosts } from "@/lib/blog-posts";
+
+export const metadata: Metadata = {
+  title: "Blog | Semantix",
+  description: "Semantix 的语义记忆、跨会话复用与 Agent 基础设施文章。",
+  alternates: { canonical: "/blog" },
+};
+
+export default async function BlogPage() {
+  const posts = await getBlogPosts();
+
+  return (
+    <>
+      <header className="border-b border-border bg-muted/30">
+        <div className="wrap py-16 md:py-20">
+          <p className="font-mono text-xs font-semibold text-accent">SEMANTIX BLOG</p>
+          <h1 className="mt-5 max-w-3xl text-4xl font-semibold tracking-tight md:text-6xl">
+            语义记忆与 Agent 基础设施。
+          </h1>
+          <p className="mt-6 max-w-2xl text-lg leading-8 text-muted-foreground">
+            关于跨会话复用、检索架构和开源 Agent memory 的研究与实践。
+          </p>
+        </div>
+      </header>
+
+      <section className="wrap py-12 md:py-16" aria-labelledby="latest-posts">
+        <div className="mb-8 flex items-end justify-between gap-6">
+          <h2 id="latest-posts" className="text-2xl font-semibold tracking-tight">
+            全部文章
+          </h2>
+          <span className="font-mono text-xs text-muted-foreground">{posts.length} 篇</span>
+        </div>
+
+        <div className="border-t border-border">
+          {posts.map((post) => (
+            <Link
+              key={post.slug}
+              href={`/blog/${post.slug}`}
+              className="group grid gap-4 border-b border-border py-8 transition-colors hover:bg-muted/35 md:grid-cols-[130px_minmax(0,1fr)_32px] md:px-4"
+            >
+              <time dateTime={post.updated} className="font-mono text-xs text-muted-foreground">
+                {post.updated}
+              </time>
+              <div>
+                <h3 className="max-w-3xl text-xl font-semibold leading-snug tracking-tight transition-colors group-hover:text-accent md:text-2xl">
+                  {post.title}
+                </h3>
+                <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
+                  {post.excerpt}
+                </p>
+              </div>
+              <span
+                aria-hidden="true"
+                className="hidden text-xl text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-accent md:block"
+              >
+                →
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/site/src/app/docs/faq/page.tsx
+++ b/site/src/app/docs/faq/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import { faqItems } from "@/lib/faq-items";
+import { siteIdentity } from "@/lib/site-identity";
+
+export const metadata: Metadata = {
+  title: "常见问题 | Semantix 文档",
+  description: "关于 Semantix 定位、语义缓存、自进化机制和项目参与方式的常见问题。",
+  alternates: { canonical: "/docs/faq" },
+};
+
+export default function FaqPage() {
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "@id": `${siteIdentity.productUrl}/docs/faq#faq`,
+    mainEntity: faqItems.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
+
+  return (
+    <div className="px-6 py-10 md:px-10 md:py-14 lg:px-14">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqJsonLd).replace(/</g, "\\u003c"),
+        }}
+      />
+      <div className="mx-auto max-w-4xl">
+        <p className="font-mono text-xs font-semibold text-accent">FAQ 常见问题</p>
+        <h1 className="mt-5 text-4xl font-semibold tracking-tight md:text-5xl">
+          关于 Semantix 的五个常见问题。
+        </h1>
+        <p className="mt-5 max-w-2xl text-lg leading-8 text-muted-foreground">
+          从项目定位到三级语义缓存，再到参与开发所需的验证要求。
+        </p>
+
+        <div className="mt-12 max-w-3xl border-t border-border">
+          {faqItems.map((item) => (
+            <section key={item.question} className="border-b border-border py-7">
+              <h2 className="text-lg font-semibold tracking-tight">{item.question}</h2>
+              <p className="mt-3 text-sm leading-7 text-muted-foreground">{item.answer}</p>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -5,7 +5,6 @@ import Components from "@/components/Components";
 import Roadmap from "@/components/Roadmap";
 import Community from "@/components/Community";
 import Install from "@/components/Install";
-import Faq, { faqItems } from "@/components/Faq";
 import Footer from "@/components/Footer";
 import { siteIdentity } from "@/lib/site-identity";
 
@@ -18,20 +17,6 @@ const webpageJsonLd = {
   dateModified: siteIdentity.lastUpdated,
 };
 
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "@id": `${siteIdentity.productUrl}/#faq`,
-  mainEntity: faqItems.map((item) => ({
-    "@type": "Question",
-    name: item.question,
-    acceptedAnswer: {
-      "@type": "Answer",
-      text: item.answer,
-    },
-  })),
-};
-
 export default function Home() {
   return (
     <>
@@ -39,12 +24,6 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(webpageJsonLd).replace(/</g, "\\u003c"),
-        }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(faqJsonLd).replace(/</g, "\\u003c"),
         }}
       />
       <Nav />
@@ -55,7 +34,6 @@ export default function Home() {
         <Roadmap />
         <Community />
         <Install />
-        <Faq />
       </main>
       <Footer />
     </>

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -1,16 +1,18 @@
 import type { MetadataRoute } from "next";
 import { siteIdentity } from "@/lib/site-identity";
 import { geoDocuments } from "@/lib/geo-docs";
+import { getBlogPosts } from "@/lib/blog-posts";
 
 const BASE = siteIdentity.productUrl;
 
 // output: "export" 下 sitemap route 必须显式静态化
 export const dynamic = "force-static";
 
-// 站点级入口（/、/about、/docs、/terms）+ 全部静态 docs 页面。
-// lastModified 使用站点统一身份配置（site-identity.ts / geo-docs.ts），不随每次构建变化。
-export default function sitemap(): MetadataRoute.Sitemap {
+// 站点级入口 + 全部静态 docs 与 blog 页面。
+// lastModified 使用站点身份配置和内容 frontmatter，不随每次构建变化。
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const lastModified = new Date(siteIdentity.lastUpdated);
+  const blogPosts = await getBlogPosts();
   return [
     { url: `${BASE}/`, lastModified, changeFrequency: "weekly", priority: 1 },
     {
@@ -30,6 +32,24 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(document.lastUpdated),
       changeFrequency: "weekly" as const,
       priority: 0.8,
+    })),
+    {
+      url: `${BASE}/docs/faq`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${BASE}/blog`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    ...blogPosts.map((post) => ({
+      url: `${BASE}/blog/${post.slug}`,
+      lastModified: new Date(post.updated),
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
     })),
     {
       url: `${BASE}/terms`,

--- a/site/src/components/DocsSidebar.tsx
+++ b/site/src/components/DocsSidebar.tsx
@@ -78,6 +78,23 @@ function DocumentLinks({
         </div>
       ))}
 
+      <div>
+        <p className="mb-2 px-3 text-xs font-semibold text-foreground">帮助与参考</p>
+        <Link
+          href="/docs/faq"
+          aria-current={pathname === "/docs/faq" ? "page" : undefined}
+          className={cn(
+            "block rounded-md px-3 py-2.5 text-sm transition-colors",
+            pathname === "/docs/faq"
+              ? "bg-accent/10 font-semibold text-accent"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground",
+          )}
+        >
+          常见问题
+          <span className="mt-0.5 block text-xs font-normal opacity-75">定位、缓存与参与方式</span>
+        </Link>
+      </div>
+
       <div className="border-t border-border pt-5">
         <a
           href="https://github.com/Gnosil/semantix"

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -4,6 +4,7 @@ import { siteIdentity } from "@/lib/site-identity";
 const links = [
   { label: "About", href: "/about", external: false },
   { label: "Docs", href: "/docs", external: false },
+  { label: "Blog", href: "/blog", external: false },
   { label: "Terms", href: "/terms", external: false },
   { label: "Privacy", href: "/privacy", external: false },
   {

--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -10,6 +10,7 @@ const links: NavLink[] = [
   { label: "组件", labelEn: "Components", href: "/#components" },
   { label: "路线图", labelEn: "Roadmap", href: "/#roadmap" },
   { label: "文档", labelEn: "Docs", href: "/docs" },
+  { label: "博客", labelEn: "Blog", href: "/blog" },
   { label: "社区", labelEn: "Community", href: "/#community" },
   { label: "安装", labelEn: "Install", href: "/#start" },
 ];
@@ -58,12 +59,12 @@ export default function Nav() {
         </Link>
 
         {/* 桌面端中间导航链接（移动端隐藏） */}
-        <nav className="hidden items-center gap-4 md:flex lg:gap-6">
+        <nav className="hidden items-center gap-4 xl:flex 2xl:gap-6">
           {links.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className="shrink-0 whitespace-nowrap text-xs text-muted-foreground transition-colors hover:text-accent lg:text-sm"
+              className="shrink-0 whitespace-nowrap text-xs text-muted-foreground transition-colors hover:text-accent 2xl:text-sm"
             >
               <span className="font-semibold">{link.labelEn}</span> {link.label}
             </Link>
@@ -93,7 +94,7 @@ export default function Nav() {
             aria-label={open ? "关闭菜单" : "打开菜单"}
             aria-expanded={open}
             onClick={() => setOpen((v) => !v)}
-            className="flex size-9 items-center justify-center rounded-md border border-border text-foreground md:hidden"
+            className="flex size-9 items-center justify-center rounded-md border border-border text-foreground xl:hidden"
           >
             <span className="flex flex-col gap-[5px]">
               <span
@@ -122,7 +123,7 @@ export default function Nav() {
       {/* 移动端全屏菜单面板 */}
       <div
         className={cn(
-          "absolute inset-x-0 top-16 z-40 h-[calc(100vh-4rem)] overflow-y-auto bg-white/95 backdrop-blur transition-opacity duration-200 md:hidden",
+          "absolute inset-x-0 top-16 z-40 h-[calc(100vh-4rem)] overflow-y-auto bg-white/95 backdrop-blur transition-opacity duration-200 xl:hidden",
           open ? "opacity-100" : "pointer-events-none opacity-0",
         )}
       >

--- a/site/src/lib/blog-posts.ts
+++ b/site/src/lib/blog-posts.ts
@@ -1,0 +1,70 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  updated: string;
+  order: number;
+  excerpt: string;
+  content: string;
+};
+
+const blogDirectory = path.join(process.cwd(), "..", "docs", "blog");
+
+function readFrontmatter(source: string) {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) throw new Error("Blog post is missing frontmatter");
+
+  const values = Object.fromEntries(
+    match[1]
+      .split(/\r?\n/)
+      .map((line) => line.match(/^([a-zA-Z]+):\s*(.+)$/))
+      .filter((entry): entry is RegExpMatchArray => Boolean(entry))
+      .map((entry) => [entry[1], entry[2].replace(/^['\"]|['\"]$/g, "")]),
+  );
+
+  return { values, body: source.slice(match[0].length) };
+}
+
+function createExcerpt(body: string) {
+  const paragraph = body
+    .replace(/^# .+\r?\n+/, "")
+    .split(/\r?\n\r?\n/)
+    .find((block) => block.trim() && !block.trimStart().startsWith("#"));
+
+  return normalizeVisibleText((paragraph ?? "").replace(/\s+/g, " ").trim());
+}
+
+function normalizeVisibleText(value: string) {
+  return value.replace(/\s*—\s*/g, " - ").replaceAll("–", "-");
+}
+
+async function readBlogPost(fileName: string): Promise<BlogPost> {
+  const source = await readFile(path.join(blogDirectory, fileName), "utf8");
+  const { values, body } = readFrontmatter(source);
+
+  if (!values.title || !values.updated || !values.order) {
+    throw new Error(`${fileName} has incomplete blog frontmatter`);
+  }
+
+  return {
+    slug: fileName.replace(/\.md$/, ""),
+    title: values.title,
+    updated: values.updated,
+    order: Number(values.order),
+    excerpt: createExcerpt(body),
+    content: normalizeVisibleText(body),
+  };
+}
+
+export async function getBlogPosts() {
+  const files = (await readdir(blogDirectory)).filter((file) => file.endsWith(".md"));
+  const posts = await Promise.all(files.map(readBlogPost));
+  return posts.sort((left, right) => left.order - right.order);
+}
+
+export async function getBlogPost(slug: string) {
+  const posts = await getBlogPosts();
+  return posts.find((post) => post.slug === slug);
+}

--- a/site/src/lib/faq-items.ts
+++ b/site/src/lib/faq-items.ts
@@ -1,5 +1,3 @@
-import Reveal from "@/components/Reveal";
-
 export const faqItems = [
   {
     question: "Semantix 是什么？",
@@ -26,38 +24,4 @@ export const faqItems = [
     answer:
       "在 github.com/Gnosil/semantix 提 issue 或开 PR。当前 M0 阶段按工作单元推进，PR 需附 go vet 与 go test 全绿的验证结果。",
   },
-];
-
-export default function Faq() {
-  return (
-    <section id="faq" className="relative overflow-hidden py-24">
-      <div aria-hidden="true" className="pointer-events-none absolute inset-0 hidden lg:block">
-        <div className="absolute -left-48 bottom-16 h-[360px] w-[360px] rounded-full bg-[oklch(0.608_0.14_165/0.06)] blur-3xl" />
-      </div>
-      <div className="relative wrap">
-        <Reveal>
-          <p className="font-mono text-sm font-medium text-accent">FAQ 常见问题</p>
-          <h2 className="mt-2 text-3xl font-bold tracking-tight md:text-4xl">
-            常见问题。
-          </h2>
-          <p className="mt-1 text-muted-foreground">
-            Five questions answered in facts.
-          </p>
-        </Reveal>
-
-        <div className="mt-12 max-w-3xl space-y-4">
-          {faqItems.map((item, i) => (
-            <Reveal key={item.question} delay={i * 60}>
-              <div className="rounded-lg border border-border bg-white p-6">
-                <h3 className="font-semibold">{item.question}</h3>
-                <p className="mt-2 text-sm leading-7 text-muted-foreground">
-                  {item.answer}
-                </p>
-              </div>
-            </Reveal>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
+] as const;


### PR DESCRIPTION
## 改动内容

- 在顶部导航和页脚新增独立 `Blog` 入口
- 新增 `/blog` 索引页，并将 `docs/blog` 中的 4 篇文章静态发布为详情页
- 为 Blog 文章添加动态 metadata、BlogPosting JSON-LD 与 sitemap 条目
- 将首页 FAQ 迁移到 `/docs/faq`
- 在文档左侧目录新增“常见问题”入口
- 将 FAQPage JSON-LD 从首页迁移到文档 FAQ 页面
- 更新 `llms.txt`、sitemap 和内容测试
- 将导航桌面展开断点调整为 `xl`，避免新增菜单后产生拥挤
- 让 robots 测试兼容 Windows 与 Linux 换行符

## 用户影响

Blog 与 Docs 成为两个独立内容入口；FAQ 归入 Docs 信息架构，首页更聚焦产品介绍，文章和问答也能被搜索引擎及 AI crawler 正确发现。

## 验证

- `npm run check`
- 18 个静态页面成功生成
- 13/13 内容测试通过
- `/blog/`、Blog 详情页和 `/docs/faq/` 本地返回 HTTP 200
- 首页不再输出 FAQ 区块
- ESLint 无错误，保留现有 `<img>` 性能提示