### PR TITLE
feat(site): 为代码框增加复制按钮

### DIFF
--- a/site/scripts/copy-code.test.mjs
+++ b/site/scripts/copy-code.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const home = await readFile(new URL("../out/index.html", import.meta.url), "utf8");
+
+test("every compact code box exposes a copy control", () => {
+  const copyButtons = home.match(/aria-label="复制代码"/g) ?? [];
+
+  assert.equal(copyButtons.length, 10);
+  assert.ok(home.includes("$ go install semantix/cmd/semantix"));
+});

--- a/site/src/components/CopyCode.tsx
+++ b/site/src/components/CopyCode.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+type CopyCodeProps = {
+  code: string;
+  className?: string;
+  prompt?: boolean;
+  tone?: "light" | "dark";
+};
+
+type CopyState = "idle" | "copied" | "failed";
+
+function fallbackCopy(code: string) {
+  const textarea = document.createElement("textarea");
+  textarea.value = code;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  const copied = document.execCommand("copy");
+  textarea.remove();
+
+  if (!copied) {
+    throw new Error("Copy command was rejected");
+  }
+}
+
+export default function CopyCode({
+  code,
+  className = "",
+  prompt = false,
+  tone = "light",
+}: CopyCodeProps) {
+  const [state, setState] = useState<CopyState>("idle");
+  const resetTimer = useRef<number | undefined>(undefined);
+  const isDark = tone === "dark";
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== undefined) {
+        window.clearTimeout(resetTimer.current);
+      }
+    },
+    [],
+  );
+
+  async function handleCopy() {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+      } else {
+        fallbackCopy(code);
+      }
+      setState("copied");
+    } catch {
+      try {
+        fallbackCopy(code);
+        setState("copied");
+      } catch {
+        setState("failed");
+      }
+    }
+
+    if (resetTimer.current !== undefined) {
+      window.clearTimeout(resetTimer.current);
+    }
+    resetTimer.current = window.setTimeout(() => setState("idle"), 1800);
+  }
+
+  const label = state === "copied" ? "已复制" : state === "failed" ? "重试" : "复制";
+
+  return (
+    <div className={`relative ${className}`}>
+      <pre
+        className={`overflow-x-auto rounded-md p-3 pr-24 font-mono text-xs ${
+          isDark
+            ? "border border-white/10 bg-[oklch(0.21_0.006_260)] text-slate-300"
+            : "border border-border/60 bg-[oklch(0.976_0.005_165)] text-[oklch(0.45_0.02_260)]"
+        }`}
+      >
+        <code>{prompt ? `$ ${code}` : code}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={`${label}代码`}
+        className={`absolute right-2.5 top-1/2 inline-flex h-8 -translate-y-1/2 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+          isDark
+            ? "border-white/15 bg-[oklch(0.27_0.008_260)] text-slate-300 hover:border-emerald-400/60 hover:text-emerald-300"
+            : "border-border/80 bg-white text-muted-foreground hover:border-accent/60 hover:text-accent"
+        }`}
+      >
+        {state === "copied" ? (
+          <Check aria-hidden="true" className="size-3.5" />
+        ) : (
+          <Copy aria-hidden="true" className="size-3.5" />
+        )}
+        <span aria-live="polite">{label}</span>
+      </button>
+    </div>
+  );
+}

--- a/site/src/components/Features.tsx
+++ b/site/src/components/Features.tsx
@@ -1,5 +1,6 @@
 import type { Feature } from "@/types/content";
 import Reveal from "@/components/Reveal";
+import CopyCode from "@/components/CopyCode";
 
 const features: Feature[] = [
   {
@@ -96,9 +97,7 @@ export default function Features() {
                 <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
                   {f.body}
                 </p>
-                <pre className="mt-4 overflow-x-auto rounded-md border border-border/60 bg-[oklch(0.976_0.005_165)] p-3 font-mono text-xs text-[oklch(0.45_0.02_260)]">
-                  <code>{f.code}</code>
-                </pre>
+                <CopyCode className="mt-4" code={f.code} />
                 <a
                   href={f.evidence}
                   target="_blank"

--- a/site/src/components/Hero.tsx
+++ b/site/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 import Reveal from "@/components/Reveal";
 import ParticleCanvas from "@/components/ParticleCanvas";
+import CopyCode from "@/components/CopyCode";
 import { siteIdentity } from "@/lib/site-identity";
 
 export default function Hero() {
@@ -80,9 +81,11 @@ export default function Hero() {
               <p className="mt-1 text-sm text-muted-foreground">
                 extract / search 切片提取与 BM25 检索
               </p>
-              <pre className="mt-3 overflow-x-auto rounded-md border border-border/60 bg-[oklch(0.976_0.005_165)] p-3 font-mono text-xs text-[oklch(0.45_0.02_260)]">
-                <code>$ go install semantix/cmd/semantix</code>
-              </pre>
+              <CopyCode
+                className="mt-3"
+                code="go install semantix/cmd/semantix"
+                prompt
+              />
             </div>
           </div>
           </div>

--- a/site/src/components/Install.tsx
+++ b/site/src/components/Install.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Reveal from "@/components/Reveal";
+import CopyCode from "@/components/CopyCode";
 
 const steps = [
   {
@@ -65,9 +66,7 @@ export default function Install() {
                   </span>
                 </h3>
                 <p className="mt-1 text-sm text-muted-foreground">{step.desc}</p>
-                <pre className="mt-4 overflow-x-auto rounded-md bg-[oklch(0.21_0.006_260)] p-3 font-mono text-xs text-slate-300">
-                  {step.code}
-                </pre>
+                <CopyCode className="mt-4" code={step.code} tone="dark" />
                 <div className="mt-auto pt-4 text-sm">
                   {step.external ? (
                     <a


### PR DESCRIPTION
## 变更\n- 为首页 CLI、Features 与安装步骤中的 10 个代码框统一增加复制按钮\n- 复制成功后短暂显示「已复制」，失败时提供重试状态\n- 命令提示符 $ 仅用于展示，复制内容可直接粘贴执行\n- 为 Clipboard API 不可用或被拒绝的环境提供回退方案\n- 补充静态导出测试，确保所有目标代码框都暴露复制入口\n\n## 验收\n- 
pm run check\n- lint：0 errors（保留 Nav.tsx 现有的 1 条 img warning）\n- typecheck：通过\n- build：18 个静态页面通过\n- tests：14/14 通过