### PR TITLE
polish site code blocks

### DIFF
--- a/site/src/components/CopyCode.tsx
+++ b/site/src/components/CopyCode.tsx
@@ -7,6 +7,7 @@ type CopyCodeProps = {
   code: string;
   className?: string;
   prompt?: boolean;
+  singleLine?: boolean;
   tone?: "light" | "dark";
 };
 
@@ -33,6 +34,7 @@ export default function CopyCode({
   code,
   className = "",
   prompt = false,
+  singleLine = false,
   tone = "light",
 }: CopyCodeProps) {
   const [state, setState] = useState<CopyState>("idle");
@@ -74,12 +76,22 @@ export default function CopyCode({
   const label = state === "copied" ? "已复制" : state === "failed" ? "重试" : "复制";
 
   return (
-    <div className={`relative ${className}`}>
+    <div
+      className={`flex min-w-0 overflow-hidden rounded-md border ${
+        isDark
+          ? "border-white/10 bg-[oklch(0.21_0.006_260)]"
+          : "border-border/60 bg-[oklch(0.976_0.005_165)]"
+      } ${className}`}
+    >
       <pre
-        className={`overflow-x-auto rounded-md p-3 pr-24 font-mono text-xs ${
+        className={`min-w-0 flex-1 p-3 font-mono leading-5 ${
+          singleLine
+            ? "whitespace-pre-wrap break-words text-[11px] sm:whitespace-nowrap"
+            : "whitespace-pre-wrap break-words text-xs"
+        } ${
           isDark
-            ? "border border-white/10 bg-[oklch(0.21_0.006_260)] text-slate-300"
-            : "border border-border/60 bg-[oklch(0.976_0.005_165)] text-[oklch(0.45_0.02_260)]"
+            ? "text-slate-300"
+            : "text-[oklch(0.45_0.02_260)]"
         }`}
       >
         <code>{prompt ? `$ ${code}` : code}</code>
@@ -88,18 +100,21 @@ export default function CopyCode({
         type="button"
         onClick={handleCopy}
         aria-label={`${label}代码`}
-        className={`absolute right-2.5 top-1/2 inline-flex h-8 -translate-y-1/2 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 ${
+        title={label}
+        className={`flex w-11 shrink-0 items-center justify-center border-l transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent active:translate-y-px ${
           isDark
-            ? "border-white/15 bg-[oklch(0.27_0.008_260)] text-slate-300 hover:border-emerald-400/60 hover:text-emerald-300"
-            : "border-border/80 bg-white text-muted-foreground hover:border-accent/60 hover:text-accent"
+            ? "border-white/10 bg-[oklch(0.25_0.008_260)] text-slate-300 hover:bg-[oklch(0.29_0.01_260)] hover:text-emerald-300"
+            : "border-border/60 bg-white text-accent hover:bg-accent/5"
         }`}
       >
         {state === "copied" ? (
-          <Check aria-hidden="true" className="size-3.5" />
+          <Check aria-hidden="true" className="size-4" strokeWidth={1.8} />
         ) : (
-          <Copy aria-hidden="true" className="size-3.5" />
+          <Copy aria-hidden="true" className="size-4" strokeWidth={1.8} />
         )}
-        <span aria-live="polite">{label}</span>
+        <span className="sr-only" aria-live="polite">
+          {label}
+        </span>
       </button>
     </div>
   );

--- a/site/src/components/Hero.tsx
+++ b/site/src/components/Hero.tsx
@@ -85,6 +85,7 @@ export default function Hero() {
                 className="mt-3"
                 code="go install semantix/cmd/semantix"
                 prompt
+                singleLine
               />
             </div>
           </div>

--- a/site/src/components/Install.tsx
+++ b/site/src/components/Install.tsx
@@ -66,7 +66,7 @@ export default function Install() {
                   </span>
                 </h3>
                 <p className="mt-1 text-sm text-muted-foreground">{step.desc}</p>
-                <CopyCode className="mt-4" code={step.code} tone="dark" />
+                <CopyCode className="mt-4" code={step.code} prompt />
                 <div className="mt-auto pt-4 text-sm">
                   {step.external ? (
                     <a


### PR DESCRIPTION
## 变更
- 复制按钮改为独立右侧图标区，不再遮挡代码
- 顶部 CLI 命令在桌面端保持单行，移动端可换行
- 安装区代码框统一为浅色样式，长命令在卡片内自然换行
- 命令提示符 `$` 仅用于展示，复制内容仍可直接执行

## 原因
原复制按钮使用绝对定位，会覆盖长代码；代码框依赖横向滚动条时还可能隐藏命令开头。

## 用户影响
代码始终完整可见且可复制，首页和安装区的代码框样式保持一致。

## 验收
- `npm run check`
- lint：0 errors（主分支现有 2 条 img warning）
- typecheck：通过
- build：34 个静态页面通过
- tests：16/16 通过