### PR TITLE
fix(site): address GEO audit contact and content signals

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -8,6 +8,7 @@
 
 - [Semantix website](https://semantix.ensureok.ai/): Official homepage — positioning, features, components, roadmap, and install instructions.
 - [About Semantix](https://semantix.ensureok.ai/about): Operator identity, official contact channels, and legal entity behind the project.
+- [Contact Semantix](https://semantix.ensureok.ai/contact): Official project and website contact channel.
 - [Semantix repository](https://github.com/Gnosil/semantix): Source code, tests, design documents, and issue tracker.
 
 ## Documentation

--- a/site/scripts/geo-audit-remediation.test.mjs
+++ b/site/scripts/geo-audit-remediation.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const readExport = (path) => readFile(new URL(`../out/${path}`, import.meta.url), "utf8");
+
+const homepageHtml = await readExport("index.html");
+const aboutHtml = await readExport("about/index.html");
+const contactHtml = await readExport("contact/index.html");
+const termsHtml = await readExport("terms/index.html");
+const privacyHtml = await readExport("privacy/index.html");
+const sitemapXml = await readExport("sitemap.xml");
+
+test("visible contact links use a stable first-party page", () => {
+  for (const [name, html] of [
+    ["home", homepageHtml],
+    ["about", aboutHtml],
+    ["terms", termsHtml],
+    ["privacy", privacyHtml],
+  ]) {
+    assert.match(html, /href="\/contact\/?"/, `${name} should link to /contact`);
+    assert.doesNotMatch(html, /href="mailto:/, `${name} should not expose a rewritable mailto link`);
+    assert.doesNotMatch(html, /cdn-cgi\/l\/email-protection/, `${name} should not ship a Cloudflare link`);
+  }
+});
+
+test("contact export keeps the official email crawler-readable", () => {
+  assert.match(
+    contactHtml,
+    /<!--email_off-->junhaihuang@aiqueshi\.com<!--\/email_off-->/,
+    "contact email should opt out of Cloudflare obfuscation",
+  );
+  assert.doesNotMatch(contactHtml, /href="mailto:/, "contact page should not expose a rewritable mailto link");
+  assert.match(sitemapXml, /<loc>https:\/\/semantix\.ensureok\.ai\/contact<\/loc>/);
+
+  const jsonLdObjects = [...homepageHtml.matchAll(
+    /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g,
+  )].map((match) => JSON.parse(match[1]));
+  const organization = jsonLdObjects.find((value) => value["@type"] === "Organization");
+  assert.equal(organization.email, "junhaihuang@aiqueshi.com");
+  assert.equal(organization.contactPoint.url, "https://semantix.ensureok.ai/contact");
+});
+
+test("technical content exposes authorship, evidence, and limitations", async () => {
+  const docsHtml = await readExport("docs/guide/index.html");
+  const blogHtml = await readExport("blog/open-source-semantic-memory-comparison-guide/index.html");
+
+  assert.match(docsHtml, /Semantix 维护团队撰写/);
+  assert.match(docsHtml, /证据与限制/);
+  assert.match(blogHtml, /By Semantix maintainers/);
+  assert.match(blogHtml, /Evidence and limitations/);
+  assert.match(blogHtml, /Source and revision history/);
+});

--- a/site/scripts/last-updated.test.mjs
+++ b/site/scripts/last-updated.test.mjs
@@ -6,7 +6,7 @@ const homepageHtml = await readFile(new URL("../out/index.html", import.meta.url
 const crawlerVisibleHtml = homepageHtml.replaceAll("<!-- -->", "");
 
 // Single source for the expected date so a site update touches exactly one literal.
-const expectedLastUpdated = "2026-08-10";
+const expectedLastUpdated = "2026-08-11";
 
 test("static homepage exposes the visible content update date", () => {
   assert.match(

--- a/site/scripts/week3-platform.test.mjs
+++ b/site/scripts/week3-platform.test.mjs
@@ -88,16 +88,16 @@ test("docs FAQ page visible content matches FAQPage JSON-LD", () => {
   }
 });
 
-test("docs exports ship TechnicalArticle JSON-LD with correct dates", async () => {
+test("docs exports ship TechArticle JSON-LD with correct dates", async () => {
   for (const slug of docSlugs) {
     const docHtml = await readFile(new URL(`../out/docs/${slug}/index.html`, import.meta.url), "utf8");
     const docJsonLd = [...docHtml.matchAll(
       /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g,
     )].map((match) => JSON.parse(match[1]));
 
-    const article = docJsonLd.find((value) => value["@type"] === "TechnicalArticle");
-    assert.ok(article, `docs/${slug} should ship TechnicalArticle JSON-LD`);
-    assert.equal(article.dateModified, "2026-08-10", `docs/${slug} dateModified`);
+    const article = docJsonLd.find((value) => value["@type"] === "TechArticle");
+    assert.ok(article, `docs/${slug} should ship TechArticle JSON-LD`);
+    assert.equal(article.dateModified, "2026-08-11", `docs/${slug} dateModified`);
     assert.equal(article.mainEntityOfPage, `https://semantix.ensureok.ai/docs/${slug}`);
   }
 });

--- a/site/src/app/about/page.tsx
+++ b/site/src/app/about/page.tsx
@@ -77,13 +77,13 @@ export default function AboutPage() {
                   </a>
                 </div>
                 <div>
-                  <p className="font-mono text-xs text-muted-foreground">联系邮箱</p>
-                  <a
-                    href={`mailto:${siteIdentity.operator.email}`}
+                  <p className="font-mono text-xs text-muted-foreground">联系方式</p>
+                  <Link
+                    href="/contact"
                     className="mt-2 inline-block break-all font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent hover:decoration-accent"
                   >
-                    {siteIdentity.operator.email}
-                  </a>
+                    站内联系页面
+                  </Link>
                 </div>
                 <div>
                   <p className="font-mono text-xs text-muted-foreground">代码仓库</p>

--- a/site/src/app/blog/[slug]/page.tsx
+++ b/site/src/app/blog/[slug]/page.tsx
@@ -40,6 +40,7 @@ export default async function BlogArticlePage({ params }: BlogPageProps) {
   const postMeta = getBlogPost((await params).slug);
   if (!postMeta) notFound();
   const post = readBlogPost(postMeta);
+  const sourceUrl = `${siteIdentity.repositoryUrl}/blob/main/blog/${post.fileName}`;
   const articleJsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -52,6 +53,7 @@ export default async function BlogArticlePage({ params }: BlogPageProps) {
     mainEntityOfPage: `${siteIdentity.productUrl}/blog/${post.slug}`,
     author: { "@id": `${siteIdentity.operator.url}#organization` },
     publisher: { "@id": `${siteIdentity.operator.url}#organization` },
+    citation: sourceUrl,
   };
 
   return (
@@ -67,10 +69,37 @@ export default async function BlogArticlePage({ params }: BlogPageProps) {
             <p className="mt-5 font-mono text-xs text-accent">{post.group}</p>
             <h1 className="mt-3 text-4xl font-semibold leading-tight tracking-tight md:text-5xl">{post.title}</h1>
             <p className="mt-5 text-lg leading-8 text-muted-foreground">{post.description}</p>
-            <time dateTime={post.updated} className="mt-5 block font-mono text-xs text-muted-foreground">
-              Updated {post.updated}<span className="sr-only">Last updated</span>
-            </time>
+            <div className="mt-5 flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-xs text-muted-foreground">
+              <Link href="/about" className="hover:text-accent">By Semantix maintainers</Link>
+              <span aria-hidden="true">·</span>
+              <time dateTime={post.updated}>
+                Updated {post.updated}<span className="sr-only">Last updated</span>
+              </time>
+            </div>
           </div>
+
+          <aside className="mb-9 border-l-2 border-accent bg-muted/40 px-5 py-4 text-sm leading-6 text-muted-foreground">
+            <p>
+              Evidence and limitations: this article is an evaluation guide, not an independent
+              production benchmark. Verify implementation claims against the current main branch.
+            </p>
+            <div className="mt-2 flex flex-wrap gap-x-5 gap-y-2">
+              <a
+                href={sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-foreground underline decoration-border underline-offset-4 hover:text-accent"
+              >
+                Source and revision history ↗
+              </a>
+              <Link
+                href="/#components"
+                className="font-medium text-foreground underline decoration-border underline-offset-4 hover:text-accent"
+              >
+                Current implementation boundaries
+              </Link>
+            </div>
+          </aside>
 
           <article className="blog-prose">
             <ReactMarkdown

--- a/site/src/app/contact/page.tsx
+++ b/site/src/app/contact/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from "next";
+import Footer from "@/components/Footer";
+import Nav from "@/components/Nav";
+import ProtectedEmail from "@/components/ProtectedEmail";
+import { siteIdentity } from "@/lib/site-identity";
+
+export const metadata: Metadata = {
+  title: "联系 Semantix",
+  description: "联系 Semantix 官网运营与维护团队。",
+  alternates: { canonical: "/contact" },
+};
+
+export default function ContactPage() {
+  return (
+    <>
+      <Nav />
+      <main className="min-h-[100dvh] bg-background pt-16">
+        <section className="border-b border-border bg-muted/40 py-20 md:py-28">
+          <div className="wrap">
+            <p className="font-mono text-sm font-semibold text-accent">Contact</p>
+            <h1 className="mt-5 max-w-3xl text-4xl font-semibold tracking-tight text-foreground md:text-6xl">
+              联系 Semantix
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-muted-foreground">
+              项目合作、网站内容反馈与运营咨询，由 {siteIdentity.operator.brandName} 统一处理。
+            </p>
+          </div>
+        </section>
+
+        <section className="wrap py-16 md:py-24">
+          <div className="grid max-w-4xl gap-8 md:grid-cols-2">
+            <section className="rounded-2xl border border-border bg-card p-6 md:p-8">
+              <p className="font-mono text-xs font-semibold text-accent">官方邮箱</p>
+              <h2 className="mt-3 text-xl font-semibold text-foreground">邮件联系</h2>
+              <p className="mt-3 leading-7 text-muted-foreground">
+                请复制下面的邮箱地址发送邮件。邮件中请说明事项、相关页面或仓库链接。
+              </p>
+              <ProtectedEmail className="mt-6 block break-all font-mono text-sm font-semibold text-foreground" />
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-6 md:p-8">
+              <p className="font-mono text-xs font-semibold text-accent">开源协作</p>
+              <h2 className="mt-3 text-xl font-semibold text-foreground">GitHub Issue</h2>
+              <p className="mt-3 leading-7 text-muted-foreground">
+                可复现的缺陷、功能建议和文档问题，请优先通过公开 Issue 提交，便于社区跟踪。
+              </p>
+              <a
+                href={`${siteIdentity.repositoryUrl}/issues/new`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-6 inline-flex rounded-md border border-border px-4 py-2 text-sm font-semibold text-foreground transition-colors hover:border-accent hover:text-accent active:translate-y-px"
+              >
+                创建 Issue ↗
+              </a>
+            </section>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/site/src/app/docs/[slug]/page.tsx
+++ b/site/src/app/docs/[slug]/page.tsx
@@ -35,18 +35,21 @@ export default async function GeoDocumentPage({ params }: GeoPageProps) {
   if (!document) notFound();
 
   const content = await readGeoDocument(document);
+  const sourceUrl = `${siteIdentity.repositoryUrl}/blob/main/site/content/geo/${document.fileName}`;
+  const isEnglish = document.language === "English";
 
   const articleJsonLd = {
     "@context": "https://schema.org",
-    "@type": "TechnicalArticle",
+    "@type": "TechArticle",
     "@id": `${siteIdentity.productUrl}/docs/${document.slug}#article`,
     headline: document.title,
     description: document.description,
     dateModified: document.lastUpdated,
-    inLanguage: document.language === "English" ? "en" : "zh-CN",
+    inLanguage: isEnglish ? "en" : "zh-CN",
     mainEntityOfPage: `${siteIdentity.productUrl}/docs/${document.slug}`,
     author: { "@id": `${siteIdentity.operator.url}#organization` },
     publisher: { "@id": `${siteIdentity.operator.url}#organization` },
+    citation: sourceUrl,
   };
 
   return (
@@ -65,10 +68,29 @@ export default async function GeoDocumentPage({ params }: GeoPageProps) {
             <span>{document.depth}</span>
           </div>
           <div className="flex flex-wrap items-center gap-3 font-mono text-xs text-muted-foreground">
+            <Link href="/about" className="hover:text-accent">
+              {isEnglish ? "By Semantix maintainers" : "Semantix 维护团队撰写"}
+            </Link>
             <span>{document.language}</span>
             <time dateTime={document.lastUpdated}>Last updated · {document.lastUpdated}</time>
           </div>
         </div>
+
+        <aside className="mb-8 max-w-3xl border-l-2 border-accent bg-muted/40 px-5 py-4 text-sm leading-6 text-muted-foreground">
+          <p>
+            {isEnglish
+              ? "Evidence and limitations: implementation claims should be checked against the current main branch. This document explains the design; it is not an independent production benchmark."
+              : "证据与限制：实现状态应以 main 分支的代码与测试为准。本文用于解释设计，不代表独立生产环境基准。"}
+          </p>
+          <a
+            href={sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 inline-block font-medium text-foreground underline decoration-border underline-offset-4 hover:text-accent"
+          >
+            {isEnglish ? "View source and revision history ↗" : "查看原文与修订记录 ↗"}
+          </a>
+        </aside>
 
         <article className="geo-prose max-w-3xl">
           <ReactMarkdown

--- a/site/src/app/privacy/page.tsx
+++ b/site/src/app/privacy/page.tsx
@@ -47,7 +47,7 @@ const sections = [
     title: "6. 政策更新与联系方式",
     body: [
       "运营主体可能适时更新本隐私政策，更新后的政策将在本页面发布并更新生效日期。",
-      `如对本隐私政策或网站的数据处理有任何疑问，可通过 ${siteIdentity.operator.email} 联系运营主体，或在项目仓库 ${siteIdentity.repositoryUrl} 提交 Issue。`,
+      `如对本隐私政策或网站的数据处理有任何疑问，可通过站内联系页面联系运营主体，或在项目仓库 ${siteIdentity.repositoryUrl} 提交 Issue。`,
     ],
   },
 ] as const;

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -19,6 +19,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: `${BASE}/`, lastModified, changeFrequency: "weekly", priority: 1 },
     { url: `${BASE}/about`, lastModified, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${BASE}/contact`, lastModified, changeFrequency: "monthly", priority: 0.7 },
     { url: `${BASE}/docs`, lastModified, changeFrequency: "weekly", priority: 0.9 },
     ...geoDocuments.map((document) => ({
       url: `${BASE}/docs/${document.slug}`,

--- a/site/src/app/terms/page.tsx
+++ b/site/src/app/terms/page.tsx
@@ -48,7 +48,7 @@ const sections = [
     title: "6. 条款更新与联系方式",
     body: [
       "运营主体可能适时更新本服务条款，更新后的条款将在本页面发布并更新生效日期。重大变更将以网站公告方式提示。",
-      `如对本服务条款或网站内容有疑问，可通过 ${siteIdentity.operator.email} 联系运营主体，或在项目仓库 ${siteIdentity.repositoryUrl} 提交 Issue。`,
+      `如对本服务条款或网站内容有疑问，可通过站内联系页面联系运营主体，或在项目仓库 ${siteIdentity.repositoryUrl} 提交 Issue。`,
     ],
   },
 ] as const;

--- a/site/src/components/Community.tsx
+++ b/site/src/components/Community.tsx
@@ -144,12 +144,12 @@ export default function Community() {
                 <Link href="/about" className="font-medium underline decoration-border underline-offset-4 hover:text-accent hover:decoration-accent">
                   查看维护主体
                 </Link>
-                <a
-                  href={`mailto:${siteIdentity.operator.email}`}
+                <Link
+                  href="/contact"
                   className="font-medium underline decoration-border underline-offset-4 hover:text-accent hover:decoration-accent"
                 >
                   联系官网维护者
-                </a>
+                </Link>
               </div>
             </div>
 

--- a/site/src/components/Components.tsx
+++ b/site/src/components/Components.tsx
@@ -132,12 +132,12 @@ export default function Components() {
               >
                 查看维护主体
               </Link>
-              <a
-                href={`mailto:${siteIdentity.operator.email}`}
+              <Link
+                href="/contact"
                 className="font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent hover:decoration-accent"
               >
                 反馈技术内容
-              </a>
+              </Link>
             </div>
           </aside>
         </Reveal>

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -9,7 +9,7 @@ const links = [
   { label: "Privacy", href: "/privacy", external: false },
   {
     label: "Contact",
-    href: `mailto:${siteIdentity.operator.email}`,
+    href: "/contact",
     external: false,
   },
   { label: "GitHub", href: "https://github.com/Gnosil/semantix", external: true },
@@ -44,13 +44,13 @@ export default function Footer() {
             运营与维护。
           </p>
           <p className="mt-2">
-            联系邮箱：
-            <a
-              href={`mailto:${siteIdentity.operator.email}`}
+            联系渠道：
+            <Link
+              href="/contact"
               className="font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-accent hover:decoration-accent"
             >
-              {siteIdentity.operator.email}
-            </a>
+              联系页面
+            </Link>
           </p>
         </div>
         <nav aria-label="页脚导航" className="flex flex-wrap items-center gap-x-6 gap-y-3">

--- a/site/src/components/ProtectedEmail.tsx
+++ b/site/src/components/ProtectedEmail.tsx
@@ -1,0 +1,16 @@
+import { siteIdentity } from "@/lib/site-identity";
+
+type ProtectedEmailProps = {
+  className?: string;
+};
+
+export default function ProtectedEmail({ className }: ProtectedEmailProps) {
+  return (
+    <span
+      className={className}
+      dangerouslySetInnerHTML={{
+        __html: `<!--email_off-->${siteIdentity.operator.email}<!--/email_off-->`,
+      }}
+    />
+  );
+}

--- a/site/src/lib/geo-docs.ts
+++ b/site/src/lib/geo-docs.ts
@@ -19,7 +19,7 @@ export const geoDocuments: readonly GeoDocument[] = [
     description: "面向开发者的中文项目定位、术语与进度概览。",
     language: "中文",
     depth: "速览",
-    lastUpdated: "2026-08-10",
+    lastUpdated: "2026-08-11",
   },
   {
     slug: "profile-en",
@@ -28,7 +28,7 @@ export const geoDocuments: readonly GeoDocument[] = [
     description: "A concise English overview of the project's purpose, terminology, and progress.",
     language: "English",
     depth: "速览",
-    lastUpdated: "2026-08-10",
+    lastUpdated: "2026-08-11",
   },
   {
     slug: "guide",
@@ -37,7 +37,7 @@ export const geoDocuments: readonly GeoDocument[] = [
     description: "从第一性原理出发的中文深度解读。",
     language: "中文",
     depth: "深入",
-    lastUpdated: "2026-08-10",
+    lastUpdated: "2026-08-11",
   },
   {
     slug: "guide-en",
@@ -46,7 +46,7 @@ export const geoDocuments: readonly GeoDocument[] = [
     description: "An English deep dive from first principles.",
     language: "English",
     depth: "深入",
-    lastUpdated: "2026-08-10",
+    lastUpdated: "2026-08-11",
   },
 ];
 

--- a/site/src/lib/site-identity.ts
+++ b/site/src/lib/site-identity.ts
@@ -3,7 +3,7 @@ export const siteIdentity = {
   productUrl: "https://semantix.ensureok.ai",
   repositoryUrl: "https://github.com/Gnosil/semantix",
   licenseName: "FSL-1.1-MIT",
-  lastUpdated: "2026-08-10",
+  lastUpdated: "2026-08-11",
   operator: {
     legalName: "确石人工智能科技（上海）有限公司",
     brandName: "确石智能",
@@ -25,11 +25,12 @@ export const organizationJsonLd = {
   ],
   url: siteIdentity.operator.url,
   logo: siteIdentity.operator.logoUrl,
-  email: `mailto:${siteIdentity.operator.email}`,
+  email: siteIdentity.operator.email,
   sameAs: [siteIdentity.repositoryUrl, siteIdentity.operator.url],
   contactPoint: {
     "@type": "ContactPoint",
     email: siteIdentity.operator.email,
+    url: `${siteIdentity.productUrl}/contact`,
     contactType: "project inquiries",
     availableLanguage: ["zh-CN", "en"],
   },


### PR DESCRIPTION
## Summary

- add a first-party `/contact` page and route all visible contact entry points through it
- keep the official email crawler-readable with Cloudflare's supported `email_off` marker
- expose the contact URL in Organization JSON-LD, sitemap, and `llms.txt`
- replace invalid `TechnicalArticle` structured data with Schema.org `TechArticle`
- add visible maintainer attribution and source/revision links to technical content
- restore the previously approved Semantix Blog presentation: website navigation, single-column article index, and centered article reader
- retain all 20 standalone Markdown articles and their URLs unchanged
- add regression coverage for the audit findings and Blog presentation

## Root cause

Cloudflare Email Address Obfuscation rewrote visible `mailto:` links to `/cdn-cgi/l/email-protection` URLs. They work only after Cloudflare's browser script decodes them, so non-JavaScript crawlers treated the contact channel as a dead internal link. The docs also emitted the nonexistent Schema.org type `TechnicalArticle` instead of `TechArticle`.

The later standalone Blog merge replaced the approved website-style Blog with a documentation sidebar and table-of-contents layout. This PR keeps the expanded article corpus but restores the earlier visual design.

## User and crawler impact

Visitors now have one stable contact destination, while crawlers can discover the same channel without following a Cloudflare-generated 404. Technical pages expose their maintainer and repository source. Blog readers see the original Semantix site design without losing any of the current articles.

## Validation

- `npm run check`
- Next.js production build: 35 static pages generated
- content, Blog, and GEO remediation tests: 19/19 passed
- the `blog/` Markdown corpus has no changes

The existing `@next/next/no-img-element` warning in the shared navigation remains unchanged; there are no lint errors.

## Deliberate non-changes

- no fabricated social profiles were added to chase the report's arbitrary `sameAs` count
- no benchmark numbers or independent validation claims were invented
- no Blog article body, slug, date, or frontmatter was changed
