### PR TITLE
fix(site): reveal nav on first scroll

### DIFF
--- a/site/scripts/nav-intro.test.mjs
+++ b/site/scripts/nav-intro.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const navSource = await readFile(new URL("../src/components/Nav.tsx", import.meta.url), "utf8");
+
+test("homepage navigation reacts to the first downward scroll intent", () => {
+  assert.match(navSource, /event\.deltaY > 0/);
+  assert.match(navSource, /addEventListener\("wheel", onScrollIntent/);
+  assert.match(navSource, /addEventListener\("touchmove", onTouchMove/);
+  assert.match(navSource, /setVisible\(!intro \|\| window\.scrollY > 8\)/);
+});
+
+test("navigation enters with a transition instead of delayed layout insertion", () => {
+  assert.doesNotMatch(navSource, /!visible && "hidden"/);
+  assert.match(navSource, /-translate-y-full opacity-0/);
+  assert.match(navSource, /translate-y-0 opacity-100/);
+});

--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -25,14 +25,28 @@ export default function Nav() {
     const onScroll = () => {
       setScrolled(window.scrollY > 8);
       const intro = document.getElementById("brand-intro");
-      const revealAt = intro ? intro.offsetTop + intro.offsetHeight - 64 : 0;
-      setVisible(Boolean(intro && window.scrollY >= revealAt));
+      setVisible(!intro || window.scrollY > 8);
     };
+
+    const onScrollIntent = (event: WheelEvent) => {
+      if (event.deltaY > 0 && document.getElementById("brand-intro")) {
+        setVisible(true);
+      }
+    };
+
+    const onTouchMove = () => {
+      if (document.getElementById("brand-intro")) setVisible(true);
+    };
+
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("wheel", onScrollIntent, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
     window.addEventListener("resize", onScroll);
     return () => {
       window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("wheel", onScrollIntent);
+      window.removeEventListener("touchmove", onTouchMove);
       window.removeEventListener("resize", onScroll);
     };
   }, []);
@@ -49,7 +63,7 @@ export default function Nav() {
     <header
       className={cn(
         "fixed top-0 z-50 w-full border-b transition-all duration-300",
-        !visible && "hidden",
+        visible ? "translate-y-0 opacity-100" : "pointer-events-none -translate-y-full opacity-0",
         scrolled || open
           ? "border-border bg-white/85 backdrop-blur"
           : "border-transparent bg-transparent",


### PR DESCRIPTION
## What changed

- reveal the fixed navigation as soon as the user makes a downward wheel gesture
- support the same immediate reveal for touch scrolling
- retain the navigation once the document has moved beyond 8px
- replace delayed `display: none` insertion with a smooth top-entry transition
- add regression coverage for the intro-to-navigation timing

## Why

The opening animation previously waited until the entire 165svh intro section had nearly passed before showing the navigation. This left the top edge empty after the user had already started scrolling.

## Verification

- `npm run lint` — no errors; one pre-existing image warning
- `npm run typecheck` — passed
- `npm run build` — 35 static pages generated
- `npm run test:content` — 26/26 passed
