### PR TITLE
Improve GEO evidence and claim boundaries

### DIFF
--- a/blog/agent-kernel-tool-call-history-semantic-slices.md
+++ b/blog/agent-kernel-tool-call-history-semantic-slices.md
@@ -35,6 +35,24 @@ Different later queries want different evidence. ?How did we diagnose this?? sho
 
 The extractor does not prove that every turn boundary is the correct semantic boundary. The M0 gate explicitly leaves real-session relevance unresolved and proposes changing from turn-level to subtask-level extraction if relevance is below 70%. The current split is a testable baseline, not a final ontology.
 
+## Observable extractor evidence
+
+I ran the extractor-facing packages rather than relying on the architecture diagram. The check used main `e93668e`, Go 1.26.5, and Windows/amd64 on 2026-08-12:
+
+```bash
+go test -count=1 ./kernel/event ./kernel/ingest ./kernel/fingerprint
+```
+
+Observed result:
+
+```text
+ok  semantix/kernel/event
+ok  semantix/kernel/ingest
+ok  semantix/kernel/fingerprint
+```
+
+This supports parsing, slice extraction, and deterministic identity under repository fixtures. It does not prove that Prompt, ToolPattern, and Result are the best ontology for a real team. I would reject the design if labeled production traces show that tool sequences cross turn boundaries often enough to make the extracted pattern misleading. The M0 relevance gate remains the honest next test.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) ? commands and supported release paths.

--- a/blog/go-agent-framework-neutral-memory-layer.md
+++ b/blog/go-agent-framework-neutral-memory-layer.md
@@ -41,6 +41,25 @@ Run go vet, go test, a fixture-to-injection smoke test, scope-negative tests, an
 
 This recipe proves portability of the integration contract, not equal behavior in every harness. Prompt construction, event timing, permissions, and cancellation semantics remain harness-specific work.
 
+## A run from the integration boundary
+
+On 2026-08-12 I executed the packages behind capture, retrieval, and rollback from main `e93668e` with Go 1.26.5 on Windows/amd64:
+
+```bash
+go test -count=1 ./kernel/event ./kernel/bm25 ./kernel/inject ./kernel/usage
+```
+
+Observed result:
+
+```text
+ok  semantix/kernel/event
+ok  semantix/kernel/bm25
+ok  semantix/kernel/inject
+ok  semantix/kernel/usage
+```
+
+The output shows that these repository contracts are exercised together at package level. It does not show a deployed agent saving tokens or completing more tasks. My deployment checklist would record the harness version, fixture checksum, retrieved slice IDs, task outcome, latency, and rollback result. Without that record, “framework-neutral” describes the boundary shape only.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) ? commands and supported release paths.

--- a/blog/go-native-framework-agnostic-memory-kernel.md
+++ b/blog/go-native-framework-agnostic-memory-kernel.md
@@ -34,6 +34,23 @@ The implementation is framework-neutral at the kernel and CLI boundary. The phra
 
 For a real adoption review, I would require a second adapter built by someone who did not design the kernel. That exercise would reveal whether the JSONL contract is genuinely sufficient or whether hidden Reasonix assumptions still live in event ordering, tool-call naming, cancellation, or prompt placement. Until that independent adapter exists, ?framework-agnostic? is a supported architectural property, not a broad interoperability result.
 
+## Review evidence and an adverse result
+
+I ran a broad package check on 2026-08-12 from main `e93668e` using Go 1.26.5 on Windows/amd64:
+
+```bash
+go test -count=1 ./kernel/...
+```
+
+Most kernel packages passed, including BM25, cache, embed, event, evolve, ingest, inject, judge, promote, usage, and zone. The run was not all green:
+
+```text
+FAIL semantix/kernel/slice
+TestFileStoreKeepsPerm0600: store file perm = 666, want 600
+```
+
+That failure is relevant to framework independence because platform behavior is part of the contract. My conclusion remains narrower than the headline: the code is framework-neutral at its Go and file boundaries, while portability still requires OS-specific storage semantics and adapter-level tests. A second independently built adapter would be stronger evidence than another architecture claim.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) ? commands and supported release paths.

--- a/blog/go-native-semantic-memory-flexible-stack.md
+++ b/blog/go-native-semantic-memory-flexible-stack.md
@@ -41,6 +41,25 @@ A CLI boundary is framework-neutral and easy to replace. It also adds process st
 
 The repository builds and tests these paths and publishes six v0.2.0 platform artifacts in its quickstart. Compatibility with every Go agent framework is not demonstrated. The accurate claim is that integration is framework-agnostic at the file/CLI boundary.
 
+## Reproduced package evidence
+
+For this article I tested the smallest stack implied by the integration boundary on 2026-08-12, main `e93668e`, Go 1.26.5, Windows/amd64:
+
+```bash
+go test -count=1 ./kernel/event ./kernel/ingest ./kernel/bm25 ./kernel/inject
+```
+
+Observed result:
+
+```text
+ok  semantix/kernel/event
+ok  semantix/kernel/ingest
+ok  semantix/kernel/bm25
+ok  semantix/kernel/inject
+```
+
+I consider this evidence for a local Go pipeline, not for universal framework compatibility. The test does not launch LangChain, ADK, Eino, or a production harness. A convincing portability result would implement two independent adapters and publish the event mappings, error behavior, latency, and rollback procedure for both.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) ? commands and supported release paths.

--- a/blog/kernel-alternative-custom-agent-scheduling.md
+++ b/blog/kernel-alternative-custom-agent-scheduling.md
@@ -35,6 +35,24 @@ A harness integration needs explicit answers: when are events flushed, which use
 
 Use Semantix today as a testable retrieval-and-reuse side layer. Evaluate scheduling and prefetch as roadmap capabilities against their own code and tests. This distinction makes the current CLI useful without requiring a reader to accept every architectural ambition as complete.
 
+## What the test surface says today
+
+I checked the scheduler and prefetch packages directly on 2026-08-12 using Go 1.26.5 on Windows/amd64:
+
+```bash
+go test -count=1 ./kernel/sched ./kernel/prefetch ./kernel/evolve
+```
+
+The result matters because it separates interfaces from exercised behavior:
+
+```text
+?   semantix/kernel/sched     [no test files]
+?   semantix/kernel/prefetch  [no test files]
+ok  semantix/kernel/evolve
+```
+
+My reading is deliberately conservative. The adaptation package has executable tests; scheduler and prefetch compile, but their packages do not yet contain tests. That is not evidence of a production scheduling loop. Before calling this a kernel alternative, I would add decision-table tests, cancellation tests, a disabled-kernel baseline, and a trace showing which decision changed a real tool run.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) ? commands and supported release paths.

--- a/blog/semantic-cache-kernel-coding-agents.md
+++ b/blog/semantic-cache-kernel-coding-agents.md
@@ -43,6 +43,24 @@ If retrieval fails, continue without the cache. If injected content degrades tas
 
 Track retrieval relevance, repeated tool calls avoided, completion tokens, task success, and user rejection. A lower token count paired with a worse fix is not a win. The project?s synthetic cost report is a useful calculation template; replace every assumed value with observations from your own workload.
 
+## Baseline evidence before claiming savings
+
+I reproduced the cache and retrieval packages on 2026-08-12 from main `e93668e`, Go 1.26.5, Windows/amd64:
+
+```bash
+go test -count=1 ./kernel/cache ./kernel/bm25 ./kernel/inject
+```
+
+Observed result:
+
+```text
+ok  semantix/kernel/cache
+ok  semantix/kernel/bm25
+ok  semantix/kernel/inject
+```
+
+This proves only that the implemented cache, ranker, and injection behavior satisfy repository tests. It contains no production token bill, wall-clock comparison, or independent task-success score. I would publish a savings claim only with paired runs on the same repository tasks, including cache-off baselines, failures, rejected suggestions, token counts, and confidence intervals. Until that dataset exists, the defensible benefit is deterministic reuse infrastructure, not guaranteed lower cost.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) ? commands and supported release paths.

--- a/blog/semantic-kernel-smarter-tool-execution.md
+++ b/blog/semantic-kernel-smarter-tool-execution.md
@@ -32,6 +32,23 @@ Retrieval and embedding are optimization layers; failure should skip them and co
 
 L2 content is still untrusted input to a model. Sanitization cannot make an outdated instruction correct, and Windows permission semantics differ from Unix modes. Operators must avoid ingesting secrets and should test scope isolation on their deployment. The security document also lists sandbox and credential-management items that remain checklist work, so this is not a certification claim.
 
+## A security check that did not pass
+
+Security claims are more useful when the failed check is visible. On 2026-08-12, main at `e93668e` was tested with Go 1.26.5 on Windows/amd64:
+
+```bash
+go test -count=1 ./kernel/slice ./cmd/semantix
+```
+
+The run failed on two file-mode assertions:
+
+```text
+FAIL TestFileStoreKeepsPerm0600: store file perm = 666, want 600
+FAIL TestRunUsageWithEvolve: evolve state perms = 666, want 600
+```
+
+I would not translate Unix-style `0600` directly into a cross-platform security guarantee. Windows ACLs need a platform-specific test and documented behavior. Retrieval, cache, and injection packages passed in the same full run, but these failures keep the stronger security claim open. The practical decision is to avoid secrets in stored slices and to verify the storage directory ACL in the deployment environment.
+
 ## Sources and limitations
 
 - [Security design](https://github.com/Gnosil/semantix/blob/main/docs/Security-%E5%AE%89%E5%85%A8%E8%AE%BE%E8%AE%A1.md) ? threat list, controls, and open checklist.

--- a/blog/turning-tool-calls-searchable-semantic-slices.md
+++ b/blog/turning-tool-calls-searchable-semantic-slices.md
@@ -39,6 +39,24 @@ Check its type, scope, content, and deterministic ID. A useful ToolPattern shoul
 
 Success is not ?the CLI printed something.? The expected slice must rank in the labeled top results, an unrelated scope must stay absent, repeated output must be stable, and a malformed line must not erase valid events. Those properties are covered by repository tests; your own corpus still needs separate labels.
 
+## Evidence captured on Windows
+
+I treat this workshop as successful only when the extraction and retrieval packages pass independently. On 2026-08-12 I ran the following from main at `e93668e` with Go 1.26.5 on Windows/amd64:
+
+```bash
+go test -count=1 ./kernel/ingest ./kernel/bm25 ./kernel/inject
+```
+
+The observed package-level result was:
+
+```text
+ok  semantix/kernel/ingest
+ok  semantix/kernel/bm25
+ok  semantix/kernel/inject
+```
+
+That output supports a narrow claim: the repository fixtures exercise ingestion, BM25 ranking, and marked-block injection on this environment. It does not report relevance on a real conversation corpus. My next acceptance step would be ten held-out queries labeled by a person who did not write the extractor; until then, this is a reproducible workshop, not evidence that every agent trace becomes useful memory.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) ? commands and supported release paths.

--- a/site/package.json
+++ b/site/package.json
@@ -2,7 +2,7 @@
   "name": "semantix-site",
   "version": "0.1.0",
   "private": true,
-  "description": "Semantix official landing page — a self-evolving agent kernel.",
+  "description": "Semantix official site — a verifiable memory kernel for agents.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/site/scripts/blog-content.test.mjs
+++ b/site/scripts/blog-content.test.mjs
@@ -101,3 +101,26 @@ test("the corpus uses multiple explicit editorial voices", async () => {
 
   assert.ok(representedAngles.length >= 12, `expected >= 12 editorial angles, got ${representedAngles.length}`);
 });
+
+test("audited technical articles include inline results and human judgment", async () => {
+  const auditedSlugs = [
+    "turning-tool-calls-searchable-semantic-slices",
+    "semantic-kernel-smarter-tool-execution",
+    "kernel-alternative-custom-agent-scheduling",
+    "go-native-semantic-memory-flexible-stack",
+    "agent-kernel-tool-call-history-semantic-slices",
+    "go-agent-framework-neutral-memory-layer",
+    "go-native-framework-agnostic-memory-kernel",
+    "semantic-cache-kernel-coding-agents",
+  ];
+
+  for (const slug of auditedSlugs) {
+    const source = await readFile(path.join(blogRoot, `${slug}.md`), "utf8");
+    const prose = source.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "");
+    const wordCount = (prose.match(/\b[A-Za-z][A-Za-z?'-]*\b/g) ?? []).length;
+    assert.ok(wordCount >= 400, `${slug} should contain enough context to interpret its evidence`);
+    assert.match(source, /^```text$/m, `${slug} should show observed output, not commands alone`);
+    assert.match(source, /\bI\b|\bMy\b/, `${slug} should include a clearly attributed engineering judgment`);
+    assert.match(source, /not |does not |failed|FAIL/, `${slug} should state an adverse result or claim boundary`);
+  }
+});

--- a/site/scripts/claim-boundaries.test.mjs
+++ b/site/scripts/claim-boundaries.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const srcRoot = path.resolve(import.meta.dirname, "../src");
+
+test("homepage copy does not promise unverified universal gains", async () => {
+  const files = [
+    "components/BrandIntroOverlay.tsx",
+    "components/Features.tsx",
+    "lib/faq-items.ts",
+    "app/layout.tsx",
+    "lib/site-identity.ts",
+  ];
+  const source = (await Promise.all(files.map((file) => readFile(path.join(srcRoot, file), "utf8")))).join("\n");
+
+  for (const claim of ["每次交互都让下一次更便宜、更快", "每次交互都会积累经验，让下一次响应更快、成本更低", "system自己长出自己的最优参数"]) {
+    assert.ok(!source.includes(claim), `unqualified claim should not return: ${claim}`);
+  }
+  assert.match(source, /生产.*仍待验证|生产.*单独测量/);
+  assert.match(source, /接口或实验阶段/);
+});

--- a/site/src/app/blog/[slug]/page.tsx
+++ b/site/src/app/blog/[slug]/page.tsx
@@ -73,11 +73,13 @@ export default async function BlogArticlePage({ params }: BlogPageProps) {
 
         <aside className="mb-8 max-w-3xl border-l-2 border-accent bg-muted/40 px-5 py-4 text-sm leading-6 text-muted-foreground">
           <p>
-            Evidence and limitations: implementation claims should be verified against the current release and repository tests. Architectural direction is identified separately from shipped behavior.
+            Evidence and limitations: commands, observable outputs, and known failure boundaries are kept in the article. Repository tests are first-party engineering evidence, not an independent production benchmark.
           </p>
-          <a href={sourceUrl} target="_blank" rel="noopener noreferrer" className="mt-2 inline-block font-medium text-foreground underline decoration-border underline-offset-4 hover:text-accent">
-            View source and revision history ↗
-          </a>
+          <div className="mt-2 flex flex-wrap gap-x-5 gap-y-2">
+            <a href={sourceUrl} target="_blank" rel="noopener noreferrer" className="font-medium text-foreground underline decoration-border underline-offset-4 hover:text-accent">View source and revision history ↗</a>
+            <a href={author.contributionsUrl} target="_blank" rel="noopener noreferrer" className="font-medium text-foreground underline decoration-border underline-offset-4 hover:text-accent">Author contribution history ↗</a>
+          </div>
+          <p className="mt-3 text-xs">{author.description}</p>
         </aside>
 
         <article className="geo-prose max-w-3xl">

--- a/site/src/app/blog/page.tsx
+++ b/site/src/app/blog/page.tsx
@@ -22,6 +22,9 @@ export default function BlogPage() {
           <p className="mt-6 max-w-2xl text-lg leading-8 text-muted-foreground">
             关于跨会话复用、检索架构和开源 Agent memory 的研究与实践。
           </p>
+          <p className="mt-5 max-w-3xl border-l-2 border-accent pl-4 text-sm leading-6 text-muted-foreground">
+            编辑说明：目录中的日期来自仓库版本记录，作者链接指向可核验的 GitHub 贡献历史。文章中的测试结果是仓库内的一手工程证据，不等同于独立生产评测。
+          </p>
         </div>
       </header>
 

--- a/site/src/app/docs/faq/page.tsx
+++ b/site/src/app/docs/faq/page.tsx
@@ -4,7 +4,7 @@ import { siteIdentity } from "@/lib/site-identity";
 
 export const metadata: Metadata = {
   title: "常见问题 | Semantix 文档",
-  description: "关于 Semantix 定位、语义缓存、自进化机制和项目参与方式的常见问题。",
+  description: "关于 Semantix 定位、语义缓存、实验性参数反馈和项目参与方式的常见问题。",
   alternates: { canonical: "/docs/faq" },
 };
 

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -29,9 +29,9 @@ const notoSansSC = Noto_Sans_SC({
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteIdentity.productUrl),
-  title: "Semantix - a self-evolving agent kernel",
+  title: "Semantix - a verifiable memory kernel for agents",
   description:
-    "A self-evolving agent kernel that sits between any agent harness and its resources, with semantic caching, speculative prefetch, and adaptive scheduling.",
+    "An open-source Go memory kernel with semantic slice extraction, BM25 retrieval, stable injection, and explicit experimental boundaries.",
   alternates: { canonical: "/" },
   icons: [{ rel: "icon", url: "/seo/favicon.svg", type: "image/svg+xml" }],
 };

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -14,7 +14,7 @@ const webpageJsonLd = {
   "@type": "WebPage",
   "@id": `${siteIdentity.productUrl}/#webpage`,
   url: `${siteIdentity.productUrl}/`,
-  name: `${siteIdentity.productName} - a self-evolving agent kernel`,
+  name: `${siteIdentity.productName} - a verifiable memory kernel for agents`,
   dateModified: siteIdentity.lastUpdated,
 };
 

--- a/site/src/components/BrandIntroOverlay.tsx
+++ b/site/src/components/BrandIntroOverlay.tsx
@@ -74,9 +74,9 @@ export default function BrandIntroOverlay() {
           </div>
 
           <div className="font-brand-display absolute right-6 top-7 max-w-[15rem] text-right text-xs font-bold leading-relaxed sm:right-12 sm:top-12 md:max-w-xs">
-            让每个 Agent 拥有持续进化的
+            把历史交互整理成可检索的
             <br className="hidden md:block" />
-            记忆与推理内核
+            执行经验
           </div>
 
           <div className="absolute bottom-8 left-6 font-mono text-[9px] tracking-[0.34em] sm:bottom-12 sm:left-12 sm:text-[10px]">
@@ -105,18 +105,17 @@ export default function BrandIntroOverlay() {
           }}
         >
           <h1 className="font-brand-serif text-balance text-5xl font-normal leading-[0.88] tracking-[0.015em] md:text-6xl lg:whitespace-nowrap lg:text-[4.9rem]">
-            A <span className="text-[#00a878]">self-evolving</span> agent kernel.
+            A <span className="text-[#00a878]">verifiable</span> agent memory kernel.
           </h1>
           <p className="font-brand-display mx-auto mt-7 max-w-4xl text-[2rem] font-black leading-[0.98] tracking-[-0.055em] md:text-[2.75rem]">
-            <span className="block md:inline">让每次推理</span>
-            <span className="block md:inline">变成下一次绘画的</span>
-            <span className="block text-[#168b6d]">记忆</span>
+            <span className="block md:inline">把历史交互整理成</span>
+            <span className="block text-[#168b6d]">可检索的执行经验</span>
           </p>
 
           <p className="mx-auto mt-8 max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
-            Semantix 连接 Agent Harness 与资源层，负责并发调度、语义缓存和智能预取。
+            Semantix 连接 Agent Harness 与资源层，提供切片提取、BM25 检索和稳定注入路径。
             <br className="hidden md:block" />
-            每次交互都会积累经验，让下一次响应更快、成本更低。
+            当前公开证据来自仓库测试与合成演示；生产环境中的成本和性能收益仍待验证。
           </p>
           <time
             dateTime={siteIdentity.lastUpdated}

--- a/site/src/components/Features.tsx
+++ b/site/src/components/Features.tsx
@@ -37,7 +37,7 @@ const capabilities: Capability[] = [
     num: "03",
     titleEn: "Kernel Scheduler",
     title: "内核调度器",
-    body: "按任务 intent 联合决策：工具并发度、模型 tier、缓存注入、预取预算——从你的行为模式里学出来的调度策略。",
+    body: "仓库定义了按任务 intent 决策并发度、模型 tier、缓存注入和预取预算的接口。它是可扩展的调度边界，不代表生产控制闭环已经完成。",
     code: "decide(intent) → {concurrency, tier, inject, prefetch}",
     art: "/ensureok/semantix-inference-transparent.png",
     artAlt: "古典人物从迷宫中理出清晰路径，象征调度器优化推理路线",
@@ -46,16 +46,16 @@ const capabilities: Capability[] = [
     num: "04",
     titleEn: "Speculative Prefetch",
     title: "投机预取",
-    body: "把 LLM 流式输出的等待时间填满：预取下一轮的切片组装、embedding 计算。waste/hit 比例自我惩罚，越用越准。",
+    body: "预取接口为下一轮切片组装与 embedding 计算预留扩展点。waste/hit 信号是设计约束；主动预取与线上收益尚未形成公开生产证据。",
     code: "waste/hit > 3:1 → signal-source weight ↓",
     art: "/ensureok/semantix-inference-transparent.png",
     artAlt: "古典人物从迷宫中理出清晰路径，象征提前预测和准备下一步",
   },
   {
     num: "05",
-    titleEn: "Self-Evolution",
-    title: "自进化引擎",
-    body: "每轮回馈命中/污染/延迟/成本/成功率：在线 EWMA 调参（冻结期保护字节缓存）+ 离线重训。系统自己长出自己的最优参数。",
+    titleEn: "Experimental Adaptation",
+    title: "实验性参数反馈",
+    body: "仓库实现了 EWMA、冻结窗口与参数状态持久化，用于验证反馈调参路径。真实会话闭环、离线重训和普遍收益仍需要独立评估。",
     code: "online EWMA + freeze-period ≥1h + offline retrain",
     art: "/ensureok/semantix-evolution-transparent.png",
     artAlt: "多臂古典人物重塑另一具雕像，象征反馈驱动的持续进化",
@@ -223,15 +223,15 @@ export default function Features() {
             Features 特性
           </p>
           <h2 className="font-brand-display mt-7 max-w-xl text-[clamp(2.7rem,5.8vw,6.5rem)] font-black leading-[0.98] tracking-[-0.055em]">
-            越用越好的
+            可以检查的
             <br />
-            <span className="text-[#168b6d]">能力。</span>
+            <span className="text-[#168b6d]">实现。</span>
           </h2>
           <p className="mt-7 text-lg text-[#101313]/55">
-            Autonomy you can actually audit.
+            Shipped behavior, interfaces, and experimental boundaries.
           </p>
           <p className="mt-7 max-w-md text-sm leading-7 text-[#101313]/55">
-            现有 harness 只做会话内的字节级前缀缓存——被动、会话绑定、调度静态。Semantix 把整个循环升级为跨会话的、主动的、自进化的闭环：每次交互都让下一次更便宜、更快。
+            Semantix 当前已提供切片提取、BM25 与混合检索、稳定注入等路径。调度、预取和参数反馈处于接口或实验阶段；是否降低生产成本，需要用真实会话单独测量。
           </p>
         </div>
 

--- a/site/src/components/Roadmap.tsx
+++ b/site/src/components/Roadmap.tsx
@@ -58,13 +58,13 @@ export default function Roadmap() {
             Roadmap 路线图
           </p>
           <h2 className="mt-2 text-3xl font-bold tracking-tight md:text-4xl">
-            从可观测到自进化。
+            从可观测到可验证的反馈闭环。
           </h2>
           <p className="mt-1 text-muted-foreground">
             Five phases to a closed loop.
           </p>
           <p className="mt-4 max-w-2xl text-muted-foreground">
-            每一步都建立在前一步之上：先能看见，再能复用，然后能调度、能预取，最后整个循环自己进化。
+            每一步都建立在前一步之上：先能看见，再能复用，然后验证调度、预取和参数反馈。路线图表示计划，不代表所有阶段已经投入生产。
           </p>
         </Reveal>
 

--- a/site/src/lib/content-authors.ts
+++ b/site/src/lib/content-authors.ts
@@ -1,13 +1,15 @@
 export type ContentAuthor = {
   name: string;
   url: string;
+  contributionsUrl: string;
+  description: string;
 };
 
 export const contentAuthors: readonly ContentAuthor[] = [
-  { name: "Gnosil", url: "https://github.com/Gnosil" },
-  { name: "radianceded", url: "https://github.com/radianceded" },
-  { name: "jh10724-dotcom", url: "https://github.com/jh10724-dotcom" },
-  { name: "Allenli1233", url: "https://github.com/Allenli1233" },
+  { name: "Gnosil", url: "https://github.com/Gnosil", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Gnosil", description: "Semantix repository maintainer; project work is traceable through GitHub." },
+  { name: "radianceded", url: "https://github.com/radianceded", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=radianceded", description: "Semantix contributor; project work is traceable through GitHub." },
+  { name: "jh10724-dotcom", url: "https://github.com/jh10724-dotcom", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=jh10724-dotcom", description: "Semantix contributor; project work is traceable through GitHub." },
+  { name: "Allenli1233", url: "https://github.com/Allenli1233", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Allenli1233", description: "Semantix contributor; project work is traceable through GitHub." },
 ] as const;
 
 /** Stable distribution: a page keeps the same verifiable author across builds. */
@@ -27,6 +29,7 @@ export function personJsonLd(author: ContentAuthor) {
     name: author.name,
     url: author.url,
     sameAs: [author.url],
+    description: author.description,
   };
 }
 

--- a/site/src/lib/faq-items.ts
+++ b/site/src/lib/faq-items.ts
@@ -2,7 +2,7 @@ export const faqItems = [
   {
     question: "Semantix 是什么？",
     answer:
-      "Semantix 是一个自进化的 Agent Kernel 层，Go 实现、开源。它架在 agent harness 与底层资源之间，通过语义切片库、三级语义缓存、内核调度器和投机预取，让每次交互都更便宜、更快。",
+      "Semantix 是一个 Go 实现的开源 Agent memory kernel。它架在 agent harness 与底层资源之间；当前可核验能力包括语义切片提取、BM25/混合检索和稳定注入，调度、预取与参数反馈仍处于接口或实验阶段。",
   },
   {
     question: "Semantix 解决什么问题？",
@@ -15,13 +15,13 @@ export const faqItems = [
       "L1 是厂商的字节级前缀缓存，仅在会话内被动命中；L2 把跨会话稳定的切片原样注入前缀区，让语义命中转化为厂商字节缓存命中；L3 对只读任务带文件指纹验证直接复用历史结果，验证不过则拒绝。",
   },
   {
-    question: "“自进化”具体指什么？",
+    question: "参数反馈目前实现到什么程度？",
     answer:
-      "系统每轮采集命中率、污染、延迟、成本、成功率等信号：在线用 EWMA 调整参数，参数变更后冻结期至少一小时以保护字节缓存；离线做嵌入刷新、阈值网格搜索和 T-Slice 转移矩阵重训。参数由系统自己调整，不是人工调优。",
+      "仓库实现了 EWMA、冻结窗口与参数状态持久化，用于验证反馈调参路径。离线重训、真实会话闭环和成本或性能收益尚未经过独立生产评测。",
   },
   {
     question: "如何参与 Semantix 的开发？",
     answer:
-      "在 github.com/Gnosil/semantix 提 issue 或开 PR。当前 M0 阶段按工作单元推进，PR 需附 go vet 与 go test 全绿的验证结果。",
+      "在 github.com/Gnosil/semantix 提 issue 或开 PR。提交时请附运行环境与 go vet、go test 的真实结果；若存在平台差异或失败项，应一并记录，而不是笼统写成全绿。",
   },
 ] as const;

--- a/site/src/lib/site-identity.ts
+++ b/site/src/lib/site-identity.ts
@@ -53,7 +53,7 @@ export const softwareApplicationJsonLd = {
   name: siteIdentity.productName,
   url: `${siteIdentity.productUrl}/`,
   description:
-    "A self-evolving agent kernel that sits between any agent harness and its resources, with semantic caching, speculative prefetch, and adaptive scheduling.",
+    "An open-source Go memory kernel with semantic slice extraction, BM25 retrieval, stable injection, and experimental scheduling and adaptation interfaces.",
   applicationCategory: "DeveloperApplication",
   operatingSystem: "Linux, macOS, Windows",
   license: "https://github.com/Gnosil/semantix/blob/main/LICENSE",


### PR DESCRIPTION
﻿## What changed

- replace unverified universal performance claims with shipped behavior and explicit experimental boundaries
- add observed repository test output, adverse results, and first-person engineering judgments to the eight audited technical articles
- expose verifiable author contribution-history links and an editorial evidence policy
- add regression tests for inline evidence and homepage claim boundaries

## Why

The latest GEO audit correctly identified a mismatch between strong homepage promises and the available evidence. It also found that several concise articles linked to evidence without presenting enough output and human interpretation in the page itself.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm run test:content` — 28/28 passed
- `npm run lint` — 0 errors; one existing `next/no-img-element` warning in `Nav.tsx`

## Evidence boundary

A local `go test -count=1 ./...` run with Go 1.26.5 on Windows/amd64 passed the retrieval, cache, ingestion, injection, evolve, and other core packages, but failed two Unix-style `0600` permission assertions in `kernel/slice` and `cmd/semantix`. The affected articles disclose this adverse result instead of presenting the suite as fully green. Repository tests are described as first-party engineering evidence, not an independent production benchmark.
