### PR TITLE
feat(sec): complete RFC 9116 security.txt fields

### DIFF
--- a/site/public/.well-known/security.txt
+++ b/site/public/.well-known/security.txt
@@ -2,5 +2,7 @@
 # Report vulnerabilities privately via GitHub Security Advisory (preferred) — do NOT open public issues for security findings.
 
 Contact: https://github.com/Gnosil/semantix/security/advisories/new
-Expires: 2027-08-10T00:00:00.000Z
+Contact: mailto:junhaihuang@aiqueshi.com
+Expires: 2027-08-12T00:00:00Z
+Preferred-Languages: zh, en
 Canonical: https://semantix.ensureok.ai/.well-known/security.txt


### PR DESCRIPTION
## Summary

Resolves #85. Completes the existing `site/public/.well-known/security.txt` (added in `4bdb08c`) so it satisfies every acceptance criterion in the issue:

- **Contact (mailto)**: `mailto:junhaihuang@aiqueshi.com` — matches `site-identity.ts` `operator.email` (already public on About/Terms/Contact pages)
- **Contact (GitHub Advisory)**: kept as the preferred private reporting channel (RFC 9116 allows multiple `Contact` fields)
- **Preferred-Languages**: `zh, en`
- **Expires**: refreshed to `2027-08-12T00:00:00Z` (one-year maintenance horizon, per issue suggestion — never permanent)

## Scope

- `site/public/.well-known/security.txt` — 3 lines added (`+3 -1`)

## Validation

- [x] `npm run build` — pass; verified `out/.well-known/security.txt` is present in the static export and identical to the `public/` source
- [x] `npm run test:content` — 28/28 tests pass
- [x] `npm run lint` / `npm run typecheck` — pass (no code changes; sanity-checked)
- [ ] Deployed URL returns 200 — deployment is out of scope here; the static export contains the file so it will be served at `/.well-known/security.txt`

## Compatibility and data impact

None. Static asset only; no CLI, schema, contract, or stored-data changes.

## Security and privacy

- Contact email is the already-public operator email (`site-identity.ts`), no new private data introduced
- No internal addresses or personal identifiers added
- GitHub Security Advisory remains the preferred channel

## Related issues

Fixes #85