### PR TITLE
feat(site): add published dates and separate BlogPosting datePublished

### DIFF
--- a/blog/agent-kernel-tool-call-history-semantic-slices.md
+++ b/blog/agent-kernel-tool-call-history-semantic-slices.md
@@ -2,6 +2,7 @@
 title: "From Noisy Tool Traces to Three Reusable Slice Types"
 description: "An annotated teardown of how prompt, tool-pattern, and result slices are derived from agent session JSONL."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Slices"
 order: 101
 ---

--- a/blog/cross-session-reuse-guide.md
+++ b/blog/cross-session-reuse-guide.md
@@ -2,6 +2,7 @@
 title: "Lab Notes: Reusing One Coding-Agent Session in the Next"
 description: "A hands-on lab that captures one session, retrieves it with new wording, and checks the resulting reuse block."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Evaluation Guides"
 order: 3
 ---

--- a/blog/cross-session-semantic-cache-layer.md
+++ b/blog/cross-session-semantic-cache-layer.md
@@ -2,6 +2,7 @@
 title: "Postmortem: Why the Agent Re-read the Same Repository Again"
 description: "A postmortem-style analysis of repeated repository discovery and the cache layer that can prevent it."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Cache"
 order: 201
 ---

--- a/blog/go-agent-framework-neutral-memory-layer.md
+++ b/blog/go-agent-framework-neutral-memory-layer.md
@@ -2,6 +2,7 @@
 title: "Integration Recipe: A Memory Sidecar for Any Go Agent Harness"
 description: "A concrete integration recipe covering capture, extraction, retrieval, injection, and rollback."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Go & Framework Independence"
 order: 402
 ---

--- a/blog/go-native-framework-agnostic-memory-kernel.md
+++ b/blog/go-native-framework-agnostic-memory-kernel.md
@@ -2,6 +2,7 @@
 title: "Code Review: Is the Memory Kernel Really Framework-Agnostic?"
 description: "A code-review checklist testing whether Semantix is genuinely independent of agent frameworks."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Go & Framework Independence"
 order: 403
 ---

--- a/blog/go-native-semantic-memory-flexible-stack.md
+++ b/blog/go-native-semantic-memory-flexible-stack.md
@@ -2,6 +2,7 @@
 title: "Go Builder?s Guide: Add Local Memory Without Choosing a Framework"
 description: "A Go-focused builder guide for integrating local semantic memory through a CLI and stable data contracts."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Go & Framework Independence"
 order: 401
 ---

--- a/blog/kernel-alternative-custom-agent-scheduling-teams.md
+++ b/blog/kernel-alternative-custom-agent-scheduling-teams.md
@@ -2,6 +2,7 @@
 title: "Team Decision Record: Buy a Kernel Layer or Keep the Custom Glue?"
 description: "A team decision record comparing shared kernel policy with custom per-harness scheduling and memory glue."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Scheduling & Harness"
 order: 303
 ---

--- a/blog/kernel-alternative-custom-agent-scheduling.md
+++ b/blog/kernel-alternative-custom-agent-scheduling.md
@@ -2,6 +2,7 @@
 title: "Control-Loop Walkthrough: What the Kernel Does Before a Tool Call"
 description: "A control-loop walkthrough separating shipped retrieval behavior from scheduling and prefetch direction."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Scheduling & Harness"
 order: 304
 ---

--- a/blog/kernel-smarter-agent-tool-execution.md
+++ b/blog/kernel-smarter-agent-tool-execution.md
@@ -2,6 +2,7 @@
 title: "Architecture Review: Put Execution Policy Beside the Harness"
 description: "An architecture review of the case for a separate execution kernel, including integration and failure costs."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Scheduling & Harness"
 order: 301
 ---

--- a/blog/open-source-semantic-memory-comparison-guide.md
+++ b/blog/open-source-semantic-memory-comparison-guide.md
@@ -2,6 +2,7 @@
 title: "Architecture Review: Comparing Agent Memory by Failure Mode"
 description: "An architecture-review rubric that compares memory systems by scope leaks, stale reuse, observability, and recovery behavior."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Evaluation Guides"
 order: 4
 ---

--- a/blog/open-source-semantic-memory-shortlist.md
+++ b/blog/open-source-semantic-memory-shortlist.md
@@ -2,6 +2,7 @@
 title: "A Skeptic?s Shortlist for Open-Source Agent Memory"
 description: "A skeptical shortlist method that begins with disqualifiers, reproducible trials, and operational ownership instead of vendor categories."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Evaluation Guides"
 order: 2
 ---

--- a/blog/persistent-memory-open-source-evaluation-guide.md
+++ b/blog/persistent-memory-open-source-evaluation-guide.md
@@ -2,6 +2,7 @@
 title: "Persistent Memory for Coding Agents: An Evidence-First Evaluation Worksheet"
 description: "A procurement-style worksheet for testing persistent agent memory with observable commands, failure criteria, and evidence grades."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Evaluation Guides"
 order: 1
 ---

--- a/blog/reusable-agent-experience-searchable.md
+++ b/blog/reusable-agent-experience-searchable.md
@@ -2,6 +2,7 @@
 title: "Field Note: Searchable Experience Is Not Conversation History"
 description: "A field note distinguishing searchable execution experience from transcripts, summaries, and generic vector storage."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Slices"
 order: 103
 ---

--- a/blog/semantic-cache-kernel-coding-agents.md
+++ b/blog/semantic-cache-kernel-coding-agents.md
@@ -2,6 +2,7 @@
 title: "Runbook: Stop Paying for Repeated Repository Discovery"
 description: "An operational runbook for detecting repeated discovery, capturing evidence, and enabling semantic reuse safely."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Cache"
 order: 203
 ---

--- a/blog/semantic-cache-layer-repeated-lookups.md
+++ b/blog/semantic-cache-layer-repeated-lookups.md
@@ -2,6 +2,7 @@
 title: "Debug Diary: BM25 Found It, Hybrid Ranked It First"
 description: "A debugging diary that compares lexical, hash-vector, and hybrid retrieval without overstating semantic quality."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Cache"
 order: 205
 ---

--- a/blog/semantic-kernel-smarter-tool-execution.md
+++ b/blog/semantic-kernel-smarter-tool-execution.md
@@ -2,6 +2,7 @@
 title: "Threat Model: When Reused Agent Context Becomes an Attack Surface"
 description: "A threat-model view of semantic injection, stale results, credentials, local storage, and safe degradation."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Scheduling & Harness"
 order: 302
 ---

--- a/blog/semantic-slices-reusable-execution-knowledge.md
+++ b/blog/semantic-slices-reusable-execution-knowledge.md
@@ -2,6 +2,7 @@
 title: "Design Memo: Why Semantix Stores Slices Instead of Sessions"
 description: "A concise design memo explaining the decision to store typed semantic slices and the tradeoffs it introduces."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Slices"
 order: 104
 ---

--- a/blog/semantix-l1-l3-caching-niche.md
+++ b/blog/semantix-l1-l3-caching-niche.md
@@ -2,6 +2,7 @@
 title: "Whiteboard: Three Caches, Three Different Risks"
 description: "A whiteboard explanation of L1 byte caching, L2 semantic injection, and L3 verified result reuse."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Cache"
 order: 202
 ---

--- a/blog/stop-paying-twice-repository-context.md
+++ b/blog/stop-paying-twice-repository-context.md
@@ -2,6 +2,7 @@
 title: "Cost Notebook: What Repository Context Actually Costs Twice"
 description: "A transparent cost notebook separating measured events, assumptions, and the data needed for a real savings claim."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Cache"
 order: 204
 ---

--- a/blog/turning-tool-calls-searchable-semantic-slices.md
+++ b/blog/turning-tool-calls-searchable-semantic-slices.md
@@ -2,6 +2,7 @@
 title: "Workshop: Make a Past Tool Sequence Searchable"
 description: "A workshop-style walkthrough for extracting tool patterns, searching them, and inspecting retrieval differences."
 updated: 2026-08-12
+published: 2026-08-10
 group: "Semantic Slices"
 order: 102
 ---

--- a/docs/superpowers/specs/2026-08-11-standalone-blog-design.md
+++ b/docs/superpowers/specs/2026-08-11-standalone-blog-design.md
@@ -29,7 +29,7 @@ Articles are grouped using frontmatter into:
 4. Scheduling & Harness
 5. Go & Framework Independence
 
-Each document contains `title`, `description`, `updated`, `group`, and `order` metadata. Slugs are stable English filenames.
+Each document contains `title`, `description`, `published`, `updated`, `group`, and `order` metadata. `published` is the original publication date and must be no later than `updated`. Slugs are stable English filenames.
 
 ## Interface
 

--- a/site/scripts/blog-content.test.mjs
+++ b/site/scripts/blog-content.test.mjs
@@ -57,11 +57,13 @@ test("blog corpus contains twenty standalone, valid Markdown articles", async ()
   for (const file of files) {
     const source = await readFile(path.join(blogRoot, file), "utf8");
     const meta = parseFrontmatter(source);
-    for (const key of ["title", "description", "updated", "group", "order"]) {
+    for (const key of ["title", "description", "updated", "published", "group", "order"]) {
       assert.ok(meta[key], `${file} is missing ${key}`);
     }
     assert.ok(allowedGroups.has(meta.group), `${file} has invalid group ${meta.group}`);
     assert.match(meta.updated, /^\d{4}-\d{2}-\d{2}$/);
+    assert.match(meta.published, /^\d{4}-\d{2}-\d{2}$/);
+    assert.ok(meta.published <= meta.updated, `${file}: published must not be after updated`);
     assert.equal((source.match(/^# /gm) ?? []).length, 1, `${file} must contain one H1`);
     assert.ok((source.match(/^## /gm) ?? []).length >= 1, `${file} must contain an H2`);
     const slug = file.replace(/\.md$/, "");

--- a/site/src/app/blog/[slug]/page.tsx
+++ b/site/src/app/blog/[slug]/page.tsx
@@ -39,7 +39,7 @@ export default async function BlogArticlePage({ params }: BlogPageProps) {
     headline: post.title,
     description: post.description,
     dateModified: post.updated,
-    datePublished: post.updated,
+    datePublished: post.published,
     inLanguage: "en",
     mainEntityOfPage: `${siteIdentity.productUrl}/blog/${post.slug}`,
     author: personJsonLd(author),
@@ -62,6 +62,8 @@ export default async function BlogArticlePage({ params }: BlogPageProps) {
             <a href={author.url} target="_blank" rel="author noopener noreferrer" className="hover:text-accent">
               By {author.name}
             </a>
+            <span aria-hidden="true">·</span>
+            <time dateTime={post.published}>Published {post.published}</time>
             <span aria-hidden="true">·</span>
             <time dateTime={post.updated}>Updated {post.updated}</time>
             <span aria-hidden="true">·</span>

--- a/site/src/lib/blog-shared.ts
+++ b/site/src/lib/blog-shared.ts
@@ -12,6 +12,7 @@ export type BlogPostMeta = {
   slug: string;
   title: string;
   description: string;
+  published: string;
   updated: string;
   group: BlogGroup;
   order: number;

--- a/site/src/lib/blog.ts
+++ b/site/src/lib/blog.ts
@@ -28,7 +28,7 @@ function parseFrontmatter(source: string, fileName: string) {
     );
   }
 
-  const required = ["title", "description", "updated", "group", "order"];
+  const required = ["title", "description", "updated", "published", "group", "order"];
   for (const key of required) {
     if (!values.get(key)) throw new Error(`Missing ${key} in blog/${fileName}`);
   }
@@ -43,6 +43,7 @@ function parseFrontmatter(source: string, fileName: string) {
     title: values.get("title")!,
     description: values.get("description")!,
     updated: values.get("updated")!,
+    published: values.get("published")!,
     group,
     order,
     content: source.slice(match[0].length),
@@ -79,6 +80,7 @@ export function listBlogPosts(): BlogPostMeta[] {
         fileName: entry.name,
         title: meta.title,
         description: meta.description,
+        published: meta.published,
         updated: meta.updated,
         group: meta.group,
         order: meta.order,


### PR DESCRIPTION
## Summary

Add an independent \published\ (original publication date) frontmatter field to all 20 blog articles, separating it from \updated\ (last-modified date).

## Changes

- \log/*.md\: add \published: 2026-08-10\ to all 20 articles (verified no omissions)
- \site/src/lib/blog-shared.ts\: add \published\ to \BlogPostMeta\
- \site/src/lib/blog.ts\: parse and propagate \published\
- \site/src/app/blog/[slug]/page.tsx\:
  - JSON-LD \datePublished\ now uses \post.published\ instead of \post.updated\ (fixes schema.org semantics)
  - render \Published\ time element on article page
- \site/scripts/blog-content.test.mjs\: assert \published\ required, \YYYY-MM-DD\ format, and \published <= updated\
- \docs/superpowers/specs/2026-08-11-standalone-blog-design.md\: sync frontmatter metadata list

## Verification

- \
ode --test site/scripts/blog-content.test.mjs\: 4/4 pass