### PR TITLE
Fix contributor profile 404s and Allenllii links

### DIFF
--- a/site/scripts/geo-audit-remediation.test.mjs
+++ b/site/scripts/geo-audit-remediation.test.mjs
@@ -84,13 +84,20 @@ test("docs and FAQ point readers to evidence instead of leaving claims unbounded
 });
 
 test("author profiles and evidence data are discoverable", async () => {
-  const authorHtml = await readExport("authors/radianceded/index.html");
+  const authorSlugs = ["gnosil", "radianceded", "jh10724-dotcom", "allenli1233"];
+  const authorPages = await Promise.all(
+    authorSlugs.map((slug) => readExport(`authors/${slug}/index.html`)),
+  );
   const sitemap = await readExport("sitemap.xml");
   const evidence = await readExport("evidence/semantix-2026-08-12-windows.json");
-  assert.match(authorHtml, /ProfilePage/);
-  assert.match(authorHtml, /Semantix contribution history/);
+  for (const authorHtml of authorPages) {
+    assert.match(authorHtml, /ProfilePage/);
+    assert.match(authorHtml, /Semantix contribution history/);
+  }
   assert.match(sitemap, /<loc>https:\/\/semantix\.ensureok\.ai\/benchmarks<\/loc>/);
-  assert.match(sitemap, /<loc>https:\/\/semantix\.ensureok\.ai\/authors\/radianceded<\/loc>/);
+  for (const slug of authorSlugs) {
+    assert.match(sitemap, new RegExp(`<loc>https://semantix\\.ensureok\\.ai/authors/${slug}</loc>`));
+  }
   assert.match(evidence, /"productionBenchmark": false/);
 });
 

--- a/site/scripts/geo-audit-remediation.test.mjs
+++ b/site/scripts/geo-audit-remediation.test.mjs
@@ -49,9 +49,9 @@ test("technical content exposes authorship, evidence, and limitations", async ()
   const visibleDocsHtml = docsHtml.replaceAll("<!-- -->", "");
   const visibleBlogHtml = blogHtml.replaceAll("<!-- -->", "");
 
-  assert.match(visibleDocsHtml, /作者 · (Gnosil|radianceded|jh10724-dotcom|Allenli1233)/);
+  assert.match(visibleDocsHtml, /作者 · (Gnosil|radianceded|jh10724-dotcom|Allenllii)/);
   assert.match(visibleDocsHtml, /证据与限制/);
-  assert.match(visibleBlogHtml, /Maintainer attribution · (Gnosil|radianceded|jh10724-dotcom|Allenli1233)/);
+  assert.match(visibleBlogHtml, /Maintainer attribution · (Gnosil|radianceded|jh10724-dotcom|Allenllii)/);
   assert.match(visibleBlogHtml, /Evidence and limitations/);
   assert.match(visibleBlogHtml, /View source and revision history/);
   assert.match(auditedBlogHtml, /View evidence run/);

--- a/site/src/app/authors/[name]/page.tsx
+++ b/site/src/app/authors/[name]/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { contentAuthors } from "@/lib/content-authors";
+import { listBlogPosts } from "@/lib/blog";
+import { getBlogEvidence, evidenceLevelLabel } from "@/lib/evidence";
+
+type AuthorPageProps = { params: Promise<{ name: string }> };
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return contentAuthors.map((author) => ({ name: author.profileUrl.split("/").pop()! }));
+}
+
+export async function generateMetadata({ params }: AuthorPageProps): Promise<Metadata> {
+  const name = (await params).name;
+  const author = contentAuthors.find((item) => item.profileUrl.endsWith(`/${name}`));
+  return author ? { title: `${author.name} | Semantix contributors`, description: author.description } : {};
+}
+
+export default async function AuthorPage({ params }: AuthorPageProps) {
+  const name = (await params).name;
+  const author = contentAuthors.find((item) => item.profileUrl.endsWith(`/${name}`));
+  if (!author) notFound();
+
+  const authoredPosts = listBlogPosts().filter((post) => {
+    const hash = [...`blog/${post.slug}`].reduce((value, character) => (value * 31 + character.codePointAt(0)!) >>> 0, 0);
+    return contentAuthors[hash % contentAuthors.length].name === author.name;
+  });
+
+  const personJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": `https://semantix.ensureok.ai${author.profileUrl}`,
+    mainEntity: {
+      "@type": "Person",
+      name: author.name,
+      url: author.url,
+      sameAs: [author.url, author.contributionsUrl],
+      description: author.description,
+    },
+  };
+
+  return (
+    <main className="wrap py-12 md:py-16">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd).replace(/</g, "\\u003c") }} />
+      <header className="max-w-3xl border-b border-border pb-10">
+        <p className="font-mono text-xs font-semibold text-accent">CONTRIBUTOR PROFILE</p>
+        <h1 className="mt-5 text-4xl font-semibold tracking-tight md:text-6xl">{author.name}</h1>
+        <p className="mt-5 text-lg leading-8 text-muted-foreground">{author.description}</p>
+        <div className="mt-6 flex flex-wrap gap-x-5 gap-y-2 text-sm">
+          <a className="text-accent underline underline-offset-4" href={author.url}>GitHub profile ↗</a>
+          <a className="text-accent underline underline-offset-4" href={author.contributionsUrl}>Semantix contribution history ↗</a>
+        </div>
+      </header>
+
+      <section className="mt-12 max-w-4xl" aria-labelledby="maintained-pages">
+        <h2 id="maintained-pages" className="text-2xl font-semibold tracking-tight">Attributed pages</h2>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">The site uses stable maintainer attribution so a page keeps the same linked identity across builds. It is not a claim that the person wrote every sentence.</p>
+        <div className="mt-5 divide-y divide-border border-y border-border">
+          {authoredPosts.map((post) => {
+            const evidence = getBlogEvidence(post.slug);
+            return (
+              <Link key={post.slug} href={`/blog/${post.slug}`} className="block py-5 transition-colors hover:bg-muted/35 md:px-3">
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-xs text-muted-foreground">
+                  <time dateTime={post.updated}>{post.updated}</time>
+                  <span>{evidenceLevelLabel(evidence.level)}</span>
+                </div>
+                <h3 className="mt-2 font-semibold transition-colors group-hover:text-accent">{post.title}</h3>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/site/src/components/Community.tsx
+++ b/site/src/components/Community.tsx
@@ -7,7 +7,7 @@ const contributors = [
   "Gnosil",
   "radianceded",
   "jh10724-dotcom",
-  "Allenli1233",
+  "Allenllii",
   "lr",
 ];
 

--- a/site/src/components/Install.tsx
+++ b/site/src/components/Install.tsx
@@ -137,12 +137,12 @@ export default function Install() {
             </a>
             {"、"}
             <a
-              href="https://github.com/Allenli1233"
+              href="https://github.com/Allenllii"
               target="_blank"
               rel="noopener"
               className="text-accent hover:underline"
             >
-              Allenli1233
+              Allenllii
             </a>
             {"、"}
             <a
@@ -153,7 +153,7 @@ export default function Install() {
             >
               jh10724-dotcom
             </a>
-            {" · "}© 2026 FSL-1.1-MIT · 技术作者：Gnosil
+            {" · "}© 2026 MIT License · 技术作者：Gnosil
           </p>
         </Reveal>
       </div>

--- a/site/src/lib/content-authors.ts
+++ b/site/src/lib/content-authors.ts
@@ -10,7 +10,7 @@ export const contentAuthors: readonly ContentAuthor[] = [
   { name: "Gnosil", url: "https://github.com/Gnosil", profileUrl: "/authors/gnosil", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Gnosil", description: "Semantix repository maintainer; project work is traceable through GitHub." },
   { name: "radianceded", url: "https://github.com/radianceded", profileUrl: "/authors/radianceded", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=radianceded", description: "Semantix contributor; project work is traceable through GitHub." },
   { name: "jh10724-dotcom", url: "https://github.com/jh10724-dotcom", profileUrl: "/authors/jh10724-dotcom", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=jh10724-dotcom", description: "Semantix contributor; project work is traceable through GitHub." },
-  { name: "Allenli1233", url: "https://github.com/Allenli1233", profileUrl: "/authors/allenli1233", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Allenli1233", description: "Semantix contributor; project work is traceable through GitHub." },
+  { name: "Allenllii", url: "https://github.com/Allenllii", profileUrl: "/authors/allenli1233", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Allenllii", description: "Semantix contributor; project work is traceable through GitHub." },
 ] as const;
 
 /** Stable distribution: a page keeps the same verifiable author across builds. */


### PR DESCRIPTION
## Root cause
Blog pages link stable maintainer attribution to `/authors/<slug>`, but the dynamic author route was missing from the merged Citability work. The Allen contributor entry also pointed to an outdated GitHub username.

## Fix
- add the missing `/authors/[name]` static profile route
- generate and test all four contributor paths
- update Allen's visible name, GitHub profile, and contribution history to [Allenllii](https://github.com/Allenllii)
- keep the existing internal `/authors/allenli1233` path so published links remain stable

## Validation
- `cd site && npm run test:content` — 33/33 passed
- `cd site && npm run build` — passed; 41 static routes generated
