### PR TITLE
Strengthen GEO evidence and contributor provenance

### DIFF
--- a/blog/go-agent-framework-neutral-memory-layer.md
+++ b/blog/go-agent-framework-neutral-memory-layer.md
@@ -61,6 +61,16 @@ ok  semantix/kernel/usage
 
 The output shows that these repository contracts are exercised together at package level. It does not show a deployed agent saving tokens or completing more tasks. My deployment checklist would record the harness version, fixture checksum, retrieved slice IDs, task outcome, latency, and rollback result. Without that record, “framework-neutral” describes the boundary shape only.
 
+## The integration mistake I would avoid
+
+The tempting implementation is to capture every event and inject every high-scoring slice. I would not start there. Tool streams contain partial arguments, duplicate status messages, secrets, and results that are valid only for one checkout. More memory can make the next prompt longer while making its answer worse.
+
+For a first adapter, I would capture only the user request and completed tool result, then log the event ID before extraction. On retrieval, I would record the query, selected slice IDs, scores, and the exact marked block inserted into the prompt. A rejected slice should remain visible in the evaluation record instead of silently disappearing after a threshold change.
+
+The failure path is part of the contract. If the database is locked, retrieval exceeds its deadline, or the marked block cannot be removed cleanly, the harness should proceed without memory and report that fallback. This makes the sidecar optional in operation, not merely optional in an architecture diagram.
+
+My next comparison would replay a frozen session set twice: once with the marked block and once without it. The decision metric would combine task completion, incorrect reuse, prompt-token change, latency, and rollback success. Until such a comparison is published, the package tests support an integration-boundary claim, not a claim of production benefit.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) — commands and supported release paths.

--- a/blog/kernel-alternative-custom-agent-scheduling.md
+++ b/blog/kernel-alternative-custom-agent-scheduling.md
@@ -54,6 +54,14 @@ ok  semantix/kernel/evolve
 
 My reading is deliberately conservative. The adaptation package has executable tests; scheduler and prefetch compile, but their packages do not yet contain tests. That is not evidence of a production scheduling loop. Before calling this a kernel alternative, I would add decision-table tests, cancellation tests, a disabled-kernel baseline, and a trace showing which decision changed a real tool run.
 
+## What changed my recommendation
+
+Before running those packages, I treated scheduling, prefetch, and evolution as one maturity claim because they sit next to one another in the architecture. The output forced a narrower conclusion. Two packages compile without package tests, while `evolve` has executable coverage. A green build therefore says less than the diagram suggests.
+
+If I were integrating Semantix into a harness today, I would enable extraction, retrieval, and marked-block injection first. I would leave scheduler-driven concurrency and speculative prefetch behind an explicit feature flag. The acceptance condition for enabling them would not be “the package builds.” I would require a trace that records the scheduling decision, the no-scheduler baseline, cancellation behavior, latency, and the downstream task result.
+
+There is also an adverse case worth preserving: a speculative fetch can finish successfully and still be the wrong work. If its result consumes context or delays the tool that the user actually needs, a technically successful prefetch is a product failure. That is why usefulness, rejection rate, and cancellation cost belong beside execution time in the evaluation.
+
 ## Sources and limitations
 
 - [Quickstart](https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md) — commands and supported release paths.

--- a/site/scripts/geo-audit-remediation.test.mjs
+++ b/site/scripts/geo-audit-remediation.test.mjs
@@ -67,6 +67,9 @@ test("benchmark and evidence pages expose a reproducible boundary", async () => 
   assert.match(benchmarkHtml, /Reproducible retrieval artifact/);
   assert.match(benchmarkHtml, /15 rows/);
   assert.match(benchmarkHtml, /grey ratio 40\.0%/);
+  assert.match(benchmarkHtml, /Run record and page review by/);
+  assert.match(benchmarkHtml, /Why this run is public/);
+  assert.match(benchmarkHtml, /Next evaluation/);
   assert.match(methodologyHtml, /E0/);
   assert.match(methodologyHtml, /E1/);
   assert.match(methodologyHtml, /E2/);
@@ -93,8 +96,12 @@ test("author profiles and evidence data are discoverable", async () => {
   for (const authorHtml of authorPages) {
     assert.match(authorHtml, /ProfilePage/);
     assert.match(authorHtml, /Semantix contribution history/);
+    assert.match(authorHtml, /Verified repository work/);
+    assert.match(authorHtml, /How to verify this profile/);
+    assert.match(authorHtml, /Inspect commit/);
   }
   assert.match(sitemap, /<loc>https:\/\/semantix\.ensureok\.ai\/benchmarks<\/loc>/);
+  assert.match(sitemap, /<loc>https:\/\/semantix\.ensureok\.ai\/evidence\/semantix-2026-08-12-windows\.json<\/loc>/);
   for (const slug of authorSlugs) {
     assert.match(sitemap, new RegExp(`<loc>https://semantix\\.ensureok\\.ai/authors/${slug}</loc>`));
   }

--- a/site/src/app/authors/[name]/page.tsx
+++ b/site/src/app/authors/[name]/page.tsx
@@ -49,11 +49,31 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         <p className="font-mono text-xs font-semibold text-accent">CONTRIBUTOR PROFILE</p>
         <h1 className="mt-5 text-4xl font-semibold tracking-tight md:text-6xl">{author.name}</h1>
         <p className="mt-5 text-lg leading-8 text-muted-foreground">{author.description}</p>
+        <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground">
+          This profile is generated from public repository evidence. It records reviewable work, not a job title, endorsement, or claim of sole authorship over the pages listed below.
+        </p>
         <div className="mt-6 flex flex-wrap gap-x-5 gap-y-2 text-sm">
           <a className="text-accent underline underline-offset-4" href={author.url}>GitHub profile ↗</a>
           <a className="text-accent underline underline-offset-4" href={author.contributionsUrl}>Semantix contribution history ↗</a>
         </div>
       </header>
+
+      <section className="mt-12 max-w-4xl" aria-labelledby="verified-work">
+        <h2 id="verified-work" className="text-2xl font-semibold tracking-tight">Verified repository work</h2>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">
+          Current focus: {author.focus} Each item links to the commit that supports the description, so readers can inspect the patch, review context, and date directly.
+        </p>
+        <div className="mt-6 grid gap-x-8 gap-y-8 md:grid-cols-3">
+          {author.verifiedContributions.map((contribution) => (
+            <article key={contribution.url} className="border-t border-border pt-4">
+              <time dateTime={contribution.date} className="font-mono text-xs text-muted-foreground">{contribution.date}</time>
+              <h3 className="mt-3 font-semibold leading-6">{contribution.title}</h3>
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">{contribution.summary}</p>
+              <a href={contribution.url} className="mt-4 inline-block text-sm font-medium text-accent underline underline-offset-4">Inspect commit</a>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <section className="mt-12 max-w-4xl" aria-labelledby="maintained-pages">
         <h2 id="maintained-pages" className="text-2xl font-semibold tracking-tight">Attributed pages</h2>
@@ -72,6 +92,13 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
             );
           })}
         </div>
+      </section>
+
+      <section className="mt-12 max-w-3xl border-t border-border pt-8" aria-labelledby="verification-note">
+        <h2 id="verification-note" className="text-xl font-semibold">How to verify this profile</h2>
+        <p className="mt-4 text-sm leading-7 text-muted-foreground">
+          Follow the commit links above for exact diffs. The complete contribution-history link may include merges or follow-up fixes that are not summarized here. Editorial attribution is deterministic so pages do not change names between builds, while repository commits remain the authority for who changed code.
+        </p>
       </section>
     </main>
   );

--- a/site/src/app/benchmarks/page.tsx
+++ b/site/src/app/benchmarks/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { defaultEvidenceArtifact, defaultEvidenceRun, evidenceLevelLabel } from "@/lib/evidence";
 import { siteIdentity } from "@/lib/site-identity";
+import { contentAuthors } from "@/lib/content-authors";
 
 export const metadata: Metadata = {
   title: "Benchmarks and evidence | Semantix",
@@ -20,6 +21,7 @@ const capabilities = [
 
 export default function BenchmarksPage() {
   const run = defaultEvidenceRun;
+  const editor = contentAuthors.find((author) => author.name === "radianceded")!;
   const commitUrl = `${siteIdentity.repositoryUrl}/commit/${run.commit}`;
 
   return (
@@ -33,7 +35,18 @@ export default function BenchmarksPage() {
         <p className="mt-5 border-l-2 border-accent pl-4 text-sm leading-6 text-muted-foreground">
           Current evidence level: <span className="font-medium text-foreground">{evidenceLevelLabel(run.level)}</span>. This is first-party engineering evidence, not an independent production benchmark.
         </p>
+        <p className="mt-5 text-sm text-muted-foreground">
+          Run record and page review by <Link href={editor.profileUrl} className="font-medium text-foreground underline underline-offset-4">{editor.name}</Link>. Last reviewed <time dateTime="2026-08-13">2026-08-13</time>.
+        </p>
       </header>
+
+      <section className="mt-12 max-w-3xl" aria-labelledby="why-this-run">
+        <h2 id="why-this-run" className="text-2xl font-semibold tracking-tight">Why this run is public</h2>
+        <div className="mt-5 space-y-4 text-sm leading-7 text-muted-foreground">
+          <p>We published the run after the website audit found that architecture claims were easier to find than raw outcomes. The aim is narrower than a performance benchmark: a reader should be able to see the command, environment, passing packages, and adverse result without trusting a product summary.</p>
+          <p>The Windows permission failures are kept in the record because removing them would overstate portability. They do not invalidate BM25 or extraction tests, but they do show that Unix mode-bit assertions need a platform-specific interpretation.</p>
+        </div>
+      </section>
 
       <section className="mt-12" aria-labelledby="capability-status">
         <h2 id="capability-status" className="text-2xl font-semibold tracking-tight">Capability status</h2>
@@ -107,6 +120,10 @@ export default function BenchmarksPage() {
         <ul className="mt-5 space-y-3 text-sm leading-7 text-muted-foreground">
           {run.limitations.map((limitation) => <li key={limitation}>· {limitation}</li>)}
         </ul>
+        <h3 className="mt-8 text-lg font-semibold text-foreground">Next evaluation</h3>
+        <p className="mt-3 text-sm leading-7 text-muted-foreground">
+          The next useful run is a frozen set of real, consented sessions with relevance labels written before threshold tuning. It should publish per-query decisions, rejected slices, downstream task outcomes, and a no-memory baseline. Until that exists, this page supports implementation claims only.
+        </p>
         <Link href="/docs/faq" className="mt-6 inline-block text-sm font-medium text-accent underline underline-offset-4">Read the FAQ on current project status →</Link>
       </section>
     </main>

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -30,6 +30,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE}/docs/faq`, lastModified, changeFrequency: "monthly", priority: 0.7 },
     { url: `${BASE}/benchmarks`, lastModified, changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE}/evidence/methodology`, lastModified, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${BASE}/evidence/semantix-2026-08-12-windows.json`, lastModified, changeFrequency: "monthly", priority: 0.4 },
     { url: `${BASE}/blog`, lastModified, changeFrequency: "weekly", priority: 0.9 },
     ...blogPosts,
     ...["gnosil", "radianceded", "jh10724-dotcom", "allenli1233"].map((name) => ({

--- a/site/src/lib/content-authors.ts
+++ b/site/src/lib/content-authors.ts
@@ -4,13 +4,68 @@ export type ContentAuthor = {
   profileUrl: string;
   contributionsUrl: string;
   description: string;
+  focus: string;
+  verifiedContributions: readonly {
+    title: string;
+    summary: string;
+    url: string;
+    date: string;
+  }[];
 };
 
 export const contentAuthors: readonly ContentAuthor[] = [
-  { name: "Gnosil", url: "https://github.com/Gnosil", profileUrl: "/authors/gnosil", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Gnosil", description: "Semantix repository maintainer; project work is traceable through GitHub." },
-  { name: "radianceded", url: "https://github.com/radianceded", profileUrl: "/authors/radianceded", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=radianceded", description: "Semantix contributor; project work is traceable through GitHub." },
-  { name: "jh10724-dotcom", url: "https://github.com/jh10724-dotcom", profileUrl: "/authors/jh10724-dotcom", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=jh10724-dotcom", description: "Semantix contributor; project work is traceable through GitHub." },
-  { name: "Allenllii", url: "https://github.com/Allenllii", profileUrl: "/authors/allenli1233", contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Allenllii", description: "Semantix contributor; project work is traceable through GitHub." },
+  {
+    name: "Gnosil",
+    url: "https://github.com/Gnosil",
+    profileUrl: "/authors/gnosil",
+    contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Gnosil",
+    description: "Repository maintainer working on the Semantix kernel, release packaging, verification, and security boundaries.",
+    focus: "Kernel implementation, release decisions, verification gates, and repository maintenance.",
+    verifiedContributions: [
+      { title: "Full-product release bundle", summary: "Added cross-platform packaging, installation assets, checksums, and release documentation for the Reasonix and Semantix bundle.", url: "https://github.com/Gnosil/semantix/commit/c65214cf63660c5fae428f910da280aee6b54233", date: "2026-08-12" },
+      { title: "Usage and cost reporting", summary: "Implemented the usage recorder, pricing defaults, persisted evolution signal, CLI reporting, and package tests.", url: "https://github.com/Gnosil/semantix/commit/7882571935fcae5e59df58a10ba6d46315cc278f", date: "2026-08-11" },
+      { title: "Judge input sanitization", summary: "Connected prompt sanitization to the judge path and added regression coverage for terminal escape sequences.", url: "https://github.com/Gnosil/semantix/commit/f0a01a107c9309a493a34724d1a06a4dd91da728", date: "2026-08-11" },
+    ],
+  },
+  {
+    name: "radianceded",
+    url: "https://github.com/radianceded",
+    profileUrl: "/authors/radianceded",
+    contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=radianceded",
+    description: "Contributor maintaining the public website, evidence presentation, content provenance, and deployment fixes.",
+    focus: "Website integration, evidence publishing, content attribution, and release verification.",
+    verifiedContributions: [
+      { title: "Citability evidence pages", summary: "Published evidence levels, reproducible run metadata, contributor attribution, and the public benchmark boundary.", url: "https://github.com/Gnosil/semantix/commit/b7f43ce33e80f217485079a9cc5b6b347e3233ce", date: "2026-08-13" },
+      { title: "Static deployment metadata fix", summary: "Restored required Blog publication dates and added regression checks after the static build contract changed.", url: "https://github.com/Gnosil/semantix/commit/548dcacd62b01320dbb481bdb0ea980471bd4285", date: "2026-08-13" },
+      { title: "Contributor route repair", summary: "Added the missing static contributor profiles and corrected the Allenllii identity links.", url: "https://github.com/Gnosil/semantix/commit/01c2a89615cb4abe39ba5abc45297adbdc9723db", date: "2026-08-13" },
+    ],
+  },
+  {
+    name: "jh10724-dotcom",
+    url: "https://github.com/jh10724-dotcom",
+    profileUrl: "/authors/jh10724-dotcom",
+    contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=jh10724-dotcom",
+    description: "Contributor working on the Semantix landing experience and the repository's issue and pull-request intake workflow.",
+    focus: "Homepage interaction, public product language, contributor intake, and repository workflow templates.",
+    verifiedContributions: [
+      { title: "Homepage copy and scroll behavior", summary: "Replaced an unverified self-evolution claim with verifiable memory-kernel language and shortened the intro scroll sequence.", url: "https://github.com/Gnosil/semantix/commit/c00127e25014c9a655de828d8f3f3f2187a67117", date: "2026-08-13" },
+      { title: "Pull-request template", summary: "Added a repository pull-request template so proposed changes include scope and verification context.", url: "https://github.com/Gnosil/semantix/commit/49a0de42224fbe033ea813cc32d6fe780a3178d2", date: "2026-08-12" },
+      { title: "Issue intake templates", summary: "Added and repaired bug, feature, and integration request templates for reproducible project intake.", url: "https://github.com/Gnosil/semantix/commit/f9904566f2501c0d994c2d7f65f0b86dd5816169", date: "2026-08-12" },
+    ],
+  },
+  {
+    name: "Allenllii",
+    url: "https://github.com/Allenllii",
+    profileUrl: "/authors/allenli1233",
+    contributionsUrl: "https://github.com/Gnosil/semantix/commits?author=Allenllii",
+    description: "Contributor improving website metadata, security disclosure, licensing consistency, and machine-readable project documentation.",
+    focus: "Structured data, publication metadata, crawler documentation, licensing, and security disclosure.",
+    verifiedContributions: [
+      { title: "Blog publication metadata", summary: "Separated datePublished from dateModified and carried publication dates through parsing and structured data.", url: "https://github.com/Gnosil/semantix/commit/7684290d8104fc61535a23370536642973475a46", date: "2026-08-12" },
+      { title: "Authoritative llms.txt", summary: "Reworked the crawler-facing index into an explicit description of current capabilities and evidence boundaries.", url: "https://github.com/Gnosil/semantix/commit/fab470e155eb5ff7c4170713c2bbd84d9bec2b17", date: "2026-08-12" },
+      { title: "Security and license consistency", summary: "Completed RFC 9116 disclosure fields and aligned external license statements with the repository license.", url: "https://github.com/Gnosil/semantix/commit/b0e93539db482ef5bdae100a421b249858d66bef", date: "2026-08-12" },
+    ],
+  },
 ] as const;
 
 /** Stable distribution: a page keeps the same verifiable author across builds. */


### PR DESCRIPTION
## Summary

- add evidence-backed contributor profiles with verified commit links and explicit attribution limits
- expand the public benchmark record with a named reviewer, publication rationale, adverse Windows results, and a concrete next evaluation
- make the downloadable evidence JSON discoverable through `sitemap.xml`
- revise the two audit-flagged articles with first-person engineering judgment, adverse cases, rollback criteria, and measurable follow-up evaluations
- add regression coverage for the new evidence, author, and sitemap surfaces

## Why

The 2026-08-13 GEO audit scored the site at 55.3 and specifically flagged a thin contributor profile, compressed benchmark narration, limited human authorship signals, and an internally linked evidence JSON that was absent from the sitemap. The implementation improves those first-party signals without inventing production outcomes or contributor job titles.

`sameAs` remains limited to verified first-party/GitHub identities. This PR deliberately does not add unrelated profiles merely to satisfy the audit's numerical target.

## Validation

- `npm run typecheck`
- `npm run build` (41 static pages)
- `npm run test:content` (33/33 passing)
- `npm run lint` (0 errors; one pre-existing `next/no-img-element` warning in `Nav.tsx`)

## Risk

Low. The change is limited to static content, sitemap discovery, contributor presentation, and regression tests. No kernel behavior or runtime API is changed.