### PR TITLE
fix(site): prevent brand-intro bottom cards from being clipped

### DIFF
--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -190,6 +190,24 @@
   text-wrap: nowrap;
 }
 
+/* Title block: shift up on shorter viewports so the GitHub/CLI cards
+   (incl. the copy-code box) are not clipped by the sticky 100svh frame. */
+.brand-intro-title-block {
+  top: 48%;
+}
+
+@media (max-height: 860px) {
+  .brand-intro-title-block {
+    top: 44%;
+  }
+}
+
+@media (max-height: 740px) {
+  .brand-intro-title-block {
+    top: 40%;
+  }
+}
+
 /* ---- site-wide patterns (extracted from reasonix.io) ---- */
 @layer utilities {
   .wrap {

--- a/site/src/components/BrandIntroOverlay.tsx
+++ b/site/src/components/BrandIntroOverlay.tsx
@@ -97,7 +97,7 @@ export default function BrandIntroOverlay() {
         </p>
 
         <div
-          className="absolute inset-x-0 top-[48%] z-10 px-6 text-center text-[#101313]"
+          className="brand-intro-title-block absolute inset-x-0 z-10 px-6 text-center text-[#101313]"
           style={{
             opacity: titleProgress,
             transform: `translateY(${(1 - titleProgress) * 56}px)`,
@@ -107,12 +107,12 @@ export default function BrandIntroOverlay() {
           <h1 className="font-brand-serif text-balance text-5xl font-normal leading-[0.88] tracking-[0.015em] md:text-6xl lg:whitespace-nowrap lg:text-[4.9rem]">
             A <span className="text-[#00a878]">verifiable</span> agent memory kernel.
           </h1>
-          <p className="font-brand-display mx-auto mt-7 max-w-4xl text-[2rem] font-black leading-[0.98] tracking-[-0.055em] md:text-[2.75rem]">
+          <p className="font-brand-display mx-auto mt-5 max-w-4xl text-[1.9rem] font-black leading-[0.98] tracking-[-0.055em] md:text-[2.5rem]">
             <span className="block md:inline">把历史交互整理成</span>
             <span className="block text-[#168b6d]">可检索的执行经验</span>
           </p>
 
-          <p className="mx-auto mt-8 max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
+          <p className="mx-auto mt-6 max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
             Semantix 连接 Agent Harness 与资源层，提供切片提取、BM25 检索和稳定注入路径。
             <br className="hidden md:block" />
             当前公开证据来自仓库测试与合成演示；生产环境中的成本和性能收益仍待验证。
@@ -124,7 +124,7 @@ export default function BrandIntroOverlay() {
             Last updated · {siteIdentity.lastUpdated}
           </time>
 
-          <div className="mx-auto mt-8 hidden max-w-3xl grid-cols-2 gap-4 text-left md:grid">
+          <div className="mx-auto mt-6 hidden max-w-3xl grid-cols-2 gap-4 text-left md:grid">
             <div className="relative overflow-hidden rounded-lg border border-border bg-white p-4 transition-colors hover:border-accent">
               <ParticleCanvas className="pointer-events-none absolute inset-0 opacity-45" />
               <div className="relative">


### PR DESCRIPTION
修复首页 brand-intro 开场层在较矮视口下底部卡片被裁切的问题（下侧略有遮挡）。

## 问题
标题区块 absolute top-48% + GitHub/CLI 卡片网格整体高度超出 sticky 100svh 视口，被 overflow-hidden 裁掉：
- 1350x800 视口：卡片底边（含 go install 代码框）超出 29px
- 1350x720 视口：超出 70px

## 修复
- 新增 .brand-intro-title-block 高度媒体查询：默认 top 48%，视口高 <860px 时 44%，<740px 时 40%
- 适度压缩垂直节奏：副标题 mt-7→mt-5、字号 md 2.75rem→2.5rem，描述与卡片网格 mt-8→mt-6

## 验证
- headless 浏览器实测 9 种视口（1350x720/800/900、1920x1080、1366x768、1280x760、1440x900、1536x864、768x1024）均无元素溢出
- npm run typecheck 通过；lint 仅既有 Nav.tsx 警告