### PR TITLE
chore: restore issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,100 @@
+name: Bug report
+description: Report a reproducible problem in Semantix
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Remove secrets, private source code, personal data, and sensitive local paths from all examples and logs.
+
+  - type: input
+    id: version
+    attributes:
+      label: Semantix version
+      description: Run `semantix version` or provide the release, tag, or commit used.
+      placeholder: "v0.3.1 or commit SHA"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - GitHub Release binary
+        - Agent Skill installer
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the operating system, architecture, and relevant agent or harness.
+      placeholder: "macOS 15, arm64, Codex"
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command or integration
+      description: Show the command or integration path that triggered the problem.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reliable sequence that reproduces the issue.
+      placeholder: |
+        1. Prepare ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs or output
+      description: Do not include API keys, credentials, private code, personal data, or sensitive local paths.
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Include related issues, screenshots, sample sessions, or other useful context.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: I removed secrets, private code, personal data, and sensitive paths.
+          required: true
+        - label: I can reproduce this problem using the information above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,77 @@
+name: Feature request
+description: Suggest an improvement or new capability for Semantix
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Semantix. Describe the problem first so the proposed solution can be evaluated in context.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem, limitation, or repeated workflow should Semantix address?
+      placeholder: Describe who encounters the problem, when it occurs, and why the current behavior is insufficient.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or capability you would like to add.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative designs you considered.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary area
+      description: Select the area most affected by this request.
+      options:
+        - Semantic slices and extraction
+        - Retrieval and ranking
+        - L2 injection or L3 reuse
+        - Scheduling or prefetch
+        - Evaluation and benchmarks
+        - CLI and configuration
+        - Agent or harness integration
+        - Documentation or website
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Suggested acceptance criteria
+      description: What observable behavior or result would show that this request is complete?
+      placeholder: |
+        - Given ...
+        - When ...
+        - Then ...
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Include related issues, examples, benchmarks, screenshots, or references.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This request describes a concrete problem or use case.
+          required: true


### PR DESCRIPTION
## Summary

Restore the structured bug-report and feature-request forms that were prepared on the earlier community-template branch but were not included when its PR was merged.

## Impact

Contributors receive guided intake for reproducible bugs and problem-first feature proposals. No production code or runtime behavior changes.

## Validation

- parsed both YAML files successfully
- ran `git diff --check`
- confirmed the branch contains only the two missing issue forms
