### PR TITLE
feat(embed): model-backed embedder with hash fallback (Issue #63)

### DIFF
--- a/cmd/semantix/embedder.go
+++ b/cmd/semantix/embedder.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"semantix/kernel/embed"
+	"semantix/kernel/slice"
+)
+
+// embedBatch bounds one remote embeddings call (keeps responses well under
+// the client's read limit).
+const embedBatch = 64
+
+// embedItems computes vectors for extracted slices in batches of embedBatch
+// and stores them in Slice.Embedding, recording the embedder provenance
+// (model + dimension) in Slice.Meta. A remote failure inside ModelEmbedder
+// degrades to hash vectors (fail-soft), so this only errors when the
+// fallback itself fails.
+func embedItems(emb embed.Embedder, items []*slice.Slice, kind string) error {
+	for start := 0; start < len(items); start += embedBatch {
+		end := min(start+embedBatch, len(items))
+		texts := make([]string, 0, end-start)
+		for _, item := range items[start:end] {
+			texts = append(texts, string(item.Content))
+		}
+		vecs, err := emb.Embed(texts)
+		if err != nil {
+			return err
+		}
+		for j, v := range vecs {
+			items[start+j].Embedding = append([]float32(nil), v...)
+			items[start+j].Meta.EmbedModel = kind
+			items[start+j].Meta.EmbedDim = len(v)
+		}
+	}
+	return nil
+}
+
+// buildEmbedder constructs the CLI embedder from the --embedder flag.
+// hash keeps the zero-dependency default; model wires a remote
+// OpenAI-compatible embeddings API from the environment
+// (SEMANTIX_EMBED_BASE_URL / SEMANTIX_EMBED_MODEL / SEMANTIX_EMBED_API_KEY).
+// Remote failures degrade to hash inside ModelEmbedder (fail-soft);
+// OnFallback surfaces a one-line warning on the CLI stderr.
+func buildEmbedder(kind string, warn io.Writer) (embed.Embedder, error) {
+	switch kind {
+	case "hash":
+		return embed.HashEmbedder{}, nil
+	case "model":
+		cfg := embed.ModelEmbedderConfig{
+			BaseURL: os.Getenv("SEMANTIX_EMBED_BASE_URL"),
+			Model:   os.Getenv("SEMANTIX_EMBED_MODEL"),
+			APIKey:  os.Getenv("SEMANTIX_EMBED_API_KEY"),
+			OnFallback: func(err error) {
+				fmt.Fprintf(warn, "semantix: embed API unavailable (%v); fell back to hash embedding\n", err)
+			},
+		}
+		return embed.NewModelEmbedder(cfg)
+	default:
+		return nil, fmt.Errorf("invalid --embedder %q (want hash or model)", kind)
+	}
+}

--- a/cmd/semantix/embedder_test.go
+++ b/cmd/semantix/embedder_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/embed"
+	"semantix/kernel/slice"
+)
+
+// emptyStderr is defined in main_test.go; keep a local buffer writer helper
+// instead of depending on test file ordering.
+
+func TestBuildEmbedderHash(t *testing.T) {
+	emb, err := buildEmbedder("hash", &emptyStderr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := emb.(embed.HashEmbedder); !ok {
+		t.Fatalf("got %T, want HashEmbedder", emb)
+	}
+}
+
+func TestBuildEmbedderInvalid(t *testing.T) {
+	if _, err := buildEmbedder("onnx", &emptyStderr{}); err == nil {
+		t.Fatal("want error for invalid embedder")
+	}
+}
+
+func TestBuildEmbedderModelMissingEnv(t *testing.T) {
+	t.Setenv("SEMANTIX_EMBED_BASE_URL", "")
+	t.Setenv("SEMANTIX_EMBED_MODEL", "")
+	t.Setenv("SEMANTIX_EMBED_API_KEY", "")
+	if _, err := buildEmbedder("model", &emptyStderr{}); err == nil {
+		t.Fatal("want error when env is missing")
+	}
+}
+
+func TestBuildEmbedderModelEnvSet(t *testing.T) {
+	t.Setenv("SEMANTIX_EMBED_BASE_URL", "http://127.0.0.1:9")
+	t.Setenv("SEMANTIX_EMBED_MODEL", "test-model")
+	t.Setenv("SEMANTIX_EMBED_API_KEY", "sk-test")
+	emb, err := buildEmbedder("model", &emptyStderr{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := emb.(*embed.ModelEmbedder); !ok {
+		t.Fatalf("got %T, want *ModelEmbedder", emb)
+	}
+}
+
+// TestSearchVectorModelEmbedder runs the full search path against a mock
+// embeddings API: request goes to the endpoint, results come back scored.
+func TestSearchVectorModelEmbedder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// deterministic mock vectors: first text gets [1,0], others [0,1]
+		var body struct {
+			Input []string `json:"input"`
+		}
+		json.NewDecoder(r.Body).Decode(&body)
+		var data []map[string]any
+		for _, text := range body.Input {
+			v := []float32{0, 1}
+			if strings.Contains(text, "修复") {
+				v = []float32{1, 0}
+			}
+			data = append(data, map[string]any{"embedding": v})
+		}
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	defer srv.Close()
+
+	t.Setenv("SEMANTIX_EMBED_BASE_URL", srv.URL)
+	t.Setenv("SEMANTIX_EMBED_MODEL", "test-model")
+	t.Setenv("SEMANTIX_EMBED_API_KEY", "sk-test")
+
+	dir := t.TempDir()
+	db := filepath.Join(dir, "lib.db")
+	store, err := slice.NewFileStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []string{"修复 go 测试失败", "配置 CI 流水线"} {
+		sl := &slice.Slice{ID: "m-" + c[:4], Type: slice.Prompt, Scope: slice.Project, Content: []byte(c)}
+		if err := store.Put(sl); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run([]string{"search", "--query", "修复测试失败", "--db", db, "--retriever", "vector", "--embedder", "model", "--limit", "2"}, &out, &errOut, productionDependencies())
+	if code != 0 {
+		t.Fatalf("search code = %d, stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "修复 go 测试失败") {
+		t.Fatalf("search missed the repair slice:\n%s", out.String())
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("unexpected stderr (no fallback should happen): %s", errOut.String())
+	}
+}
+
+// TestSearchVectorModelEmbedderFallback verifies the fail-soft path end to
+// end: a 500 from the API degrades to hash vectors, search still works, and
+// a warning lands on stderr.
+func TestSearchVectorModelEmbedderFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("SEMANTIX_EMBED_BASE_URL", srv.URL)
+	t.Setenv("SEMANTIX_EMBED_MODEL", "test-model")
+	t.Setenv("SEMANTIX_EMBED_API_KEY", "sk-test")
+
+	dir := t.TempDir()
+	db := filepath.Join(dir, "lib.db")
+	store, _ := slice.NewFileStore(db)
+	for _, c := range []string{"修复 go 测试失败", "配置 CI 流水线"} {
+		sl := &slice.Slice{ID: "f-" + c[:4], Type: slice.Prompt, Scope: slice.Project, Content: []byte(c)}
+		if err := store.Put(sl); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := run([]string{"search", "--query", "修复测试失败", "--db", db, "--retriever", "vector", "--embedder", "model", "--limit", "2"}, &out, &errOut, productionDependencies())
+	if code != 0 {
+		t.Fatalf("search code = %d (fail-soft must not crash), stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "修复 go 测试失败") {
+		t.Fatalf("fallback search missed the repair slice:\n%s", out.String())
+	}
+	if !strings.Contains(errOut.String(), "fell back to hash embedding") {
+		t.Fatalf("stderr lacks fallback warning: %s", errOut.String())
+	}
+}
+
+// TestEmbedItemsWritesEmbeddingAndMeta verifies embedding + provenance are
+// stored on extracted slices.
+func TestEmbedItemsWritesEmbeddingAndMeta(t *testing.T) {
+	items := []*slice.Slice{
+		{ID: "a", Content: []byte("hello")},
+		{ID: "b", Content: []byte("world")},
+	}
+	if err := embedItems(embed.HashEmbedder{}, items, "hash"); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range items {
+		if len(item.Embedding) != 256 {
+			t.Fatalf("%s: embedding dim = %d, want 256", item.ID, len(item.Embedding))
+		}
+		if item.Meta.EmbedModel != "hash" || item.Meta.EmbedDim != 256 {
+			t.Fatalf("%s: meta = %+v, want model=hash dim=256", item.ID, item.Meta)
+		}
+	}
+}
+
+// TestEmbedItemsBatching verifies more than embedBatch slices produce
+// multiple remote calls.
+func TestEmbedItemsBatching(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var body struct {
+			Input []string `json:"input"`
+		}
+		json.NewDecoder(r.Body).Decode(&body)
+		if len(body.Input) > embedBatch {
+			t.Errorf("batch size %d exceeds %d", len(body.Input), embedBatch)
+		}
+		var data []map[string]any
+		for range body.Input {
+			data = append(data, map[string]any{"embedding": []float32{1, 0}})
+		}
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	defer srv.Close()
+
+	emb, err := embed.NewModelEmbedder(embed.ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	items := make([]*slice.Slice, embedBatch*2+3)
+	for i := range items {
+		items[i] = &slice.Slice{ID: "s", Content: []byte("x")}
+	}
+	if err := embedItems(emb, items, "model"); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 {
+		t.Fatalf("server called %d times, want 3 (2 full batches + 1 remainder)", calls)
+	}
+	for i, item := range items {
+		if len(item.Embedding) != 2 || item.Meta.EmbedDim != 2 || item.Meta.EmbedModel != "model" {
+			t.Fatalf("item %d: embedding=%v meta=%+v", i, item.Embedding, item.Meta)
+		}
+	}
+}
+
+// TestEmbedItemsEmpty verifies a nil/empty item list is a no-op.
+func TestEmbedItemsEmpty(t *testing.T) {
+	if err := embedItems(embed.HashEmbedder{}, nil, "hash"); err != nil {
+		t.Fatal(err)
+	}
+	if err := embedItems(embed.HashEmbedder{}, []*slice.Slice{}, "hash"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/semantix/extract.go
+++ b/cmd/semantix/extract.go
@@ -27,6 +27,7 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 	language := flags.String("language", "", "language metadata")
 	fingerprintPaths := flags.String("fingerprint", "", "comma-separated relative paths to fingerprint (sha256) into each slice's Deps")
 	l3Safe := flags.Bool("l3-safe", false, "mark dependency-free Result slices as explicitly L3-reusable (opt-in; ignored when --fingerprint is set)")
+	embedder := flags.String("embedder", "hash", "embedder for stored slices: hash (default, zero-dependency) | model (remote OpenAI-compatible API; see SEMANTIX_EMBED_* env)")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -91,6 +92,14 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 	items, err := extractor.Extract(data, meta)
 	if err != nil {
 		return fmt.Errorf("extract slices: %w", err)
+	}
+
+	emb, err := buildEmbedder(*embedder, stderr)
+	if err != nil {
+		return err
+	}
+	if err := embedItems(emb, items, *embedder); err != nil {
+		return fmt.Errorf("embed slices: %w", err)
 	}
 
 	dbPath := selectDB(scope, *dbOverride, *projectDB, *userDB)

--- a/cmd/semantix/search.go
+++ b/cmd/semantix/search.go
@@ -33,6 +33,7 @@ func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error
 	userDB := flags.String("user-db", defaultUserDB(), "user database path")
 	jsonOutput := flags.Bool("json", false, "write JSON results")
 	retriever := flags.String("retriever", "bm25", "retriever: bm25 (default) | vector (hash-embedding) | hybrid (RRF fusion)")
+	embedder := flags.String("embedder", "hash", "embedder: hash (default, zero-dependency) | model (remote OpenAI-compatible API; see SEMANTIX_EMBED_* env)")
 	zf := addZoneFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -93,7 +94,10 @@ func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error
 	var hits []slice.Hit
 	switch *retriever {
 	case "vector", "hybrid":
-		emb := embed.HashEmbedder{}
+		emb, err := buildEmbedder(*embedder, stderr)
+		if err != nil {
+			return err
+		}
 		texts := make([]string, len(items))
 		for i, item := range items {
 			texts[i] = string(item.Content)

--- a/kernel/embed/model.go
+++ b/kernel/embed/model.go
@@ -1,0 +1,126 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ModelEmbedderConfig wires a remote OpenAI-compatible embeddings API
+// (Issue #63, option A). The API key is read from the environment
+// (SEMANTIX_EMBED_API_KEY), never stored in config or code. Fallback
+// defaults to HashEmbedder{} so a remote failure degrades to the
+// zero-dependency hash vectors instead of failing the caller (fail-soft).
+type ModelEmbedderConfig struct {
+	BaseURL  string // e.g. https://api.openai.com/v1
+	Model    string // e.g. text-embedding-3-small
+	APIKey   string
+	Timeout  time.Duration // 0 -> 30s
+	Dim      int           // expected vector dimension; 0 disables the check
+	Fallback Embedder      // nil -> HashEmbedder{}
+	// OnFallback, when set, is called once per degraded batch with the
+	// error that caused the fallback (used by the CLI to warn on stderr).
+	OnFallback func(error)
+}
+
+// ModelEmbedder implements Embedder over a remote embeddings endpoint.
+type ModelEmbedder struct {
+	cfg ModelEmbedderConfig
+	hc  *http.Client
+}
+
+// NewModelEmbedder validates the config and builds the embedder.
+func NewModelEmbedder(cfg ModelEmbedderConfig) (*ModelEmbedder, error) {
+	if cfg.BaseURL == "" || cfg.Model == "" {
+		return nil, fmt.Errorf("embed: base-url and model are required")
+	}
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("embed: API key is required (set SEMANTIX_EMBED_API_KEY)")
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	if cfg.Fallback == nil {
+		cfg.Fallback = HashEmbedder{}
+	}
+	return &ModelEmbedder{cfg: cfg, hc: &http.Client{Timeout: cfg.Timeout}}, nil
+}
+
+// Embed asks the remote endpoint for vectors and L2-normalizes them (the
+// VectorIndex contract: cosine == dot product). Any remote failure — HTTP
+// status, transport error, timeout, malformed body, or dimension mismatch —
+// degrades the whole batch to the configured fallback (fail-soft); an error
+// is returned only when the fallback itself fails.
+func (m *ModelEmbedder) Embed(texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+	vecs, err := m.call(context.Background(), texts)
+	if err != nil {
+		if m.cfg.OnFallback != nil {
+			m.cfg.OnFallback(err)
+		}
+		return m.cfg.Fallback.Embed(texts)
+	}
+	return vecs, nil
+}
+
+func (m *ModelEmbedder) call(ctx context.Context, texts []string) ([][]float32, error) {
+	body := map[string]any{
+		"model": m.cfg.Model,
+		"input": texts,
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("embed: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.cfg.BaseURL+"/embeddings", bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("embed: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.cfg.APIKey)
+	resp, err := m.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embed: call: %w", err)
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("embed: read: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Status only — never echo the response body: a user-configured
+		// endpoint/proxy could reflect the Authorization header into it.
+		return nil, fmt.Errorf("embed: %s: HTTP %d (use https endpoints)", m.cfg.BaseURL+"/embeddings", resp.StatusCode)
+	}
+	var parsed struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return nil, fmt.Errorf("embed: response: %w", err)
+	}
+	if len(parsed.Data) != len(texts) {
+		return nil, fmt.Errorf("embed: response has %d vectors, want %d", len(parsed.Data), len(texts))
+	}
+	if m.cfg.Dim > 0 {
+		for i, d := range parsed.Data {
+			if len(d.Embedding) != m.cfg.Dim {
+				return nil, fmt.Errorf("embed: vector %d has dim %d, want %d", i, len(d.Embedding), m.cfg.Dim)
+			}
+		}
+	}
+	vecs := make([][]float32, len(parsed.Data))
+	for i, d := range parsed.Data {
+		vec := append([]float32(nil), d.Embedding...)
+		normalize(vec)
+		vecs[i] = vec
+	}
+	return vecs, nil
+}

--- a/kernel/embed/model_test.go
+++ b/kernel/embed/model_test.go
@@ -1,0 +1,348 @@
+package embed
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestModelEmbedderRequestFormat verifies the OpenAI-embeddings request
+// shape (path, auth, model, input) against a mock server.
+func TestModelEmbedderRequestFormat(t *testing.T) {
+	var gotBody map[string]any
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"embedding":[0.5,0.5,0.0]}]}`))
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "text-embedding-3-small", APIKey: "sk-test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs, err := m.Embed([]string{"hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) != 3 {
+		t.Fatalf("vecs = %v, want 1 vector of dim 3", vecs)
+	}
+	if !strings.HasPrefix(gotAuth, "Bearer ") {
+		t.Errorf("auth header = %q, want Bearer", gotAuth)
+	}
+	if gotBody["model"] != "text-embedding-3-small" {
+		t.Errorf("model = %v", gotBody["model"])
+	}
+	inputs, _ := gotBody["input"].([]any)
+	if len(inputs) != 1 || inputs[0] != "hello" {
+		t.Errorf("input = %v, want [hello]", gotBody["input"])
+	}
+}
+
+// TestModelEmbedderOrderingAndNormalization verifies vectors come back in
+// input order and are L2-normalized (the VectorIndex contract).
+func TestModelEmbedderOrderingAndNormalization(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Deliberately unnormalized and reversed magnitude to catch order bugs.
+		w.Write([]byte(`{"data":[{"embedding":[0.0,3.0,0.0,0.0]},{"embedding":[2.0,0.0,0.0,0.0]}]}`))
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs, err := m.Embed([]string{"first", "second"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vecs[0][1] != 1.0 || vecs[0][0] != 0.0 {
+		t.Errorf("first vector = %v, want [0 1 0 0]", vecs[0])
+	}
+	if vecs[1][0] != 1.0 {
+		t.Errorf("second vector = %v, want [1 0 0 0]", vecs[1])
+	}
+	for i, v := range vecs {
+		if norm(v) < 1-1e-6 || norm(v) > 1+1e-6 {
+			t.Errorf("vector %d not normalized: norm=%f", i, norm(v))
+		}
+	}
+}
+
+func norm(v []float32) float64 {
+	var s float64
+	for _, x := range v {
+		s += float64(x) * float64(x)
+	}
+	return math.Sqrt(s)
+}
+
+// TestModelEmbedderFallbackOnHTTPError verifies a 500 response degrades to
+// the fallback (fail-soft) without an error.
+func TestModelEmbedderFallbackOnHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var gotFallbackErr error
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+		OnFallback: func(err error) { gotFallbackErr = err },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := HashEmbedder{}.Embed([]string{"hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.Embed([]string{"hello"})
+	if err != nil {
+		t.Fatalf("fallback must be fail-soft: %v", err)
+	}
+	if len(got) != len(want) || len(got[0]) != len(want[0]) {
+		t.Fatalf("got %d vectors of dim %d, want %d of dim %d", len(got), len(got[0]), len(want), len(want[0]))
+	}
+	for i := range got[0] {
+		if got[0][i] != want[0][i] {
+			t.Fatalf("fallback vector differs from HashEmbedder output at %d", i)
+		}
+	}
+	if gotFallbackErr == nil {
+		t.Error("OnFallback not called")
+	}
+}
+
+// TestModelEmbedderFallbackOnTimeout verifies a hanging server plus a short
+// timeout degrades to the fallback instead of hanging or crashing.
+func TestModelEmbedderFallbackOnTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k", Timeout: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	got, err := m.Embed([]string{"hello"})
+	if err != nil {
+		t.Fatalf("fallback must be fail-soft: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("fallback took %v, timeout not enforced", elapsed)
+	}
+	if len(got) != 1 || len(got[0]) == 0 {
+		t.Fatalf("fallback output malformed: %v", got)
+	}
+}
+
+// TestModelEmbedderFallbackOnBadJSON verifies a malformed body degrades.
+func TestModelEmbedderFallbackOnBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.Embed([]string{"hello"})
+	if err != nil {
+		t.Fatalf("fallback must be fail-soft: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d vectors, want 1", len(got))
+	}
+}
+
+// TestModelEmbedderFallbackOnCountMismatch verifies a data length that does
+// not match the input count degrades (no silent misalignment).
+func TestModelEmbedderFallbackOnCountMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"embedding":[1.0,0.0]}]}`))
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.Embed([]string{"a", "b"})
+	if err != nil {
+		t.Fatalf("fallback must be fail-soft: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d vectors, want 2", len(got))
+	}
+}
+
+// TestModelEmbedderDimCheck verifies Dim>0 rejects mismatched dimensions.
+func TestModelEmbedderDimCheck(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"embedding":[1.0,0.0,0.0]}]}`))
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k", Dim: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.Embed([]string{"hello"})
+	if err != nil {
+		t.Fatalf("fallback must be fail-soft: %v", err)
+	}
+	if len(got) != 1 || len(got[0]) != 256 {
+		t.Fatalf("want hash fallback of dim 256, got %d vectors (dim %d)", len(got), len(got[0]))
+	}
+}
+
+// TestModelEmbedderFallbackErrorPropagation verifies an error surfaces only
+// when the fallback itself fails.
+func TestModelEmbedderFallbackErrorPropagation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	boom := errors.New("fallback broken")
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+		Fallback: failingEmbedder{err: boom},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Embed([]string{"hello"}); !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want fallback error %v", err, boom)
+	}
+}
+
+type failingEmbedder struct{ err error }
+
+func (f failingEmbedder) Embed([]string) ([][]float32, error) { return nil, f.err }
+
+// TestModelEmbedderEmptyInput verifies empty input performs no request and
+// returns empty vectors.
+func TestModelEmbedderEmptyInput(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs, err := m.Embed(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vecs) != 0 {
+		t.Fatalf("got %d vectors, want 0", len(vecs))
+	}
+	if calls != 0 {
+		t.Fatalf("server called %d times, want 0", calls)
+	}
+}
+
+// TestNewModelEmbedderValidation verifies constructor checks.
+func TestNewModelEmbedderValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ModelEmbedderConfig
+	}{
+		{"missing base-url", ModelEmbedderConfig{Model: "m", APIKey: "k"}},
+		{"missing model", ModelEmbedderConfig{BaseURL: "http://x", APIKey: "k"}},
+		{"missing key", ModelEmbedderConfig{BaseURL: "http://x", Model: "m"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewModelEmbedder(tc.cfg); err == nil {
+				t.Fatal("want validation error")
+			}
+		})
+	}
+}
+
+// TestModelEmbedderConcurrentEmbed verifies concurrent embedding batches
+// stay independent (the client and config are shared read-only state).
+func TestModelEmbedderConcurrentEmbed(t *testing.T) {
+	var mu sync.Mutex
+	var inputs [][]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		inputs = append(inputs, body["input"].([]any))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"embedding":[1.0,0.0]}]}`))
+	}))
+	defer srv.Close()
+
+	m, err := NewModelEmbedder(ModelEmbedderConfig{
+		BaseURL: srv.URL, Model: "m", APIKey: "k",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			text := string(rune('a' + i))
+			vecs, err := m.Embed([]string{text})
+			if err != nil {
+				t.Errorf("embed %q: %v", text, err)
+				return
+			}
+			if len(vecs) != 1 || len(vecs[0]) != 2 {
+				t.Errorf("embed %q: got %v", text, vecs)
+			}
+		}(i)
+	}
+	wg.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(inputs) != 8 {
+		t.Fatalf("server saw %d requests, want 8", len(inputs))
+	}
+	for i, in := range inputs {
+		if len(in) != 1 {
+			t.Fatalf("request %d input = %v, want 1 element", i, in)
+		}
+	}
+}

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -87,6 +87,12 @@ type SliceMeta struct {
 	// when Deps is empty, so a shared/injected library cannot silently
 	// mark results reusable.
 	L3Safe bool `json:"l3_safe,omitempty"`
+	// EmbedModel / EmbedDim record the provenance of Slice.Embedding
+	// (Issue #63): which embedder produced the vector and its dimension, so
+	// future retrieval can detect mixed-dimension libraries instead of
+	// silently skipping dimension-mismatched vectors.
+	EmbedModel string `json:"embed_model,omitempty"`
+	EmbedDim   int    `json:"embed_dim,omitempty"`
 }
 
 // Slice is the core semantic slice value.


### PR DESCRIPTION
实现 Issue #63（M1-U12b）方案 A：远端 OpenAI 兼容 embeddings API 的模型级 Embedder，零第三方依赖（仅标准库 net/http）。

## 内容

### kernel/embed/model.go（新）
- `ModelEmbedder`：POST /embeddings、Bearer 认证、L2 归一化输出（对齐 VectorIndex 契约：cosine==dot）
- **fail-soft 降级**：HTTP 状态/传输错误/超时/坏 JSON/数量不匹配/维度不符 → 整批回退 `Fallback`（默认 `HashEmbedder{}`），仅 fallback 也失败才返回 error
- 配置：`SEMANTIX_EMBED_BASE_URL / SEMANTIX_EMBED_MODEL / SEMANTIX_EMBED_API_KEY`（env，不落配置）；可选 `Dim` 校验、`OnFallback` 告警回调

### cmd/semantix
- `search` / `extract` 新增 `--embedder hash|model`（默认 hash，保持零依赖零外发）
- `extract --embedder model`：每批 64 条一次 API 调用，向量写入已预留的 `Slice.Embedding`，并在 `Slice.Meta` 记录 `EmbedModel/EmbedDim`（防将来维度混用）

### kernel/slice
- `SliceMeta` 新增 `EmbedModel` / `EmbedDim`（omitempty，旧数据向后兼容）

## 测试
- `kernel/embed/model_test.go`：请求格式（path/auth/model/input）、顺序对齐+归一化、500/超时/坏 JSON/数量不匹配/Dim 不符降级、fallback 错误传播、空输入零请求、并发安全、构造参数校验
- `cmd/semantix/embedder_test.go`：CLI 构建与 env 处理、mock API 端到端 search、端到端降级（stderr 告警）、64/批分批、provenance 写入

## 验证
- `go vet ./...` 全绿
- `go test -race ./...` 新代码全绿；仅 2 个**改动前已存在**的 Windows 平台失败（`TestRunUsageWithEvolve`、`TestFileStoreKeepsPerm0600`，0o600 权限位在 Windows 不成立），Linux CI 预期全绿

## 边界（刻意不做）
- 不引入任何第三方依赖（go.mod 无变化）
- 不改 lookup.go（工具侧仍 BM25）
- search 保持现算模式（单次查询内 embedder 一致，规避 hash 256 维与 model 维度混用时 VectorIndex 静默跳过问题）
- 无请求重试：一次失败即整批回退 hash

Refs #63