### PR TITLE
feat(prefetch): Issue 62 — speculative prefetch Planner MVP (transition matrix + read-only whitelist + budget)

### DIFF
--- a/docs/specs/issue-62-prefetch-planner.md
+++ b/docs/specs/issue-62-prefetch-planner.md
@@ -1,0 +1,169 @@
+# Spec：投机预取 Planner MVP（Issue 62 / M1-U18）
+
+> 对应 Issue：`#62 M1-U18: 投机预取 Planner MVP（kernel/prefetch，P2 暂缓可选）`
+> 真源约束：接口冻结于 `kernel/prefetch/prefetch.go`（`PrefetchTask` / `Prefetcher`），本 PR **不改接口签名**；
+> 架构基线：`docs/Agent-Infra-架构设计.md` §5.2（T-Slice 转移概率、只读预取、预算控制）；
+> 事件契约：`kernel/event/event.go` 已定义 `PrefetchHit` / `PrefetchWaste`（本 PR 不发事件，见 §1 不在范围）。
+>
+> **状态（2026-08-13）**：本文档为 Issue 62 实现规格，先审后写。
+
+## 1. 目标与范围
+
+**核心目标**：实现 `kernel/prefetch/` 的 MVP——基于切片库 ToolPattern 切片学习
+T-Slice 转移矩阵，在 LLM 流式等待期规划**只读**预取任务，并执行后将结果以
+Result 切片入库。
+
+**范围内**：
+
+- `planner.go`：转移矩阵学习（工具名序列 → 下一工具概率，2-gram 计数）
+- 预算控制：只读工具白名单 + 每轮 token 预算截断 + 任务数上限
+- `runner.go`：执行只读预取任务 → 结果入库（Result 切片）
+- 默认 `Executor`（slice-assembly）：按预测工具检索切片库并组装内容
+- 测试：转移矩阵学习 / 预算截断 / 白名单拒绝写操作（fail-closed）
+- spec 文档：本文档
+
+**不在范围内**（后续单元，本 PR 不实现）：
+
+- `PrefetchHit` / `PrefetchWaste` 事件发射与总线接线（事件类型已冻结，发射在
+  evolve 闭环 / harness 挂载点接入时补，见 `docs/events.md` §3）
+- evolve 自惩罚（waste/hit 比例降权信号源）——属 `kernel/evolve` 职责
+- `embedding` 类任务执行（当前无 embedder，`PrefetchTask.Kind` 保留但不生成）
+- `file` 类任务（低优先级；转移矩阵只有工具名、无参数，MVP 不猜测文件路径，
+  见 §2.4 数据模型限制）
+- `sched.Decider` 的 `RoundPlan.PrefetchIDs` 接线（联合决策属 M3 调度器）
+- `kernel/prefetch/prefetch.go` 接口签名变更（冻结）
+
+## 2. 设计
+
+### 2.1 包结构（全部新增，不改既有文件）
+
+```
+kernel/prefetch/
+├── prefetch.go   # 既有冻结接口，不改
+├── planner.go    # 新增：Planner（转移矩阵 + 白名单 + 预算）实现 Prefetcher
+├── runner.go     # 新增：Runner（执行任务 → Result 切片入库）+ Executor 接口
+└── *_test.go     # 新增：planner_test.go / runner_test.go
+```
+
+### 2.2 转移矩阵（planner.go）
+
+数据源：`slice.Store.List(Project)` 中 `Type == slice.ToolPattern` 的切片。
+ToolPattern 切片的 `Content` 是**空格分隔的工具名序列**（见
+`kernel/slice/extractor.go` 的 `toolPatternSlice`，如 `"grep readFile editFile test"`）。
+
+- 2-gram 计数：对每条序列中相邻两工具 `A → B`，`count[A][B]++`、`total[A]++`；
+- 转移概率：`P(B|A) = count[A][B] / total[A]`（未出现过的转移记 0）；
+- 矩阵在 `Learn()` 时构建并缓存（并发读安全，`sync.RWMutex`）；
+- 确定性：同一切片库 → 同一矩阵（map 遍历只用于构建，查询按概率降序、
+  平局按工具名字典序，输出顺序字节稳定）。
+
+### 2.3 Planner（实现 `Prefetcher` 接口）
+
+```go
+type Planner struct {
+    Store     slice.Store   // ToolPattern 切片数据源（必填）
+    WhiteList []string      // 只读工具白名单；空 = 空计划（fail-closed）
+    Budget    int           // 每轮预算（token）；<=0 用 DefaultBudget
+    MaxTasks  int           // 每轮任务数上限；<=0 用 DefaultMaxTasks
+    // 内部：matrix + RWMutex，Learn() 填充
+}
+
+func (p *Planner) Learn() error
+func (p *Planner) Plan(lastToolNames []string) ([]PrefetchTask, error)
+```
+
+`Plan` 决策链（严格顺序，保证 fail-closed 优先于预算优先于截断）：
+
+1. 矩阵未学习 → 返回空计划（不报错，不猜测）；
+2. `lastToolNames` 为空或全为空串 → 返回空计划；
+3. 取最近一个工具名 `A`，按 `P(·|A)` 降序取候选（平局按工具名字典序）；
+4. **白名单过滤（fail-closed）**：候选目标 `B ∉ WhiteList` 一律丢弃——
+   非只读工具**永不**进入预取计划；`WhiteList` 为空时计划恒为空；
+5. 预算截断：任务按概率降序逐个加入，累计 `Cost` 超过 `Budget` 即停止；
+6. 任务数截断：不超过 `MaxTasks`。
+
+生成的 `PrefetchTask`：
+
+- `Kind = "slice-assembly"`（本 MVP 唯一生成种类）；
+- `Key = 预测的下一工具名 B`（执行器据此检索候选切片，见 §2.5）；
+- `Cost`：估算 token 成本（每任务 `DefaultTaskCost` 常量），用于预算累计。
+
+**默认常量**：`DefaultBudget = 1000`（token/轮）、`DefaultMaxTasks = 3`、
+`DefaultTaskCost = 200`（token/任务）。
+
+### 2.4 数据模型限制（诚实声明）
+
+转移矩阵只含**工具名**，不含参数。因此无法从序列得知具体文件路径或切片 ID：
+`file` 类任务（需要路径）在本 MVP 不生成，避免无依据的猜测；
+`slice-assembly` 以"预测工具名"为检索键从切片库取候选，是唯一有依据的资源来源。
+
+### 2.5 Runner 与 Executor（runner.go）
+
+```go
+// Executor 执行单个只读预取任务，返回将被存为 Result 切片的内容。
+type Executor interface {
+    Execute(ctx context.Context, t PrefetchTask) ([]byte, error)
+}
+
+// Runner 串行执行任务列表，成功结果以 Result 切片写入 Store。
+type Runner struct {
+    Store    slice.Store
+    Executor Executor
+    Scope    slice.Scope // 入库切片的作用域（默认 slice.Project）
+}
+
+func (r *Runner) Run(ctx context.Context, tasks []PrefetchTask) ([]string, error)
+```
+
+- 串行执行（MVP 保守；预取是后台低优先，不抢占真实工具调用）；每任务的
+  **时长上限由调用方传入的 `ctx` 控制**（如等待期剩余时间）；
+- 成功结果构造为 `slice.Slice{Type: slice.Result, Scope: r.Scope, Content: content,
+  Meta: {SourceSession: "prefetch:" + t.Key}}` 后 `Store.Put`；切片 ID 由内容哈希
+  决定（复用 `kernel/slice` 的确定性 ID 约定，同内容不重复入库）；
+- `Run` 返回成功入库的切片 ID 列表；单个任务失败不影响其余任务
+  （记录并继续，返回汇总错误）。
+
+默认执行器 `SliceAssembler`（本 PR 提供）：
+
+```go
+type SliceAssembler struct {
+    Index slice.Index // 候选切片检索（必填）
+    K     int         // 每任务检索切片数；<=0 用 3
+}
+// Execute(t)：Index.Search(t.Key, K, Project) → 命中按 ID 字典序组装
+// "--- slice <id> ---\n<content>" → 返回。
+```
+
+### 2.6 并发安全
+
+`Planner` 的矩阵缓存读写走 `RWMutex`：`Learn` 持写锁重建，`Plan` 持读锁查询，
+可被调度器并发调用（对齐 `sched` 并发契约）。`Runner` 无共享可变状态（`Store`
+自身线程安全——`slice/fileStore` 已有互斥）。
+
+## 3. 测试计划（与 issue 验收一一对应）
+
+| 测试 | 断言 |
+|---|---|
+| `TestLearnTransitionMatrix` | 演示切片库（确定性构造）→ `Learn()` → `P(readFile\|grep)` 最高、`P(editFile\|readFile)` 精确值正确；重复 `Learn` 幂等 |
+| `TestPlanPredictsTopK` | `Plan(["grep"])` → 返回概率降序、白名单内的任务；`Key`/`Kind` 正确 |
+| `TestPlanBudgetTruncation` | `Budget` 很小 → 返回任务 Cost 总和 ≤ Budget，且高概率者优先保留 |
+| `TestPlanWhiteListFailClosed` | 候选含 `writeFile`/`editFile`（非白名单）→ 永不进入计划；`WhiteList` 为空 → 计划恒空 |
+| `TestPlanEmptyOrUnlearned` | 未 `Learn()` / 空 `lastToolNames` → 空计划不报错 |
+| `TestRunnerStoresResultSlice` | 执行 slice-assembly 任务 → Store 出现 `Type==Result` 切片，内容含源切片文本 |
+| `TestPlanConcurrent` | 并发 `Plan`（`-race`）无数据竞争 |
+
+## 4. 验收标准（对应 issue 原文）
+
+- [ ] `go vet ./...` 全绿
+- [ ] `go test -race ./...` 全绿（含新增 `kernel/prefetch` 测试）
+- [ ] 转移矩阵从演示切片库可学习（确定性测试，见 §3 第一行）
+- [ ] 非只读工具永不进入预取计划（fail-closed，见 §3 白名单测试）
+
+## 5. 风险与边界
+
+| 风险/边界 | 等级 | 说明 |
+|---|---|---|
+| 转移矩阵只含工具名、无参数 | 已知限制 | `file` 类任务不生成；`slice-assembly` 以工具名为检索键，命中率待真实数据验证（M3） |
+| 预取命中率未知 | 中 | 本 PR 只交付"规划 + 执行入库"能力；`PrefetchHit/Waste` 观测接线在后续 evolve 闭环，届时用真实数据调参 |
+| 预算为 token 估算 | 低 | `Cost` 是常量估算，非真实计费；MVP 阶段用于截断语义验证 |
+| 执行副作用 | 无（设计保证） | 只有白名单工具可被预测、只有 `slice-assembly` 执行、执行只读 Store/Index 操作 |

--- a/kernel/prefetch/planner.go
+++ b/kernel/prefetch/planner.go
@@ -1,0 +1,207 @@
+package prefetch
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"semantix/kernel/slice"
+)
+
+// Planner is the Issue 62 MVP: it learns a T-Slice transition matrix from the
+// slice library's ToolPattern slices and plans read-only prefetch tasks for
+// the next predicted tool. Contract with the frozen interface:
+//
+//	- PrefetchTask.Kind is always "slice-assembly" (see spec §2.3): the matrix
+//	  only carries tool names, never arguments, so file-path guessing is
+//	  explicitly out of scope; the predicted tool name becomes the task Key
+//	  and the executor retrieves candidate slices by it.
+//	- fail-closed: a predicted target that is not in WhiteList never enters
+//	  the plan; an empty WhiteList yields an always-empty plan.
+//	- budget: candidates (probability-descending, tie-broken by name) are
+//	  accumulated until the per-round Budget (token) or MaxTasks cap is hit.
+type Planner struct {
+	// Store is the ToolPattern slice source for Learn (required).
+	Store slice.Store
+	// WhiteList lists the only tools allowed to appear in a plan. Empty means
+	// fail-closed: Plan returns no tasks. A predicted non-white-listed tool is
+	// always dropped before any budget consideration.
+	WhiteList []string
+	// Budget is the per-round token budget; <=0 uses DefaultBudget.
+	Budget int
+	// MaxTasks caps tasks per round; <=0 uses DefaultMaxTasks.
+	MaxTasks int
+
+	mu     sync.RWMutex
+	matrix *transitionMatrix // set by Learn; nil until then
+}
+
+// Defaults for the MVP budget control.
+const (
+	// DefaultBudget is the default per-round prefetch budget in estimated
+	// tokens.
+	DefaultBudget = 1000
+	// DefaultMaxTasks caps tasks per round.
+	DefaultMaxTasks = 3
+	// DefaultTaskCost is the estimated token cost of one slice-assembly task.
+	DefaultTaskCost = 200
+)
+
+// Learn rebuilds the transition matrix from the ToolPattern slices in
+// p.Store (scope Project). It is idempotent: calling it twice with the same
+// store yields the same matrix.
+func (p *Planner) Learn() error {
+	if p.Store == nil {
+		return fmt.Errorf("prefetch: Planner.Store is required")
+	}
+	patterns, err := p.Store.List(slice.Project)
+	if err != nil {
+		return fmt.Errorf("prefetch: learn: list slices: %w", err)
+	}
+	m := newTransitionMatrix()
+	for _, s := range patterns {
+		if s == nil || s.Type != slice.ToolPattern {
+			continue
+		}
+		m.addSeq(strings.Fields(string(s.Content)))
+	}
+	p.mu.Lock()
+	p.matrix = m
+	p.mu.Unlock()
+	return nil
+}
+
+// Plan implements the frozen Prefetcher interface. It returns no tasks (and
+// no error) when the matrix is not learned, when no usable last tool name is
+// given, or when the whitelist is empty — never a guess.
+func (p *Planner) Plan(lastToolNames []string) ([]PrefetchTask, error) {
+	p.mu.RLock()
+	m := p.matrix
+	p.mu.RUnlock()
+	if m == nil {
+		return nil, nil // not learned: no guesses
+	}
+	last := lastToolName(lastToolNames)
+	if last == "" {
+		return nil, nil
+	}
+	white := whitelistSet(p.WhiteList)
+	if len(white) == 0 {
+		return nil, nil // fail-closed: empty whitelist means no prefetch
+	}
+
+	budget := p.budget()
+	maxTasks := p.maxTasks()
+	var tasks []PrefetchTask
+	spent := 0
+	for _, c := range m.next(last) {
+		if _, ok := white[c.Name]; !ok {
+			continue // fail-closed: non-read-only tools never enter the plan
+		}
+		cost := DefaultTaskCost
+		if spent+cost > budget {
+			break // budget truncation; candidates arrive probability-descending
+		}
+		tasks = append(tasks, PrefetchTask{Kind: "slice-assembly", Key: c.Name, Cost: cost})
+		spent += cost
+		if len(tasks) >= maxTasks {
+			break
+		}
+	}
+	return tasks, nil
+}
+
+func (p *Planner) budget() int {
+	if p.Budget <= 0 {
+		return DefaultBudget
+	}
+	return p.Budget
+}
+
+func (p *Planner) maxTasks() int {
+	if p.MaxTasks <= 0 {
+		return DefaultMaxTasks
+	}
+	return p.MaxTasks
+}
+
+// lastToolName returns the last non-blank tool name in the sequence, or "".
+func lastToolName(names []string) string {
+	for i := len(names) - 1; i >= 0; i-- {
+		if n := strings.TrimSpace(names[i]); n != "" {
+			return n
+		}
+	}
+	return ""
+}
+
+// whitelistSet normalizes WhiteList into a set; blanks are dropped.
+func whitelistSet(list []string) map[string]bool {
+	out := make(map[string]bool, len(list))
+	for _, n := range list {
+		if n = strings.TrimSpace(n); n != "" {
+			out[n] = true
+		}
+	}
+	return out
+}
+
+// candidate is one possible next tool with its learned probability.
+type candidate struct {
+	Name string
+	Prob float64
+}
+
+// transitionMatrix counts 2-grams (from -> to) over tool-name sequences.
+type transitionMatrix struct {
+	counts map[string]map[string]int
+	totals map[string]int
+}
+
+func newTransitionMatrix() *transitionMatrix {
+	return &transitionMatrix{
+		counts: make(map[string]map[string]int),
+		totals: make(map[string]int),
+	}
+}
+
+// addSeq learns the adjacent pairs of one tool-name sequence.
+func (m *transitionMatrix) addSeq(seq []string) {
+	for i := 0; i+1 < len(seq); i++ {
+		from, to := seq[i], seq[i+1]
+		if from == "" || to == "" {
+			continue
+		}
+		if m.counts[from] == nil {
+			m.counts[from] = make(map[string]int)
+		}
+		m.counts[from][to]++
+		m.totals[from]++
+	}
+}
+
+// prob returns P(to|from); 0 for an unseen transition.
+func (m *transitionMatrix) prob(from, to string) float64 {
+	total := m.totals[from]
+	if total == 0 {
+		return 0
+	}
+	return float64(m.counts[from][to]) / float64(total)
+}
+
+// next returns the successors of from sorted by probability descending, ties
+// broken by name ascending (deterministic output).
+func (m *transitionMatrix) next(from string) []candidate {
+	var out []candidate
+	for to := range m.counts[from] {
+		out = append(out, candidate{Name: to, Prob: m.prob(from, to)})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Prob != out[j].Prob {
+			return out[i].Prob > out[j].Prob
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/kernel/prefetch/planner_test.go
+++ b/kernel/prefetch/planner_test.go
@@ -1,0 +1,264 @@
+package prefetch
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// demoStore builds a deterministic ToolPattern slice library:
+//
+//	tp0: grep readFile editFile test
+//	tp1: grep readFile test
+//	tp2: readFile editFile test
+//
+// Learned probabilities (2-grams):
+//
+//	P(readFile|grep)    = 2/2 = 1.0
+//	P(editFile|readFile) = 2/3
+//	P(test|readFile)     = 1/3
+func demoStore(t *testing.T) slice.Store {
+	t.Helper()
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	patterns := []string{
+		"grep readFile editFile test",
+		"grep readFile test",
+		"readFile editFile test",
+	}
+	for i, p := range patterns {
+		if err := st.Put(&slice.Slice{
+			ID:      fmt.Sprintf("tp%d", i),
+			Type:    slice.ToolPattern,
+			Scope:   slice.Project,
+			Content: []byte(p),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return st
+}
+
+// Issue 62 acceptance: the transition matrix is learnable from a demo slice
+// library, deterministically.
+func TestLearnTransitionMatrix(t *testing.T) {
+	p := &Planner{Store: demoStore(t)}
+	if err := p.Learn(); err != nil {
+		t.Fatal(err)
+	}
+
+	p.mu.RLock()
+	m := p.matrix
+	p.mu.RUnlock()
+	if m == nil {
+		t.Fatal("matrix not learned")
+	}
+	cases := []struct {
+		from, to string
+		want     float64
+	}{
+		{"grep", "readFile", 1.0},
+		{"readFile", "editFile", 2.0 / 3.0},
+		{"readFile", "test", 1.0 / 3.0},
+		{"grep", "writeFile", 0.0}, // unseen transition
+	}
+	for _, c := range cases {
+		if got := m.prob(c.from, c.to); got != c.want {
+			t.Errorf("P(%s|%s) = %v, want %v", c.to, c.from, got, c.want)
+		}
+	}
+
+	// Idempotent: re-learning yields the same matrix.
+	if err := p.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if got := p.matrix.prob("readFile", "editFile"); got != 2.0/3.0 {
+		t.Errorf("after re-learn P(editFile|readFile) = %v, want 2/3", got)
+	}
+}
+
+func TestPlanPredictsTopK(t *testing.T) {
+	p := &Planner{Store: demoStore(t), WhiteList: []string{"readFile", "grep", "lookup", "search"}}
+	if err := p.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := p.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("Plan([grep]) = %d tasks, want 1", len(tasks))
+	}
+	tk := tasks[0]
+	if tk.Kind != "slice-assembly" || tk.Key != "readFile" || tk.Cost != DefaultTaskCost {
+		t.Fatalf("task = %+v, want {slice-assembly readFile %d}", tk, DefaultTaskCost)
+	}
+}
+
+// Probability-descending order: lookup (2/3) precedes readFile (1/3).
+func TestPlanOrderProbabilityDesc(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, p := range []string{"grep readFile editFile test", "grep lookup search", "grep lookup search"} {
+		if err := st.Put(&slice.Slice{ID: fmt.Sprintf("tp%d", i), Type: slice.ToolPattern, Scope: slice.Project, Content: []byte(p)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pl := &Planner{Store: st, WhiteList: []string{"readFile", "lookup"}}
+	if err := pl.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := pl.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 2 || tasks[0].Key != "lookup" || tasks[1].Key != "readFile" {
+		t.Fatalf("Plan order = %+v, want [lookup readFile]", tasks)
+	}
+}
+
+func TestPlanBudgetTruncation(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, p := range []string{"grep readFile editFile test", "grep lookup search", "grep lookup search"} {
+		if err := st.Put(&slice.Slice{ID: fmt.Sprintf("tp%d", i), Type: slice.ToolPattern, Scope: slice.Project, Content: []byte(p)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// High-probability candidate survives a tight budget; low one is truncated
+	// by budget (not by whitelist).
+	pl := &Planner{Store: st, WhiteList: []string{"readFile", "lookup"}, Budget: 250}
+	if err := pl.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := pl.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 || tasks[0].Key != "lookup" {
+		t.Fatalf("Plan with Budget=250 = %+v, want [lookup] only", tasks)
+	}
+
+	// Budget below one task cost yields an empty plan.
+	pl2 := &Planner{Store: st, WhiteList: []string{"readFile", "lookup"}, Budget: 10}
+	if err := pl2.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err = pl2.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("Plan with Budget=10 = %d tasks, want 0", len(tasks))
+	}
+}
+
+// Issue 62 acceptance: non-read-only tools never enter the plan (fail-closed).
+func TestPlanWhiteListFailClosed(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// writeFile/editFile are write tools; the learned successor of grep is writeFile.
+	for i, p := range []string{"grep writeFile editFile", "grep writeFile editFile"} {
+		if err := st.Put(&slice.Slice{ID: fmt.Sprintf("tp%d", i), Type: slice.ToolPattern, Scope: slice.Project, Content: []byte(p)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pl := &Planner{Store: st, WhiteList: []string{"readFile"}}
+	if err := pl.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := pl.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("non-white-listed write tool entered the plan: %+v", tasks)
+	}
+
+	// Empty whitelist is fail-closed too.
+	pl2 := &Planner{Store: st}
+	if err := pl2.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	if tasks, err = pl2.Plan([]string{"grep"}); err != nil || len(tasks) != 0 {
+		t.Fatalf("empty whitelist must yield empty plan, got %+v, %v", tasks, err)
+	}
+}
+
+// Generic invariant: every planned Key is white-listed.
+func TestPlanKeysAlwaysWhiteListed(t *testing.T) {
+	pl := &Planner{Store: demoStore(t), WhiteList: []string{"grep", "readFile"}}
+	if err := pl.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := pl.Plan([]string{"readFile"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	white := map[string]bool{"grep": true, "readFile": true}
+	for _, tk := range tasks {
+		if !white[tk.Key] {
+			t.Fatalf("task key %q not in whitelist", tk.Key)
+		}
+	}
+}
+
+func TestPlanEmptyOrUnlearned(t *testing.T) {
+	// Not learned: no guesses, no error.
+	pl := &Planner{Store: demoStore(t), WhiteList: []string{"readFile"}}
+	if tasks, err := pl.Plan([]string{"grep"}); err != nil || len(tasks) != 0 {
+		t.Fatalf("unlearned Plan = %+v, %v; want empty, nil", tasks, err)
+	}
+
+	// Learned but no usable last tool name.
+	if err := pl.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	for _, names := range [][]string{nil, {}, {""}, {"  "}} {
+		if tasks, err := pl.Plan(names); err != nil || len(tasks) != 0 {
+			t.Fatalf("Plan(%v) = %+v, %v; want empty, nil", names, tasks, err)
+		}
+	}
+}
+
+func TestPlanConcurrent(t *testing.T) {
+	pl := &Planner{Store: demoStore(t), WhiteList: []string{"readFile", "grep", "test"}}
+	if err := pl.Learn(); err != nil {
+		t.Fatal(err)
+	}
+	const g = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, g)
+	for i := 0; i < g; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if _, err := pl.Plan([]string{"grep"}); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}

--- a/kernel/prefetch/runner.go
+++ b/kernel/prefetch/runner.go
@@ -1,0 +1,119 @@
+package prefetch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"semantix/kernel/slice"
+)
+
+// Executor runs one read-only prefetch task and returns the content bytes to
+// be persisted as a Result slice. The kernel stays decoupled from any
+// concrete tool: an adapter provides its own Executor for harness tools;
+// SliceAssembler is the built-in slice-library-backed one (spec §2.5).
+type Executor interface {
+	Execute(ctx context.Context, t PrefetchTask) ([]byte, error)
+}
+
+// Runner executes a plan's tasks serially and persists successful results as
+// Result slices in the store. Tasks are low-priority background work: serial
+// execution keeps them from competing with real tool calls, and the per-task
+// duration bound is the caller's ctx (e.g. remaining stream-wait time).
+type Runner struct {
+	// Store receives the persisted Result slices (required).
+	Store slice.Store
+	// Executor performs each task (required).
+	Executor Executor
+	// Scope is the slice scope for stored results; the zero value (Session)
+	// is treated as Project, since prefetch results are meant for reuse
+	// across sessions.
+	Scope slice.Scope
+}
+
+// Run executes tasks in order and stores each successful result. It returns
+// the stored slice IDs; one failing task does not abort the rest, and any
+// failures are joined into the returned error.
+func (r *Runner) Run(ctx context.Context, tasks []PrefetchTask) ([]string, error) {
+	if r.Store == nil || r.Executor == nil {
+		return nil, errors.New("prefetch: Runner requires Store and Executor")
+	}
+	scope := r.Scope
+	if scope == 0 {
+		scope = slice.Project
+	}
+	var ids []string
+	var errs []error
+	for _, t := range tasks {
+		content, err := r.Executor.Execute(ctx, t)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("prefetch: execute %s %q: %w", t.Kind, t.Key, err))
+			continue
+		}
+		sl := &slice.Slice{
+			Type:    slice.Result,
+			Scope:   scope,
+			Content: content,
+			Weight:  1.0,
+			Meta:    slice.SliceMeta{SourceSession: "prefetch:" + t.Key},
+		}
+		sl.ID = resultSliceID(content, scope)
+		if err := r.Store.Put(sl); err != nil {
+			errs = append(errs, fmt.Errorf("prefetch: store result for %q: %w", t.Key, err))
+			continue
+		}
+		ids = append(ids, sl.ID)
+	}
+	return ids, errors.Join(errs...)
+}
+
+// SliceAssembler is the default read-only executor (spec §2.5): it retrieves
+// candidate slices for the task's key (a predicted tool name) and assembles
+// their content so the next tool round can reuse them without a search.
+type SliceAssembler struct {
+	// Index provides candidate-slice retrieval (required).
+	Index slice.Index
+	// K is the number of candidates per task; <=0 uses 3.
+	K int
+}
+
+// Execute searches the project-scoped index for t.Key and returns the
+// top-K slices' content, assembled in canonical (ID-sorted) order for
+// byte-stable output (DeepSeek prefix-cache friendly, mirroring kernel/inject).
+func (a *SliceAssembler) Execute(ctx context.Context, t PrefetchTask) ([]byte, error) {
+	if a.Index == nil {
+		return nil, errors.New("prefetch: SliceAssembler requires Index")
+	}
+	k := a.K
+	if k <= 0 {
+		k = 3
+	}
+	hits, err := a.Index.Search(t.Key, k, slice.Project)
+	if err != nil {
+		return nil, fmt.Errorf("slice-assembly %q: search: %w", t.Key, err)
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].Slice.ID < hits[j].Slice.ID })
+	var b strings.Builder
+	for _, h := range hits {
+		fmt.Fprintf(&b, "--- slice %s ---\n%s\n", h.Slice.ID, h.Slice.Content)
+	}
+	return []byte(b.String()), nil
+}
+
+// resultSliceID mirrors kernel/slice's deterministic content-derived ID
+// (sha256 of type|scope|content, first 8 bytes, hex). kernel/slice does not
+// export its sliceID, and this file is the only other place a Result slice
+// is constructed, so the 5-line algorithm is duplicated here with a
+// cross-reference; if kernel/slice ever exports it, call that instead.
+// Keeping the algorithm identical is what makes the "same content does not
+// re-store" dedup property hold across both constructors.
+func resultSliceID(content []byte, scope slice.Scope) string {
+	h := sha256.New()
+	h.Write([]byte{byte(slice.Result), byte(scope)})
+	h.Write(content)
+	return hex.EncodeToString(h.Sum(nil)[:8])
+}

--- a/kernel/prefetch/runner_test.go
+++ b/kernel/prefetch/runner_test.go
@@ -1,0 +1,193 @@
+package prefetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/slice"
+)
+
+// fakeExecutor returns canned content per key and fails the listed keys.
+type fakeExecutor struct {
+	results map[string][]byte
+	fails   map[string]error
+}
+
+func (f *fakeExecutor) Execute(_ context.Context, t PrefetchTask) ([]byte, error) {
+	if err, ok := f.fails[t.Key]; ok {
+		return nil, err
+	}
+	return f.results[t.Key], nil
+}
+
+func seedIndexedSlice(t *testing.T, st slice.Store, ix slice.Index, id, content string) {
+	t.Helper()
+	// Source candidates are Context slices so the dedup assertion can count
+	// only the Runner-persisted Result slices.
+	s := &slice.Slice{ID: id, Type: slice.Context, Scope: slice.Project, Content: []byte(content)}
+	if err := st.Put(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := ix.Insert(s); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunnerStoresResultSlice(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ix := bm25.New()
+	seedIndexedSlice(t, st, ix, "s1", "readFile usage documentation")
+
+	r := &Runner{Store: st, Executor: &SliceAssembler{Index: ix, K: 3}}
+	ids, err := r.Run(context.Background(), []PrefetchTask{{Kind: "slice-assembly", Key: "readFile", Cost: 200}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("Run returned %d ids, want 1", len(ids))
+	}
+	got, err := st.Get(ids[0])
+	if err != nil || got == nil {
+		t.Fatalf("stored slice not found: %v, %v", got, err)
+	}
+	if got.Type != slice.Result {
+		t.Fatalf("stored type = %v, want Result", got.Type)
+	}
+	if got.Meta.SourceSession != "prefetch:readFile" {
+		t.Fatalf("SourceSession = %q, want prefetch:readFile", got.Meta.SourceSession)
+	}
+	content := string(got.Content)
+	if !strings.Contains(content, "--- slice s1 ---") || !strings.Contains(content, "readFile usage documentation") {
+		t.Fatalf("assembled content missing source slice text: %q", content)
+	}
+	if len(got.ID) != 16 { // 8 content-hash bytes, hex
+		t.Fatalf("result slice ID = %q, want 16 hex chars", got.ID)
+	}
+}
+
+// Default scope: zero-value Scope is stored as Project.
+func TestRunnerDefaultScopeIsProject(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &Runner{Store: st, Executor: &fakeExecutor{results: map[string][]byte{"k": []byte("c")}}}
+	if _, err := r.Run(context.Background(), []PrefetchTask{{Key: "k"}}); err != nil {
+		t.Fatal(err)
+	}
+	all, err := st.List(slice.Project)
+	if err != nil || len(all) != 1 {
+		t.Fatalf("expected 1 project slice, got %d (%v)", len(all), err)
+	}
+}
+
+// One failing task must not abort the others; the failure is surfaced.
+func TestRunnerFailureContinues(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &Runner{
+		Store: st,
+		Executor: &fakeExecutor{
+			results: map[string][]byte{"good": []byte("good result")},
+			fails:   map[string]error{"bad": errors.New("boom")},
+		},
+	}
+	ids, err := r.Run(context.Background(), []PrefetchTask{{Key: "bad"}, {Key: "good"}})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("Run error = %v, want boom", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("Run ids = %v, want only the good result", ids)
+	}
+	all, _ := st.List(slice.Project)
+	if len(all) != 1 {
+		t.Fatalf("store has %d slices, want 1 (failed task must not persist)", len(all))
+	}
+}
+
+func TestRunnerRequiresFields(t *testing.T) {
+	r := &Runner{}
+	if _, err := r.Run(context.Background(), []PrefetchTask{{Key: "k"}}); err == nil {
+		t.Fatal("expected error for missing Store/Executor")
+	}
+}
+
+// SliceAssembler output is canonical (ID-sorted) regardless of index order.
+func TestSliceAssemblerCanonicalOrder(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ix := bm25.New()
+	seedIndexedSlice(t, st, ix, "bbb", "banana docs")
+	seedIndexedSlice(t, st, ix, "aaa", "apple docs")
+
+	content, err := (&SliceAssembler{Index: ix, K: 10}).Execute(context.Background(), PrefetchTask{Key: "docs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	iA, iB := strings.Index(text, "--- slice aaa ---"), strings.Index(text, "--- slice bbb ---")
+	if iA < 0 || iB < 0 || iA > iB {
+		t.Fatalf("assembled content not ID-sorted: %q", text)
+	}
+}
+
+func TestSliceAssemblerEmptyHits(t *testing.T) {
+	ix := bm25.New() // empty index
+	content, err := (&SliceAssembler{Index: ix, K: 3}).Execute(context.Background(), PrefetchTask{Key: "readFile"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(content) != 0 {
+		t.Fatalf("expected empty content for no hits, got %q", content)
+	}
+}
+
+// Deterministic dedup: assembling the same source twice stores one slice.
+func TestRunnerStoresDedupByContent(t *testing.T) {
+	st, err := slice.NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ix := bm25.New()
+	seedIndexedSlice(t, st, ix, "s1", "stable candidate content")
+
+	r := &Runner{Store: st, Executor: &SliceAssembler{Index: ix, K: 3}}
+	for i := 0; i < 2; i++ {
+		if _, err := r.Run(context.Background(), []PrefetchTask{{Kind: "slice-assembly", Key: "stable"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	all, err := st.List(slice.Project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := 0
+	for _, s := range all {
+		if s.Type == slice.Result {
+			results++
+		}
+	}
+	if results != 1 {
+		t.Fatalf("expected 1 deduped Result slice, got %d (%s)", results, fmt.Sprint(ids(all)))
+	}
+}
+
+func ids(slices []*slice.Slice) []string {
+	out := make([]string, len(slices))
+	for i, s := range slices {
+		out[i] = s.ID
+	}
+	return out
+}


### PR DESCRIPTION
## Issue #62 M1-U18：投机预取 Planner MVP

Closes #62（MVP 范围）。

### 实现内容

- **`kernel/prefetch/planner.go`** — `Planner` 实现冻结接口 `Prefetcher`：
  - T-Slice **2-gram 转移矩阵**：从切片库 `ToolPattern` 切片（空格分隔工具名序列）学习 `P(B|A)`；`Learn()` 构建并缓存（`RWMutex` 并发安全），同库同矩阵（确定性）；
  - **fail-closed 只读白名单**：预测目标 `∉ WhiteList` 一律丢弃，非只读工具**永不**进入预取计划；白名单为空 → 计划恒空；
  - **预算控制**：按概率降序累计 `Cost` 截断到 `Budget`（默认 1000 token/轮）+ `MaxTasks`（默认 3）上限；输出顺序确定性（概率降序、平局按名字典序）。
- **`kernel/prefetch/runner.go`** — `Runner` + `Executor` 接口（内核与具体执行解耦）：
  - 串行执行只读任务，失败不中断（`errors.Join` 汇总）；结果以 **Result 切片**写入 Store（内容哈希 ID 去重，与 `kernel/slice` 的 ID 约定一致）；
  - 内置 `SliceAssembler` 默认执行器：按预测工具名检索切片库，ID 字典序组装（字节稳定，prefix-cache 友好）。
- **测试（15 个）**：矩阵学习确定性/幂等、概率降序、预算截断（高概率优先保留）、白名单拒绝写操作、未学习空计划、并发 `-race`、Runner 入库/去重/失败续跑/默认作用域、SliceAssembler 规范顺序。
- **`docs/specs/issue-62-prefetch-planner.md`** — 实现规格（先审后写）。

### 不在本 PR（见 spec §1）

`PrefetchHit/Waste` 事件发射（类型已冻结，接线归 evolve 闭环）、embedding 执行、`sched.RoundPlan.PrefetchIDs` 联合决策接线、`file` 类任务（矩阵无参数，不猜测路径）。

### 验收

- [x] `go vet ./...` 全绿
- [x] `go test -race ./...` 全绿（Windows 本地需 cgo+gcc 不可用，已在 WSL Ubuntu go1.26.5 原生验证全包通过）
- [x] 转移矩阵从演示切片库可学习（`TestLearnTransitionMatrix` 确定性测试）
- [x] 非只读工具永不进入预取计划（`TestPlanWhiteListFailClosed` fail-closed）

分支：`feat/prefetch-planner`，基于 `upstream/main` @8ac48ee，4 个分步 commit。