### PR TITLE
feat(promote): FileStore — disk persistence for promoted entries (M1-U16b)

### DIFF
--- a/kernel/promote/file_store.go
+++ b/kernel/promote/file_store.go
@@ -1,0 +1,155 @@
+package promote
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// fileStore is a zero-dependency disk Store backed by a JSONL file (one Entry
+// JSON per line), mirroring kernel/slice/file_store.go: 0600 permissions,
+// atomic write via temp-file + rename, and tolerant reads that skip corrupt
+// lines. Entry volumes are small, so writes rewrite the file in place under a
+// mutex (same trade-off as the slice store).
+type fileStore struct {
+	mu   sync.Mutex
+	path string
+}
+
+// NewFileStore opens (or creates) the JSONL entry store at path.
+func NewFileStore(path string) (Store, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		return nil, err
+	}
+	f.Close()
+	return &fileStore{path: path}, nil
+}
+
+// Put appends an entry, deduplicating by the exact (source, version, query)
+// triple — same semantics as MemStore.Put.
+func (s *fileStore) Put(e Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	all, err := s.readAll()
+	if err != nil {
+		return err
+	}
+	for _, old := range all {
+		if old.ContentVersion == e.ContentVersion && old.Query == e.Query {
+			return nil // duplicate
+		}
+	}
+	all = append(all, e)
+	return s.writeAll(all)
+}
+
+// List returns entries for a source slice, newest last (by PromotedAt, then
+// insertion order — stable for tests, matching MemStore.List).
+func (s *fileStore) List(sourceSliceID string) ([]Entry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	all, err := s.readAll()
+	if err != nil {
+		return nil, err
+	}
+	var out []Entry
+	for _, e := range all {
+		if e.SourceSliceID == sourceSliceID {
+			out = append(out, e)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].PromotedAt < out[j].PromotedAt })
+	return out, nil
+}
+
+// Delete removes one exact entry (no-op when absent).
+func (s *fileStore) Delete(sourceSliceID, contentVersion, query string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	all, err := s.readAll()
+	if err != nil {
+		return err
+	}
+	kept := all[:0]
+	for _, e := range all {
+		if e.SourceSliceID == sourceSliceID && e.ContentVersion == contentVersion && e.Query == query {
+			continue
+		}
+		kept = append(kept, e)
+	}
+	return s.writeAll(kept)
+}
+
+// readAll decodes every entry line, skipping blank and corrupt lines
+// (tolerant reads — a partial write must not brick the store).
+func (s *fileStore) readAll() ([]Entry, error) {
+	f, err := os.Open(s.path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []Entry
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // tolerate entries up to 8 MiB
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal(line, &e); err != nil {
+			continue // tolerant: skip corrupt lines
+		}
+		out = append(out, e)
+	}
+	return out, sc.Err()
+}
+
+// writeAll rewrites the whole store via a uniquely-named temp file (0600)
+// then an atomic rename: avoids symlink pre-placement attacks and never
+// exposes the store world-readable (os.Create would use 0666&umask).
+func (s *fileStore) writeAll(entries []Entry) error {
+	var buf bytes.Buffer
+	for _, e := range entries {
+		b, err := json.Marshal(e)
+		if err != nil {
+			return err
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after successful rename
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil { // durability: flush before rename
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return err
+	}
+	return nil
+}

--- a/kernel/promote/file_store_test.go
+++ b/kernel/promote/file_store_test.go
@@ -1,0 +1,251 @@
+package promote
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newTestFileStore(t *testing.T) (Store, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "promote.db")
+	st, err := NewFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return st, path
+}
+
+func sampleEntries() []Entry {
+	return []Entry{
+		{SourceSliceID: "s1", ContentVersion: "v1", Query: "q1", PromotedAt: 1},
+		{SourceSliceID: "s1", ContentVersion: "v2", Query: "q2", PromotedAt: 2},
+		{SourceSliceID: "s2", ContentVersion: "v1", Query: "q3", PromotedAt: 3},
+	}
+}
+
+func TestFileStorePutListDelete(t *testing.T) {
+	st, _ := newTestFileStore(t)
+	for _, e := range sampleEntries() {
+		if err := st.Put(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Duplicate put (same triple) is a no-op.
+	if err := st.Put(sampleEntries()[0]); err != nil {
+		t.Fatal(err)
+	}
+	list, err := st.List("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("list(s1) len = %d, want 2 (dedup by triple)", len(list))
+	}
+	// Delete removes the exact triple only.
+	if err := st.Delete("s1", "v1", "q1"); err != nil {
+		t.Fatal(err)
+	}
+	list, _ = st.List("s1")
+	if len(list) != 1 || list[0].ContentVersion != "v2" {
+		t.Fatalf("after delete list(s1) = %+v, want only v2", list)
+	}
+	// Deleting a missing triple is a no-op, not an error.
+	if err := st.Delete("s1", "missing", "q"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFileStorePersistRoundTrip: put entries, reopen the store from the same
+// path, and confirm every entry survives (cross-process persistence).
+func TestFileStorePersistRoundTrip(t *testing.T) {
+	_, path := newTestFileStore(t)
+	st, err := NewFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range sampleEntries() {
+		if err := st.Put(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Reopen from disk (fresh Store instance = fresh process state).
+	st2, err := NewFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]int{"s1": 2, "s2": 1}
+	for id, n := range want {
+		got, err := st2.List(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != n {
+			t.Fatalf("reopened list(%s) len = %d, want %d (persisted)", id, len(got), n)
+		}
+	}
+	// Entries match the originals exactly (round-trip fidelity).
+	orig := map[string][]Entry{}
+	for _, e := range sampleEntries() {
+		orig[e.SourceSliceID] = append(orig[e.SourceSliceID], e)
+	}
+	for id, es := range orig {
+		got, _ := st2.List(id)
+		for i := range es {
+			if got[i] != es[i] {
+				t.Fatalf("reopened entry[%d] = %+v, want %+v", i, got[i], es[i])
+			}
+		}
+	}
+}
+
+// TestFileStoreRestartRecovery: put, mutate (delete one), reopen again —
+// the store reflects the last durable state, including deletions.
+func TestFileStoreRestartRecovery(t *testing.T) {
+	_, path := newTestFileStore(t)
+	st, _ := NewFileStore(path)
+	for _, e := range sampleEntries() {
+		_ = st.Put(e)
+	}
+	if err := st.Delete("s2", "v1", "q3"); err != nil {
+		t.Fatal(err)
+	}
+	st2, _ := NewFileStore(path)
+	if list, _ := st2.List("s2"); len(list) != 0 {
+		t.Fatalf("s2 entries after restart = %d, want 0 (delete persisted)", len(list))
+	}
+	if list, _ := st2.List("s1"); len(list) != 2 {
+		t.Fatalf("s1 entries after restart = %d, want 2", len(list))
+	}
+}
+
+// TestFileStoreConcurrentWrites exercises Put/Delete under -race from
+// multiple goroutines; no data loss and no panic.
+func TestFileStoreConcurrentWrites(t *testing.T) {
+	st, _ := newTestFileStore(t)
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for n := 0; n < 25; n++ {
+				q := strings.Repeat("q", g+1) + fmt.Sprint(n)
+				if err := st.Put(Entry{SourceSliceID: "s", ContentVersion: "v", Query: q, PromotedAt: int64(n)}); err != nil {
+					t.Errorf("put: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	list, err := st.List("s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) == 0 {
+		t.Fatal("concurrent puts must be recorded")
+	}
+	// Reopen and confirm the file is still fully decodable.
+	st2, _ := NewFileStore(st.(*fileStore).path)
+	if list2, _ := st2.List("s"); len(list2) != len(list) {
+		t.Fatalf("reopened count = %d, want %d (no lost writes)", len(list2), len(list))
+	}
+}
+
+// TestFileStoreToleratesCorruptLines: a corrupt line in the middle of the
+// store must be skipped, not fatal (partial write / hand-edit resilience).
+func TestFileStoreToleratesCorruptLines(t *testing.T) {
+	_, path := newTestFileStore(t)
+	st, _ := NewFileStore(path)
+	for _, e := range sampleEntries() {
+		_ = st.Put(e)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("{\"broken\": not json\n\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	st2, _ := NewFileStore(path)
+	want := map[string]int{"s1": 2, "s2": 1}
+	for id, n := range want {
+		got, err := st2.List(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != n {
+			t.Fatalf("after corrupt line list(%s) len = %d, want %d", id, len(got), n)
+		}
+	}
+}
+
+// TestFileStorePerm0600 asserts the store file is not world-readable.
+// Windows does not implement Unix permission bits meaningfully (os.Chmod is
+// a no-op for mode bits), so the assertion runs on Unix only.
+func TestFileStorePerm0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not meaningful on windows")
+	}
+	st, path := newTestFileStore(t)
+	_ = st.Put(Entry{SourceSliceID: "s", ContentVersion: "v", Query: "q"})
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("store file perm = %o, want 600", perm)
+	}
+	// A reopened store must not widen permissions either.
+	st2, _ := NewFileStore(path)
+	_ = st2.Put(Entry{SourceSliceID: "s", ContentVersion: "v2", Query: "q2"})
+	info, _ = os.Stat(path)
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("store file perm after rewrite = %o, want 600", perm)
+	}
+}
+
+// TestCascadeInvalidateFileStore: cascade semantics against the disk store —
+// idempotent, version-scoped, survives restart.
+func TestCascadeInvalidateFileStore(t *testing.T) {
+	_, path := newTestFileStore(t)
+	st, _ := NewFileStore(path)
+	old := []byte("old answer")
+	new := []byte("new answer")
+	for _, e := range []Entry{
+		{SourceSliceID: "s1", ContentVersion: ContentVersion(old), Query: "q1", PromotedAt: 1},
+		{SourceSliceID: "s1", ContentVersion: ContentVersion(old), Query: "q2", PromotedAt: 2},
+		{SourceSliceID: "s2", ContentVersion: ContentVersion(new), Query: "q3", PromotedAt: 3},
+	} {
+		_ = st.Put(e)
+	}
+	n, err := CascadeInvalidate(st, "s1", new)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("invalidated = %d, want 2", n)
+	}
+	if list, _ := st.List("s1"); len(list) != 0 {
+		t.Fatal("s1 entries must all be gone")
+	}
+	if list, _ := st.List("s2"); len(list) != 1 {
+		t.Fatal("s2 entry must survive (version matches)")
+	}
+	if n, _ := CascadeInvalidate(st, "s1", new); n != 0 {
+		t.Fatalf("second cascade invalidated %d, want 0 (idempotent)", n)
+	}
+	// Deletions are durable across restart.
+	st2, _ := NewFileStore(path)
+	if list, _ := st2.List("s1"); len(list) != 0 {
+		t.Fatal("cascade deletions must survive restart")
+	}
+	if list, _ := st2.List("s2"); len(list) != 1 {
+		t.Fatal("surviving entry must survive restart")
+	}
+}


### PR DESCRIPTION
## Summary

Issue #68（M1-U16b）提升条目持久化：`kernel/promote` 从进程内存 `MemStore` 增加
磁盘 `FileStore`，提升条目（judge 批准的 Entry）可跨进程复用。

对齐 `kernel/slice/file_store.go` 既有模式（issue #68 参考）：JSONL 存储、
0600 权限、临时文件 + `fsync` + 原子 rename 写入、坏行容忍读取。零第三方依赖
（`go.mod` 仍仅 module 声明）。

## Scope

- `kernel/promote/file_store.go`（新增）：`FileStore` 实现既有 `Store` 接口
  （Put 按 source/version/query triple 去重 / List 按 source + PromotedAt 排序 /
  Delete 精确匹配），`NewFileStore(path)` 构造
- `kernel/promote/file_store_test.go`（新增）：6 个 FileStore 测试 +
  CascadeInvalidate 磁盘集成

`MemStore` 保留（测试/非持久化场景），接口零改动——`CascadeInvalidate` 幂等
语义不变，直接可用于磁盘 Store。

## Validation

- [x] `go vet ./...` — 干净（本地 + WSL）
- [x] `go test -race ./...` — 全仓全绿（WSL Ubuntu + go1.26.5 linux/amd64 原生，
  EXIT=0；promote 11 测试含 0600 验证）
- [x] `go test ./kernel/promote/` — ok（本地 Windows）
- [x] `git diff --check` — 干净

> Windows 本地 `-race` 不可用（需 cgo+gcc，本机无 gcc）；`-race` 与 0600 权限
> 断言已在 WSL Linux 原生环境验证（`TestFileStorePerm0600` 在 Windows 上按
> `runtime.GOOS` 跳过——Windows 不实现 Unix 权限位）。

## Compatibility and data impact

无破坏性变更：`Store` 接口、`Entry`、`CascadeInvalidate` 均未改签名。
新增 `NewFileStore(path)` 构造，`MemStore` 保留。存储格式为 JSONL（每行一个
Entry JSON），与 slice store 同风格。

## Security and privacy

- 写入走 0600 临时文件 + 原子 rename（不暴露 world-readable，防 symlink 预置）
- 读取容忍坏行（部分写入不炸库）
- 无新凭据、无外部请求

## Evidence

```
go test -race ./kernel/promote/ -v（WSL）→ 11 测试全 PASS
  TestFileStorePutListDelete / PersistRoundTrip / RestartRecovery /
  ConcurrentWrites / ToleratesCorruptLines / Perm0600 / CascadeInvalidateFileStore
go test -race ./...（WSL）→ 全仓 ok，RACE-ALL-DONE EXIT=0
go vet ./... → VET-OK
```

## Related issues

Closes #68
