### PR TITLE
feat(sched/prefetch): M1-U18b — RuleDecider + MatrixPrefetcher 权威实现落库与整合

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Write operations are never blindly replayed.
 
 # Adaptive Kernel Scheduler
 
-> **Status: in progress** — a rule-based decider exists in `kernel/sched`; learned model-tiering and concurrency learning are planned.
+> **Status: shipped (MVP)** — `kernel/sched.RuleDecider` implements parallel groups, a behavior-learning gate, model tiering, and prefetch hints (see `docs/Agile路线图.md` H3); provider-level model switching is planned.
 
 Semantix is not only a cache.
 
@@ -340,7 +340,7 @@ Optimization should never come before task correctness.
 
 # Speculative Prefetch
 
-> **Status: design phase** — only the interface skeleton (`kernel/prefetch`) exists; implementation is planned for a later milestone.
+> **Status: shipped (MVP)** — `kernel/prefetch` ships `Planner` (offline, Issue 62) + `MatrixPrefetcher` (online, hit/waste feedback) plus a `Runner`; wired into the scheduler via `prefetch.AsPlanFunc` (see `docs/Agile路线图.md` H5).
 
 Agent execution contains a surprising amount of waiting.
 
@@ -900,8 +900,8 @@ Architecture v2                    ✅
 P0 · Observability                ✅  kernel/event + kernel/usage (cost savings)
 P1 · Semantic Slice Library       🚧  extract + BM25/hybrid search shipped; local embeddings + ANN pending
 P2 · Semantic Cache               🚧  L2 injection + L3 verified reuse shipped; real-harness e2e pending
-P3 · Adaptive Scheduler           🚧  rule-based decider (kernel/sched); learned tiering pending
-P4 · Speculative Prefetch         ⏳  interface skeleton only (kernel/prefetch)
+P3 · Adaptive Scheduler           ✅  kernel/sched.RuleDecider — parallel groups + behavior gate + tier + prefetch hints (MVP)
+P4 · Speculative Prefetch         ✅  Planner (offline seed) + MatrixPrefetcher (online, hit/waste) + Runner (MVP)
 P5 · Evolution Loop               ✅  kernel/evolve — online adaptation + offline optimization (MVP)
 ```
 

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -1,0 +1,225 @@
+// Package prefetch implements the M3 MVP speculative prefetcher (N12):
+// during LLM wait time, fill the idle window with cheap read-only work that
+// the next tool round is likely to need. Only read-only targets are ever
+// proposed (prefetching must never cause side effects).
+//
+// Design (see 总体架构-流程树.md §N12 and Agent-Infra-架构设计.md §P4):
+//   - transition matrix: tool-name bigrams observed from real rounds give
+//     P(next | last); high-confidence successors become prefetch candidates;
+//   - budget: each task carries a cost; Plan stops once the total budget is
+//     exhausted (single prefetch ≤ 2k token equivalent by default);
+//   - waste penalty: hit/waste feedback per candidate decays its confidence
+//     (waste/hit > 3:1 auto-demotes), so the prefetcher learns when betting
+//     is worth it — the same signal family the evolution engine consumes.
+//
+// The Prefetcher interface (Plan) is frozen since U1; two implementations
+// ship side by side (see docs/Agile路线图.md H5):
+//
+//   - Planner (planner.go, Issue 62 MVP): offline — Learn() rebuilds the
+//     transition matrix from the slice library's ToolPattern slices; a
+//     whitelist makes it fail-closed (empty whitelist = no prefetch).
+//   - MatrixPrefetcher (this file, N12 authority): online — Observe()
+//     updates bigram counts per executed tool, hit/waste feedback decays
+//     candidate confidence (waste/hit > 3:1 auto-demotes), and only tools
+//     observed read-only are ever proposed.
+//
+// They are complementary (offline seed vs online learning); the harness
+// picks one and wires it into sched.RuleDecider via AsPlanFunc.
+package prefetch
+
+import (
+	"sort"
+	"sync"
+)
+
+// Config carries operator knobs; zero values select documented defaults.
+type Config struct {
+	// TopK caps the number of tasks returned per Plan (default 3).
+	TopK int
+	// MinConf is the minimum transition probability for a candidate to be
+	// proposed (default 0.5, aligned with evolve.PrefetchConf).
+	MinConf float64
+	// MaxCost caps the total estimated cost of one Plan (default 2000,
+	// i.e. ~2k tokens of assembly work per wait window).
+	MaxCost int
+	// BaseCost is the estimated cost of one slice-assembly task
+	// (default 512; assembly re-reads a few slices).
+	BaseCost int
+	// WasteHitLimit: candidates whose waste/hit EWMA ratio exceeds this are
+	// demoted (default 3.0 — N12 "waste/hit > 3:1 自动降权").
+	WasteHitLimit float64
+	// Decay is the EWMA smoothing for hit/waste rates (default 0.2).
+	Decay float64
+}
+
+// Defaults returns the built-in configuration.
+func Defaults() Config {
+	return Config{
+		TopK:          3,
+		MinConf:       0.5,
+		MaxCost:       2000,
+		BaseCost:      512,
+		WasteHitLimit: 3.0,
+		Decay:         0.2,
+	}
+}
+
+// MatrixPrefetcher learns tool-transition patterns and plans speculative
+// read-only prefetch tasks. Safe for concurrent use.
+type MatrixPrefetcher struct {
+	mu       sync.Mutex
+	cfg      Config
+	bigrams  map[string]map[string]int // prev -> next -> count
+	counts   map[string]int            // prev -> total transitions
+	readOnly map[string]bool           // next -> observed read-only (safe to prefetch)
+	hit      map[string]float64        // key -> EWMA hit rate
+	waste    map[string]float64        // key -> EWMA waste rate
+}
+
+// NewMatrixPrefetcher builds a MatrixPrefetcher with cfg (zero → Defaults).
+func NewMatrixPrefetcher(cfg Config) *MatrixPrefetcher {
+	def := Defaults()
+	if cfg.TopK <= 0 {
+		cfg.TopK = def.TopK
+	}
+	if cfg.MinConf <= 0 || cfg.MinConf > 1 {
+		cfg.MinConf = def.MinConf
+	}
+	if cfg.MaxCost <= 0 {
+		cfg.MaxCost = def.MaxCost
+	}
+	if cfg.BaseCost <= 0 {
+		cfg.BaseCost = def.BaseCost
+	}
+	if cfg.WasteHitLimit <= 0 {
+		cfg.WasteHitLimit = def.WasteHitLimit
+	}
+	if cfg.Decay <= 0 || cfg.Decay > 1 {
+		cfg.Decay = def.Decay
+	}
+	return &MatrixPrefetcher{
+		cfg:      cfg,
+		bigrams:  make(map[string]map[string]int),
+		counts:   make(map[string]int),
+		readOnly: make(map[string]bool),
+		hit:      make(map[string]float64),
+		waste:    make(map[string]float64),
+	}
+}
+
+// Observe records one tool transition prev -> next. readOnly marks whether
+// next is a safe (read-only) prefetch target; only read-only successors are
+// ever proposed by Plan. The harness should call this once per executed
+// tool, chaining transitions within and across rounds.
+func (m *MatrixPrefetcher) Observe(prev, next string, readOnly bool) {
+	if prev == "" || next == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.bigrams[prev]; !ok {
+		m.bigrams[prev] = make(map[string]int)
+	}
+	m.bigrams[prev][next]++
+	m.counts[prev]++
+	if readOnly {
+		m.readOnly[next] = true
+	}
+}
+
+// Plan implements the frozen Prefetcher interface: given the last tool
+// names, propose the most likely read-only successors within budget.
+// Unknown last tools (no history) yield an empty plan, never an error.
+func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) {
+	if len(lastToolNames) == 0 {
+		return nil, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	last := lastToolNames[len(lastToolNames)-1]
+	transitions := m.bigrams[last]
+	total := m.counts[last]
+	if total == 0 || len(transitions) == 0 {
+		return nil, nil
+	}
+
+	type cand struct {
+		key  string
+		prob float64
+	}
+	var cands []cand
+	for next, cnt := range transitions {
+		if !m.readOnly[next] {
+			continue // never prefetch a writer
+		}
+		prob := float64(cnt) / float64(total)
+		if prob < m.cfg.MinConf {
+			continue
+		}
+		if m.demoted(next) {
+			continue // waste/hit penalty
+		}
+		cands = append(cands, cand{key: next, prob: prob})
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].prob > cands[j].prob })
+
+	var tasks []PrefetchTask
+	cost := 0
+	for _, c := range cands {
+		if len(tasks) >= m.cfg.TopK {
+			break
+		}
+		if cost+m.cfg.BaseCost > m.cfg.MaxCost {
+			break
+		}
+		tasks = append(tasks, PrefetchTask{
+			Kind: "slice-assembly",
+			Key:  c.key,
+			Cost: m.cfg.BaseCost,
+		})
+		cost += m.cfg.BaseCost
+	}
+	return tasks, nil
+}
+
+// ObserveHit marks a planned prefetch as useful (the predicted tool was
+// actually called).
+func (m *MatrixPrefetcher) ObserveHit(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hit[key] = ewma(m.hit[key], 1, m.cfg.Decay)
+}
+
+// ObserveWaste marks a planned prefetch as wasted (the predicted tool was
+// not called, or its result was unused).
+func (m *MatrixPrefetcher) ObserveWaste(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waste[key] = ewma(m.waste[key], 1, m.cfg.Decay)
+}
+
+// Stats returns a snapshot of the transition matrix (observability).
+type Stats struct {
+	Transitions int            // total observed transitions
+	Pairs       map[string]int // prev -> total transitions
+	TopNext     map[string]int // prev -> next -> count (flattened key "prev→next")
+}
+
+// demoted reports whether a candidate's waste/hit ratio exceeds the limit.
+// Caller holds m.mu. A candidate with zero waste is never demoted.
+func (m *MatrixPrefetcher) demoted(key string) bool {
+	w, h := m.waste[key], m.hit[key]
+	if w == 0 {
+		return false
+	}
+	if h == 0 {
+		return true // all waste, no hits: demote
+	}
+	return w/h > m.cfg.WasteHitLimit
+}
+
+// ewma folds one binary sample into a rate.
+func ewma(prev, sample, alpha float64) float64 {
+	return alpha*sample + (1-alpha)*prev
+}

--- a/kernel/prefetch/matrix_test.go
+++ b/kernel/prefetch/matrix_test.go
@@ -1,0 +1,197 @@
+package prefetch
+
+import (
+	"sync"
+	"testing"
+)
+
+// --- transition learning ---
+
+func TestPlanReturnsHighConfidenceSuccessor(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	// bash -> grep 9/10, bash -> read_file 1/10
+	for i := 0; i < 9; i++ {
+		m.Observe("bash", "grep", true)
+	}
+	m.Observe("bash", "read_file", true)
+
+	tasks, err := m.Plan([]string{"bash"})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(tasks) == 0 {
+		t.Fatal("want at least one task")
+	}
+	if tasks[0].Key != "grep" {
+		t.Fatalf("want grep first, got %v", tasks)
+	}
+	if tasks[0].Kind != "slice-assembly" {
+		t.Fatalf("want slice-assembly kind, got %s", tasks[0].Kind)
+	}
+}
+
+func TestPlanEmptyOnUnknownLastTool(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	m.Observe("bash", "grep", true)
+	tasks, err := m.Plan([]string{"never_seen"})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if tasks != nil {
+		t.Fatalf("want nil, got %v", tasks)
+	}
+}
+
+func TestPlanEmptyWithoutHistory(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	tasks, err := m.Plan([]string{"bash"})
+	if err != nil || tasks != nil {
+		t.Fatalf("want nil,nil got %v,%v", tasks, err)
+	}
+}
+
+// --- safety: never prefetch writers ---
+
+func TestPlanNeverPrefetchesWriters(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	m.Observe("bash", "edit_file", false) // writer: not marked read-only
+	m.Observe("bash", "grep", true)
+	tasks, _ := m.Plan([]string{"bash"})
+	for _, task := range tasks {
+		if task.Key == "edit_file" {
+			t.Fatalf("must never prefetch a writer: %v", tasks)
+		}
+	}
+	if len(tasks) != 1 || tasks[0].Key != "grep" {
+		t.Fatalf("want only grep, got %v", tasks)
+	}
+}
+
+// --- confidence filter ---
+
+func TestPlanMinConfFilter(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.8})
+	for i := 0; i < 5; i++ {
+		m.Observe("bash", "grep", true)
+	}
+	m.Observe("bash", "ls", true) // 1/6 ≈ 0.17 < 0.8
+	tasks, _ := m.Plan([]string{"bash"})
+	if len(tasks) != 1 || tasks[0].Key != "grep" {
+		t.Fatalf("low-confidence successor must be filtered, got %v", tasks)
+	}
+}
+
+// --- budget & topk ---
+
+func TestPlanRespectsTopKAndBudget(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.1, TopK: 2, MaxCost: 1024, BaseCost: 512})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "grep", true)
+		m.Observe("bash", "ls", true)
+		m.Observe("bash", "find", true)
+		m.Observe("bash", "cat", true)
+	}
+	tasks, _ := m.Plan([]string{"bash"})
+	if len(tasks) != 2 { // TopK=2, budget 1024 = 2×512
+		t.Fatalf("want 2 tasks, got %v", tasks)
+	}
+}
+
+// --- waste penalty ---
+
+func TestWastePenaltyDemotesCandidate(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{WasteHitLimit: 3.0})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "grep", true)
+	}
+	// heavy waste, no hits -> ratio ∞ -> demoted
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("grep")
+	}
+	tasks, _ := m.Plan([]string{"bash"})
+	if tasks != nil {
+		t.Fatalf("all-waste candidate must be demoted, got %v", tasks)
+	}
+}
+
+func TestWastePenaltyAllowsHealthyCandidate(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{WasteHitLimit: 3.0})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "grep", true)
+	}
+	// hits outweigh waste -> ratio 1/4 = 0.25 < 3 -> still proposed
+	m.ObserveHit("grep")
+	m.ObserveHit("grep")
+	m.ObserveHit("grep")
+	m.ObserveHit("grep")
+	m.ObserveWaste("grep")
+	tasks, _ := m.Plan([]string{"bash"})
+	if len(tasks) != 1 || tasks[0].Key != "grep" {
+		t.Fatalf("healthy candidate must survive, got %v", tasks)
+	}
+}
+
+// --- determinism & concurrency ---
+
+func TestPlanDeterministicOrder(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	// equal counts: sort by probability only, so ties are stable by sort
+	// stability? sort.Slice is not stable — keep probabilities distinct.
+	for i := 0; i < 5; i++ {
+		m.Observe("bash", "grep", true)
+	}
+	for i := 0; i < 3; i++ {
+		m.Observe("bash", "ls", true)
+	}
+	t1, _ := m.Plan([]string{"bash"})
+	t2, _ := m.Plan([]string{"bash"})
+	if t1[0].Key != t2[0].Key {
+		t.Fatalf("nondeterministic order: %v vs %v", t1, t2)
+	}
+}
+
+func TestConcurrentObserveAndPlan(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				m.Observe("bash", "grep", true)
+				_, _ = m.Plan([]string{"bash"})
+			}
+		}()
+	}
+	wg.Wait()
+	tasks, err := m.Plan([]string{"bash"})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(tasks) == 0 {
+		t.Fatal("expected learned transitions after concurrent observe")
+	}
+}
+
+// --- edge cases ---
+
+func TestObserveIgnoresEmpty(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	m.Observe("", "grep", true)
+	m.Observe("bash", "", true)
+	tasks, _ := m.Plan([]string{"bash"})
+	if tasks != nil {
+		t.Fatalf("empty transitions must not create state, got %v", tasks)
+	}
+}
+
+func TestPlanUsesLastToolOfSequence(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	m.Observe("bash", "grep", true)
+	m.Observe("grep", "read_file", true)
+	// sequence [bash, grep] → last is grep → read_file
+	tasks, _ := m.Plan([]string{"bash", "grep"})
+	if len(tasks) != 1 || tasks[0].Key != "read_file" {
+		t.Fatalf("want read_file, got %v", tasks)
+	}
+}

--- a/kernel/prefetch/planfunc.go
+++ b/kernel/prefetch/planfunc.go
@@ -1,0 +1,23 @@
+package prefetch
+
+// AsPlanFunc adapts any Prefetcher to the scheduler's prefetch-plan shape
+// (func(lastToolNames []string) []string) so sched.RuleDecider can hold a
+// prefetcher without importing this package — the dependency direction stays
+// sched → nothing. Each planned task is reduced to its Key; a nil prefetcher,
+// an errored plan, or an empty plan all yield nil.
+func AsPlanFunc(p Prefetcher) func(lastToolNames []string) []string {
+	if p == nil {
+		return func([]string) []string { return nil }
+	}
+	return func(lastToolNames []string) []string {
+		tasks, err := p.Plan(lastToolNames)
+		if err != nil || len(tasks) == 0 {
+			return nil
+		}
+		keys := make([]string, 0, len(tasks))
+		for _, t := range tasks {
+			keys = append(keys, t.Key)
+		}
+		return keys
+	}
+}

--- a/kernel/prefetch/planfunc_test.go
+++ b/kernel/prefetch/planfunc_test.go
@@ -1,0 +1,82 @@
+package prefetch
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// fakePrefetcher is a scripted Prefetcher for adapter tests.
+type fakePrefetcher struct {
+	tasks []PrefetchTask
+	err   error
+	last  []string // records the last Plan input
+}
+
+func (f *fakePrefetcher) Plan(last []string) ([]PrefetchTask, error) {
+	f.last = append([]string(nil), last...)
+	return f.tasks, f.err
+}
+
+func TestAsPlanFuncReducesTasksToKeys(t *testing.T) {
+	f := &fakePrefetcher{tasks: []PrefetchTask{
+		{Kind: "slice-assembly", Key: "search", Cost: 512},
+		{Kind: "slice-assembly", Key: "read_file", Cost: 512},
+	}}
+	fn := AsPlanFunc(f)
+	got := fn([]string{"complete_step", "search"})
+	want := []string{"search", "read_file"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AsPlanFunc keys = %v, want %v", got, want)
+	}
+	if !reflect.DeepEqual(f.last, []string{"complete_step", "search"}) {
+		t.Fatalf("last tool names not forwarded: %v", f.last)
+	}
+}
+
+func TestAsPlanFuncNilPrefetcher(t *testing.T) {
+	fn := AsPlanFunc(nil)
+	if got := fn([]string{"search"}); got != nil {
+		t.Fatalf("nil prefetcher should yield nil plan, got %v", got)
+	}
+}
+
+func TestAsPlanFuncErrorYieldsNil(t *testing.T) {
+	f := &fakePrefetcher{err: errors.New("boom")}
+	fn := AsPlanFunc(f)
+	if got := fn([]string{"search"}); got != nil {
+		t.Fatalf("errored plan should yield nil, got %v", got)
+	}
+}
+
+func TestAsPlanFuncEmptyPlanYieldsNil(t *testing.T) {
+	f := &fakePrefetcher{}
+	fn := AsPlanFunc(f)
+	if got := fn([]string{"search"}); got != nil {
+		t.Fatalf("empty plan should yield nil, got %v", got)
+	}
+}
+
+func TestAsPlanFuncWorksWithMatrixPrefetcher(t *testing.T) {
+	// Integration: the real online prefetcher wired through the adapter
+	// behaves the same as calling Plan directly.
+	m := NewMatrixPrefetcher(Config{})
+	m.Observe("search", "read_file", true)
+	m.Observe("search", "read_file", true)
+	m.Observe("search", "write_file", false)
+
+	direct, err := m.Plan([]string{"search"})
+	if err != nil {
+		t.Fatalf("direct Plan: %v", err)
+	}
+	directKeys := make([]string, 0, len(direct))
+	for _, task := range direct {
+		directKeys = append(directKeys, task.Key)
+	}
+
+	fn := AsPlanFunc(m)
+	got := fn([]string{"search"})
+	if !reflect.DeepEqual(got, directKeys) {
+		t.Fatalf("AsPlanFunc = %v, direct Plan keys = %v", got, directKeys)
+	}
+}

--- a/kernel/sched/rule_decider.go
+++ b/kernel/sched/rule_decider.go
@@ -1,0 +1,336 @@
+// Package sched implements the M3 MVP scheduler (N04): one tool round's
+// resource orchestration — parallel groups, model tier, injection list, and
+// prefetch hints — decided by deterministic rules plus a light behavior-
+// learning overlay.
+//
+// Design (see 总体架构-流程树.md §N04 and Agent-Infra-架构设计.md §P3):
+//   - static base: contiguous known read-only tools form parallel groups,
+//     writers/unknowns/blacklisted tools run serially (provider order kept);
+//   - behavior learning: a read-only tool whose recent success history is
+//     below the floor is treated as unsafe to parallelize (candidates must
+//     pass the behavior gate, per N04 "候选须过静态数据依赖检查");
+//   - tier: writer presence or a large round → pro, otherwise the default
+//     (flash) tier;
+//   - injection list: SliceHits ids in canonical (ID-ascending) order, so the
+//     byte-stable prefix-cache invariant is preserved.
+//
+// The Decider interface itself (DecideRound) is frozen since U1; this file
+// adds the concrete implementation.
+package sched
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"semantix/kernel/slice"
+)
+
+// SerialToolNames are the built-in tools that never join a parallel group
+// (kept in sync with the reasonix harness partitionToolCalls blacklist:
+// complete_step, todo_write, wait, bash_output, use_capability, compress).
+var SerialToolNames = map[string]struct{}{
+	"complete_step":  {},
+	"todo_write":     {},
+	"wait":           {},
+	"bash_output":    {},
+	"use_capability": {},
+	"compress":       {},
+}
+
+// PrefetchPlanFunc optionally maps the current round's tool names to
+// prefetch target keys (tool names). The kernel prefetch package plugs in
+// here so RoundPlan.PrefetchIDs stays populated without sched importing
+// prefetch (keeps the dependency direction sched → nothing).
+type PrefetchPlanFunc func(lastToolNames []string) []string
+
+// Config carries operator knobs; zero values select documented defaults.
+type Config struct {
+	// MaxParallel caps how many read-only tools may run in one parallel
+	// group (default 8, mirrors the harness runParallel semaphore).
+	MaxParallel int
+	// MinSamples is the behavior-statistics sample count a tool needs
+	// before the success gate applies (default 5).
+	MinSamples int
+	// SuccessFloor: a read-only tool whose success rate is below this
+	// (with >= MinSamples samples) is pulled out of parallel groups
+	// (default 0.7).
+	SuccessFloor float64
+	// ComplexTools: a round with more calls than this is scheduled to the
+	// pro tier (default 3).
+	ComplexTools int
+	// DefaultTier names the cheap tier (default "flash").
+	DefaultTier string
+	// ProTier names the strong tier (default "pro").
+	ProTier string
+	// InjectMax caps the InjectIDs list length (default 8).
+	InjectMax int
+	// SerialTools adds extra tool names that never parallelize, on top of
+	// the built-in SerialToolNames set.
+	SerialTools []string
+}
+
+// Defaults returns the built-in configuration.
+func Defaults() Config {
+	return Config{
+		MaxParallel:  8,
+		MinSamples:   5,
+		SuccessFloor: 0.7,
+		ComplexTools: 3,
+		DefaultTier:  "flash",
+		ProTier:      "pro",
+		InjectMax:    8,
+	}
+}
+
+// toolStat is one tool's recent behavior history (all access under
+// RuleDecider.mu).
+type toolStat struct {
+	runs     int
+	failures int
+	durMs    int64
+}
+
+// successRate returns the tool's observed success rate; 1 for no history.
+func (t *toolStat) successRate() float64 {
+	if t == nil || t.runs == 0 {
+		return 1
+	}
+	return float64(t.runs-t.failures) / float64(t.runs)
+}
+
+// RuleDecider is the concrete M3 Decider. Safe for concurrent use: each
+// DecideRound call is independent and Observe only mutates stats under the
+// lock. It is a plain struct (no interface split) so the harness can hold
+// it directly; it satisfies the frozen Decider interface.
+type RuleDecider struct {
+	mu         sync.Mutex
+	cfg        Config
+	stats      map[string]*toolStat
+	prefetchFn PrefetchPlanFunc
+}
+
+// NewRuleDecider builds a RuleDecider with cfg (zero values → Defaults).
+func NewRuleDecider(cfg Config) *RuleDecider {
+	def := Defaults()
+	if cfg.MaxParallel <= 0 {
+		cfg.MaxParallel = def.MaxParallel
+	}
+	if cfg.MinSamples <= 0 {
+		cfg.MinSamples = def.MinSamples
+	}
+	if cfg.SuccessFloor <= 0 || cfg.SuccessFloor > 1 {
+		cfg.SuccessFloor = def.SuccessFloor
+	}
+	if cfg.ComplexTools <= 0 {
+		cfg.ComplexTools = def.ComplexTools
+	}
+	if cfg.DefaultTier == "" {
+		cfg.DefaultTier = def.DefaultTier
+	}
+	if cfg.ProTier == "" {
+		cfg.ProTier = def.ProTier
+	}
+	if cfg.InjectMax <= 0 {
+		cfg.InjectMax = def.InjectMax
+	}
+	return &RuleDecider{
+		cfg:   cfg,
+		stats: make(map[string]*toolStat),
+	}
+}
+
+// SetPrefetchPlanFunc wires the optional prefetch planner (nil disables).
+func (d *RuleDecider) SetPrefetchPlanFunc(fn PrefetchPlanFunc) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.prefetchFn = fn
+}
+
+// DecideRound implements the frozen Decider interface.
+func (d *RuleDecider) DecideRound(ctx context.Context, in RoundInput) (RoundPlan, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	plan := RoundPlan{
+		ParallelGroups: d.partition(in.ToolCalls),
+		Tier:           decideTier(in.ToolCalls, d.cfg),
+		InjectIDs:      canonicalInjectIDs(in.SliceHits, d.cfg.InjectMax),
+	}
+	if d.prefetchFn != nil {
+		plan.PrefetchIDs = d.prefetchFn(toolNames(in.ToolCalls))
+	}
+	return plan, nil
+}
+
+// Observe feeds one completed tool round back into the behavior statistics.
+// Every executed tool call should be reported once; unexecuted (blocked/
+// cancelled) calls should be reported with success=false when the failure
+// is attributed to the tool itself. Duration is milliseconds.
+func (d *RuleDecider) Observe(name string, success bool, durMs int64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	st := d.stats[name]
+	if st == nil {
+		st = &toolStat{}
+		d.stats[name] = st
+	}
+	st.runs++
+	if !success {
+		st.failures++
+	}
+	st.durMs += durMs
+}
+
+// ToolStatSnapshot is the exported, immutable view of one tool's history.
+type ToolStatSnapshot struct {
+	Runs        int
+	Failures    int
+	DurationMs  int64
+	SuccessRate float64
+}
+
+// Stats returns a snapshot of the observed per-tool statistics (for
+// observability / the cost dashboard).
+func (d *RuleDecider) Stats() map[string]ToolStatSnapshot {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]ToolStatSnapshot, len(d.stats))
+	for name, st := range d.stats {
+		out[name] = ToolStatSnapshot{
+			Runs:        st.runs,
+			Failures:    st.failures,
+			DurationMs:  st.durMs,
+			SuccessRate: st.successRate(),
+		}
+	}
+	return out
+}
+
+// serialNames merges built-in and configured serial tools into one set.
+func (d *RuleDecider) serialNames() map[string]struct{} {
+	if len(d.cfg.SerialTools) == 0 {
+		return SerialToolNames
+	}
+	out := make(map[string]struct{}, len(SerialToolNames)+len(d.cfg.SerialTools))
+	for n := range SerialToolNames {
+		out[n] = struct{}{}
+	}
+	for _, n := range d.cfg.SerialTools {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
+// partition splits calls into parallel groups (contiguous read-only calls
+// that pass both the static blacklist and the behavior gate) and serial
+// singles, preserving provider order. A read-only tool whose behavior
+// history fails the success gate is pulled into its own serial slot —
+// conservative: an unreliable read may still be re-run safely, but must not
+// run concurrently with siblings that could depend on it. Called with d.mu
+// held.
+func (d *RuleDecider) partition(calls []ToolCallInfo) [][]string {
+	serial := d.serialNames()
+	var groups [][]string
+	for i := 0; i < len(calls); {
+		if d.parallelisable(calls[i], serial) {
+			start := i
+			i++
+			for i < len(calls) && d.parallelisable(calls[i], serial) {
+				i++
+			}
+			// Sub-split oversized groups under the cap.
+			cap := d.cfg.MaxParallel
+			for s := start; s < i; s += cap {
+				end := s + cap
+				if end > i {
+					end = i
+				}
+				groups = append(groups, ids(calls[s:end]))
+			}
+			continue
+		}
+		groups = append(groups, []string{calls[i].CallID})
+		i++
+	}
+	return groups
+}
+
+// parallelisable reports whether call may join a parallel group: known
+// read-only, not blacklisted, and passing the behavior gate. Called with
+// d.mu held.
+func (d *RuleDecider) parallelisable(c ToolCallInfo, serial map[string]struct{}) bool {
+	if !c.ReadOnly {
+		return false
+	}
+	if _, black := serial[c.Name]; black {
+		return false
+	}
+	return d.passesBehaviorGate(c.Name)
+}
+
+// passesBehaviorGate applies the behavior-learning overlay: a tool with
+// enough history whose success rate falls below the floor runs serially.
+// Unknown tools (no history) pass by default. Called with d.mu held.
+func (d *RuleDecider) passesBehaviorGate(name string) bool {
+	st := d.stats[name]
+	if st == nil || st.runs < d.cfg.MinSamples {
+		return true // no evidence yet: default to the static rule
+	}
+	return st.successRate() >= d.cfg.SuccessFloor
+}
+
+// decideTier maps a round to a model tier: any writer or a large round goes
+// to the pro tier, everything else to the default (flash) tier.
+func decideTier(calls []ToolCallInfo, cfg Config) string {
+	for _, c := range calls {
+		if !c.ReadOnly {
+			return cfg.ProTier
+		}
+	}
+	if len(calls) > cfg.ComplexTools {
+		return cfg.ProTier
+	}
+	return cfg.DefaultTier
+}
+
+// canonicalInjectIDs returns hit slice ids in canonical (ID-ascending)
+// order, capped at InjectMax. Canonical order keeps the injected block
+// byte-stable across rounds — never score order (inject §design invariants).
+func canonicalInjectIDs(hits []slice.Hit, max int) []string {
+	ids := make([]string, 0, len(hits))
+	for _, h := range hits {
+		if h.Slice != nil {
+			ids = append(ids, h.Slice.ID)
+		}
+	}
+	sort.Strings(ids)
+	if max > 0 && len(ids) > max {
+		ids = ids[:max]
+	}
+	return ids
+}
+
+// toolNames returns the call names in round order (used for prefetch).
+func toolNames(calls []ToolCallInfo) []string {
+	names := make([]string, len(calls))
+	for i, c := range calls {
+		names[i] = c.Name
+	}
+	return names
+}
+
+// ids extracts CallIDs preserving order.
+func ids(calls []ToolCallInfo) []string {
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = c.CallID
+	}
+	return out
+}
+
+// stripPrefix normalizes a tool name for stats lookup (lower-case, trimmed).
+func stripPrefix(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}

--- a/kernel/sched/rule_decider_test.go
+++ b/kernel/sched/rule_decider_test.go
@@ -1,0 +1,316 @@
+package sched
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// helpers
+
+func call(id, name string, ro bool) ToolCallInfo {
+	return ToolCallInfo{CallID: id, Name: name, ReadOnly: ro}
+}
+
+func hit(id string, score float64) slice.Hit {
+	return slice.Hit{Slice: &slice.Slice{ID: id}, Score: score}
+}
+
+func idsOf(groups [][]string) [][]string { return groups }
+
+func flatten(groups [][]string) []string {
+	var out []string
+	for _, g := range groups {
+		out = append(out, g...)
+	}
+	return out
+}
+
+// --- static partitioning ---
+
+func TestPartitionReadOnlyParallelWritersSerial(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	in := RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "grep", true),
+		call("b", "read_file", true),
+		call("c", "bash", false),
+		call("d", "ls", true),
+	}}
+	plan, err := d.DecideRound(context.Background(), in)
+	if err != nil {
+		t.Fatalf("DecideRound: %v", err)
+	}
+	// a+b parallel; c serial; d serial (single trailing read-only is a
+	// one-element group, still its own group).
+	if len(plan.ParallelGroups) != 3 {
+		t.Fatalf("want 3 groups, got %v", plan.ParallelGroups)
+	}
+	if got := flatten(plan.ParallelGroups); got[0] != "a" || got[1] != "b" || got[2] != "c" || got[3] != "d" {
+		t.Fatalf("order broken: %v", got)
+	}
+}
+
+func TestPartitionBlacklistNeverParallel(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	in := RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "read_file", true),
+		call("b", "complete_step", true), // read-only declared but blacklisted
+		call("c", "wait", true),
+		call("d", "grep", true),
+	}}
+	plan, err := d.DecideRound(context.Background(), in)
+	if err != nil {
+		t.Fatalf("DecideRound: %v", err)
+	}
+	// a alone, b alone, c alone, d alone: blacklist breaks contiguity.
+	if len(plan.ParallelGroups) != 4 {
+		t.Fatalf("want 4 groups, got %v", plan.ParallelGroups)
+	}
+}
+
+func TestPartitionMaxParallelSubsplit(t *testing.T) {
+	d := NewRuleDecider(Config{MaxParallel: 2})
+	var calls []ToolCallInfo
+	for i := 0; i < 5; i++ {
+		calls = append(calls, call(string(rune('a'+i)), "read_file", true))
+	}
+	plan, err := d.DecideRound(context.Background(), RoundInput{ToolCalls: calls})
+	if err != nil {
+		t.Fatalf("DecideRound: %v", err)
+	}
+	if len(plan.ParallelGroups) != 3 { // 2+2+1
+		t.Fatalf("want 3 capped groups, got %v", plan.ParallelGroups)
+	}
+	if len(plan.ParallelGroups[0]) != 2 || len(plan.ParallelGroups[2]) != 1 {
+		t.Fatalf("cap not applied: %v", plan.ParallelGroups)
+	}
+}
+
+// --- behavior learning ---
+
+func TestBehaviorGatePullsUnreliableReadOutOfParallel(t *testing.T) {
+	d := NewRuleDecider(Config{MinSamples: 3, SuccessFloor: 0.7})
+	// grep fails 2 of 3 → success rate 0.33 < 0.7 → must go serial.
+	for i := 0; i < 2; i++ {
+		d.Observe("grep", false, 10)
+	}
+	d.Observe("grep", true, 10)
+
+	in := RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "grep", true),
+		call("b", "read_file", true),
+	}}
+	plan, err := d.DecideRound(context.Background(), in)
+	if err != nil {
+		t.Fatalf("DecideRound: %v", err)
+	}
+	// grep (failing gate) and read_file (no history, passes) must NOT share
+	// a group: two serial singles.
+	if len(plan.ParallelGroups) != 2 {
+		t.Fatalf("want grep split out, got %v", plan.ParallelGroups)
+	}
+	for _, g := range plan.ParallelGroups {
+		if len(g) != 1 {
+			t.Fatalf("group not serialized: %v", plan.ParallelGroups)
+		}
+	}
+}
+
+func TestBehaviorGateUnknownToolPasses(t *testing.T) {
+	d := NewRuleDecider(Config{MinSamples: 3, SuccessFloor: 0.7})
+	// No history for read_file → static rule applies (parallel).
+	in := RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "grep", true),
+		call("b", "read_file", true),
+	}}
+	plan, err := d.DecideRound(context.Background(), in)
+	if err != nil {
+		t.Fatalf("DecideRound: %v", err)
+	}
+	if len(plan.ParallelGroups) != 1 || len(plan.ParallelGroups[0]) != 2 {
+		t.Fatalf("want one parallel pair, got %v", plan.ParallelGroups)
+	}
+}
+
+func TestBehaviorGateRecoversAfterImprovement(t *testing.T) {
+	d := NewRuleDecider(Config{MinSamples: 3, SuccessFloor: 0.5})
+	for i := 0; i < 3; i++ {
+		d.Observe("grep", false, 5)
+	}
+	in := RoundInput{ToolCalls: []ToolCallInfo{call("a", "grep", true), call("b", "read_file", true)}}
+	plan, _ := d.DecideRound(context.Background(), in)
+	if len(plan.ParallelGroups) != 2 {
+		t.Fatalf("unreliable grep must be serial first, got %v", plan.ParallelGroups)
+	}
+	// Now grep succeeds 3 more times → 3/6 = 0.5 → passes floor 0.5 (>=).
+	for i := 0; i < 3; i++ {
+		d.Observe("grep", true, 5)
+	}
+	plan, _ = d.DecideRound(context.Background(), in)
+	if len(plan.ParallelGroups) != 1 || len(plan.ParallelGroups[0]) != 2 {
+		t.Fatalf("recovered grep should parallelize again, got %v", plan.ParallelGroups)
+	}
+}
+
+// --- tier ---
+
+func TestTierRules(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	// all read-only, small → flash
+	plan, _ := d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "grep", true), call("b", "read_file", true),
+	}})
+	if plan.Tier != "flash" {
+		t.Fatalf("want flash, got %s", plan.Tier)
+	}
+	// writer present → pro
+	plan, _ = d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "grep", true), call("b", "bash", false),
+	}})
+	if plan.Tier != "pro" {
+		t.Fatalf("want pro (writer), got %s", plan.Tier)
+	}
+	// many read-only calls → pro
+	var many []ToolCallInfo
+	for i := 0; i < 4; i++ {
+		many = append(many, call(string(rune('a'+i)), "grep", true))
+	}
+	plan, _ = d.DecideRound(context.Background(), RoundInput{ToolCalls: many})
+	if plan.Tier != "pro" {
+		t.Fatalf("want pro (complex), got %s", plan.Tier)
+	}
+}
+
+func TestTierCustomNames(t *testing.T) {
+	d := NewRuleDecider(Config{DefaultTier: "cheap", ProTier: "strong"})
+	plan, _ := d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "grep", true), call("b", "bash", false),
+	}})
+	if plan.Tier != "strong" {
+		t.Fatalf("want strong, got %s", plan.Tier)
+	}
+}
+
+// --- injection ids ---
+
+func TestInjectIDsCanonicalOrderAndCap(t *testing.T) {
+	d := NewRuleDecider(Config{InjectMax: 2})
+	in := RoundInput{SliceHits: []slice.Hit{
+		hit("z-slice", 0.9),
+		hit("a-slice", 0.8),
+		hit("m-slice", 0.7),
+	}}
+	plan, err := d.DecideRound(context.Background(), in)
+	if err != nil {
+		t.Fatalf("DecideRound: %v", err)
+	}
+	want := []string{"a-slice", "m-slice"} // ID-ascending, capped at 2
+	if !equalStrings(plan.InjectIDs, want) {
+		t.Fatalf("want %v, got %v", want, plan.InjectIDs)
+	}
+}
+
+func TestInjectIDsNilSliceSafe(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	plan, _ := d.DecideRound(context.Background(), RoundInput{SliceHits: []slice.Hit{
+		{Slice: nil, Score: 1},
+		hit("b", 0.5),
+	}})
+	if !equalStrings(plan.InjectIDs, []string{"b"}) {
+		t.Fatalf("want [b], got %v", plan.InjectIDs)
+	}
+}
+
+// --- prefetch callback ---
+
+func TestPrefetchPlanFuncWired(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	called := false
+	d.SetPrefetchPlanFunc(func(names []string) []string {
+		called = true
+		return []string{"read_file"}
+	})
+	plan, _ := d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "bash", true),
+	}})
+	if !called {
+		t.Fatal("prefetch func not called")
+	}
+	if !equalStrings(plan.PrefetchIDs, []string{"read_file"}) {
+		t.Fatalf("want [read_file], got %v", plan.PrefetchIDs)
+	}
+}
+
+func TestPrefetchPlanFuncNil(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	plan, _ := d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "bash", true),
+	}})
+	if plan.PrefetchIDs != nil {
+		t.Fatalf("want nil prefetch, got %v", plan.PrefetchIDs)
+	}
+}
+
+// --- stats / concurrency ---
+
+func TestStatsSnapshot(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	d.Observe("grep", true, 10)
+	d.Observe("grep", false, 20)
+	s := d.Stats()
+	st, ok := s["grep"]
+	if !ok {
+		t.Fatal("grep missing from stats")
+	}
+	if st.Runs != 2 || st.Failures != 1 || st.DurationMs != 30 {
+		t.Fatalf("unexpected stats %+v", st)
+	}
+	if st.SuccessRate != 0.5 {
+		t.Fatalf("want 0.5, got %f", st.SuccessRate)
+	}
+}
+
+func TestConcurrentDecideAndObserve(t *testing.T) {
+	d := NewRuleDecider(Config{MinSamples: 10})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				d.Observe("grep", j%2 == 0, int64(j))
+				_, _ = d.DecideRound(context.Background(), RoundInput{
+					ToolCalls: []ToolCallInfo{call("a", "grep", true)},
+				})
+			}
+		}()
+	}
+	wg.Wait()
+	if len(d.Stats()) == 0 {
+		t.Fatal("stats empty after concurrent observe")
+	}
+}
+
+// --- helpers ---
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := append([]string(nil), a...)
+	bb := append([]string(nil), b...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	for i := range aa {
+		if aa[i] != bb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// silence unused import guard (idsOf keeps flatten used in tests)
+var _ = idsOf


### PR DESCRIPTION
Closes #122

## 交付内容

落地 M1-U18b：kernel 侧 sched/prefetch 权威实现（此前仅存在于工作区，未提交）。

| 文件 | 说明 |
|---|---|
| `kernel/sched/rule_decider.go` + 测试 | M3 MVP Decider：并行分组（静态黑名单 + 行为学习门）、tier 决策、注入 ID 规范序、prefetch 挂载点（14 测试） |
| `kernel/prefetch/matrix.go` + 测试 | 在线 `MatrixPrefetcher`：工具转移矩阵 + 只读观察 + hit/waste EWMA 浪费惩罚（12 测试） |
| `kernel/prefetch/planfunc.go` + 测试 | **整合适配器** `AsPlanFunc`：任意 `Prefetcher` → `func([]string) []string`，与 `sched.PrefetchPlanFunc` 签名兼容，sched 包保持零依赖（5 测试） |
| `README.md` | P3/P4 状态：design phase / in progress → shipped (MVP) |

## 整合决策（Issue 62 讨论线记录）

`kernel/prefetch` 存在两套 Prefetcher 实现，**保留两者、职责互补**：

- **`Planner`**（`planner.go`，Issue 62 交付物）：**离线** — `Learn()` 从切片库 ToolPattern 切片重建转移矩阵，白名单 fail-closed（空白名单 = 不预取）。
- **`MatrixPrefetcher`**（`matrix.go`）：**在线** — `Observe()` 每次工具执行增量更新 bigram，hit/waste 反馈衰减置信度（waste/hit > 3:1 自动降权），只预取观察为只读的工具。

harness 按场景选型（重启后离线种子 vs 运行期在线学习），通过新增的 `prefetch.AsPlanFunc` 挂到 `sched.RuleDecider.SetPrefetchPlanFunc`，依赖方向保持 `sched → nothing`。

## 验证

- `go vet ./...` ✅
- `go test -race ./...` ✅（全部包绿，含新增 31 个测试）