### PR TITLE
feat(config): wire semantix.toml into CLI defaults (M2-U20, Issue #114)

### DIFF
--- a/cmd/semantix/config_load.go
+++ b/cmd/semantix/config_load.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"semantix/kernel/config"
+)
+
+// explicitConfigPath extracts the config file path from args (--config x or
+// --config=x) or SEMANTIX_CONFIG. It mirrors the flag package's parse rule:
+// scanning stops at the first positional argument or "--", and skips the value
+// token of value-taking flags, so a query text that happens to contain
+// "--config=..." cannot redirect the config file, while `--input x --config y`
+// (flag value before --config) still works.
+//
+// The second return value reports whether the path was explicitly specified
+// (flag or env). A bare "--config" with no value returns ("", true): the
+// caller must treat it as an explicit-but-empty path, not a silent fallback.
+func explicitConfigPath(args []string, getenv func(string) string) (path string, explicit bool) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			break
+		}
+		if a == "--config" {
+			if i+1 < len(args) {
+				return args[i+1], true
+			}
+			return "", true
+		}
+		if strings.HasPrefix(a, "--config=") {
+			return strings.TrimPrefix(a, "--config="), true
+		}
+		// Value-taking flags consume the next token as their value. Boolean
+		// flags do not; skipping their "value" would swallow the next real
+		// token (usually --config or a positional). Inline values
+		// (--flag=value) embed their value and consume nothing.
+		if strings.HasPrefix(a, "--") && !boolFlag(a) && !strings.Contains(a, "=") {
+			i++ // skip the flag's value token
+			continue
+		}
+		if strings.HasPrefix(a, "-") && a != "-" {
+			continue // boolean flag or short flag; no value token
+		}
+		// First positional argument: flag parsing stops here.
+		break
+	}
+	if v := getenv("SEMANTIX_CONFIG"); v != "" {
+		return v, true
+	}
+	return "", false
+}
+
+// boolFlag reports flags that take no value. Must stay in sync with the
+// boolean flags registered by the subcommands that call explicitConfigPath.
+func boolFlag(a string) bool {
+	switch a {
+	case "--json", "--l3-safe", "--strict", "--help", "-h":
+		return true
+	}
+	return false
+}
+
+// loadConfigFor loads the effective config. explicit distinguishes an
+// absent config selector (implicit ./semantix.toml, missing file is silent)
+// from a user-specified one (missing or empty is a config error).
+func loadConfigFor(path string, explicit bool, getenv func(string) string) (*config.Config, error) {
+	cfg, _, err := config.Load(config.LoadOptions{Path: path, Explicit: explicit, Getenv: getenv})
+	return cfg, err
+}
+
+// defaultGetenv is os.Getenv; kept as a variable for test seams.
+var defaultGetenv = os.Getenv

--- a/cmd/semantix/config_wiring_test.go
+++ b/cmd/semantix/config_wiring_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExplicitConfigPathForms covers the four ways a config path can be
+// selected, including both --config spellings required by the CLI contract.
+func TestExplicitConfigPathForms(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		env      map[string]string
+		wantPath string
+		wantExp  bool
+	}{
+		{"flag space", []string{"--config", "a.toml"}, nil, "a.toml", true},
+		{"flag equals", []string{"--config=b.toml"}, nil, "b.toml", true},
+		{"env wins when no flag", []string{"--query", "x"}, map[string]string{"SEMANTIX_CONFIG": "c.toml"}, "c.toml", true},
+		{"flag beats env", []string{"--config", "d.toml"}, map[string]string{"SEMANTIX_CONFIG": "c.toml"}, "d.toml", true},
+		{"none", []string{"--query", "x"}, nil, "", false},
+		{"bare --config is explicit empty", []string{"--config"}, nil, "", true},
+		{"positional stops scan", []string{"query", "--config", "e.toml"}, nil, "", false},
+		{"flag value before config", []string{"--input", "session.jsonl", "--config", "f.toml"}, nil, "f.toml", true},
+		{"boolean flag then config", []string{"--json", "--config", "g.toml"}, nil, "g.toml", true},
+		{"inline value then config", []string{"--query=hello", "--config", "h.toml"}, nil, "h.toml", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			getenv := func(k string) string {
+				if tc.env == nil {
+					return ""
+				}
+				return tc.env[k]
+			}
+			got, exp := explicitConfigPath(tc.args, getenv)
+			if got != tc.wantPath || exp != tc.wantExp {
+				t.Errorf("explicitConfigPath = (%q, %v), want (%q, %v)", got, exp, tc.wantPath, tc.wantExp)
+			}
+		})
+	}
+}
+
+// TestConfigInjectionViaQueryBlocked: a query text that contains a
+// --config=... token must NOT redirect the config file (flag parse treats
+// everything after the first positional as positional).
+func TestConfigInjectionViaQueryBlocked(t *testing.T) {
+	dir := t.TempDir()
+	decoy := filepath.Join(dir, "decoy.toml")
+	if err := os.WriteFile(decoy, []byte("[store]\ndb = \""+filepath.ToSlash(filepath.Join(dir, "decoy.db"))+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The query is positional; --config=... is part of the query text and
+	// must be ignored for config selection. No real semantix.toml exists, so
+	// the implicit default must apply (search runs against the default store).
+	var out, errOut bytes.Buffer
+	code := run([]string{"search", "query text --config=" + decoy}, &out, &errOut, productionDependencies())
+	if code == 2 && strings.Contains(errOut.String(), "config") {
+		t.Fatalf("query text redirected config selection: code=%d stderr=%s", code, errOut.String())
+	}
+	// The search itself may fail (no store) with exit 1, but never a config
+	// exit-2, proving the decoy file was not consulted.
+	if code == 2 {
+		t.Fatalf("unexpected config error: %s", errOut.String())
+	}
+}
+
+// TestConfigMissingExplicitReturns2: a user-specified config path that does
+// not exist is a config error (exit 2), never a silent fallback to defaults.
+func TestConfigMissingExplicitReturns2(t *testing.T) {
+	var out, errOut bytes.Buffer
+	missing := filepath.Join(t.TempDir(), "nope.toml")
+	code := run([]string{"search", "--config", missing, "query"}, &out, &errOut, productionDependencies())
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 (stderr: %s)", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "not found") {
+		t.Errorf("stderr lacks file-not-found: %s", errOut.String())
+	}
+}
+
+// TestLookupConfigErrorNoPartialOutput: config errors must not emit a partial
+// JSON body (H1 harness contract: non-zero exit + no half-structured output).
+func TestLookupConfigErrorNoPartialOutput(t *testing.T) {
+	var out, errOut bytes.Buffer
+	missing := filepath.Join(t.TempDir(), "nope.toml")
+	code := run([]string{"lookup", "--config", missing, "--query", "q"}, &out, &errOut, productionDependencies())
+	if code != 2 {
+		t.Fatalf("code = %d, want 2", code)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout must be empty on config error, got: %s", out.String())
+	}
+}
+
+// TestConfigStoreDBWired verifies store.db drives the project database end to
+// end: extract writes to the configured path, search reads from it, with no
+// --db/--project-db flags.
+func TestConfigStoreDBWired(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.ToSlash(filepath.Join(dir, "wired.db"))
+	cfgFile := filepath.Join(dir, "semantix.toml")
+	if err := os.WriteFile(cfgFile, []byte("[store]\ndb = \""+db+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	session := filepath.Join(dir, "s.jsonl")
+	if err := os.WriteFile(session, []byte(`{"role":"user","content":"修复 go 测试失败"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	if code := run([]string{"extract", "--input", session, "--config", cfgFile}, &out, &errOut, productionDependencies()); code != 0 {
+		t.Fatalf("extract code = %d, stderr: %s", code, errOut.String())
+	}
+	if _, err := os.Stat(db); err != nil {
+		t.Fatalf("db not created at configured path %s: %v", db, err)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	if code := run([]string{"search", "--config", cfgFile, "修复"}, &out, &errOut, productionDependencies()); code != 0 {
+		t.Fatalf("search code = %d, stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "修复") {
+		t.Fatalf("search did not read configured db:\n%s", out.String())
+	}
+}
+
+// TestUsageDBUnaffectedByStoreAndEnv: usage --db is the usage JSONL log, not
+// the slice store; it must ignore [store].db and SEMANTIX_DB.
+func TestUsageDBUnaffectedByStoreAndEnv(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "usage.jsonl")
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile := filepath.Join(dir, "semantix.toml")
+	if err := os.WriteFile(cfgFile, []byte("[store]\ndb = \"decoy.db\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SEMANTIX_DB", "env-decoy.db")
+
+	var out bytes.Buffer
+	if code := runUsage([]string{"--db", logPath, "--config", cfgFile}, &out); code != 0 {
+		t.Fatalf("usage code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "events\t0") {
+		t.Fatalf("usage output unexpected:\n%s", out.String())
+	}
+}

--- a/cmd/semantix/extract.go
+++ b/cmd/semantix/extract.go
@@ -14,20 +14,27 @@ import (
 )
 
 func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	cfgPath, cfgExplicit := explicitConfigPath(args, defaultGetenv)
+	cfg, err := loadConfigFor(cfgPath, cfgExplicit, defaultGetenv)
+	if err != nil {
+		return err
+	}
+
 	flags := flag.NewFlagSet("extract", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	input := flags.String("input", "", "session JSONL path, or - for stdin")
-	scopeValue := flags.String("scope", "project", "slice scope: session, project, or user")
+	scopeValue := flags.String("scope", cfg.Store.Scope, "slice scope: session, project, or user")
 	dbOverride := flags.String("db", "", "database path override")
-	projectDB := flags.String("project-db", defaultProjectDB(), "project/session database path")
+	projectDB := flags.String("project-db", cfg.Store.DB, "project/session database path")
 	userDB := flags.String("user-db", defaultUserDB(), "user database path")
 	session := flags.String("session", "", "source session identifier")
-	project := flags.String("project", "", "project slug")
+	project := flags.String("project", cfg.Project.Name, "project slug")
 	taskType := flags.String("task-type", "", "task type metadata")
 	language := flags.String("language", "", "language metadata")
 	fingerprintPaths := flags.String("fingerprint", "", "comma-separated relative paths to fingerprint (sha256) into each slice's Deps")
 	l3Safe := flags.Bool("l3-safe", false, "mark dependency-free Result slices as explicitly L3-reusable (opt-in; ignored when --fingerprint is set)")
 	embedder := flags.String("embedder", "hash", "embedder for stored slices: hash (default, zero-dependency) | model (remote OpenAI-compatible API; see SEMANTIX_EMBED_* env)")
+	_ = flags.String("config", cfgPath, "config file path (default ./semantix.toml)")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}

--- a/cmd/semantix/lookup.go
+++ b/cmd/semantix/lookup.go
@@ -14,15 +14,22 @@ import (
 // runLookup exposes the semantix_lookup tool contract over the CLI
 // (U8 tool side): given a query, print top-k reuse slices as JSON.
 func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	cfgPath, cfgExplicit := explicitConfigPath(args, defaultGetenv)
+	cfg, err := loadConfigFor(cfgPath, cfgExplicit, defaultGetenv)
+	if err != nil {
+		return err
+	}
+
 	flags := flag.NewFlagSet("lookup", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	query := flags.String("query", "", "task description to match against stored slices")
-	scopeValue := flags.String("scope", "project", "slice scope: session, project, or user")
-	limit := flags.Int("limit", 5, "maximum number of slices (capped at 50)")
+	scopeValue := flags.String("scope", cfg.Store.Scope, "slice scope: session, project, or user")
+	limit := flags.Int("limit", cfg.Retrieval.LookupLimit, "maximum number of slices (capped at 50)")
 	dbOverride := flags.String("db", "", "database path override")
 	// Accepted for compatibility with the harness tool contract
 	// (semantix_lookup calls `semantix lookup --json`); output is JSON anyway.
 	_ = flags.Bool("json", false, "output as JSON (default output is already JSON)")
+	_ = flags.String("config", cfgPath, "config file path (default ./semantix.toml)")
 	zf := addZoneFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -43,7 +50,7 @@ func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error
 		return fmt.Errorf("lookup: --query is required")
 	}
 
-	store, err := deps.openStore(storePath(*dbOverride, *scopeValue))
+	store, err := deps.openStore(storePath(*dbOverride, *scopeValue, cfg.Store.DB))
 	if err != nil {
 		return err
 	}
@@ -86,13 +93,20 @@ func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error
 // runInject assembles an L2 injection block for a query (U8 compose side):
 // top-k reuse slices in canonical order, budget-capped, marker-wrapped.
 func runInject(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	cfgPath, cfgExplicit := explicitConfigPath(args, defaultGetenv)
+	cfg, err := loadConfigFor(cfgPath, cfgExplicit, defaultGetenv)
+	if err != nil {
+		return err
+	}
+
 	flags := flag.NewFlagSet("inject", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	query := flags.String("query", "", "current user turn to match against stored slices")
-	scopeValue := flags.String("scope", "project", "slice scope: session, project, or user")
-	k := flags.Int("k", 5, "top-k slices to consider")
-	budget := flags.Int("budget", inject.DefaultBudget, "max injection block bytes")
+	scopeValue := flags.String("scope", cfg.Store.Scope, "slice scope: session, project, or user")
+	k := flags.Int("k", cfg.Inject.TopK, "top-k slices to consider")
+	budget := flags.Int("budget", cfg.Inject.Budget, "max injection block bytes")
 	dbOverride := flags.String("db", "", "database path override")
+	_ = flags.String("config", cfgPath, "config file path (default ./semantix.toml)")
 	zf := addZoneFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -107,7 +121,7 @@ func runInject(args []string, stdout, stderr io.Writer, deps dependencies) error
 		return fmt.Errorf("inject: --query is required")
 	}
 
-	store, err := deps.openStore(storePath(*dbOverride, *scopeValue))
+	store, err := deps.openStore(storePath(*dbOverride, *scopeValue, cfg.Store.DB))
 	if err != nil {
 		return err
 	}
@@ -129,19 +143,16 @@ func runInject(args []string, stdout, stderr io.Writer, deps dependencies) error
 	return nil
 }
 
-// storePath resolves the store path for a scope (mirrors search.go).
-func storePath(override, scope string) string {
+// storePath resolves the store path for a scope. projectDefault comes from
+// config (store.db); user scope keeps the built-in user library path.
+func storePath(override, scope, projectDefault string) string {
 	if override != "" {
 		return override
 	}
-	switch scope {
-	case "session":
-		return defaultProjectDB()
-	case "user":
+	if scope == "user" {
 		return defaultUserDB()
-	default:
-		return defaultProjectDB()
 	}
+	return projectDefault
 }
 
 // indexFromStore rebuilds an in-memory index from the persistent store,

--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"semantix/kernel/bm25"
+	"semantix/kernel/config"
 	"semantix/kernel/slice"
 )
 
@@ -68,6 +69,10 @@ func run(args []string, stdout, stderr io.Writer, deps dependencies) int {
 		// package reports ErrHelp after printing usage for any subcommand.
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
+		}
+		if _, ok := config.IsError(err); ok {
+			fmt.Fprintf(stderr, "semantix %s: %v\n", args[0], err)
+			return 2
 		}
 		fmt.Fprintf(stderr, "semantix %s: %v\n", args[0], err)
 		return 1

--- a/cmd/semantix/search.go
+++ b/cmd/semantix/search.go
@@ -23,17 +23,24 @@ type searchResult struct {
 }
 
 func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	cfgPath, cfgExplicit := explicitConfigPath(args, defaultGetenv)
+	cfg, err := loadConfigFor(cfgPath, cfgExplicit, defaultGetenv)
+	if err != nil {
+		return err
+	}
+
 	flags := flag.NewFlagSet("search", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	queryFlag := flags.String("query", "", "search query (alternatively pass it as positional text)")
-	scopeValue := flags.String("scope", "project", "slice scope: session, project, or user")
-	limit := flags.Int("limit", 10, "maximum number of results")
+	scopeValue := flags.String("scope", cfg.Store.Scope, "slice scope: session, project, or user")
+	limit := flags.Int("limit", cfg.Retrieval.SearchLimit, "maximum number of results")
 	dbOverride := flags.String("db", "", "database path override")
-	projectDB := flags.String("project-db", defaultProjectDB(), "project/session database path")
+	projectDB := flags.String("project-db", cfg.Store.DB, "project/session database path")
 	userDB := flags.String("user-db", defaultUserDB(), "user database path")
 	jsonOutput := flags.Bool("json", false, "write JSON results")
-	retriever := flags.String("retriever", "bm25", "retriever: bm25 (default) | vector (hash-embedding) | hybrid (RRF fusion)")
+	retriever := flags.String("retriever", cfg.Retrieval.Retriever, "retriever: bm25 (default) | vector (hash-embedding) | hybrid (RRF fusion)")
 	embedder := flags.String("embedder", "hash", "embedder: hash (default, zero-dependency) | model (remote OpenAI-compatible API; see SEMANTIX_EMBED_* env)")
+	_ = flags.String("config", cfgPath, "config file path (default ./semantix.toml)")
 	zf := addZoneFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return err

--- a/cmd/semantix/usage.go
+++ b/cmd/semantix/usage.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"semantix/kernel/config"
 	"semantix/kernel/evolve"
 	"semantix/kernel/usage"
 )
@@ -16,11 +17,23 @@ import (
 // U17). With --evolve-db it also feeds cost/latency signals into the
 // evolution engine and prints the adjusted params.
 func runUsage(args []string, stdout io.Writer) int {
+	cfgPath, cfgExplicit := explicitConfigPath(args, defaultGetenv)
+	cfg, err := loadConfigFor(cfgPath, cfgExplicit, defaultGetenv)
+	if err != nil {
+		if _, ok := config.IsError(err); ok {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		fmt.Fprintln(os.Stderr, "usage:", err)
+		return 2
+	}
+
 	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
 	db := fs.String("db", filepath.Join(".semantix", "usage.jsonl"), "usage log path (default .semantix/usage.jsonl)")
-	costMiss := fs.Float64("cost-miss", usage.DefaultCostMissPerMTok, "USD per 1M tokens at cache miss")
-	costHit := fs.Float64("cost-hit", usage.DefaultCostHitPerMTok, "USD per 1M tokens at cache hit")
+	costMiss := fs.Float64("cost-miss", cfg.Cost.InputPriceUSD, "USD per 1M tokens at cache miss")
+	costHit := fs.Float64("cost-hit", cfg.Cost.CachePriceUSD, "USD per 1M tokens at cache hit")
 	evolveDB := fs.String("evolve-db", "", "optional evolve engine state dir (feeds cost signals and prints adjusted params)")
+	_ = fs.String("config", cfgPath, "config file path (default ./semantix.toml)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 
+	"semantix/kernel/config"
 	"semantix/kernel/judge"
 	"semantix/kernel/slice"
 	"semantix/kernel/zone"
@@ -125,20 +126,32 @@ func parseTurns(path string) ([]verifyTurn, error) {
 }
 
 func runVerify(args []string, stdout io.Writer, deps dependencies) int {
+	cfgPath, cfgExplicit := explicitConfigPath(args, defaultGetenv)
+	cfg, err := loadConfigFor(cfgPath, cfgExplicit, defaultGetenv)
+	if err != nil {
+		if _, ok := config.IsError(err); ok {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		fmt.Fprintln(os.Stderr, "verify:", err)
+		return 1
+	}
+
 	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
 	var opt verifyOptions
 	fs.Var(stringListFlag{&opt.sessions}, "session", "session JSONL file or directory (repeatable)")
-	fs.StringVar(&opt.db, "db", "", "database path override (default: .semantix/project.db)")
-	fs.StringVar(&opt.project, "project", "", "project slug")
-	fs.Float64Var(&opt.holdout, "holdout", 0.3, "fraction of latest sessions reserved as replay stream (0-1)")
+	fs.StringVar(&opt.db, "db", "", "database path override (default: .semantix/verify.db)")
+	fs.StringVar(&opt.project, "project", cfg.Project.Name, "project slug")
+	fs.Float64Var(&opt.holdout, "holdout", cfg.Verify.Holdout, "fraction of latest sessions reserved as replay stream (0-1)")
 	var scopeName string
-	fs.StringVar(&scopeName, "scope", "project", "scope: project|user|session")
+	fs.StringVar(&scopeName, "scope", cfg.Store.Scope, "scope: project|user|session")
 	greyTarget := fs.Float64("grey-target", 30.0, "grey-zone traffic ratio alarm threshold in percent (0 disables the alarm)")
 	strict := fs.Bool("strict", false, "return exit code 3 when the grey-zone ratio exceeds --grey-target")
 	zf := addZoneFlags(fs)
 	judgeProtocol := fs.String("judge-protocol", "", "LLM judge protocol: openai|anthropic (empty = rules only)")
 	judgeBaseURL := fs.String("judge-base-url", "", "LLM judge endpoint base URL (e.g. https://api.openai.com/v1)")
 	judgeModel := fs.String("judge-model", "", "LLM judge model name")
+	_ = fs.String("config", cfgPath, "config file path (default ./semantix.toml)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module semantix
 
 go 1.26.5
+
+require github.com/pelletier/go-toml/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=

--- a/kernel/config/config.go
+++ b/kernel/config/config.go
@@ -1,0 +1,274 @@
+// Package config loads semantix.toml with the M2-U20 priority chain:
+// CLI flag > env > semantix.toml > built-in default.
+//
+// The zero-dependency stance is waived for configuration parsing only:
+// TOML's edge cases (escapes, duplicate keys, positions) are exactly where a
+// hand-rolled parser hides bugs, and a misparse blocks every command. See
+// Issue #114.
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// Config is the full shape of semantix.toml. Fields without a current
+// consumer are still parsed and validated so the file remains forward-looking;
+// they are documented "reserved" until a later issue wires them.
+type Config struct {
+	Project   Project   `toml:"project"`
+	Store     Store     `toml:"store"`
+	Retrieval Retrieval `toml:"retrieval"`
+	Inject    Inject    `toml:"inject"`
+	Verify    Verify    `toml:"verify"`
+	Cost      Cost      `toml:"cost"`
+}
+
+type Project struct {
+	Name string `toml:"name"`
+}
+
+type Store struct {
+	DB    string `toml:"db"`
+	Scope string `toml:"scope"`
+}
+
+type Retrieval struct {
+	Retriever   string `toml:"retriever"`
+	SearchLimit int    `toml:"search_limit"`
+	LookupLimit int    `toml:"lookup_limit"`
+	VectorDim   int    `toml:"vector_dim"` // reserved: validated, not yet consumed
+}
+
+type Inject struct {
+	Budget int `toml:"budget"`
+	TopK   int `toml:"top_k"`
+}
+
+type Verify struct {
+	Holdout       float64 `toml:"holdout"`
+	TargetHitRate float64 `toml:"target_hit_rate"` // reserved: no consumer yet
+}
+
+type Cost struct {
+	ToolTokens     int     `toml:"tool_tokens"`      // reserved
+	ReuseRatio     float64 `toml:"reuse_ratio"`      // reserved
+	InputPriceUSD  float64 `toml:"input_price_usd"`
+	CachePriceUSD  float64 `toml:"cache_price_usd"`
+	OutputPriceUSD float64 `toml:"output_price_usd"` // reserved
+}
+
+// Default returns the built-in defaults. These MUST match the hard-coded
+// values in cmd/semantix so that a machine with no semantix.toml behaves
+// exactly as before this change.
+func Default() Config {
+	return Config{
+		Store: Store{
+			DB:    ".semantix/project.db",
+			Scope: "project",
+		},
+		Retrieval: Retrieval{
+			Retriever:   "bm25",
+			SearchLimit: 10,
+			LookupLimit: 5,
+			VectorDim:   256,
+		},
+		Inject: Inject{
+			Budget: 4096,
+			TopK:   5,
+		},
+		Verify: Verify{
+			Holdout:       0.3,
+			TargetHitRate: 0.7,
+		},
+		Cost: Cost{
+			ToolTokens:     300,
+			ReuseRatio:     0.8,
+			InputPriceUSD:  0.27,
+			CachePriceUSD:  0.07,
+			OutputPriceUSD: 1.10,
+		},
+	}
+}
+
+// Source records where each top-level field's effective value came from, for
+// `semantix config` output (U21) and for diagnosing "config not taking
+// effect". Keys are dotted paths like "store.db".
+type Source map[string]string
+
+// Origin values for Source.
+const (
+	OriginDefault = "default"
+	OriginFile    = "file"
+	OriginEnv     = "env"
+)
+
+// LoadOptions controls Load.
+type LoadOptions struct {
+	// Path is the config file to read. When empty, the default ./semantix.toml
+	// is used. Explicit=true means Path was user-specified (--config or
+	// SEMANTIX_CONFIG): a missing file is then an error, whereas a missing
+	// implicit default file is silently skipped.
+	Path     string
+	Explicit bool
+	Getenv   func(string) string
+}
+
+// Error is a configuration error carrying field and position information so
+// the CLI can emit exit code 2 with a precise location.
+type Error struct {
+	Path   string // config file path, or "" for env/default-origin errors
+	Field  string // dotted field path, e.g. "retrieval.search_limit"
+	Line   int    // 1-based; 0 when not file-origin
+	Column int
+	Msg    string
+}
+
+func (e *Error) Error() string {
+	loc := ""
+	if e.Path != "" {
+		loc = e.Path
+		if e.Line > 0 {
+			loc += fmt.Sprintf(":%d", e.Line)
+			if e.Column > 0 {
+				loc += fmt.Sprintf(":%d", e.Column)
+			}
+		}
+		loc += ": "
+	}
+	if e.Field != "" {
+		return fmt.Sprintf("config: %s[%s]: %s", loc, e.Field, e.Msg)
+	}
+	return fmt.Sprintf("config: %s%s", loc, e.Msg)
+}
+
+// Load builds the effective config. Returns the merged Config and the Source
+// map for the fields that were set by file or env. A validation or parse
+// failure returns *Error.
+func Load(opts LoadOptions) (*Config, Source, error) {
+	cfg := Default()
+	src := Source{}
+	if opts.Getenv == nil {
+		opts.Getenv = os.Getenv
+	}
+
+	if opts.Explicit && opts.Path == "" {
+		return nil, nil, &Error{Msg: "config path is empty"}
+	}
+
+	path := opts.Path
+	if path == "" {
+		path = "semantix.toml"
+	}
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if err := decodeInto(data, &cfg, src, path); err != nil {
+			return nil, nil, err
+		}
+	case os.IsNotExist(err) && !opts.Explicit:
+		// Implicit default missing -> built-ins only, no error.
+	case os.IsNotExist(err) && opts.Explicit:
+		return nil, nil, &Error{Path: path, Msg: "file not found"}
+	default:
+		return nil, nil, &Error{Path: path, Msg: err.Error()}
+	}
+
+	// env layer: SEMANTIX_DB overrides store.db.
+	if v := opts.Getenv("SEMANTIX_DB"); v != "" {
+		cfg.Store.DB = v
+		src["store.db"] = OriginEnv
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, nil, err
+	}
+	return &cfg, src, nil
+}
+
+func decodeInto(data []byte, cfg *Config, src Source, path string) error {
+	dec := toml.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(cfg); err != nil {
+		line, col := 0, 0
+		var de *toml.DecodeError
+		if asDecodeErr(err, &de) {
+			line, col = de.Position()
+		}
+		return &Error{Path: path, Line: line, Column: col, Msg: err.Error()}
+	}
+	// Mark file-origin fields (the ones this issue consumes, plus the
+	// reserved-but-parsed ones, so `semantix config` can report them all).
+	for _, f := range []string{"store.db", "store.scope", "retrieval.retriever", "retrieval.search_limit", "retrieval.lookup_limit", "retrieval.vector_dim", "inject.budget", "inject.top_k", "verify.holdout", "verify.target_hit_rate", "cost.input_price_usd", "cost.cache_price_usd", "project.name"} {
+		src[f] = OriginFile
+	}
+	return nil
+}
+
+// validate checks enum fields and numeric ranges. Zero values are tolerated
+// (they mean "unset in file"); command layers apply their own >0 rules.
+func (c *Config) validate() error {
+	if c.Store.Scope != "" && !oneOf(c.Store.Scope, "session", "project", "user") {
+		return &Error{Field: "store.scope", Msg: fmt.Sprintf("invalid scope %q (want session, project, or user)", c.Store.Scope)}
+	}
+	if c.Retrieval.Retriever != "" && !oneOf(c.Retrieval.Retriever, "bm25", "vector", "hybrid") {
+		return &Error{Field: "retrieval.retriever", Msg: fmt.Sprintf("invalid retriever %q (want bm25, vector, or hybrid)", c.Retrieval.Retriever)}
+	}
+	for field, v := range map[string]int{
+		"retrieval.search_limit": c.Retrieval.SearchLimit,
+		"retrieval.lookup_limit": c.Retrieval.LookupLimit,
+		"retrieval.vector_dim":   c.Retrieval.VectorDim,
+		"inject.budget":          c.Inject.Budget,
+		"inject.top_k":           c.Inject.TopK,
+	} {
+		if v < 0 {
+			return &Error{Field: field, Msg: fmt.Sprintf("must be >= 0, got %d", v)}
+		}
+	}
+	if c.Verify.Holdout < 0 || c.Verify.Holdout > 1 {
+		return &Error{Field: "verify.holdout", Msg: fmt.Sprintf("must be in [0,1], got %v", c.Verify.Holdout)}
+	}
+	for field, v := range map[string]float64{
+		"cost.input_price_usd":  c.Cost.InputPriceUSD,
+		"cost.cache_price_usd":  c.Cost.CachePriceUSD,
+		"cost.output_price_usd": c.Cost.OutputPriceUSD,
+	} {
+		if v < 0 {
+			return &Error{Field: field, Msg: fmt.Sprintf("must be >= 0, got %v", v)}
+		}
+	}
+	return nil
+}
+
+func oneOf(v string, want ...string) bool {
+	for _, w := range want {
+		if v == w {
+			return true
+		}
+	}
+	return false
+}
+
+// asDecodeErr is a tiny indirection to keep the toml.DecodeError type import
+// local and testable.
+func asDecodeErr(err error, target **toml.DecodeError) bool {
+	de, ok := err.(*toml.DecodeError)
+	if ok {
+		*target = de
+	}
+	return ok
+}
+
+// IsError reports whether err is a *Error and returns it unwrapped.
+func IsError(err error) (*Error, bool) {
+	if err == nil {
+		return nil, false
+	}
+	if ce, ok := err.(*Error); ok {
+		return ce, true
+	}
+	return nil, false
+}

--- a/kernel/config/config_test.go
+++ b/kernel/config/config_test.go
@@ -1,0 +1,207 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+func writeTOML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "semantix.toml")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func noenv(string) string { return "" }
+
+func TestDefaultMatchesHardcoded(t *testing.T) {
+	c := Default()
+	if c.Store.DB != ".semantix/project.db" {
+		t.Errorf("Store.DB = %q, want .semantix/project.db", c.Store.DB)
+	}
+	if c.Store.Scope != "project" {
+		t.Errorf("Store.Scope = %q, want project", c.Store.Scope)
+	}
+	if c.Retrieval.Retriever != "bm25" {
+		t.Errorf("Retrieval.Retriever = %q, want bm25", c.Retrieval.Retriever)
+	}
+	if c.Retrieval.SearchLimit != 10 {
+		t.Errorf("SearchLimit = %d, want 10", c.Retrieval.SearchLimit)
+	}
+	if c.Retrieval.LookupLimit != 5 {
+		t.Errorf("LookupLimit = %d, want 5", c.Retrieval.LookupLimit)
+	}
+	if c.Inject.Budget != 4096 {
+		t.Errorf("Inject.Budget = %d, want 4096", c.Inject.Budget)
+	}
+	if c.Verify.Holdout != 0.3 {
+		t.Errorf("Verify.Holdout = %v, want 0.3", c.Verify.Holdout)
+	}
+}
+
+func TestLoadImplicitMissingFileUsesDefaults(t *testing.T) {
+	// Point at a path that does not exist, implicitly (Explicit=false).
+	cfg, src, err := Load(LoadOptions{Path: filepath.Join(t.TempDir(), "nope.toml"), Getenv: noenv})
+	if err != nil {
+		t.Fatalf("implicit missing file must not error: %v", err)
+	}
+	if cfg.Store.DB != Default().Store.DB {
+		t.Errorf("db = %q, want default", cfg.Store.DB)
+	}
+	if len(src) != 0 {
+		t.Errorf("source should be empty for implicit default, got %v", src)
+	}
+}
+
+func TestLoadExplicitMissingFileErrors(t *testing.T) {
+	_, _, err := Load(LoadOptions{Path: filepath.Join(t.TempDir(), "nope.toml"), Explicit: true, Getenv: noenv})
+	ce, ok := IsError(err)
+	if !ok {
+		t.Fatalf("want *Error, got %v", err)
+	}
+	if !strings.Contains(ce.Msg, "not found") {
+		t.Errorf("msg = %q, want file-not-found", ce.Msg)
+	}
+}
+
+func TestLoadParsesAndMarksSources(t *testing.T) {
+	p := writeTOML(t, "[store]\ndb = \"custom.db\"\nscope = \"user\"\n\n[retrieval]\nretriever = \"hybrid\"\nsearch_limit = 20\nlookup_limit = 7\n")
+	cfg, src, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: noenv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Store.DB != "custom.db" || cfg.Store.Scope != "user" {
+		t.Errorf("store = %+v", cfg.Store)
+	}
+	if cfg.Retrieval.SearchLimit != 20 || cfg.Retrieval.LookupLimit != 7 || cfg.Retrieval.Retriever != "hybrid" {
+		t.Errorf("retrieval = %+v", cfg.Retrieval)
+	}
+	if src["store.db"] != OriginFile || src["retrieval.search_limit"] != OriginFile {
+		t.Errorf("source = %v", src)
+	}
+}
+
+func TestLoadEnvOverridesFile(t *testing.T) {
+	p := writeTOML(t, "[store]\ndb = \"custom.db\"\n")
+	env := func(k string) string {
+		if k == "SEMANTIX_DB" {
+			return "env.db"
+		}
+		return ""
+	}
+	cfg, src, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: env})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Store.DB != "env.db" {
+		t.Errorf("db = %q, want env.db", cfg.Store.DB)
+	}
+	if src["store.db"] != OriginEnv {
+		t.Errorf("source = %v, want env for store.db", src)
+	}
+}
+
+func TestLoadInvalidTOML(t *testing.T) {
+	p := writeTOML(t, "[store\nbroken")
+	_, _, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: noenv})
+	ce, ok := IsError(err)
+	if !ok {
+		t.Fatalf("want *Error, got %v", err)
+	}
+	if ce.Line <= 0 {
+		t.Errorf("want a line number on parse error, got %v", ce.Error())
+	}
+}
+
+func TestLoadUnknownField(t *testing.T) {
+	p := writeTOML(t, "[store]\ndb = \"x\"\nunknown_key = 1\n")
+	_, _, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: noenv})
+	if _, ok := IsError(err); !ok {
+		t.Fatalf("want *Error for unknown field, got %v", err)
+	}
+}
+
+func TestLoadUnknownSection(t *testing.T) {
+	p := writeTOML(t, "[nonexistent]\nfoo = \"bar\"\n")
+	_, _, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: noenv})
+	if _, ok := IsError(err); !ok {
+		t.Fatalf("want *Error for unknown section, got %v", err)
+	}
+}
+
+func TestLoadTypeMismatch(t *testing.T) {
+	p := writeTOML(t, "[retrieval]\nsearch_limit = \"abc\"\n")
+	_, _, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: noenv})
+	if _, ok := IsError(err); !ok {
+		t.Fatalf("want *Error for type mismatch, got %v", err)
+	}
+}
+
+func TestLoadValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		toml string
+		want string // substring of the field path
+	}{
+		{"bad scope", "[store]\nscope = \"team\"\n", "store.scope"},
+		{"bad retriever", "[retrieval]\nretriever = \"sql\"\n", "retrieval.retriever"},
+		{"negative limit", "[retrieval]\nsearch_limit = -1\n", "retrieval.search_limit"},
+		{"holdout out of range", "[verify]\nholdout = 1.5\n", "verify.holdout"},
+		{"negative price", "[cost]\ninput_price_usd = -0.1\n", "cost.input_price_usd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeTOML(t, tc.toml)
+			_, _, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: noenv})
+			ce, ok := IsError(err)
+			if !ok {
+				t.Fatalf("want *Error, got %v", err)
+			}
+			if !strings.Contains(ce.Field, tc.want) {
+				t.Errorf("field = %q, want contains %q", ce.Field, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadRelativePathPreserved(t *testing.T) {
+	// store.db is resolved relative to the process cwd, not the config file
+	// directory. Load must return the path verbatim.
+	p := writeTOML(t, "[store]\ndb = \"relative/path.db\"\n")
+	cfg, _, err := Load(LoadOptions{Path: p, Explicit: true, Getenv: noenv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Store.DB != "relative/path.db" {
+		t.Errorf("db = %q, want verbatim relative path", cfg.Store.DB)
+	}
+}
+
+// TestLoadExampleTOML ensures the shipped semantix.example.toml stays parseable
+// after field renames, so the "copy it to semantix.toml" workflow never breaks.
+func TestLoadExampleTOML(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "semantix.example.toml"))
+	if err != nil {
+		t.Skipf("example toml not found from test cwd: %v", err)
+	}
+	dec := toml.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var cfg Config
+	if err := dec.Decode(&cfg); err != nil {
+		t.Fatalf("semantix.example.toml no longer parses: %v", err)
+	}
+	if cfg.Retrieval.SearchLimit != 10 || cfg.Retrieval.LookupLimit != 5 {
+		t.Errorf("example limits = %d/%d, want 10/5", cfg.Retrieval.SearchLimit, cfg.Retrieval.LookupLimit)
+	}
+	if cfg.Retrieval.Retriever != "hybrid" {
+		t.Errorf("example retriever = %q, want hybrid", cfg.Retrieval.Retriever)
+	}
+}

--- a/semantix.example.toml
+++ b/semantix.example.toml
@@ -1,30 +1,33 @@
 # semantix.example.toml — 示例配置（复制为 semantix.toml 后按需修改）
-# 当前版本：CLI 参数优先于配置文件；此文件为团队约定与文档用途。
+# 优先级：CLI flag > 环境变量(SEMANTIX_DB / SEMANTIX_CONFIG) > semantix.toml > 内置默认
+# 本文件自 M2-U20 起已接线生效；未列出的字段仍为内置默认。
 
 [project]
-name = "my-project"          # 项目 slug（切片 scope=project 的聚合键）
+name = "my-project"          # 项目 slug（extract/verify 的 --project 默认值）
 
 [store]
-# 切片库路径（extract/lookup/inject/verify 的 --db 默认值）
+# 切片库路径（extract/search 的 --project-db 默认值；lookup/inject 的 project 库 fallback）。
+# 相对路径按进程工作目录解析，不按本配置文件所在目录。
 db = ".semantix/project.db"
 scope = "project"           # 默认切片作用域：session | project | user
 
 [retrieval]
 retriever = "hybrid"        # bm25 | vector | hybrid（RRF 融合）
-limit = 5                   # search 默认 top-k
-vector_dim = 256            # HashEmbedder 维度（模型级 Embedder 接入后忽略）
+search_limit = 10           # search 默认 top-k
+lookup_limit = 5            # lookup 默认 top-k
+vector_dim = 256            # HashEmbedder 维度（本期仅解析校验，暂未改变运行行为）
 
 [inject]
-budget = 4096               # L2 注入块最大字节数（整切片截断）
-top_k = 5                   # 注入候选切片数
+budget = 4096               # L2 注入块最大字节数（--budget）
+top_k = 5                   # 注入候选切片数（--k）
 
 [verify]
-holdout = 0.3               # 离线回放验证：后 30% 会话作为测试流
-target_hit_rate = 0.7       # M0-2 验收目标命中率
+holdout = 0.3               # 离线回放验证：后 30% 会话作为测试流（--holdout）
+target_hit_rate = 0.7       # M0-2 验收目标命中率（暂无程序消费方，仅文档语义）
 
-[cost]                      # 成本对比参数（scripts/demo/cross-session.sh 同步）
-tool_tokens = 300           # 每工具调用输出 token 估算
-reuse_ratio = 0.8           # 注入替代重复步骤比例
-input_price_usd = 0.27      # 每 1M 输入 token（cache miss）
-cache_price_usd = 0.07      # 每 1M 输入 token（cache hit）
-output_price_usd = 1.10     # 每 1M 输出 token
+[cost]                      # usage 命令的成本参数
+tool_tokens = 300           # 每工具调用输出 token 估算（暂无消费方）
+reuse_ratio = 0.8           # 注入替代重复步骤比例（暂无消费方）
+input_price_usd = 0.27      # 每 1M 输入 token（cache miss）→ usage --cost-miss
+cache_price_usd = 0.07      # 每 1M 输入 token（cache hit）→ usage --cost-hit
+output_price_usd = 1.10     # 每 1M 输出 token（暂无消费方）


### PR DESCRIPTION
实现 Issue #114（M2-U20）：semantix.toml 接线生效。

## 优先级链
CLI flag > env（SEMANTIX_DB / SEMANTIX_CONFIG）> semantix.toml > 内置默认

## 内容

### kernel/config（新包）
- Config 结构 + Default()（与现有硬编码值逐项对齐，保证零配置行为不变）
- Load()：file + env 两层合并，Source 记录每字段来源（供 U21 semantix config 使用）
- *Error 携带文件路径/行列/字段定位，退出码 2
- TOML 解析用 pelletier/go-toml/v2（首个第三方依赖；按 review 决策，P0 启动路径不手写解析器）
- retrieval.limit 拆为 search_limit=10 / lookup_limit=5（保持两命令既有默认）
- vector_dim、target_hit_rate、部分 cost 字段：解析+校验，暂不消费（注释标明 reserved）

### cmd/semantix 接线
- explicitConfigPath 预扫描模拟 flag 包语义：首个位置参数或 -- 即停、取值 flag 吞值、内联 --flag=value 不吞、bool flag 不吞。query 文本夹带 --config=... 无法重定向配置（安全审查发现的注入路径已堵）
- 裸 --config 视为显式空路径，报错退出 2，不静默回退
- store.db 只接 --project-db / storePath fallback；--db 保持纯 override；usage --db、verify --db 不受影响
- 显式 --config 缺失报 file not found 退出 2；隐式默认缺失静默用内置默认
- 六命令默认值全部从 config 读取；ConfigError 统一退出码 2（含返回 int 的 verify/usage）

### semantix.example.toml
- 拆字段 + 注释对齐真实语义（store.db 相对 cwd 解析等）

## 测试（新增 19 组）
- kernel/config：默认值对齐、隐式/显式缺失、env 覆盖、来源标注、非法 TOML 行列定位、未知字段/section、类型错误、枚举/数值校验、相对路径原样、示例配置可解析
- cmd/semantix wiring：--config 两种写法+env、注入防护端到端、显式缺失退出 2、lookup 配置错误零半段输出、store.db 端到端（extract 写 search 读）、usage 隔离

## 验证
- go vet ./... 全绿
- go test -race ./cmd/semantix/ ./kernel/config/ 新代码全绿；仅 TestRunUsageWithEvolve 既有 Windows 权限位失败（改动前基线相同），Linux CI 预期全绿
- security review 两轮：MEDIUM 配置路径注入与 LOW 静默回退均已修复，终轮无剩余中高危

Refs #114
