### PR TITLE
polish Semantix landing page UI

### DIFF
--- a/site/scripts/nav-intro.test.mjs
+++ b/site/scripts/nav-intro.test.mjs
@@ -4,11 +4,9 @@ import test from "node:test";
 
 const navSource = await readFile(new URL("../src/components/Nav.tsx", import.meta.url), "utf8");
 
-test("homepage navigation reacts to the first downward scroll intent", () => {
-  assert.match(navSource, /event\.deltaY > 0/);
-  assert.match(navSource, /addEventListener\("wheel", onScrollIntent/);
-  assert.match(navSource, /addEventListener\("touchmove", onTouchMove/);
-  assert.match(navSource, /setVisible\(!intro \|\| window\.scrollY > 8\)/);
+test("homepage navigation appears when the brand intro completes", () => {
+  assert.match(navSource, /setVisible\(!intro \|\| document\.documentElement\.dataset\.introComplete === "true"\)/);
+  assert.match(navSource, /addEventListener\(INTRO_COMPLETION_EVENT, onIntroCompletion/);
 });
 
 test("navigation enters with a transition instead of delayed layout insertion", () => {

--- a/site/src/components/BrandIntroOverlay.tsx
+++ b/site/src/components/BrandIntroOverlay.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useRef, useState } from "react";
 import ParticleCanvas from "@/components/ParticleCanvas";
 import CopyCode from "@/components/CopyCode";
+import {
+  INTRO_COMPLETION_EVENT,
+  type IntroCompletionDetail,
+} from "@/lib/intro-events";
 import { siteIdentity } from "@/lib/site-identity";
 
 const clamp = (value: number) => Math.min(1, Math.max(0, value));
@@ -10,9 +14,12 @@ const clamp = (value: number) => Math.min(1, Math.max(0, value));
 const range = (value: number, start: number, end: number) =>
   clamp((value - start) / (end - start));
 
+const NAV_REVEAL_PROGRESS = 0.78;
+
 export default function BrandIntroOverlay() {
   const storyRef = useRef<HTMLElement>(null);
   const frameRef = useRef<number | null>(null);
+  const introCompleteRef = useRef(false);
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
@@ -23,7 +30,23 @@ export default function BrandIntroOverlay() {
 
       const rect = story.getBoundingClientRect();
       const travel = Math.max(1, story.offsetHeight - window.innerHeight);
-      setProgress(clamp(-rect.top / travel));
+      const nextProgress = clamp(-rect.top / travel);
+      const complete = nextProgress >= NAV_REVEAL_PROGRESS;
+      const publishedComplete = document.documentElement.dataset.introComplete;
+
+      setProgress(nextProgress);
+      document.documentElement.dataset.introComplete = String(complete);
+      if (
+        introCompleteRef.current !== complete ||
+        publishedComplete !== String(complete)
+      ) {
+        introCompleteRef.current = complete;
+        window.dispatchEvent(
+          new CustomEvent<IntroCompletionDetail>(INTRO_COMPLETION_EVENT, {
+            detail: { complete },
+          }),
+        );
+      }
     };
 
     const requestUpdate = () => {
@@ -39,6 +62,7 @@ export default function BrandIntroOverlay() {
       window.removeEventListener("scroll", requestUpdate);
       window.removeEventListener("resize", requestUpdate);
       if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+      delete document.documentElement.dataset.introComplete;
     };
   }, []);
 
@@ -112,14 +136,9 @@ export default function BrandIntroOverlay() {
             <span className="block text-[#168b6d]">沉淀为可检索的记忆</span>
           </p>
 
-          <p className="mx-auto mt-6 max-w-2xl text-sm leading-6 text-muted-foreground md:text-base">
-            Semantix 连接 Agent Harness 与资源层，提供切片提取、BM25 检索和稳定注入路径。
-            <br className="hidden md:block" />
-            当前公开证据来自仓库测试与合成演示；生产环境中的成本和性能收益仍待验证。
-          </p>
           <time
             dateTime={siteIdentity.lastUpdated}
-            className="mt-3 block font-mono text-[10px] tracking-[0.12em] text-muted-foreground"
+            className="mt-6 block font-mono text-[10px] tracking-[0.12em] text-muted-foreground"
           >
             Last updated · {siteIdentity.lastUpdated}
           </time>

--- a/site/src/components/Components.tsx
+++ b/site/src/components/Components.tsx
@@ -91,7 +91,7 @@ export default function Components() {
       id="components"
       className="border-t border-[#0f735c] bg-[#168b6d] p-3 text-[#168b6d] md:p-6"
     >
-      <div className="mx-auto max-w-[1760px] bg-[#f7f6f1] px-5 py-14 md:px-10 md:py-16 lg:px-12">
+      <div className="mx-auto max-w-[1760px] bg-white px-5 py-14 md:px-10 md:py-16 lg:px-12">
         <Reveal>
           <header className="grid gap-6 border-b border-[#168b6d]/35 pb-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-end lg:gap-16">
             <div>
@@ -117,7 +117,7 @@ export default function Components() {
         <div className="mt-8 grid gap-5 md:grid-cols-2">
           {components.map((component, index) => (
             <Reveal key={component.titleEn} delay={index * 55}>
-              <article className="flex h-full flex-col border border-[#168b6d]/35 bg-[#fbfaf6] p-5 transition-colors duration-300 hover:border-[#168b6d] md:p-6">
+              <article className="flex h-full flex-col border border-[#168b6d]/35 bg-white p-5 transition-colors duration-300 hover:border-[#168b6d] md:p-6">
                 <div className="flex items-center justify-between border-b border-[#168b6d]/25 pb-4 font-mono text-[10px] font-semibold tracking-[0.18em]">
                   <span>{component.num}&nbsp; / &nbsp;{component.label}</span>
                   <span className="text-[#101313]/55">{component.status}</span>

--- a/site/src/components/Features.tsx
+++ b/site/src/components/Features.tsx
@@ -91,7 +91,7 @@ export default function Features() {
         onClick={() => setActive(isActive ? null : index)}
         aria-expanded={isActive}
         aria-controls={panelId}
-        className="group grid w-full grid-cols-[3rem_1fr_auto] items-center gap-3 border-b border-[#101313]/20 py-5 text-left md:grid-cols-[5rem_1fr_auto] md:py-7"
+        className="group grid w-full grid-cols-[3rem_1fr_auto] items-center gap-3 border-b border-[#101313]/20 py-5 text-left md:grid-cols-[5rem_1fr_auto] md:py-6"
       >
         <span
           className={`font-mono text-[10px] tracking-[0.16em] transition-colors ${
@@ -217,7 +217,7 @@ export default function Features() {
           <CopyCode key={capability.num} code={capability.code} />
         ))}
       </div>
-      <div className="mx-auto grid max-w-[1600px] gap-14 px-5 py-24 md:px-10 md:py-32 lg:grid-cols-[0.8fr_1.2fr] lg:gap-20">
+      <div className="mx-auto grid max-w-[1600px] gap-14 px-5 py-20 md:px-10 md:py-24 lg:grid-cols-[0.8fr_1.2fr] lg:gap-20">
         <div className="lg:sticky lg:top-24 lg:self-start">
           <p className="font-mono text-[10px] font-medium tracking-[0.24em] text-[#168b6d]">
             Features 特性
@@ -239,8 +239,8 @@ export default function Features() {
           {groups.map((group, groupIndex) => {
             const panelId = `semantix-feature-detail-${groupIndex}`;
             return (
-              <div key={group.label} className={groupIndex === 0 ? "" : "mt-16"}>
-                <div className="flex items-center justify-between border-b border-[#101313]/20 py-5 font-mono text-[11px] font-semibold tracking-[0.16em] text-[#168b6d] md:text-sm">
+              <div key={group.label} className={groupIndex === 0 ? "" : "mt-6"}>
+                <div className="sticky top-16 z-20 flex items-center justify-between border-b border-[#101313]/20 bg-white/95 py-4 font-mono text-[11px] font-semibold tracking-[0.16em] text-[#168b6d] backdrop-blur md:text-sm">
                   <span>{group.label}</span>
                   <span className="text-[10px] font-normal tracking-[0.12em] md:text-xs">
                     {group.action}

--- a/site/src/components/Hero.tsx
+++ b/site/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import Reveal from "@/components/Reveal";
 
 export default function Hero() {
   return (
-    <section className="relative overflow-hidden pt-12 pb-20 md:pt-16">
+    <section className="relative overflow-hidden pt-12 pb-20 md:-mt-28 md:pt-16">
       {/* 两侧装饰：光晕 + 淡色 mono 文字 */}
       <div aria-hidden="true" className="pointer-events-none absolute inset-0 hidden lg:block">
         {/* 左光晕 */}
@@ -22,56 +22,62 @@ export default function Hero() {
         {/* terminal demo */}
         <Reveal>
           <div className="mx-auto max-w-3xl text-left">
-          <div className="pane-in overflow-hidden rounded-xl border border-border bg-[oklch(0.21_0.006_260)] shadow-lg">
-            <div className="flex items-center gap-2 bg-[oklch(0.27_0.008_260)] px-4 py-3">
-              <span className="h-3 w-3 rounded-full bg-[#F87171]" />
-              <span className="h-3 w-3 rounded-full bg-[#FBBF24]" />
-              <span className="h-3 w-3 rounded-full bg-[#4ADE80]" />
-              <span className="ml-2 font-mono text-xs text-slate-400">
-                ~/semantix — extract &amp; search
-              </span>
+            <div className="pane-in overflow-hidden rounded-xl border border-border bg-[oklch(0.21_0.006_260)] shadow-lg">
+              <div className="flex items-center gap-2 bg-[oklch(0.27_0.008_260)] px-4 py-3">
+                <span className="h-3 w-3 rounded-full bg-[#F87171]" />
+                <span className="h-3 w-3 rounded-full bg-[#FBBF24]" />
+                <span className="h-3 w-3 rounded-full bg-[#4ADE80]" />
+                <span className="ml-2 font-mono text-xs text-slate-400">
+                  ~/semantix — extract &amp; search
+                </span>
+              </div>
+              <div className="px-5 py-4 font-mono text-sm leading-relaxed text-slate-300">
+                <div>
+                  <span className="text-accent">$ semantix extract</span>{" "}
+                  <span className="text-slate-400">
+                    -session sessions/2026-08-07.jsonl -scope project
+                  </span>
+                </div>
+                <div className="text-[#4ADE80]">
+                  ✓ extracted=512 slices stored=512 scope=project
+                </div>
+                <div className="text-slate-400">
+                  {"  "}P-slices 214 · C-slices 158 · T-slices 140
+                </div>
+                <div>&nbsp;</div>
+                <div>
+                  <span className="text-accent">$ semantix search</span>{" "}
+                  <span className="text-slate-400">
+                    &quot;如何缓存跨会话前缀&quot; -topk 3
+                  </span>
+                </div>
+                <div>
+                  #1 [P] id=9f2a score=7.42 &quot;stable slice injection → vendor byte
+                  cache&quot;
+                </div>
+                <div>
+                  #2 [T] id=3c81 score=6.98 &quot;grep → readFile → editFile → test&quot;
+                </div>
+                <div>
+                  #3 [C] id=b704 score=6.51 &quot;L2 freeze-period ≥1h guard&quot;
+                </div>
+                <div>&nbsp;</div>
+                <div className="text-slate-500">
+                  命中 3 slices · 0.4ms · 下次会话注入前缀，直接命中字节缓存
+                </div>
+                <div>
+                  <span className="blink inline-block h-4 w-2 bg-emerald-400 align-middle">
+                    ▍
+                  </span>
+                </div>
+              </div>
             </div>
-            <div className="px-5 py-4 font-mono text-sm leading-relaxed text-slate-300">
-              <div>
-                <span className="text-accent">$ semantix extract</span>{" "}
-                <span className="text-slate-400">
-                  -session sessions/2026-08-07.jsonl -scope project
-                </span>
-              </div>
-              <div className="text-[#4ADE80]">
-                ✓ extracted=512 slices stored=512 scope=project
-              </div>
-              <div className="text-slate-400">
-                {"  "}P-slices 214 · C-slices 158 · T-slices 140
-              </div>
-              <div>&nbsp;</div>
-              <div>
-                <span className="text-accent">$ semantix search</span>{" "}
-                <span className="text-slate-400">
-                  &quot;如何缓存跨会话前缀&quot; -topk 3
-                </span>
-              </div>
-              <div>
-                #1 [P] id=9f2a score=7.42 &quot;stable slice injection → vendor byte
-                cache&quot;
-              </div>
-              <div>
-                #2 [T] id=3c81 score=6.98 &quot;grep → readFile → editFile → test&quot;
-              </div>
-              <div>
-                #3 [C] id=b704 score=6.51 &quot;L2 freeze-period ≥1h guard&quot;
-              </div>
-              <div>&nbsp;</div>
-              <div className="text-slate-500">
-                命中 3 slices · 0.4ms · 下次会话注入前缀，直接命中字节缓存
-              </div>
-              <div>
-                <span className="blink inline-block h-4 w-2 bg-emerald-400 align-middle">
-                  ▍
-                </span>
-              </div>
-            </div>
-          </div>
+
+            <p className="mx-auto mt-8 max-w-2xl text-center text-sm leading-6 text-muted-foreground md:text-base">
+              Semantix 连接 Agent Harness 与资源层，提供切片提取、BM25 检索和稳定注入路径。
+              <br className="hidden md:block" />
+              当前公开证据来自仓库测试与合成演示；生产环境中的成本和性能收益仍待验证。
+            </p>
           </div>
         </Reveal>
       </div>

--- a/site/src/components/Nav.tsx
+++ b/site/src/components/Nav.tsx
@@ -1,8 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
+import {
+  INTRO_COMPLETION_EVENT,
+  type IntroCompletionDetail,
+} from "@/lib/intro-events";
+import { siteIdentity } from "@/lib/site-identity";
 import type { NavLink } from "@/types/content";
 
 const links: NavLink[] = [
@@ -15,39 +21,35 @@ const links: NavLink[] = [
   { label: "安装", labelEn: "Install", href: "/#start" },
 ];
 
+function NavLabel({ label, labelEn }: Pick<NavLink, "label" | "labelEn">) {
+  return (
+    <span className="inline-flex items-baseline gap-1.5">
+      <span>{labelEn}</span>
+      <span>{label}</span>
+    </span>
+  );
+}
+
 export default function Nav() {
-  const [scrolled, setScrolled] = useState(false);
   const [visible, setVisible] = useState(false);
   const [open, setOpen] = useState(false);
 
-  // 滚动状态：>8px 后白底 + 边框（对齐原站 header 行为）
+  // 首页导航由品牌开场动画发出完成信号；其他页面直接显示。
   useEffect(() => {
-    const onScroll = () => {
-      setScrolled(window.scrollY > 8);
+    const syncVisibility = () => {
       const intro = document.getElementById("brand-intro");
-      setVisible(!intro || window.scrollY > 8);
+      setVisible(!intro || document.documentElement.dataset.introComplete === "true");
     };
 
-    const onScrollIntent = (event: WheelEvent) => {
-      if (event.deltaY > 0 && document.getElementById("brand-intro")) {
-        setVisible(true);
-      }
+    const onIntroCompletion = (event: Event) => {
+      const { complete } = (event as CustomEvent<IntroCompletionDetail>).detail;
+      setVisible(complete);
     };
 
-    const onTouchMove = () => {
-      if (document.getElementById("brand-intro")) setVisible(true);
-    };
-
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("wheel", onScrollIntent, { passive: true });
-    window.addEventListener("touchmove", onTouchMove, { passive: true });
-    window.addEventListener("resize", onScroll);
+    syncVisibility();
+    window.addEventListener(INTRO_COMPLETION_EVENT, onIntroCompletion);
     return () => {
-      window.removeEventListener("scroll", onScroll);
-      window.removeEventListener("wheel", onScrollIntent);
-      window.removeEventListener("touchmove", onTouchMove);
-      window.removeEventListener("resize", onScroll);
+      window.removeEventListener(INTRO_COMPLETION_EVENT, onIntroCompletion);
     };
   }, []);
 
@@ -62,36 +64,45 @@ export default function Nav() {
   return (
     <header
       className={cn(
-        "fixed top-0 z-50 w-full border-b transition-all duration-300",
-        visible ? "translate-y-0 opacity-100" : "pointer-events-none -translate-y-full opacity-0",
-        scrolled || open
-          ? "border-border bg-white/85 backdrop-blur"
-          : "border-transparent bg-transparent",
+        "fixed top-0 z-50 w-full border-b border-border bg-white/90 backdrop-blur transition-[transform,opacity] duration-500 ease-[cubic-bezier(0.16,1,0.3,1)]",
+        visible
+          ? "translate-y-0 opacity-100 delay-100"
+          : "pointer-events-none -translate-y-full opacity-0 delay-0",
       )}
     >
       <div className="mx-auto flex h-16 w-full max-w-[1360px] items-center justify-between px-5 sm:px-6">
         {/* Logo */}
-        <Link href="/" aria-label="Semantix 首页" className="flex items-center gap-2.5">
-          <img
-            src="/seo/favicon.svg"
-            alt=""
-            className="size-8 text-foreground"
-            aria-hidden="true"
-          />
-          <span className="font-mono text-lg font-semibold text-foreground">
-            semantix
+        <a
+          href={siteIdentity.operator.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="访问 EnsureOK 官网"
+          className="block shrink-0 transition-opacity hover:opacity-65"
+        >
+          <span className="flex flex-col items-center gap-0.5 text-[#050505]">
+            <Image
+              src="/seo/favicon.svg"
+              alt=""
+              width={22}
+              height={22}
+              className="size-[1.15rem] sm:size-5"
+              aria-hidden="true"
+            />
+            <span className="font-brand-display text-[10px] font-black leading-none tracking-[0.045em] sm:text-[11px]">
+              ENSUREOK
+            </span>
           </span>
-        </Link>
+        </a>
 
         {/* 桌面端中间导航链接（移动端隐藏） */}
-        <nav className="hidden items-center gap-4 xl:flex 2xl:gap-6">
+        <nav className="hidden items-center gap-5 xl:flex 2xl:gap-7">
           {links.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className="shrink-0 whitespace-nowrap text-xs text-muted-foreground transition-colors hover:text-accent 2xl:text-sm"
+              className="font-brand-display shrink-0 whitespace-nowrap text-xs font-bold tracking-[0.025em] text-muted-foreground transition-colors hover:text-accent 2xl:text-sm"
             >
-              <span className="font-semibold">{link.labelEn}</span> {link.label}
+              <NavLabel label={link.label} labelEn={link.labelEn} />
             </Link>
           ))}
         </nav>
@@ -102,15 +113,15 @@ export default function Nav() {
             href="https://github.com/Gnosil/semantix"
             target="_blank"
             rel="noopener noreferrer"
-            className="hidden rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-accent hover:text-foreground sm:inline-block"
+            className="font-brand-display hidden rounded-md border border-border px-3 py-1.5 text-sm font-bold text-muted-foreground transition-colors hover:border-accent hover:text-foreground sm:inline-block"
           >
             GitHub <span aria-hidden="true">↗</span>
           </a>
           <Link
             href="/#start"
-            className="rounded-md bg-accent px-3 py-1.5 text-sm text-white transition-opacity hover:opacity-90"
+            className="font-brand-display rounded-md bg-accent px-3 py-1.5 text-sm font-bold text-white transition-opacity hover:opacity-90"
           >
-            <span className="font-semibold">Install</span> 安装
+            Install 安装
           </Link>
 
           {/* 汉堡按钮（移动端） */}
@@ -158,16 +169,16 @@ export default function Nav() {
               key={link.href}
               href={link.href}
               onClick={() => setOpen(false)}
-              className="rounded-lg px-3 py-4 text-lg font-medium text-foreground transition-colors hover:bg-muted"
+              className="font-brand-display rounded-lg px-3 py-4 text-lg font-bold tracking-[0.025em] text-foreground transition-colors hover:bg-muted"
             >
-              <span className="font-semibold">{link.labelEn}</span> {link.label}
+              <NavLabel label={link.label} labelEn={link.labelEn} />
             </Link>
           ))}
           <a
             href="https://github.com/Gnosil/semantix"
             target="_blank"
             rel="noopener noreferrer"
-            className="rounded-lg px-3 py-4 text-lg text-muted-foreground transition-colors hover:bg-muted"
+            className="font-brand-display rounded-lg px-3 py-4 text-lg font-bold text-muted-foreground transition-colors hover:bg-muted"
           >
             GitHub <span aria-hidden="true">↗</span>
           </a>

--- a/site/src/lib/intro-events.ts
+++ b/site/src/lib/intro-events.ts
@@ -1,0 +1,5 @@
+export const INTRO_COMPLETION_EVENT = "semantix:intro-completion";
+
+export type IntroCompletionDetail = {
+  complete: boolean;
+};


### PR DESCRIPTION
## 改动范围

6 个前端文件，纯 site 侧 UI polish（相对 `main`）：

- `site/src/components/BrandIntroOverlay.tsx`
- `site/src/components/Components.tsx`
- `site/src/components/Features.tsx`
- `site/src/components/Hero.tsx`
- `site/src/components/Nav.tsx`
- `site/src/lib/intro-events.ts`

## 行为变化

导航显示从"向下滚动意图（wheel/touchmove）触发"改为"品牌 intro 完成事件（`INTRO_COMPLETION_EVENT`）驱动"，Nav 增加 `intro-events.ts` 事件契约。

## 测试

- `site/scripts/nav-intro.test.mjs` 契约测试同步更新为品牌 intro 完成行为（9d1b14e），修复此前 Website checks 失败
- 本地 `npm run check`（lint + typecheck + build + test:content）全绿：35/35 tests pass