### PR TITLE
fix(site): show real GitHub avatars in contributor marquee

### DIFF
--- a/site/scripts/local-fonts.test.mjs
+++ b/site/scripts/local-fonts.test.mjs
@@ -20,9 +20,11 @@ test("site fonts are self-hosted through pinned Fontsource packages", () => {
 
   for (const [packageName, familyName] of fonts) {
     assert.equal(packageJson.dependencies[`@fontsource-variable/${packageName}`], "5.3.0");
+    // Fontsource CSS is loaded via JS imports in layout.tsx (Tailwind v4's
+    // LightningCSS cannot resolve bare package names in CSS @import).
     assert.match(
-      globals,
-      new RegExp(`@import ["']@fontsource-variable/${packageName}/wght\\.css["']`),
+      layout,
+      new RegExp(`import ["']@fontsource-variable/${packageName}/wght\\.css["']`),
     );
     assert.ok(globals.includes(`"${familyName}"`), `${familyName} should be used by the theme`);
     assert.ok(licenses.includes(`@fontsource-variable/${packageName}`));

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -1,6 +1,3 @@
-@import "@fontsource-variable/inter/wght.css";
-@import "@fontsource-variable/jetbrains-mono/wght.css";
-@import "@fontsource-variable/noto-sans-sc/wght.css";
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -6,6 +6,9 @@ import {
   websiteJsonLd,
 } from "@/lib/site-identity";
 import { maintainersJsonLd } from "@/lib/content-authors";
+import "@fontsource-variable/inter/wght.css";
+import "@fontsource-variable/jetbrains-mono/wght.css";
+import "@fontsource-variable/noto-sans-sc/wght.css";
 import "./globals.css";
 
 export const metadata: Metadata = {

--- a/site/src/components/Community.tsx
+++ b/site/src/components/Community.tsx
@@ -9,7 +9,6 @@ const contributors = [
   "radianceded",
   "jh10724-dotcom",
   "Allenllii",
-  "lr",
 ];
 
 const repo = siteIdentity.repositoryUrl;

--- a/site/src/components/Community.tsx
+++ b/site/src/components/Community.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 import Reveal from "@/components/Reveal";
 import { siteIdentity } from "@/lib/site-identity";
@@ -9,13 +10,6 @@ const contributors = [
   "jh10724-dotcom",
   "Allenllii",
   "lr",
-];
-
-const avatarColors = [
-  "bg-[oklch(0.608_0.14_165)]",
-  "bg-[oklch(0.524_0.12_165)]",
-  "bg-[oklch(0.45_0.1_165)]",
-  "bg-[oklch(0.35_0.08_165)]",
 ];
 
 const repo = siteIdentity.repositoryUrl;
@@ -175,18 +169,26 @@ export default function Community() {
                 <div className="crew-row">
                   {[...contributors, ...contributors].map((login, i) => (
                     <a key={`a-${i}`} href={`https://github.com/${login}`} target="_blank" rel="noopener noreferrer" title={login}>
-                      <span className={`flex h-9 w-9 items-center justify-center rounded-full border border-white/70 text-xs font-semibold text-white shadow-sm ${avatarColors[i % avatarColors.length]}`}>
-                        {login.charAt(0).toUpperCase()}
-                      </span>
+                      <Image
+                        src={`https://github.com/${login}.png`}
+                        width={72}
+                        height={72}
+                        alt={`${login} 的头像`}
+                        className="h-9 w-9 rounded-full border border-white/70 object-cover shadow-sm"
+                      />
                     </a>
                   ))}
                 </div>
                 <div className="crew-row rev mt-3">
                   {[...contributors, ...contributors].map((login, i) => (
                     <a key={`b-${i}`} href={`https://github.com/${login}`} target="_blank" rel="noopener noreferrer" title={login}>
-                      <span className={`flex h-9 w-9 items-center justify-center rounded-full border border-white/70 text-xs font-semibold text-white shadow-sm ${avatarColors[(i + 2) % avatarColors.length]}`}>
-                        {login.charAt(0).toUpperCase()}
-                      </span>
+                      <Image
+                        src={`https://github.com/${login}.png`}
+                        width={72}
+                        height={72}
+                        alt={`${login} 的头像`}
+                        className="h-9 w-9 rounded-full border border-white/70 object-cover shadow-sm"
+                      />
                     </a>
                   ))}
                 </div>


### PR DESCRIPTION
把 Community 区块的贡献者滚动头像从首字母色块改为真实 GitHub 头像，并修复合并最新 main 后暴露的网站构建检查问题。

- 头像使用 GitHub 规范地址 `https://github.com/{login}.png`，保留原链接、title 与无障碍文本
- 使用 `next/image`；站点为静态导出且已启用 `unoptimized`，无需额外远程图片域配置
- 移除没有对应作者资料的旧 `lr` 条目及不再使用的 `avatarColors`
- 将 Fontsource 样式从 `globals.css` 的包名 `@import` 移到 `layout.tsx` 的模块导入，避免 Tailwind v4 / LightningCSS 解析失败
- 同步更新本地字体测试，断言实际生效的导入位置

验证：
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:content`
- GitHub Actions：Go checks、Website checks 均通过
