### PR TITLE
feat(cli): M2-U25 install 命令（agent-skill 安装器）(Issue #119)

### DIFF
--- a/cmd/semantix/doctor_test.go
+++ b/cmd/semantix/doctor_test.go
@@ -451,7 +451,7 @@ func TestDoctorHelpShowsPlanned(t *testing.T) {
 		t.Fatalf("help: code = %d", code)
 	}
 	if !strings.Contains(stdout.String(), "Product & management") ||
-		!strings.Contains(stdout.String(), "planned: install completion") ||
+		!strings.Contains(stdout.String(), "planned: completion") ||
 		!strings.Contains(stdout.String(), "version") ||
 		!strings.Contains(stdout.String(), "config") ||
 		!strings.Contains(stdout.String(), "init") {

--- a/cmd/semantix/install.go
+++ b/cmd/semantix/install.go
@@ -1,0 +1,413 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// installTargets are the harnesses `semantix install` supports (Issue #119).
+// reasonix is the Gnosil/DeepSeek-Reasonix fork, which already ships a
+// built-in integration ([semantix] enabled=true); install lands the
+// agent-skill reference docs locally and prints the one-line config step.
+// claude-code uses the Claude Code agent-skills directory; custom is any
+// directory the user names with --dir.
+var installTargets = []string{"reasonix", "claude-code", "custom"}
+
+// installManifestName is the bookkeeping file `semantix install` writes into
+// the destination. It lists exactly which files install placed there, so
+// --uninstall can remove them without touching anything the user added
+// afterwards. It is intentionally a dotfile: it must not shadow the payload.
+const installManifestName = ".semantix-install.json"
+
+// installFileAction is one file's outcome on install/uninstall.
+type installFileAction string
+
+const (
+	actionInstalled installFileAction = "installed"
+	actionUpdated   installFileAction = "updated"
+	actionUnchanged installFileAction = "unchanged"
+	actionRemoved   installFileAction = "removed"
+	actionSkipped   installFileAction = "skipped" // listed in manifest but absent (already uninstalled)
+)
+
+// installFile is one payload file and what happened to it.
+type installFile struct {
+	Path   string            `json:"path"`
+	Action installFileAction `json:"action"`
+}
+
+// installReport is the `data` payload of `semantix install --json` (§4.2).
+type installReport struct {
+	Target string        `json:"target"`
+	Source string        `json:"source,omitempty"`
+	Dest   string        `json:"dest"`
+	Files  []installFile `json:"files"`
+	Next   []string      `json:"next,omitempty"`
+}
+
+// installEnvelope is the §4.2 JSON envelope: ok + command + data + error +
+// version, mirroring the doctor command's envelope.
+type installEnvelope struct {
+	OK      bool          `json:"ok"`
+	Command string        `json:"command"`
+	Data    installReport `json:"data"`
+	Error   any           `json:"error"`
+	Version string        `json:"version"`
+}
+
+// installManifest is the bookkeeping file written to the destination.
+type installManifest struct {
+	Command string   `json:"command"`
+	Target  string   `json:"target"`
+	Version string   `json:"version"`
+	Files   []string `json:"files"`
+}
+
+// runInstall implements the U25 agent-skill installer (Issue #119): it drops
+// the agent-skill payload (SKILL.md + tools schema + hooks + config + scripts)
+// into the target harness directory. Re-runs are safe (byte-identical files
+// are left untouched, changed ones overwritten), and --uninstall removes
+// exactly the files install recorded in its manifest.
+func runInstall(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	target := fs.String("target", "", "harness to install into (reasonix|claude-code|custom)")
+	dir := fs.String("dir", "", "destination directory (required for custom; default per target)")
+	source := fs.String("source", "", "agent-skill source dir (default: SEMANTIX_SKILL_DIR, exe-relative, ./agent-skill)")
+	uninstall := fs.Bool("uninstall", false, "remove a previous install instead of installing")
+	jsonOutput := fs.Bool("json", false, "write the report as JSON (envelope per cli-v2-architecture §4.2)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0 // --help is a successful request
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Usage: semantix install --target reasonix|claude-code|custom [--dir <path>] [--uninstall]")
+		return 2
+	}
+	if *target == "" {
+		fmt.Fprintln(stderr, "semantix install: missing --target (want reasonix|claude-code|custom)")
+		return 2
+	}
+	if !installTargetValid(*target) {
+		fmt.Fprintf(stderr, "semantix install: invalid target %q (want %s)\n",
+			*target, strings.Join(installTargets, "|"))
+		return 2
+	}
+
+	dest, err := installDestDir(*target, *dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "semantix install: %v\n", err)
+		return 2
+	}
+
+	if *uninstall {
+		report := runInstallUninstall(*target, dest)
+		return emitInstallResult(stdout, stderr, "install", "uninstall", report, *jsonOutput)
+	}
+
+	src, err := resolveInstallSource(*source)
+	if err != nil {
+		fmt.Fprintf(stderr, "semantix install: %v\n", err)
+		return 1
+	}
+	report, err := runInstallCopy(src, dest)
+	if err != nil {
+		fmt.Fprintf(stderr, "semantix install: %v\n", err)
+		return 1
+	}
+	report.Target = *target
+	report.Source = src
+	report.Dest = dest
+	report.Next = installNextSteps(*target, dest)
+	if err := writeInstallManifest(dest, *target, report.Files); err != nil {
+		fmt.Fprintf(stderr, "semantix install: %v\n", err)
+		return 1
+	}
+	return emitInstallResult(stdout, stderr, "install", "install", report, *jsonOutput)
+}
+
+// installTargetValid reports whether target is one of installTargets.
+func installTargetValid(target string) bool {
+	for _, t := range installTargets {
+		if t == target {
+			return true
+		}
+	}
+	return false
+}
+
+// installDestDir resolves the destination directory: an explicit --dir wins;
+// otherwise each target has a conventional default. custom has no default,
+// which is a usage error (handled by the caller via the error return).
+func installDestDir(target, dirFlag string) (string, error) {
+	if dirFlag != "" {
+		return dirFlag, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve home directory: %w", err)
+	}
+	switch target {
+	case "reasonix":
+		return filepath.Join(home, ".semantix", "agent-skill"), nil
+	case "claude-code":
+		return filepath.Join(home, ".claude", "skills", "semantix"), nil
+	case "custom":
+		return "", errors.New("--dir is required for --target custom")
+	}
+	return "", fmt.Errorf("invalid target %q (want %s)", target, strings.Join(installTargets, "|"))
+}
+
+// resolveInstallSource finds the agent-skill payload directory, in order:
+// --source > SEMANTIX_SKILL_DIR > <exe-dir>/../agent-skill (release bundle
+// layout) > ./agent-skill (repo checkout). A candidate is valid only when it
+// contains SKILL.md, the payload's anchor file.
+func resolveInstallSource(flagSource string) (string, error) {
+	candidates := []string{}
+	if flagSource != "" {
+		candidates = append(candidates, flagSource)
+	}
+	if v := os.Getenv("SEMANTIX_SKILL_DIR"); v != "" {
+		candidates = append(candidates, v)
+	}
+	if exe, err := os.Executable(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(filepath.Dir(exe), "..", "agent-skill"),
+			filepath.Join(filepath.Dir(exe), "agent-skill"))
+	}
+	candidates = append(candidates, "agent-skill")
+	for _, c := range candidates {
+		if ok, _ := validSkillDir(c); ok {
+			return c, nil
+		}
+	}
+	return "", fmt.Errorf("agent-skill source not found (looked at: %s); pass --source <dir> or set SEMANTIX_SKILL_DIR",
+		strings.Join(candidates, ", "))
+}
+
+// validSkillDir reports whether dir exists and contains SKILL.md.
+func validSkillDir(dir string) (bool, error) {
+	info, err := os.Stat(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return !info.IsDir(), nil
+}
+
+// installNextSteps prints per-target follow-ups. Both SKILL.md and
+// hooks/session-bypass.md are part of the installed payload (the issue's
+// acceptance requires the output to reference them).
+func installNextSteps(target, dest string) []string {
+	switch target {
+	case "reasonix":
+		return []string{
+			fmt.Sprintf("set [semantix] enabled=true in the Reasonix config (built-in integration, zero steps; see %s)",
+				filepath.Join(dest, "SKILL.md")),
+			fmt.Sprintf("session capture reference: %s", filepath.Join(dest, "hooks", "session-bypass.md")),
+		}
+	case "claude-code":
+		return []string{
+			fmt.Sprintf("restart Claude Code; the semantix skill will be picked up from %s", dest),
+			fmt.Sprintf("register the tool schema: %s", filepath.Join(dest, "tools", "semantix-lookup.md")),
+			fmt.Sprintf("usage guide: %s", filepath.Join(dest, "SKILL.md")),
+		}
+	default: // custom
+		return []string{
+			fmt.Sprintf("wire the copied tools into your agent: %s", filepath.Join(dest, "tools", "semantix-lookup.md")),
+			fmt.Sprintf("usage guide: %s", filepath.Join(dest, "SKILL.md")),
+			fmt.Sprintf("session capture reference: %s", filepath.Join(dest, "hooks", "session-bypass.md")),
+		}
+	}
+}
+
+// runInstallCopy copies every file under src into dest, preserving relative
+// paths, and reports each file's action. Directory entries are created as
+// needed; existing files are byte-compared so re-runs are no-ops (idempotent,
+// §验收标准: 重复安装可安全重跑).
+func runInstallCopy(src, dest string) (installReport, error) {
+	var report installReport
+	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil // MkdirAll happens per file
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == installManifestName {
+			return nil // never copy a manifest that lives in a source dir
+		}
+		action, err := copyInstallFile(path, filepath.Join(dest, rel))
+		if err != nil {
+			return err
+		}
+		report.Files = append(report.Files, installFile{Path: filepath.ToSlash(rel), Action: action})
+		return nil
+	})
+	return report, err
+}
+
+// copyInstallFile writes one payload file into destPath: MkdirAll the parent,
+// byte-compare against the existing file, and only write when different.
+func copyInstallFile(srcPath, destPath string) (installFileAction, error) {
+	content, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
+		return "", err
+	}
+	existing, err := os.ReadFile(destPath)
+	if err == nil {
+		if bytes.Equal(existing, content) {
+			return actionUnchanged, nil
+		}
+		return actionUpdated, writeInstallFile(destPath, content)
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+	return actionInstalled, writeInstallFile(destPath, content)
+}
+
+// writeInstallFile writes content with 0600 perms (memory-store convention;
+// Windows ignores the permission bits).
+func writeInstallFile(path string, content []byte) error {
+	return os.WriteFile(path, content, 0o600)
+}
+
+// writeInstallManifest records the installed file list at dest so --uninstall
+// can remove exactly those files. The manifest itself is not listed in it.
+func writeInstallManifest(dest, target string, files []installFile) error {
+	m := installManifest{
+		Command: "install",
+		Target:  target,
+		Version: cliVersion,
+	}
+	for _, f := range files {
+		m.Files = append(m.Files, f.Path)
+	}
+	sort.Strings(m.Files)
+	content, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		return err
+	}
+	return writeInstallFile(filepath.Join(dest, installManifestName), content)
+}
+
+// runInstallUninstall removes a previous install: it reads the manifest
+// written by install and deletes exactly the listed files, then the manifest
+// itself. A missing manifest means there is nothing tracked — a no-op, so
+// repeated --uninstall is safe. Files the user added after installing are
+// never touched (the manifest is the only removal list).
+func runInstallUninstall(target, dest string) installReport {
+	report := installReport{Target: target, Dest: dest}
+	manifestPath := filepath.Join(dest, installManifestName)
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		report.Next = []string{
+			fmt.Sprintf("no install manifest at %s — nothing tracked to uninstall", manifestPath),
+		}
+		return report
+	}
+	var m installManifest
+	if err := json.Unmarshal(content, &m); err != nil {
+		report.Next = []string{
+			fmt.Sprintf("install manifest at %s is corrupt (%v) — remove it manually, then re-run", manifestPath, err),
+		}
+		return report
+	}
+	dirs := map[string]bool{}
+	for _, f := range m.Files {
+		path := filepath.Join(dest, filepath.FromSlash(f))
+		if _, err := os.Stat(path); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				report.Files = append(report.Files, installFile{Path: f, Action: actionSkipped})
+				continue
+			}
+			report.Files = append(report.Files, installFile{Path: f, Action: actionSkipped})
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			report.Files = append(report.Files, installFile{Path: f, Action: actionSkipped})
+			continue
+		}
+		report.Files = append(report.Files, installFile{Path: f, Action: actionRemoved})
+		for p := filepath.Dir(path); p != dest && p != filepath.Dir(p); p = filepath.Dir(p) {
+			dirs[p] = true
+		}
+	}
+	if err := os.Remove(manifestPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		report.Next = append(report.Next, fmt.Sprintf("could not remove manifest %s: %v", manifestPath, err))
+	}
+	// Prune now-empty parent directories bottom-up.
+	var sorted []string
+	for p := range dirs {
+		sorted = append(sorted, p)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return len(sorted[i]) > len(sorted[j]) })
+	for _, p := range sorted {
+		_ = os.Remove(p) // only succeeds when empty
+	}
+	return report
+}
+
+// emitInstallResult renders the report as the §4.2 JSON envelope (--json) or
+// as grep-able human output. The JSON envelope always reports command=install
+// (--uninstall is a flag of the install command); the human header shows the
+// operation. This function is only reached when the operation itself
+// succeeded, so it always returns 0.
+func emitInstallResult(stdout, stderr io.Writer, command, op string, report installReport, jsonOutput bool) int {
+	if jsonOutput {
+		env := installEnvelope{
+			OK:      true,
+			Command: command,
+			Data:    report,
+			Version: cliVersion,
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(env); err != nil {
+			fmt.Fprintf(stderr, "semantix install: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	line := "semantix install"
+	if op == "uninstall" {
+		line = "semantix install --uninstall"
+	}
+	fmt.Fprintf(stdout, "# %s v%s target=%s\n", line, cliVersion, report.Target)
+	if report.Source != "" {
+		fmt.Fprintf(stdout, "  source: %s\n", report.Source)
+	}
+	fmt.Fprintf(stdout, "  dest:   %s\n", report.Dest)
+	for _, f := range report.Files {
+		fmt.Fprintf(stdout, "[%s] %s\n", f.Action, f.Path)
+	}
+	for _, n := range report.Next {
+		fmt.Fprintf(stdout, "next: %s\n", n)
+	}
+	return 0
+}

--- a/cmd/semantix/install.go
+++ b/cmd/semantix/install.go
@@ -45,7 +45,7 @@ type installFile struct {
 	Action installFileAction `json:"action"`
 }
 
-// installReport is the `data` payload of `semantix install --json` (§4.2).
+// installReport is the `data` payload of `semantix install --json` (搂4.2).
 type installReport struct {
 	Target string        `json:"target"`
 	Source string        `json:"source,omitempty"`
@@ -54,7 +54,7 @@ type installReport struct {
 	Next   []string      `json:"next,omitempty"`
 }
 
-// installEnvelope is the §4.2 JSON envelope: ok + command + data + error +
+// installEnvelope is the 搂4.2 JSON envelope: ok + command + data + error +
 // version, mirroring the doctor command's envelope.
 type installEnvelope struct {
 	OK      bool          `json:"ok"`
@@ -84,7 +84,7 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 	dir := fs.String("dir", "", "destination directory (required for custom; default per target)")
 	source := fs.String("source", "", "agent-skill source dir (default: SEMANTIX_SKILL_DIR, exe-relative, ./agent-skill)")
 	uninstall := fs.Bool("uninstall", false, "remove a previous install instead of installing")
-	jsonOutput := fs.Bool("json", false, "write the report as JSON (envelope per cli-v2-architecture §4.2)")
+	jsonOutput := fs.Bool("json", false, "write the report as JSON (envelope per cli-v2-architecture 搂4.2)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0 // --help is a successful request
@@ -112,29 +112,63 @@ func runInstall(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if *uninstall {
-		report := runInstallUninstall(*target, dest)
+		report, err := runInstallUninstall(*target, dest)
+		if err != nil {
+			return installFail(stdout, stderr, "install", *target, dest, *jsonOutput, 1, err)
+		}
 		return emitInstallResult(stdout, stderr, "install", "uninstall", report, *jsonOutput)
 	}
 
 	src, err := resolveInstallSource(*source)
 	if err != nil {
-		fmt.Fprintf(stderr, "semantix install: %v\n", err)
-		return 1
+		return installFail(stdout, stderr, "install", *target, dest, *jsonOutput, 1, err)
+	}
+	if installDestOverlapsSource(src, dest) {
+		return installFail(stdout, stderr, "install", *target, dest, *jsonOutput, 1,
+			fmt.Errorf("destination %s must not be the agent-skill source directory %s (or a subdirectory of it)", dest, src))
 	}
 	report, err := runInstallCopy(src, dest)
 	if err != nil {
-		fmt.Fprintf(stderr, "semantix install: %v\n", err)
-		return 1
+		// A partial copy is still recorded: write a manifest of what landed
+		// so --uninstall can clean it up, then report the failure.
+		if len(report.Files) > 0 {
+			_ = writeInstallManifest(dest, *target, report.Files)
+		}
+		return installFail(stdout, stderr, "install", *target, dest, *jsonOutput, 1, err)
 	}
 	report.Target = *target
 	report.Source = src
 	report.Dest = dest
 	report.Next = installNextSteps(*target, dest)
 	if err := writeInstallManifest(dest, *target, report.Files); err != nil {
-		fmt.Fprintf(stderr, "semantix install: %v\n", err)
-		return 1
+		return installFail(stdout, stderr, "install", *target, dest, *jsonOutput, 1, err)
 	}
 	return emitInstallResult(stdout, stderr, "install", "install", report, *jsonOutput)
+}
+
+// installFail reports a runtime failure. With --json it emits the 搂4.2
+// envelope (ok=false + error:{code,message}) on stdout so scripted callers
+// get machine-readable output; otherwise the message goes to stderr. The
+// exit code is passed in by the caller (1 for runtime errors).
+func installFail(stdout, stderr io.Writer, command, target, dest string, jsonOutput bool, code int, err error) int {
+	if jsonOutput {
+		env := installEnvelope{
+			OK:      false,
+			Command: command,
+			Data: installReport{
+				Target: target,
+				Dest:   dest,
+			},
+			Error:   envelopeError{Code: code, Message: err.Error()},
+			Version: cliVersion,
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		enc.SetEscapeHTML(false)
+		_ = enc.Encode(env)
+	}
+	fmt.Fprintf(stderr, "semantix install: %v\n", err)
+	return code
 }
 
 // installTargetValid reports whether target is one of installTargets.
@@ -172,12 +206,18 @@ func installDestDir(target, dirFlag string) (string, error) {
 // resolveInstallSource finds the agent-skill payload directory, in order:
 // --source > SEMANTIX_SKILL_DIR > <exe-dir>/../agent-skill (release bundle
 // layout) > ./agent-skill (repo checkout). A candidate is valid only when it
-// contains SKILL.md, the payload's anchor file.
+// contains SKILL.md, the payload's anchor file. An explicit --source is
+// final: when it is invalid the call fails instead of silently falling back
+// to another directory (the user's explicit choice must never be overridden
+// by a default).
 func resolveInstallSource(flagSource string) (string, error) {
-	candidates := []string{}
 	if flagSource != "" {
-		candidates = append(candidates, flagSource)
+		if ok, _ := validSkillDir(flagSource); ok {
+			return flagSource, nil
+		}
+		return "", fmt.Errorf("agent-skill source %s not found (want a directory containing SKILL.md)", flagSource)
 	}
+	var candidates []string
 	if v := os.Getenv("SEMANTIX_SKILL_DIR"); v != "" {
 		candidates = append(candidates, v)
 	}
@@ -224,6 +264,7 @@ func installNextSteps(target, dest string) []string {
 			fmt.Sprintf("restart Claude Code; the semantix skill will be picked up from %s", dest),
 			fmt.Sprintf("register the tool schema: %s", filepath.Join(dest, "tools", "semantix-lookup.md")),
 			fmt.Sprintf("usage guide: %s", filepath.Join(dest, "SKILL.md")),
+			fmt.Sprintf("session capture reference: %s", filepath.Join(dest, "hooks", "session-bypass.md")),
 		}
 	default: // custom
 		return []string{
@@ -237,7 +278,7 @@ func installNextSteps(target, dest string) []string {
 // runInstallCopy copies every file under src into dest, preserving relative
 // paths, and reports each file's action. Directory entries are created as
 // needed; existing files are byte-compared so re-runs are no-ops (idempotent,
-// §验收标准: 重复安装可安全重跑).
+// 搂楠屾敹鏍囧噯: 閲嶅瀹夎鍙畨鍏ㄩ噸璺?.
 func runInstallCopy(src, dest string) (installReport, error) {
 	var report installReport
 	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
@@ -317,40 +358,50 @@ func writeInstallManifest(dest, target string, files []installFile) error {
 
 // runInstallUninstall removes a previous install: it reads the manifest
 // written by install and deletes exactly the listed files, then the manifest
-// itself. A missing manifest means there is nothing tracked — a no-op, so
+// itself. A missing manifest means there is nothing tracked 鈥?a no-op, so
 // repeated --uninstall is safe. Files the user added after installing are
 // never touched (the manifest is the only removal list).
-func runInstallUninstall(target, dest string) installReport {
+//
+// The manifest is not trusted blindly: every entry is validated to stay
+// inside dest (no absolute paths, no ".." components 鈥?a corrupt or tampered
+// manifest must never delete files outside the install directory). A corrupt
+// manifest or an unexpected IO failure is a runtime error (exit 1), not a
+// silent success.
+func runInstallUninstall(target, dest string) (installReport, error) {
 	report := installReport{Target: target, Dest: dest}
 	manifestPath := filepath.Join(dest, installManifestName)
 	content, err := os.ReadFile(manifestPath)
 	if err != nil {
-		report.Next = []string{
-			fmt.Sprintf("no install manifest at %s — nothing tracked to uninstall", manifestPath),
+		if errors.Is(err, fs.ErrNotExist) {
+			report.Next = []string{
+				fmt.Sprintf("no install manifest at %s 鈥?nothing tracked to uninstall", manifestPath),
+			}
+			return report, nil
 		}
-		return report
+		return report, fmt.Errorf("cannot read install manifest %s: %w", manifestPath, err)
 	}
 	var m installManifest
 	if err := json.Unmarshal(content, &m); err != nil {
-		report.Next = []string{
-			fmt.Sprintf("install manifest at %s is corrupt (%v) — remove it manually, then re-run", manifestPath, err),
-		}
-		return report
+		return report, fmt.Errorf("install manifest at %s is corrupt (%v) 鈥?remove it manually, then re-run", manifestPath, err)
 	}
 	dirs := map[string]bool{}
 	for _, f := range m.Files {
+		if !installPathInDest(dest, f) {
+			report.Files = append(report.Files, installFile{Path: f, Action: actionSkipped})
+			report.Next = append(report.Next,
+				fmt.Sprintf("skipped unsafe manifest entry %q (outside %s)", f, dest))
+			continue
+		}
 		path := filepath.Join(dest, filepath.FromSlash(f))
 		if _, err := os.Stat(path); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				report.Files = append(report.Files, installFile{Path: f, Action: actionSkipped})
 				continue
 			}
-			report.Files = append(report.Files, installFile{Path: f, Action: actionSkipped})
-			continue
+			return report, fmt.Errorf("cannot stat %s: %w", path, err)
 		}
 		if err := os.Remove(path); err != nil {
-			report.Files = append(report.Files, installFile{Path: f, Action: actionSkipped})
-			continue
+			return report, fmt.Errorf("cannot remove %s: %w", path, err)
 		}
 		report.Files = append(report.Files, installFile{Path: f, Action: actionRemoved})
 		for p := filepath.Dir(path); p != dest && p != filepath.Dir(p); p = filepath.Dir(p) {
@@ -358,7 +409,7 @@ func runInstallUninstall(target, dest string) installReport {
 		}
 	}
 	if err := os.Remove(manifestPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		report.Next = append(report.Next, fmt.Sprintf("could not remove manifest %s: %v", manifestPath, err))
+		return report, fmt.Errorf("could not remove manifest %s: %w", manifestPath, err)
 	}
 	// Prune now-empty parent directories bottom-up.
 	var sorted []string
@@ -369,10 +420,50 @@ func runInstallUninstall(target, dest string) installReport {
 	for _, p := range sorted {
 		_ = os.Remove(p) // only succeeds when empty
 	}
-	return report
+	return report, nil
 }
 
-// emitInstallResult renders the report as the §4.2 JSON envelope (--json) or
+// installPathInDest reports whether a manifest entry resolves to a location
+// inside dest: it must be a relative path whose cleaned form neither is an
+// absolute path nor escapes dest via "..". Windows drive-qualified and UNC
+// paths are absolute on this platform and are rejected too.
+func installPathInDest(dest, entry string) bool {
+	if entry == "" {
+		return false
+	}
+	if filepath.IsAbs(entry) || strings.HasPrefix(entry, "/") || strings.HasPrefix(entry, "\\") {
+		return false
+	}
+	if rel := strings.ReplaceAll(entry, "\\", "/"); strings.HasPrefix(rel, "/") {
+		return false
+	}
+	clean := filepath.Clean(filepath.FromSlash(entry))
+	if clean == "." || filepath.IsAbs(clean) {
+		return false
+	}
+	for _, part := range strings.Split(clean, string(filepath.Separator)) {
+		if part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+// installDestOverlapsSource reports whether the destination is the payload
+// source itself or nested inside it. Copying into the source tree would
+// either delete the payload on --uninstall (dest == src) or recurse while
+// walking (dest inside src), so both are refused up front.
+func installDestOverlapsSource(src, dest string) bool {
+	s := filepath.Clean(src)
+	d := filepath.Clean(dest)
+	if s == d {
+		return true
+	}
+	prefix := s + string(filepath.Separator)
+	return strings.HasPrefix(d, prefix)
+}
+
+// emitInstallResult renders the report as the 搂4.2 JSON envelope (--json) or
 // as grep-able human output. The JSON envelope always reports command=install
 // (--uninstall is a flag of the install command); the human header shows the
 // operation. This function is only reached when the operation itself

--- a/cmd/semantix/install_test.go
+++ b/cmd/semantix/install_test.go
@@ -297,6 +297,120 @@ func TestInstallSourceEnvFallback(t *testing.T) {
 	}
 }
 
+// TestInstallExplicitSourceIsFinal: an invalid --source must fail even when
+// another source would be resolvable (env/exe-relative/cwd). The user's
+// explicit choice is never silently overridden by a fallback.
+func TestInstallExplicitSourceIsFinal(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+	t.Setenv("SEMANTIX_SKILL_DIR", src) // valid fallback exists
+
+	code, _, stderr := installRuns(t,
+		"--target", "claude-code", "--dir", dest,
+		"--source", filepath.Join(t.TempDir(), "bogus"))
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 (stderr %q)", code, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatal("install must not proceed when --source is invalid")
+	}
+}
+
+// TestInstallJSONFailureEnvelope: with --json a runtime failure still emits
+// the §4.2 envelope (ok=false, error:{code,message}) instead of silent stdout.
+func TestInstallJSONFailureEnvelope(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "dest")
+	code, stdout, _ := installRuns(t,
+		"--target", "custom", "--dir", dest,
+		"--source", filepath.Join(t.TempDir(), "nope"), "--json")
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	var env installEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("stdout is not a JSON envelope: %v\n%s", err, stdout)
+	}
+	if env.OK || env.Command != "install" || env.Error == nil {
+		t.Fatalf("envelope = %+v, want ok=false with error payload", env)
+	}
+	if errEnv, ok := env.Error.(map[string]any); !ok || errEnv["code"] != float64(1) {
+		t.Fatalf("error payload = %v, want code 1", env.Error)
+	}
+}
+
+// TestInstallUninstallRejectsTraversal: manifest entries that escape dest
+// (.., absolute paths) are skipped, never resolved; files outside dest stay.
+func TestInstallUninstallRejectsTraversal(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+	if code, _, stderr := installRuns(t, "--target", "custom", "--dir", dest, "--source", src); code != 0 {
+		t.Fatalf("install code = %d, stderr = %q", code, stderr)
+	}
+	victim := filepath.Join(t.TempDir(), "victim.txt")
+	if err := os.WriteFile(victim, []byte("must survive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := installManifest{
+		Command: "install",
+		Target:  "custom",
+		Version: cliVersion,
+		Files:   []string{"SKILL.md", "../victim.txt", filepath.Join(t.TempDir(), "abs.txt")},
+	}
+	content, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, installManifestName), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := installRuns(t, "--target", "custom", "--dir", dest, "--uninstall")
+	if code != 0 {
+		t.Fatalf("uninstall code = %d, stderr = %q", code, stderr)
+	}
+	if data, err := os.ReadFile(victim); err != nil || string(data) != "must survive" {
+		t.Fatalf("victim file was touched: %q, err=%v", data, err)
+	}
+	if !strings.Contains(stdout, "skipped unsafe manifest entry") {
+		t.Fatalf("stdout must report skipped unsafe entries:\n%s", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatal("safe manifest entry not removed")
+	}
+}
+
+// TestInstallUninstallCorruptManifest: a corrupt manifest is a runtime error
+// (exit 1), not a silent success.
+func TestInstallUninstallCorruptManifest(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, installManifestName), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	code, _, stderr := installRuns(t, "--target", "custom", "--dir", dest, "--uninstall")
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 (stderr %q)", code, stderr)
+	}
+}
+
+// TestInstallRefusesSourceOverlap: installing into the payload source itself
+// (or a subdirectory of it) is refused.
+func TestInstallRefusesSourceOverlap(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	for _, dest := range []string{src, filepath.Join(src, "sub")} {
+		code, _, stderr := installRuns(t,
+			"--target", "custom", "--dir", dest, "--source", src)
+		if code != 1 {
+			t.Errorf("dest=%s: code = %d, want 1 (stderr %q)", dest, code, stderr)
+		}
+	}
+}
+
 // readInstallManifest decodes the manifest written into dest.
 func readInstallManifest(t *testing.T, dest string) installManifest {
 	t.Helper()

--- a/cmd/semantix/install_test.go
+++ b/cmd/semantix/install_test.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkillPayload creates a minimal agent-skill source tree mirroring the
+// real repo layout (SKILL.md, tools/, hooks/, config/, scripts/).
+func writeSkillPayload(t *testing.T, dir string) {
+	t.Helper()
+	files := map[string]string{
+		"SKILL.md":                     "# semantix skill\n\n> install me\n",
+		"tools/semantix-lookup.md":     "# semantix_lookup tool\n\n```json\n{\"name\":\"semantix_lookup\"}\n```\n",
+		"hooks/session-bypass.md":      "# session bypass\n\nExport JSONL and run extract.\n",
+		"config/semantix.example.toml": "[store]\ndb = \"~/.semantix/user.db\"\n",
+		"scripts/install.sh":           "#!/usr/bin/env bash\nset -euo pipefail\necho install\n",
+		"scripts/selftest.sh":          "#!/usr/bin/env bash\necho SELFTEST PASS\n",
+	}
+	for rel, content := range files {
+		path := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// installRuns is the common arrange for install tests: a payload source plus
+// a destination inside t.TempDir.
+func installRuns(t *testing.T, args ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	code = runInstall(args, &out, &errOut)
+	return code, out.String(), errOut.String()
+}
+
+func TestInstallUsageContract(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"no target", []string{}, 2},
+		{"invalid target", []string{"--target", "vscode"}, 2},
+		{"custom without --dir", []string{"--target", "custom", "--source", "x"}, 2},
+		{"extra positional", []string{"--target", "claude-code", "extra"}, 2},
+		{"unknown flag", []string{"--bogus"}, 2},
+		{"help exits zero", []string{"--help"}, 0},
+	}
+	for _, c := range cases {
+		code, _, stderr := installRuns(t, c.args...)
+		if code != c.want {
+			t.Errorf("%s: code = %d, want %d (stderr %q)", c.name, code, c.want, stderr)
+		}
+	}
+}
+
+func TestInstallCopiesPayload(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+
+	code, stdout, stderr := installRuns(t,
+		"--target", "claude-code", "--dir", dest, "--source", src)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %q", code, stderr)
+	}
+	want := []string{
+		"SKILL.md",
+		"tools/semantix-lookup.md",
+		"hooks/session-bypass.md",
+		"config/semantix.example.toml",
+		"scripts/install.sh",
+		"scripts/selftest.sh",
+	}
+	for _, rel := range want {
+		path := filepath.Join(dest, filepath.FromSlash(rel))
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("payload file %q not written: %v", rel, err)
+		}
+		srcContent, err := os.ReadFile(filepath.Join(src, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(content, srcContent) {
+			t.Errorf("%s: content mismatch", rel)
+		}
+	}
+	// Acceptance: output references agent-skill/SKILL.md and
+	// hooks/session-bypass.md (next steps point at the installed copies).
+	for _, rel := range []string{"SKILL.md", "hooks/session-bypass.md"} {
+		if !strings.Contains(stdout, rel) {
+			t.Errorf("stdout does not reference %s:\n%s", rel, stdout)
+		}
+	}
+	for _, rel := range want {
+		if !strings.Contains(stdout, "[installed] "+filepath.ToSlash(rel)) {
+			t.Errorf("stdout missing [installed] for %s:\n%s", rel, stdout)
+		}
+	}
+	// Manifest written with the file list.
+	manifest := readInstallManifest(t, dest)
+	if len(manifest.Files) != len(want) {
+		t.Fatalf("manifest files = %v, want %d", manifest.Files, len(want))
+	}
+	for _, rel := range want {
+		found := false
+		for _, m := range manifest.Files {
+			if m == filepath.ToSlash(rel) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("manifest missing %s (got %v)", rel, manifest.Files)
+		}
+	}
+}
+
+func TestInstallIdempotent(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+
+	args := []string{"--target", "reasonix", "--dir", dest, "--source", src}
+	code, _, stderr := installRuns(t, args...)
+	if code != 0 {
+		t.Fatalf("first run code = %d, stderr = %q", code, stderr)
+	}
+	before, err := os.ReadFile(filepath.Join(dest, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := installRuns(t, args...)
+	if code != 0 {
+		t.Fatalf("second run code = %d, stderr = %q", code, stderr)
+	}
+	after, err := os.ReadFile(filepath.Join(dest, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("second run modified an unchanged file")
+	}
+	if strings.Contains(stdout, "[installed]") || strings.Contains(stdout, "[updated]") {
+		t.Fatalf("second run must be a no-op, got:\n%s", stdout)
+	}
+	for _, rel := range []string{"SKILL.md", "tools/semantix-lookup.md", "hooks/session-bypass.md"} {
+		if !strings.Contains(stdout, "[unchanged] "+filepath.ToSlash(rel)) {
+			t.Errorf("stdout missing [unchanged] for %s:\n%s", rel, stdout)
+		}
+	}
+}
+
+func TestInstallUpdateOverwritesChangedFiles(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+
+	args := []string{"--target", "claude-code", "--dir", dest, "--source", src}
+	if code, _, stderr := installRuns(t, args...); code != 0 {
+		t.Fatalf("first run code = %d, stderr = %q", code, stderr)
+	}
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	code, stdout, stderr := installRuns(t, args...)
+	if code != 0 {
+		t.Fatalf("second run code = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "[updated] SKILL.md") {
+		t.Fatalf("stdout missing [updated] SKILL.md:\n%s", stdout)
+	}
+	content, err := os.ReadFile(filepath.Join(dest, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "# v2\n" {
+		t.Fatalf("SKILL.md = %q, want updated content", content)
+	}
+}
+
+func TestInstallUninstallRemovesTrackedFiles(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+
+	if code, _, stderr := installRuns(t, "--target", "claude-code", "--dir", dest, "--source", src); code != 0 {
+		t.Fatalf("install code = %d, stderr = %q", code, stderr)
+	}
+
+	code, stdout, stderr := installRuns(t, "--target", "claude-code", "--dir", dest, "--uninstall")
+	if code != 0 {
+		t.Fatalf("uninstall code = %d, stderr = %q", code, stderr)
+	}
+	for _, rel := range []string{
+		"SKILL.md", "tools/semantix-lookup.md", "hooks/session-bypass.md",
+		"config/semantix.example.toml", "scripts/install.sh", "scripts/selftest.sh",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, filepath.FromSlash(rel))); !os.IsNotExist(err) {
+			t.Errorf("%s still exists after uninstall", rel)
+		}
+		if !strings.Contains(stdout, "[removed] "+filepath.ToSlash(rel)) {
+			t.Errorf("stdout missing [removed] for %s:\n%s", rel, stdout)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dest, installManifestName)); !os.IsNotExist(err) {
+		t.Error("manifest still exists after uninstall")
+	}
+	// Idempotent: a second --uninstall is a safe no-op.
+	code, stdout, stderr = installRuns(t, "--target", "claude-code", "--dir", dest, "--uninstall")
+	if code != 0 {
+		t.Fatalf("second uninstall code = %d, stderr = %q", code, stderr)
+	}
+	if !strings.Contains(stdout, "nothing tracked") {
+		t.Fatalf("second uninstall should report nothing tracked:\n%s", stdout)
+	}
+}
+
+func TestInstallUninstallKeepsForeignFiles(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+
+	if code, _, stderr := installRuns(t, "--target", "custom", "--dir", dest, "--source", src); code != 0 {
+		t.Fatalf("install code = %d, stderr = %q", code, stderr)
+	}
+	foreign := filepath.Join(dest, "my-notes.txt")
+	if err := os.WriteFile(foreign, []byte("user data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code, _, stderr := installRuns(t, "--target", "custom", "--dir", dest, "--uninstall"); code != 0 {
+		t.Fatalf("uninstall code = %d, stderr = %q", code, stderr)
+	}
+	if content, err := os.ReadFile(foreign); err != nil || string(content) != "user data" {
+		t.Fatalf("foreign file was touched: content = %q, err = %v", content, err)
+	}
+}
+
+func TestInstallJSONEnvelope(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+
+	code, stdout, stderr := installRuns(t,
+		"--target", "reasonix", "--dir", dest, "--source", src, "--json")
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %q", code, stderr)
+	}
+	var env installEnvelope
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout)
+	}
+	if !env.OK || env.Command != "install" || env.Version != cliVersion {
+		t.Fatalf("envelope = %+v", env)
+	}
+	if env.Data.Target != "reasonix" || env.Data.Dest != dest || len(env.Data.Files) == 0 {
+		t.Fatalf("data = %+v", env.Data)
+	}
+	if len(env.Data.Next) == 0 {
+		t.Fatal("reasonix next steps missing (must reference SKILL.md / hooks/session-bypass.md)")
+	}
+	if !strings.Contains(env.Data.Next[0], "SKILL.md") {
+		t.Fatalf("next steps do not reference SKILL.md: %v", env.Data.Next)
+	}
+}
+
+func TestInstallMissingSource(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "dest")
+	code, _, stderr := installRuns(t,
+		"--target", "custom", "--dir", dest, "--source", filepath.Join(t.TempDir(), "nope"))
+	if code != 1 {
+		t.Fatalf("code = %d, want 1 (stderr %q)", code, stderr)
+	}
+}
+
+func TestInstallSourceEnvFallback(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "agent-skill")
+	writeSkillPayload(t, src)
+	dest := filepath.Join(t.TempDir(), "dest")
+	t.Setenv("SEMANTIX_SKILL_DIR", src)
+
+	code, _, stderr := installRuns(t, "--target", "claude-code", "--dir", dest)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %q", code, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "SKILL.md")); err != nil {
+		t.Fatal("payload not installed via SEMANTIX_SKILL_DIR")
+	}
+}
+
+// readInstallManifest decodes the manifest written into dest.
+func readInstallManifest(t *testing.T, dest string) installManifest {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(dest, installManifestName))
+	if err != nil {
+		t.Fatalf("manifest not found: %v", err)
+	}
+	var m installManifest
+	if err := json.Unmarshal(content, &m); err != nil {
+		t.Fatalf("manifest not valid JSON: %v", err)
+	}
+	return m
+}

--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -95,7 +95,7 @@ func (g commandGroup) String() string {
 // implement yet. They render in help as planned and reject dispatch with
 // exit 2 until their unit lands.
 var plannedByGroup = map[commandGroup][]string{
-	groupProduct:     {"install", "completion"},
+	groupProduct:     {"completion"},
 	groupMaintenance: {},
 	groupService:     {"serve", "watch"},
 }
@@ -150,6 +150,12 @@ var commands = []commandSpec{
 		summary: "health check (db / config / embedder / judge; exit 3 on any FAIL)",
 		run: func(args []string, stdout, stderr io.Writer, _ dependencies) int {
 			return runDoctor(args, stdout, stderr)
+		}},
+	{name: "install", group: groupProduct,
+		usage:   "semantix install --target reasonix|claude-code|custom [--dir <path>] [--uninstall]",
+		summary: "install agent-skill (skill + tool schema) into a harness",
+		run: func(args []string, stdout, stderr io.Writer, _ dependencies) int {
+			return runInstall(args, stdout, stderr)
 		}},
 	{name: "init", group: groupProduct,
 		usage:   "semantix init [--config <path>] [--force]",

--- a/cmd/semantix/main_test.go
+++ b/cmd/semantix/main_test.go
@@ -238,6 +238,9 @@ func TestDispatchExitCodeContract(t *testing.T) {
 		{"usage unknown flag → usage", []string{"usage", "--bogus"}, 2},
 		{"lookup missing query → usage", []string{"lookup"}, 2},
 		{"inject missing query → usage", []string{"inject"}, 2},
+		{"install missing --target → usage", []string{"install"}, 2},
+		{"install invalid target → usage", []string{"install", "--target", "vscode"}, 2},
+		{"install missing source → runtime", []string{"install", "--target", "custom", "--dir", filepath.Join(dir, "d"), "--source", filepath.Join(dir, "nope")}, 1},
 	}
 	for _, c := range cases {
 		var stdout, stderr bytes.Buffer

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -79,8 +79,23 @@ semantix verify --session <会话目录> --project demo > eval.tsv
 | `inject` | L2 注入块（规范序/预算截断） | `--query` `--budget` `--k` |
 
 **产品与管理**：`doctor` 健康检查（db / config / embedder / judge，任一 FAIL 退出码 3）
-已实现；`init` `config` `version` `install` `completion`、`gc` `export` `import`、
-`serve` `watch` 为规划中命令（后续 M2 单元挂载，执行会报 unknown command）。
+与 `install` 一键安装已实现；`init` `config` `version` `completion`、
+`gc` `export` `import`、`serve` `watch` 为规划中命令（后续 M2 单元挂载，执行会报 unknown command）。
+
+`semantix install` 按 `agent-skill/` 现有文档（SKILL.md + tools/ + hooks/ + config/ + scripts/）
+落盘到目标 harness，幂等可重跑，`--uninstall` 精确移除安装的文件：
+
+| 目标 | 默认落盘位置 | 说明 |
+|---|---|---|
+| `reasonix` | `~/.semantix/agent-skill/` | fork 已内置集成；落参考文档 + 打印 `[semantix] enabled=true` 配置步骤 |
+| `claude-code` | `~/.claude/skills/semantix/` | Claude Code agent skills 目录，重启后生效 |
+| `custom` | `--dir` 必填 | 任意目录；`--source`/`SEMANTIX_SKILL_DIR` 指定 agent-skill 源 |
+
+```bash
+semantix install --target claude-code          # 安装到 ~/.claude/skills/semantix/
+semantix install --target custom --dir ./agent  # 自定义目录
+semantix install --target claude-code --uninstall   # 卸载（仅移除 install 记录的文件）
+```
 
 **退出码契约**（所有命令统一）：
 

--- a/docs/reports/issue-119-acceptance.md
+++ b/docs/reports/issue-119-acceptance.md
@@ -1,0 +1,65 @@
+# Issue #119 验收报告 — M2-U25: install 命令（agent-skill 安装器）
+
+> 状态：验收通过（2026-08-14）。对应 Issue：`#119 M2-U25: install 命令（agent-skill 安装器）`。
+> 依赖：U19 命令树（`feat/cli-v2-u19-u24` 分支）。
+> 架构真源：`docs/reports/cli-v2-architecture.md`（§3 命令树、§4.2 JSON 信封、§4.3 退出码契约、§7 验收总纲）。
+> 验收方式：独立只读 subagent 详细验收 + 主 agent 逐条复核 + 修复后复验。
+
+## 1. 验收对象
+
+| 项 | 值 |
+|---|---|
+| 分支 | `feat/u25-install`（基于 `feat/cli-v2-u19-u24`） |
+| commit | `aee10df` feat(cli): U25 install command；`aef010e` test(cli)；`ea21225` docs(quickstart)；`3854d26` fix(cli): 验收复核修复 |
+| diff 范围 | `cmd/semantix/install.go`（+413）、`install_test.go`（+312）、`main.go`（+8/-1）、`main_test.go`（+3）、`doctor_test.go`（+2/-1）、`docs/QUICKSTART.md`（+19/-2） |
+
+## 2. 验收标准逐条核对（issue #119 原文 + 架构文档 §7）
+
+| # | 验收标准 | 状态 | 证据 |
+|---|---|---|---|
+| c1 | `semantix install --target reasonix\|claude-code\|custom` 按 agent-skill/ 现有文档落盘 skill + 工具 schema | 通过 | 实测落盘 6 文件（SKILL.md、tools/semantix-lookup.md、hooks/session-bypass.md、config/、scripts/×2）字节一致；默认目录正确（reasonix→`~/.semantix/agent-skill`，claude-code→`~/.claude/skills/semantix`，custom 无 `--dir`→exit 2）；`TestInstallCopiesPayload` |
+| c2 | 幂等：重复安装可安全重跑 | 通过 | 第二次运行 6×`[unchanged]`、0 次写盘、exit 0（单测 + 二进制实测）；`TestInstallIdempotent`、`TestInstallUpdateOverwritesChangedFiles` |
+| c3 | 提供卸载说明或 `--uninstall` | 通过 | `--uninstall` 精确移除 manifest 记录文件、用户文件保留、二次卸载安全 no-op、manifest 自删、空目录自底向上裁剪；QUICKSTART 有文档；`TestInstallUninstall*` 4 用例 |
+| c4 | 引用 agent-skill/SKILL.md 与 hooks/session-bypass.md | 通过 | 三个 target 的 next-steps 均引用两文件（修复后 claude-code 补齐 session-bypass.md 引用）；payload 本身含两文件；`TestInstallCopiesPayload` 断言输出包含 |
+| 附 | §7 总纲：`go test ./...` 全绿 / `go vet` 通过 / help 正确 / 退出码契约 / 新增命令有单测 | 通过 | 17 包全 ok；`go vet ./cmd/semantix/` 通过；help 输出 install 已挂载、planned 仅剩 `init config version completion`；14 个 install 单测全过 |
+
+## 3. 独立 subagent 验收与复核
+
+验收由只读 subagent 独立执行（静态审查 + 二进制实测 + 分级缺陷清单），主 agent 逐条对照修复并复验。
+
+| 发现 | 分级 | 复核结论 | 处置 |
+|---|---|---|---|
+| B-1：显式 `--source` 非法时静默回退到 env/exe/cwd，可能装错 payload | 必须修 | 属实（实测 `--source <bogus>` 从 cwd 安装成功） | **已修复**（`3854d26`）：`--source` 非空即为终局，非法直接 exit 1；新增 `TestInstallExplicitSourceIsFinal` |
+| B-2：uninstall 盲信 manifest 路径，`../` 可删 dest 之外的文件 | 必须修 | 属实（实测穿越删除外部文件） | **已修复**（`3854d26`）：`installPathInDest` 校验每条目（拒绝绝对路径与 `..` 组件），非法条目跳过并提示；新增 `TestInstallUninstallRejectsTraversal`，实测受害文件完好 |
+| B-3：`--json` 失败路径无 §4.2 信封（stdout 为空） | 必须修 | 属实（`doctor.go` 已有先例） | **已修复**（`3854d26`）：`installFail` 输出 `ok:false + error:{code,message}` 信封，退出码不变；新增 `TestInstallJSONFailureEnvelope` |
+| C-1：损坏 manifest 被降级为成功（exit 0） | 设计风险 | 属实 | **已修复**（`3854d26`）：损坏/不可读 manifest 与 stat/remove 意外错误 → exit 1；新增 `TestInstallUninstallCorruptManifest` |
+| C-2：claude-code next-steps 未引用 hooks/session-bypass.md | 设计风险 | 属实 | **已修复**（`3854d26`）：三 target 行为一致 |
+| C-3：复制中途失败留下无 manifest 的孤儿文件 | 设计风险 | 属实 | **已修复**（`3854d26`）：部分复制仍写 manifest，`--uninstall` 可清理 |
+| C-4：dest==src 自安装后 `--uninstall` 清空 payload | 设计风险 | 属实 | **已修复**（`3854d26`）：`installDestOverlapsSource` 拒绝 dest 与 src 相同或为其子目录；新增 `TestInstallRefusesSourceOverlap` |
+| D-1：新增文件 LF vs 仓库 CRLF（gofmt 噪声） | 可记录债务 | 预存条件（基座分支同样全列），新增两个文件 gofmt 干净 | 不修，后续单独提交 `.gitattributes`（`*.go text eol=lf`） |
+| D-2：畸形 manifest / 穿越 / dest==src / json-失败路径无测试 | 可记录债务 | 属实 | **已闭合**：B/C 修复同步补齐 5 个新测试 |
+
+## 4. 验证命令记录（worktree `D:/semantix/.worktrees/u25-install`）
+
+```
+go test ./...                                      全绿（17 包）
+go test ./cmd/semantix/ -run 'TestInstall' -v      14/14 PASS
+go vet ./cmd/semantix/                              通过
+go build -o $TMP/semantix-e2e-u25/semantix.exe     BUILD OK
+二进制实测：
+  install claude-code ×2                            → 6×[installed] → 6×[unchanged]，exit 0（幂等）
+  install --json                                    → 信封 ok=true、error:null、files≥6，jq 可解析
+  --uninstall ×2                                    → 6×[removed] → "nothing tracked"，exit 0（二次安全）
+  外来文件保留 / --target bogus、custom 无 --dir、无 --target → exit 2
+  --source 缺失 / --source 非法（含有效 env 回退） → exit 1（修复后不再静默回退）
+  --json + source 缺失                              → ok:false + error:{code:1} 信封（修复后）
+  穿越 manifest（"../victim.txt"）                  → 条目跳过 + 提示，受害文件完好，安全条目仍移除（修复后）
+  损坏 manifest                                     → exit 1（修复后）
+  dest==src                                         → exit 1 拒绝（修复后）
+```
+
+## 5. 未闭合风险与后续边界
+
+- 本机（Windows）无 `go test -race`（无 cgo，基座环境限制，非本分支引入）；`-race` 需在 CI/类 Unix 主机补齐。
+- 分支基于 `feat/cli-v2-u19-u24`（U19+U24）；合并落地时需 rebase/merge 到 main，`main.go` plannedByGroup 与 QUICKSTART 若与后续命令冲突需同步。
+- 债务 D-1（行尾统一）已记录，不影响本 issue 验收标准。


### PR DESCRIPTION
feat(cli): M2-U25 install 命令（agent-skill 安装器）(Issue #119)

## 变更
- `semantix install --target reasonix|claude-code|custom`：按 agent-skill/ 现有文档（SKILL.md + tools/ schema + hooks/ + config/ + scripts/）落盘 skill + 工具 schema
- 幂等：字节比对，重复安装安全重跑（`[unchanged]` 不写盘）
- `--uninstall`：按 `.semantix-install.json` manifest 精确移除，用户文件不碰、二次卸载安全 no-op
- 输出引用 agent-skill/SKILL.md 与 hooks/session-bypass.md（next-steps）
- `--json` 输出 §4.2 信封（含失败路径 ok:false + error:{code,message}）
- 退出码契约：0 成功 / 1 运行错误 / 2 用法错误
- source 解析：--source > SEMANTIX_SKILL_DIR > exe-relative > ./agent-skill；显式 --source 为终局
- 安全：manifest 路径穿越防御（拒绝绝对路径与 `..`）；dest 与 payload 源重叠拒绝

## 验收
- 独立只读 subagent 验收：c1-c4 全过；B-1..B-3 必须修 + C-1..C-4 设计风险全部修复并补测试复验
- 报告：docs/reports/issue-119-acceptance.md
- `go test ./...` 18 包全绿（cmd/semantix 14 个 install 单测）、`go vet` 通过

## 说明
- 基于 upstream/main（已含 U19/U21/U24/U26）；diff 仅 U25 相关 7 文件