### PR TITLE
feat(gateway): M2-GW1 Semantix Gateway v1 — New API OpenAI 兼容网关（Issue #133）

### DIFF
--- a/cmd/semantix-gateway/main.go
+++ b/cmd/semantix-gateway/main.go
@@ -1,0 +1,64 @@
+// Command semantix-gateway runs the Semantix Gateway v1 (Issue #133): an
+// OpenAI-compatible HTTP gateway that fronts upstream LLMs with the kernel
+// three-layer cache (L3 verified reuse → L2 injection → forward).
+//
+// Design: docs/specs/newapi-gateway-design.md.
+//
+// Usage:
+//
+//	semantix-gateway --config semantix-gateway.toml
+//
+// Credentials (gateway key, upstream API keys) are injected via ${VAR}
+// references resolved from the environment; nothing secret lands in the
+// config file.
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"time"
+
+	"semantix/gateway"
+)
+
+func main() {
+	configPath := flag.String("config", "semantix-gateway.toml", "gateway config file path")
+	flag.Parse()
+
+	cfg, err := gateway.Load(*configPath)
+	if err != nil {
+		log.Fatalf("semantix-gateway: %v", err)
+	}
+	g, err := gateway.New(cfg)
+	if err != nil {
+		log.Fatalf("semantix-gateway: %v", err)
+	}
+	defer g.Close()
+
+	srv := &http.Server{
+		Addr:              cfg.Server.Addr,
+		Handler:           g,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Printf("semantix-gateway: listening on %s (%d upstream(s): %s)",
+		cfg.Server.Addr, len(cfg.Upstreams), upstreamNames(cfg))
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("semantix-gateway: %v", err)
+	}
+}
+
+func upstreamNames(cfg *gateway.Config) string {
+	names := make([]string, 0, len(cfg.Upstreams))
+	for _, u := range cfg.Upstreams {
+		names = append(names, u.Name)
+	}
+	out := ""
+	for i, n := range names {
+		if i > 0 {
+			out += ", "
+		}
+		out += n
+	}
+	return out
+}

--- a/cmd/semantix-gateway/main.go
+++ b/cmd/semantix-gateway/main.go
@@ -46,6 +46,7 @@ func main() {
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("semantix-gateway: %v", err)
 	}
+	_ = srv.Shutdown(nil) // graceful: let in-flight handlers finish
 }
 
 func upstreamNames(cfg *gateway.Config) string {

--- a/docs/reports/issue-133-acceptance.md
+++ b/docs/reports/issue-133-acceptance.md
@@ -1,0 +1,67 @@
+# Issue #133 验收报告 — M2-GW1: Semantix Gateway v1（New API OpenAI 兼容网关）
+
+> 状态：验收通过（2026-08-14）。对应 Issue：`#133 M2-GW1: Semantix Gateway v1`。
+> 设计真源：`docs/specs/newapi-gateway-design.md`（本 issue 提交）。
+> 验收方式：实现 + 单测/e2e + 独立 subagent 审查（review）+ 缺陷修复后复验。
+
+## 1. 验收对象
+
+| 项 | 值 |
+|---|---|
+| 分支 | `feat/issue-133-gateway`（基于 `upstream/main` 9cf3d53） |
+| commit | `0e31be2` docs(specs) 设计文档 · `1934f90` feat(gateway) 核心 · `39a3697` test(gateway) · `2eef877` feat(cmd) 入口 · `20464ad` fix(gateway) 审查修复 |
+| diff | 14 文件 +2559/-…（gateway/ 包 8 文件 + cmd/semantix-gateway + kernel/cache、kernel/slice 各 2 处隔离字段 + 设计文档） |
+
+## 2. Issue checklist 逐条核对
+
+| # | checklist（issue #133 原文） | 状态 | 证据 |
+|---|---|---|---|
+| 1 | 提交设计文档 `docs/specs/newapi-gateway-design.md` | ✅ | `0e31be2`（从 d3a4efd 恢复 372 行完整草案） |
+| 2 | HTTP 网关层（OpenAI 兼容 `/v1/*`）：L3 命中直接返回 → 未命中 L2 注入 → 转发上游 | ✅ | `TestE2EL3HitZeroUpstreamCalls`（hit、上游 0 调用）、`TestE2EL2InjectionForwarded`（注入块 prepend system）、SSE 透传/流式命中回放 |
+| 3 | 复用 kernel 三层缓存（cache + inject + fingerprint），零新增核心逻辑 | ✅ | gateway 全部语义委托 `cache.L3Decider` / `inject.Injector` / `ingest.Pipeline` / `usage.Recorder` / `slice.FileStore` / `fingerprint`；仅 kernel 增补 2 个隔离字段（审查修复，见 §4） |
+| 4 | 与 New API 渠道对接（HTTP 上游形态）；`lookup --json` 协议可复用 | ✅ | `TestE2EAliasMapping`（alias→upstream_model 映射）；/healthz 供渠道探活；上游 OpenAI 兼容直通（DeepSeek vendor） |
+| 5 | 验收：`go test -race ./...` 全绿 + 网关 e2e（L3 命中零上游调用、L2 注入不重复探索） | ⚠️ 部分 | e2e 两项核心在 gateway 包实测全绿（httptest 上游）；`-race` 本机无 CGO 无法运行，由 CI 承担（`.github/workflows/ci.yml:36` 已跑 `go test ./... -race`） |
+
+## 3. 端到端实测（httptest 上游，gateway 包）
+
+| 场景 | 断言 | 结果 |
+|---|---|---|
+| L3 命中 | `x-semantix-cache: hit`，上游调用 0，返回缓存内容 | ✅ |
+| L2 注入 | 上游收到 system 消息含 `[semantix-reuse]` 块，透传上游响应 | ✅ |
+| SSE 透传 | `text/event-stream` 逐块透传，`[DONE]` 保留 | ✅ |
+| L3 流式命中 | SSE 回放缓存内容 + `[DONE]`，上游 0 调用 | ✅ |
+| 鉴权/错误 | 无 key/错 key→401、未知模型→404、坏请求→400、/healthz→200 | ✅ |
+| 写记忆 | 会话 JSONL 落盘 + 异步 ingest 入库（轮询确认） | ✅ |
+| 跨上下文隔离 | 同 query 不同 system prompt → miss 走上游 | ✅ |
+| alias 映射 | `client-model` → 上游收到 `real-model` | ✅ |
+| L3Safe=false | 无 deps 未 opt-in 的 Result 拒绝复用 | ✅ |
+
+## 4. 独立 subagent 审查与修复（20464ad）
+
+| 发现 | 分级 | 处置 |
+|---|---|---|
+| L3 缓存键缺 context+model（kernel Query.ContextHash 无消费者，跨会话/跨模型可复用） | 阻断 | 修复：`SliceMeta` 增 `ContextHash/Model`，`cache.Query` 增 `Model`，`L3Decider` 对带 stamp 的查询 fail-closed（无 stamp 条目一律拒绝）；网关 `metaStore` 入库打标。kernel/cache 补 `TestDecideL3ContextIsolation` |
+| `upstream_model` 未应用（alias≠上游模型时上游 404） | 阻断 | 修复：`rewriteOutgoing` 统一替换 model + 注入块；e2e 补 alias 映射测试 |
+| `ingestWG.Add` 与 `Close().Wait` 竞态（关闭时丢写记忆） | 应修 | 修复：shutdown 互斥 + closing 标志；cmd 用 `srv.Shutdown` 优雅关闭 |
+| `x-semantix-session` 未校验（路径穿越出 sessions 目录） | 应修 | 修复：`^[A-Za-z0-9_-]{1,64}$` 白名单 |
+| 上游响应 `io.ReadAll` 无上限 | 应修 | 修复：`LimitReader(maxBodyBytes)`；上游 ≥400 转 OpenAI 错误信封 |
+| 失败请求仍写记忆（进复用库） | 应修 | 修复：sidecar 移入成功分支 |
+| judge_api_key/retriever 死配置；SSE 缺 usage trailer；/healthz 不查 store；LimitReader 静默截断 | nit | MaxBytesReader 已采纳；其余记录为债务（§6） |
+
+## 5. 验证命令
+
+```
+go test ./gateway/ ./kernel/cache/ ./cmd/semantix-gateway/   → ok
+go test ./...                                                → 16 包 ok
+go vet ./...                                                 → 通过
+go test -race ./...                                          → 本机无 CGO 不可运行，CI 承担（ci.yml:36）
+```
+
+注：`cmd/semantix` 的 `TestRunUsageWithEvolve` 与 `kernel/slice` 的 `TestFileStoreKeepsPerm0600/TestExportPerm` 在**未改动基线** 9cf3d53 上同样失败（Windows 权限位 + evolve 时序既有问题），与本 issue 无关。
+
+## 6. 未闭合风险与后续边界
+
+- **M1/M2 里程碑项未在本 issue 范围**：Claude 格式转换 + cache_control（vendor=anthropic 配置即报错，防误用）、流式命中回放的 usage trailer、Kimi/GPT 渠道实测、New API 计费对账（D1）、多项目 scope 方案 B。
+- 债务：SSE 响应侧内容不解析（流式写记忆只记请求侧）；/healthz 不实时探测切片库（store 已由 New 打开保证）；`judge_api_key`/`retriever` 配置字段为预留（kernel RuleGate 规则判定已生效，LLM judge 未接线）。
+- `-race` 运行级证据依赖 CI；本机无 C 编译器。
+- 分支未推送远端；合入后 `semantix-gateway.toml` 示例与部署（§5 compose）建议另开运维 issue。

--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -1,0 +1,372 @@
+# New API 网关集成设计 —— Semantix Gateway（v1）
+
+> 日期：2026-08-13 · 状态：规划（v1 草案）· 对应：Semantix 对外形态扩展
+> 一句话目标：以 **New API 做 OpenAI 兼容中转站**，在它后面挂一个 **Semantix Gateway**
+> （新组件，复用 kernel 三层缓存），让任意 OpenAI 兼容客户端（Claude Code / chatbox / IDE 插件等）
+> 的请求在到达上游 LLM 之前先过语义缓存——**L3 命中零上游调用、L2 注入跳过重复探索**，
+> 达成省 token、省成本的效果。
+>
+> 与既有集成方式的关系：LangChain 中间件是「消息级」读/写记忆，Reasonix fork 是「事件级」，
+> 本设计是**「请求级」的 HTTP 网关形态**——同一个「读记忆（inject/lookup）+ 写记忆（extract）」模型，
+> 只是挂在 API 网关上，零侵入任何 agent harness，天然适配所有 OpenAI 兼容客户端。
+
+---
+
+## 1. 背景与缺口
+
+### 1.1 Semantix 现状（v0.3.1）
+
+- kernel 三层语义缓存已实现：**L1** 前缀字节稳定（依赖上游前缀缓存价）、**L2** 语义切片注入（`kernel/inject`）、**L3** 已验证结果复用（`kernel/fingerprint` + `kernel/judge` + `kernel/promote`，issue-08 已验收）；
+- 成本演示（`docs/reports/m0-cost-comparison.md`）：跨会话复用**节省 79.8%**（目标 ≥20%），敏感性分析在最保守参数下仍 ≥30%；
+- 对外形态目前是**纯 CLI + kernel 库**：`extract / search / lookup / inject / verify / eval / usage`，**没有 HTTP 服务、没有 OpenAI 兼容 API 层**。
+
+### 1.2 New API 现状
+
+New API（QuantumNous/new-api，one-api 加强分支）是 **OpenAI 兼容的 API 中转/分发面板**：
+统一入口 `/v1/*`、多用户 Token 管理、渠道管理（多上游 + 模型映射 + 负载均衡 + 重试）、按模型定价计费、额度与速率限制。它本身**不带 agent loop、不做语义缓存**——这正是 Semantix 要补的位置。
+
+### 1.3 缺口与方案
+
+> **缺口**：New API 的「渠道」必须是一个 HTTP 上游，而 Semantix 没有 HTTP 层，两者无法直接对接。
+
+**方案**：新增 **Semantix Gateway**（独立 Go 进程，复用 kernel 全部包），对外暴露 OpenAI 兼容 API；
+New API 侧把它配成一个**自定义渠道**。数据流：
+
+```
+客户端 (Claude Code / chatbox / 任意 OpenAI 兼容客户端)
+   │  base_url = https://new-api.example.com
+   ▼
+New API（key 管理 / 计费 / 渠道分发）
+   │  渠道类型 = 自定义（base_url = http://semantix-gateway:8080）
+   ▼
+Semantix Gateway（★ 本设计的核心新组件）
+   │  L3 语义缓存命中 ──► 直接返回缓存结果（零上游调用）
+   │  L2 注入 + 转发 ────► 上游 LLM（DeepSeek / Claude / Kimi / GPT）
+   │  会话旁路提取 ──────► 切片库（写记忆，供下次复用）
+```
+
+---
+
+## 2. 省 token 机制与收益模型
+
+### 2.1 三层机制在网关场景的映射
+
+| 层 | 机制 | 网关中的落点 | 省钱方式 |
+|---|---|---|---|
+| **L1** | 前缀字节稳定 | 网关把注入块放在 **system 提示末尾、消息尾部之前**（Reasonix KV Cache 机制研究结论：静态在前、动态在后），且注入块 ID 规范序 → 字节稳定 | 上游按**缓存价**计费（DeepSeek miss $0.27/M vs hit $0.07/M，价差约 4 倍） |
+| **L2** | 语义切片注入 | 未命中时 `inject.Injector.Build(query)` 检索 top-k 切片，拼入请求后转发上游 | 模型**跳过重复探索**，少生成工具调用/中间步骤 → 省**输出 token**（演示中 80% 的重复步骤被替代，是主要节省来源） |
+| **L3** | 已验证结果复用 | 请求归一化 → 指纹校验（deps/mtime）→ `judge.RuleGate` 验证 → 命中直接返回缓存响应 | **零上游调用**，节省约 100% 的该请求成本 |
+
+### 2.2 收益公式（沿用 m0-cost-comparison 模型）
+
+```
+单请求成本 = P_miss × (inject_bytes + 新内容) + P_hit × 稳定前缀 + P_out × output_tokens
+
+baseline（无网关） = P_miss × 全量输入 + P_out × 全量输出
+gateway 未命中     ≈ P_hit × 注入前缀 + P_miss × 增量 + P_out × (1 - reuse_ratio) × 全量输出
+gateway L3 命中    ≈ 0（仅网关本地检索，<100ms）※ 计费上需 D1 的「合成 usage + 近零倍率」落地（§4.3）
+```
+
+- 合成演示实测：1800 → 360 completion tokens，成本 $0.001980 → $0.000399，**节省 79.8%**；
+- 网关场景（API 网关、真实重复任务）预期区间：**30%–80%**，取决于重复率（垂类工作流重复度高，收益靠近上沿）；
+- L3 命中是「纯赚」：一次缓存命中省掉该请求的全部上游费用，且延迟更低（<100ms vs 秒级）。
+
+### 2.3 目标模型单价（2026-08 参考，网关设计按此建模）
+
+| 模型 | 输入(miss) | 输入(缓存命中) | 输出 | 缓存机制 |
+|---|---|---|---|---|
+| DeepSeek-chat | $0.27/M | $0.07/M | $1.10/M | 自动前缀缓存（24h），无需显式标记 |
+| Kimi (Moonshot) | ~$0.60/M | 前缀缓存价 | ~$2.20/M | OpenAI 兼容端点，自动前缀缓存（自动性待上游确认，§3.5） |
+| GPT-4o 级 | ~$2.50/M | ~$1.25/M | ~$10/M | 自动前缀缓存（provider 侧） |
+| Claude Sonnet 级 | ~$3.00/M | ~$0.30/M | ~$15/M | 需 `cache_control:{type:"ephemeral"}` 断点（≤2 个） |
+
+> 注入块**字节稳定**是 L1 生效的前提；对 Claude 还需在注入块边界打 cache_control 断点（见 §3.8）。
+> 单价随时可能变动，网关不硬编码价格——价格只在 New API 侧做计费用，网关只透传 usage。
+
+---
+
+## 3. Semantix Gateway 组件规格
+
+### 3.1 形态与进程
+
+- **独立 Go 进程**：新 `cmd/semantix-gateway/`，复用 `kernel/` 全部包（结构铁律不变：kernel 不得反向依赖网关）；
+- 不侵入 New API（New API 无插件机制，渠道化对接是唯一合理方式）；
+- 单二进制、零第三方 HTTP 依赖（标准库 `net/http` 即可，流式用 `http.Flusher`）；
+- 切片库复用 `slice.NewFileStore`（JSONL 单文件 + 原子重写，0600/0700 权限约定延续；MVP 明确不用 bbolt，量大再评估切换）。
+
+### 3.2 OpenAI 兼容 API 端点
+
+| 端点 | 方法 | 说明 |
+|---|---|---|
+| `GET /v1/models` | 透传 | 返回可路由模型列表（网关上游已配置的模型名） |
+| `POST /v1/chat/completions` | 核心 | 完整流水线（§3.3），支持 `stream=true`（SSE） |
+| `POST /v1/completions` | 可选 | 文本补全透传（MVP 可先不做，默认 501） |
+| `GET /healthz` | 健康 | 检查切片库可打开 + 上游可达性（New API 渠道健康检查用） |
+
+请求/响应结构严格遵循 OpenAI 协议；错误响应也走 OpenAI 格式（`{"error": {"message", "type", "code"}}`），保证 New API 与客户端能正确识别。
+
+### 3.3 请求处理流水线（核心）
+
+```
+POST /v1/chat/completions {model, messages, stream, ...}
+   │
+   ├─ 1. 鉴权：校验网关 Key（New API 转发时带的上游 key，见 §4.1）
+   ├─ 2. 归一化：提取 (project/scope, 最后一条用户消息 → query, 完整 messages 指纹)
+   │        项目 scope 来源：可配置 header（如 x-project）或 New API 渠道固定值
+   ├─ 3. L3 查询：查缓存库
+   │        · 命中（指纹 + deps/mtime 校验 + RuleGate 通过）
+   │        │   ├─ 非流式：直接返回缓存响应（含原始 usage）
+   │        │   └─ 流式：按缓存响应重建 SSE 分块回放（§3.4）
+   │        · 未命中 → 4
+   ├─ 4. L2 注入：inject.Injector{Scope,K,Budget,Zones}.Build(query)
+   │        有命中 → 注入块拼入请求（system 提示末尾，字节稳定）
+   ├─ 5. 上游转发：模型映射（§3.8 适配层）→ 调用上游（超时/重试由 New API 与网关双层兜底）
+   ├─ 6. 响应：透传 content + usage；L3 候选判定（§3.5）
+   └─ 7. 异步写记忆：请求/响应旁路 → 会话 JSONL → ingest → extract（不阻塞主链路）
+```
+
+**关键原则**：
+- **缓存永不阻塞主链路**：检索、注入、写库都是本地操作（<10ms 级）；上游失败/超时按 OpenAI 错误格式返回，客户端可重试；
+- **L3 命中必须可观测**：响应头或 usage 中标记命中（如 `x-semantix-cache: hit` / `prompt_tokens_details.cached_tokens`），便于 New API 侧计费与用户看到省钱；
+- **ablation 开关**：`SEMANTIX_GATEWAY_DISABLE=1` 一键退化为纯透传（风险预案）。
+
+### 3.4 流式（SSE）
+
+- **未命中流式**：网关向上游转发 `stream=true`，把上游 SSE 事件**逐块透传**；上游若未在末块返回 usage，网关在 `[DONE]` 前补一个含注入块 usage 统计的末块；保持 `[DONE]` 终止；
+- **命中流式**：缓存存的是完整响应；网关按 OpenAI SSE 协议把缓存内容切成 `choices[0].delta.content` 分块回放（每块 ≤ 4KB 或按原缓存分块）。注意这是**重建流**：`id`/`created`、工具调用首块（`index`/`id` 必须在第一个 delta）、`finish_reason` 位置、token 边界都与上游原始流不同；M1 落地时用真实客户端回归验证（见 §8）；
+- **字节稳定注意**：透传不重排、不重写上游事件，避免破坏客户端兼容性；注入块只在请求侧生效，不触碰响应流。
+
+### 3.5 L3 语义缓存设计
+
+```
+缓存键 = hash(scope | 归一化 query | 模型名 | deps 指纹 | messages 上下文指纹)
+```
+
+- **messages 上下文指纹**：完整 messages（含 system/历史）的归一化哈希——防止不同会话历史/系统提示下**同 query 互相复用**（跨上下文复用与信息泄漏）；MVP 用全量指纹，宽松模式（仅前缀参与）待 M1 后评估；
+- **归一化 query**：最后一条用户消息去空白/规范化（复用 `sanitize` 纪律）；
+- **deps 指纹**：复用 `fingerprint.Capture/Verify`（path → sha256）+ mtime 快速失败（`SliceMeta.Mtimes`）——**文件一变缓存即失效**（issue-08 已验收的机制）；网关条目的 deps root 由配置提供（如项目根目录），缺失文件一律视为已变更 → 失效；**网关生成且 deps 为空的结果默认不进入 L3**（`l3_safe=false`，需显式配置才启用）——否则指纹/RuleGate 验证形同虚设（空 deps 时 Chain 会跳过指纹阶段）；
+- **验证**：`judge.RuleGate.Chain`（grey zone 规则，Krites §3.1）；grey 区候选可配置 `SEMANTIX_JUDGE_API_KEY` 走 LLM judge 确认；**judge 一律异步/离主链路执行**（不阻塞响应，保持 <100ms）；
+- **提升与级联失效**：`promote.Store` 存提升条目 + 包级函数 `promote.CascadeInvalidate(store, sourceSliceID, currentContent)`——上游响应内容变化（content 版本号变更）时**级联失效**同一源切片衍生的下游缓存条目；
+- **TTL**：缓存条目按模型 vendor 差异化（DeepSeek 24h / DashScope 5m / Anthropic 5m，沿用 `reasonix-kvcache-mechanisms.md` 的 vendor-aware 结论）；Kimi/Moonshot 与 GPT 的缓存 TTL **以上游文档确认后配置**（Moonshot 历史上需显式建缓存，勿假设自动生效）；
+- **模型名进缓存键**：防止 Claude 的响应被 GPT 复用（跨模型语义相同但行为/风格不同，绝不混用）；
+- **只缓存可安全复用结果**：带工具调用副作用的结果默认不入 L3（R-Slice 需 `--l3-safe` 或 deps 指纹非空，见 `SliceMeta.L3Safe`）。
+
+### 3.6 L2 注入设计
+
+- 检索：`inject.Injector`（K=5、Budget=4096、Zones 灰度分类默认开）；
+- 注入位置：**system 提示末尾**（= 前缀尾部，保证注入块之后的历史消息字节稳定 → L1 生效）；对 Claude 在注入块边界打 `cache_control` 断点；
+- 注入块形态沿用内核：`[semantix-reuse] ... [/semantix-reuse]`，**低权威定位**（内容仅供模型参考，不当作指令）；块内 ID 规范序（内核行为）保证字节稳定；
+- 注入块不改变客户端可见的 model/messages 语义，仅内部改写后转发。
+
+### 3.7 会话提取（写记忆）
+
+- **旁路落盘**：每个请求/响应对（含工具调用如存在）追加到 `~/.semantix/sessions/<gateway-session-id>.jsonl`（0600），每行 `{role, content, tool_calls}`，与 `ingest.JSONLSource` 格式兼容；
+- **提取**：异步执行 `ingest.Pipeline.Run` → 切片入库（P/C/R/T/M）；可复用现有 extract 逻辑（`cmd/semantix/extract.go`）；
+- **scope 策略**：默认 `project`（New API 渠道级隔离），可选 `user`（按客户端 key 前缀映射，见 §4.4）；
+- **写库失败不影响主链路**：提取是 best-effort，失败仅记日志 + usage 统计。
+
+### 3.8 上游适配层（DeepSeek / Claude / Kimi / GPT）
+
+网关统一对上游发 **OpenAI 兼容协议**，适配差异收敛到配置：
+
+| 上游 | base_url（示例） | 鉴权头 | 需特殊处理 |
+|---|---|---|---|
+| DeepSeek | `https://api.deepseek.com/v1` | `Authorization: Bearer` | 无需 cache_control（自动前缀缓存），刻意不发 |
+| Kimi | `https://api.moonshot.cn/v1` | 同上 | 同 OpenAI 兼容，自动前缀缓存 |
+| GPT | `https://api.openai.com/v1` | 同上 | 同 OpenAI 兼容 |
+| Claude | `https://api.anthropic.com/v1` | `x-api-key` + `anthropic-version` | ① 需要把 messages 转 Anthropic 格式（或走官方 OpenAI 兼容端点）；② 注入块边界打 `cache_control:{type:"ephemeral"}`（≤2 断点：system 尾 + 最后消息尾） |
+
+**模型映射**：`semantix-gateway.toml` 中定义 `upstreams[].model_alias`（New API 侧模型名 ↔ 上游模型名）；New API 渠道的模型名即网关的 model_alias，网关负责换成上游真实模型名。
+
+**超时与重试**：网关给上游设保守超时（connect 10s / 首字节 60s / 总时长继承 New API 配置）；重试逻辑**主要放 New API 渠道层**（New API 有重试/负载均衡），网关只做一次重试兜底（幂等 GET 类；chat 请求重试仅对网络错误）。
+
+### 3.9 配置（semantix-gateway.toml 草案）
+
+```toml
+# semantix-gateway.toml
+# 注：配置加载器需实现 ${VAR} 环境变量替换与 ~ 路径展开；
+#     任何未解析的 ${...} 启动即报错（防把字面量当凭据）。
+[server]
+addr = ":8080"
+gateway_key = "${SEMANTIX_GATEWAY_KEY}"   # New API 渠道转发时携带的 key（env 注入，不入库）
+
+[store]
+db = "~/.semantix/gateway.jsonl"          # 切片库 + L3 缓存库（JSONL 单文件，§3.1）
+scope = "project"                         # 默认切片作用域
+
+[retrieval]
+retriever = "hybrid"                      # bm25 | vector | hybrid
+top_k = 5
+budget = 4096                             # L2 注入块字节预算
+
+[cache]
+ttl_seconds = 86400                       # 默认 TTL（vendor 差异化优先）
+judge_api_key = "${SEMANTIX_JUDGE_API_KEY}"   # 可选：grey 区 LLM judge
+
+[ingest]
+sessions_dir = "~/.semantix/sessions"     # 会话旁路落盘目录
+l3_safe_default = false                   # 无 deps 的结果切片默认不进入 L3
+
+[[upstreams]]                             # 每个 New API 渠道模型对应一段
+name = "deepseek-chat"
+base_url = "https://api.deepseek.com/v1"
+api_key = "${DEEPSEEK_API_KEY}"
+model_alias = ["deepseek-chat", "ds-chat"]   # 网关侧别名（New API 渠道模型名，§4.2 第一层）
+upstream_model = "deepseek-chat"          # 上游真实模型名（§4.2 映射目标，第三层）
+vendor = "deepseek"                       # deepseek | anthropic | openai | moonshot（决定 cache_control/格式处理）
+```
+
+### 3.10 安全
+
+- 网关 Key（`SEMANTIX_GATEWAY_KEY`）由 New API 渠道配置注入（渠道密钥字段），**客户端不接触**；网关不校验客户端 key——校验在 New API 层完成（New API 已做用户认证/配额）；
+- 网关 key 支持**轮换与按渠道隔离**（每渠道独立 key 更佳）；明确边界：**New API 容器被攻破 = 网关凭据全部暴露**（内网 + 凭据不落盘缓解，不构成绝对隔离）；
+- 上游 key 只存环境变量，**不落配置文件与日志**；
+- 切片库 0600/0700 权限、原子写、防 symlink（沿用现有安全约定）；
+- 敏感内容：默认 `scope=project` 隔离；脱敏接入点预留（`sanitize` 已有，正式版按策略启用）；
+- 网关无公网暴露面：只允许 New API 所在网段访问（compose 内网即可，见 §5）。
+
+---
+
+## 4. New API 接入配置
+
+### 4.1 渠道配置
+
+New API 管理后台 → 渠道 → 新建渠道：
+
+| 字段 | 值 |
+|---|---|
+| 类型 | **自定义**（Custom / OpenAI-API 兼容，按 New API 版本选择） |
+| 名称 | semantix-gateway |
+| 代理地址 (Base URL) | `http://semantix-gateway:8080`（compose 内网名）或公网地址（若网关单独部署） |
+| 密钥 (Key) | `SEMANTIX_GATEWAY_KEY` 的值（New API 转发请求时作为 `Authorization: Bearer` 带给网关） |
+| 模型 | 该渠道要路由的模型（如 `deepseek-chat`、`claude-sonnet-4`、`kimi-k2`、`gpt-4o`） |
+| 模型映射 | 可选：New API 展示名 → 上游真实名（不映射则同名透传） |
+| 启用 | 勾选 |
+
+> 一个渠道 = 一个上游服务 + 一组模型。可**每个上游模型建一个渠道**（deepseek / claude / kimi / gpt 各一个渠道，均指向同一网关地址），便于 New API 侧按渠道做分组、权重与禁用。
+
+### 4.2 模型映射示例
+
+```
+New API 侧模型名（客户端可见）  →  网关 model_alias  →  上游真实模型
+deepseek-chat                   →  deepseek-chat      →  deepseek-chat
+claude-sonnet                   →  claude-sonnet      →  claude-sonnet-4-20250514（示例）
+kimi-k2                         →  kimi-k2            →  moonshot-v1-128k（示例）
+gpt-4o                          →  gpt-4o             →  gpt-4o
+```
+
+### 4.3 计费与配额
+
+- New API 按渠道模型**定价倍率**计费（按上游单价配置模型价格）；
+- 网关透传上游 usage，命中缓存时：
+  - **L3 命中返回合成 usage**：`completion_tokens=0`、`prompt_tokens=缓存前缀量`并标记 `prompt_tokens_details.cached_tokens` 全部为缓存——否则缓存里的 completion tokens 仍会按全价计费，「≈0 成本」不成立；
+  - New API 侧给网关渠道配**近零价格倍率**（如 0.001x）落 L3 命中的费用——**这是商业决策，见 §9 待决策项 D1**；
+- 网关 `usage` 记录（`kernel/usage.Recorder/Summarize`）用于 Semantix 侧成本统计与验证报告，与 New API 侧计费对账用。
+
+### 4.4 多用户 / 多项目隔离（可选）
+
+- 方案 A（简单）：整个网关一个 scope=project，所有用户共享切片库（适合个人/小团队）；
+- 方案 B（多项目）：New API 渠道按项目拆分（每项目一个渠道 + 固定 `x-project` header 由渠道配置注入），网关按 header 选 scope 库；
+- 方案 C（用户级）：客户端 key 前缀映射到 scope=user 库。**注意：网关看不到客户端 key**（New API 只转发渠道 key，见 §4.1），需 New API 侧透传用户身份（如按用户拆渠道 + 固定 header，或 New API 支持的用户标识转发）才可行。MVP 用 A，需要时上 B。
+
+---
+
+## 5. 部署方案（推荐：单机 Docker Compose）
+
+```
+docker-compose.yml
+├─ new-api          镜像: quantumnew/new-api  端口 3000 → 公网（或经 nginx）
+│     volumes: ./data/new-api:/data            （SQLite 持久化）
+├─ semantix-gateway 镜像: <semantix 构建产物镜像（见下）>  端口 8080（仅内网）
+│     env: SEMANTIX_GATEWAY_KEY / DEEPSEEK_API_KEY / ANTHROPIC_API_KEY / MOONSHOT_API_KEY / OPENAI_API_KEY / SEMANTIX_JUDGE_API_KEY
+│     volumes: ./data/semantix:/root/.semantix  （切片库 + 会话旁路持久化）
+└─ (可选) nginx：TLS 终结 + /v1/* 反代到 new-api:3000
+```
+
+要点：
+- **new-api 用 SQLite**（单机够用，零外部依赖）；规模上来再迁 MySQL；
+- 网关镜像：`go build ./cmd/semantix-gateway` → scratch/distroless 单二进制镜像（**零第三方依赖**——`go.mod` 无外部包，文件存储为 JSONL；镜像 <10MB）；
+- 网络：`semantix-gateway:8080` **只暴露给 new-api 容器**（compose 内部 network），不发布到宿主机；
+- 健康检查：New API 渠道可用性检测可配置为 `GET /healthz`（或渠道自检开关）；
+- 日志：stdout JSON 日志 + usage 汇总（`semantix usage` 可对账）；建议接 Loki/Promtail 或仅文件轮转。
+
+### 5.1 非 Docker 备选
+
+- 二进制直跑：`semantix-gateway` 与 `new-api` 同机/异机，`base_url` 填实际地址；用 systemd/launchd 托管 + 环境变量注入 key。
+
+---
+
+## 6. 数据流时序
+
+### 6.1 L3 命中（零上游调用）
+
+```
+客户端 ──POST /v1/chat/completions──► New API（认证/计费）──► 网关
+   │                                    ▲                        │
+   │   200 {content, usage}  ◄──────────┘  指纹+RuleGate 校验通过      │
+   │   headers: x-semantix-cache: hit     直接返回缓存响应        │
+   ◄──────────── 响应 <100ms，无上游费用 ────────────────────────┘
+```
+
+### 6.2 未命中（L2 注入 + 上游）
+
+```
+客户端 ──► New API ──► 网关
+                        ├─ inject.Build(query) → 注入块（字节稳定）
+                        ├─ 转发上游（OpenAI 兼容协议 / Claude 转格式+cache_control）
+                        ├─ 上游 200 / SSE 流
+                        ├─ 透传响应 + usage（cached_tokens 标记注入前缀）
+                        └─ 异步：旁路写会话 JSONL → ingest 提取 → L3 候选入库
+客户端 ◄── 响应 ◄──────────────────────────────────────────────
+```
+
+---
+
+## 7. 实施路线与验收标准
+
+| 阶段 | 内容 | 工期 | Gate（验收） |
+|---|---|---|---|
+| **M0 网关 MVP** | `cmd/semantix-gateway`：OpenAI 兼容层（chat/completions + SSE 透传 + /healthz）+ 鉴权 + 上游 DeepSeek 适配 + 会话旁路入库 | 1–2 周 | 任意 OpenAI 兼容客户端 → New API → 网关 → DeepSeek 全链路跑通；会话入库后 `semantix search` 可检索到切片 |
+| **M1 缓存闭环** | L2 注入 + L3 缓存（指纹/RuleGate/promote/TTL）+ 流式命中回放 + usage 标记 | +1–2 周 | 重复任务第二次命中 `x-semantix-cache: hit` 且零上游调用；合成演示成本节省 ≥30%（复用 m0-cost-comparison 脚本） |
+| **M2 多模型 + 上线** | Claude（格式转换 + cache_control）/ Kimi / GPT 适配 + 模型映射表 + 计费对账 + 健康监控 | +1 周 | 四家模型渠道全通；命中率/节省率有周报数字；New API 侧对账一致 |
+
+**M0 为决策门**：若网关形态下「请求级注入」收益显著低于预期（重复率低的场景），及时转向纯 L3 缓存策略或按会话聚合注入，控制投入在 2 周内。
+
+---
+
+## 8. 风险与边界
+
+| 风险 | 缓解 |
+|---|---|
+| L3 误命中（文件变了还复用旧结果） | deps 指纹 + mtime 快速失败 + RuleGate grey zone；副作用结果默认不入 L3（`l3_safe=false`）；**网关生成且 deps 为空的条目默认不入 L3**（§3.5） |
+| 注入块改变模型行为（低质量参考干扰） | 注入块低权威定位 + ablation 开关一键关闭 + 灰度分类（Zones）只注入明确可复用的切片 |
+| 流式命中回放兼容性 | MVP 先做非流式 L3 命中 + 流式透传；流式命中回放为 M1 项，用真实客户端回归 |
+| 敏感数据进切片库 | scope 隔离（project/user）+ 0600 权限 + 脱敏接入点预留；`scope=user` 方案 C 为可选增强 |
+| 缓存键跨模型混用 | 模型名进缓存键（§3.5），绝不跨模型复用 |
+| L3 跨上下文复用/泄漏（同 query 不同历史） | messages 上下文指纹进缓存键（§3.5）；共享 scope 仅限可信用户（§4.4） |
+| L3 缓存无界增长 / JSONL 全量重写放大 | 条目上限 + TTL 惰性清理 + 异步批量写（D4，§9） |
+| 共享 scope 切片注入投毒（对抗指令） | 方案 A 仅限可信用户；多租户用方案 B/C 隔离；judge 内容消毒 |
+| L3 命中计费不落地（completion 仍全价） | §4.3 合成 usage + New API 近零倍率（D1，§9） |
+| 网关成为单点/性能瓶颈 | 纯本地操作 <10ms；`/healthz` 探活；New API 侧可配多网关渠道做负载均衡（同一切片库需共享 volume） |
+| 上游 key 泄露 | 仅环境变量 + 内网暴露 + 日志脱敏 |
+| 计费口径不一致（网关 vs New API） | usage 统一以网关透传/回填为准，`kernel/usage` 周对账 |
+
+---
+
+## 9. 待决策项（D1–D4）
+
+| 编号 | 决策 | 选项 | 建议 |
+|---|---|---|---|
+| **D1** | L3 缓存命中是否对客户端降价 | ① New API 模型价格倍率下调（如命中 0.25x）② 不降价，省钱体现为服务方利润 ③ 仅统计展示不调价 | 个人使用建议 ①（钱省在自己账户）；商业化看②③——**上线前定** |
+| **D2** | 网关是否支持 `/v1/embeddings` 透传 | 支持 / 不支持 | MVP 不支持；有向量检索/embedding 需求再加（透传很简单） |
+| **D3** | 多用户 scope 方案 | A 单库 / B 多项目渠道 / C 用户级库 | MVP 用 A，B 按需 |
+| **D4** | 网关缓存库与切片库分库还是合库 | 分库 / 合库（同一 JSONL Store） | 合库（同一 Store，L3 缓存作为特殊 Slice 类型）+ 条目上限与 TTL 惰性清理，防无界增长 |
+
+---
+
+## 10. 结论
+
+Semantix Gateway 是 Semantix 从「agent kernel / CLI」走向「**API 网关形态**」的关键一步：
+把已验证的 79.8% 成本节省机制（L2 注入 + L3 复用 + L1 字节稳定）搬到 New API 后面，**零侵入任何客户端与 harness**，
+一条命令部署（`go build ./cmd/semantix-gateway`），天然服务 DeepSeek / Claude / Kimi / GPT 四家模型。
+M0 决策门控制投入在 2 周内，收益不成立可随时退化为纯透传。

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -1,0 +1,302 @@
+// Package gateway implements the Semantix Gateway v1 (Issue #133): an
+// OpenAI-compatible HTTP gateway that sits between New API and upstream
+// LLMs, running every request through the kernel three-layer cache before
+// forwarding. Zero new core logic — it wires kernel/cache, kernel/inject,
+// kernel/fingerprint, kernel/slice, kernel/ingest and kernel/usage.
+//
+// Design: docs/specs/newapi-gateway-design.md.
+package gateway
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config mirrors semantix-gateway.toml (design doc §3.9).
+type Config struct {
+	Server    ServerConfig      `toml:"server"`
+	Store     StoreConfig       `toml:"store"`
+	Retrieval RetrievalConfig   `toml:"retrieval"`
+	Cache     CacheConfig       `toml:"cache"`
+	Ingest    IngestConfig      `toml:"ingest"`
+	Upstreams []UpstreamConfig  `toml:"upstreams"`
+}
+
+// ServerConfig is the listener and gateway-key settings.
+type ServerConfig struct {
+	Addr       string `toml:"addr"`
+	GatewayKey string `toml:"gateway_key"`
+}
+
+// StoreConfig selects the slice store (which also holds L3 cache entries,
+// per decision D4: one JSONL store).
+type StoreConfig struct {
+	DB       string `toml:"db"`
+	Scope    string `toml:"scope"`
+	// DepsRoot is the project root that L3 dep fingerprints are verified
+	// against (design §3.5: "deps root provided by config"). Missing files
+	// fail closed → the cached entry is treated as stale.
+	DepsRoot string `toml:"deps_root"`
+}
+
+// RetrievalConfig tunes the L2 injector.
+type RetrievalConfig struct {
+	Retriever string `toml:"retriever"`
+	TopK      int    `toml:"top_k"`
+	Budget    int    `toml:"budget"`
+}
+
+// CacheConfig holds L3 policy. MVP: TTL is a gateway-side time window over
+// Slice.CreatedAt (CreatedAt==0 never expires); the kernel dep-fingerprint
+// chain remains the authority for staleness.
+type CacheConfig struct {
+	TTLSeconds int64  `toml:"ttl_seconds"`
+	JudgeAPIKey string `toml:"judge_api_key"`
+}
+
+// IngestConfig controls the session-sidecar write path.
+type IngestConfig struct {
+	SessionsDir string `toml:"sessions_dir"`
+	// UsageLog is the kernel/usage event log (design §4.3: gateway usage
+	// accounting, reconciled against New API billing).
+	UsageLog      string `toml:"usage_log"`
+	L3SafeDefault bool   `toml:"l3_safe_default"`
+}
+
+// UpstreamConfig is one model channel (New API channel = one upstream).
+type UpstreamConfig struct {
+	Name           string   `toml:"name"`
+	BaseURL        string   `toml:"base_url"`
+	APIKey         string   `toml:"api_key"`
+	ModelAlias     []string `toml:"model_alias"`
+	UpstreamModel  string   `toml:"upstream_model"`
+	Vendor         string   `toml:"vendor"`
+}
+
+// vendor names accepted by the v1 gateway. anthropic is deliberately
+// rejected: it needs message-format conversion + cache_control breakpoints
+// (design §3.8), which is a later milestone — configuring it here would
+// silently send Anthropic-format traffic to an OpenAI-style endpoint.
+var supportedVendors = map[string]bool{
+	"deepseek": true,
+	"openai":   true,
+	"moonshot": true,
+}
+
+// Load parses semantix-gateway.toml, expands ${VAR} environment references
+// and ~ paths, then validates. Any unresolved ${...} fails startup so a
+// literal placeholder can never be used as a credential.
+func Load(path string) (*Config, error) {
+	var c Config
+	if _, err := toml.DecodeFile(path, &c); err != nil {
+		return nil, fmt.Errorf("gateway config %s: %w", path, err)
+	}
+	if err := c.expand(); err != nil {
+		return nil, err
+	}
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// expand resolves ${VAR} references in every string field (fail-closed) and
+// expands a leading ~ in filesystem paths.
+func (c *Config) expand() error {
+	fields := []*string{
+		&c.Server.Addr, &c.Server.GatewayKey,
+		&c.Store.DB, &c.Store.Scope, &c.Store.DepsRoot,
+		&c.Retrieval.Retriever,
+		&c.Cache.JudgeAPIKey,
+		&c.Ingest.SessionsDir, &c.Ingest.UsageLog,
+	}
+	for i := range c.Upstreams {
+		u := &c.Upstreams[i]
+		fields = append(fields, &u.Name, &u.BaseURL, &u.APIKey, &u.UpstreamModel, &u.Vendor)
+		for j := range u.ModelAlias {
+			alias := u.ModelAlias[j]
+			fields = append(fields, &alias)
+			u.ModelAlias[j] = alias
+		}
+	}
+	for _, f := range fields {
+		if err := expandField(f); err != nil {
+			return err
+		}
+	}
+	if c.Store.DB != "" {
+		if home, err := expandHome(c.Store.DB); err != nil {
+			return err
+		} else {
+			c.Store.DB = home
+		}
+	}
+	if c.Store.DepsRoot != "" {
+		if home, err := expandHome(c.Store.DepsRoot); err != nil {
+			return err
+		} else {
+			c.Store.DepsRoot = home
+		}
+	}
+	if c.Ingest.SessionsDir != "" {
+		if home, err := expandHome(c.Ingest.SessionsDir); err != nil {
+			return err
+		} else {
+			c.Ingest.SessionsDir = home
+		}
+	}
+	if c.Ingest.UsageLog != "" {
+		if home, err := expandHome(c.Ingest.UsageLog); err != nil {
+			return err
+		} else {
+			c.Ingest.UsageLog = home
+		}
+	}
+	return nil
+}
+
+// expandField replaces every ${VAR} with the environment value, failing on
+// unknown variables (never leaves a placeholder in place).
+func expandField(v *string) error {
+	if *v == "" {
+		return nil
+	}
+	var b strings.Builder
+	rest := *v
+	for {
+		start := strings.Index(rest, "${")
+		if start < 0 {
+			b.WriteString(rest)
+			break
+		}
+		b.WriteString(rest[:start])
+		end := strings.Index(rest[start:], "}")
+		if end < 0 {
+			return fmt.Errorf("gateway config: unterminated ${ in %q", *v)
+		}
+		name := rest[start+2 : start+end]
+		val, ok := os.LookupEnv(name)
+		if !ok {
+			return fmt.Errorf("gateway config: environment variable %s is not set (referenced in %q)", name, *v)
+		}
+		b.WriteString(val)
+		rest = rest[start+end+1:]
+	}
+	*v = b.String()
+	return nil
+}
+
+// expandHome expands a leading ~ (or ~/) to the user home directory.
+func expandHome(p string) (string, error) {
+	if p == "~" || strings.HasPrefix(p, "~/") || strings.HasPrefix(p, `~\`) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("gateway config: resolve home for %q: %w", p, err)
+		}
+		if p == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, p[2:]), nil
+	}
+	return p, nil
+}
+
+// validate enforces the invariants the server depends on.
+func (c *Config) validate() error {
+	if strings.TrimSpace(c.Server.Addr) == "" {
+		return fmt.Errorf("gateway config: [server] addr is required")
+	}
+	if c.Server.GatewayKey == "" {
+		return fmt.Errorf("gateway config: [server] gateway_key is required (New API channel key)")
+	}
+	if strings.TrimSpace(c.Store.DB) == "" {
+		return fmt.Errorf("gateway config: [store] db is required")
+	}
+	if c.Store.Scope != "" && !validScope(c.Store.Scope) {
+		return fmt.Errorf("gateway config: [store] scope %q must be session, project, or user", c.Store.Scope)
+	}
+	if c.Cache.TTLSeconds < 0 {
+		return fmt.Errorf("gateway config: [cache] ttl_seconds must be >= 0 (0 disables the time window)")
+	}
+	if len(c.Upstreams) == 0 {
+		return fmt.Errorf("gateway config: at least one [[upstreams]] entry is required")
+	}
+	seenModel := map[string]string{}
+	for i := range c.Upstreams {
+		u := &c.Upstreams[i]
+		if strings.TrimSpace(u.Name) == "" {
+			return fmt.Errorf("gateway config: upstreams[%d]: name is required", i)
+		}
+		if strings.TrimSpace(u.BaseURL) == "" || strings.TrimSpace(u.APIKey) == "" {
+			return fmt.Errorf("gateway config: upstreams[%d] (%s): base_url and api_key are required", i, u.Name)
+		}
+		if strings.TrimSpace(u.UpstreamModel) == "" {
+			return fmt.Errorf("gateway config: upstreams[%d] (%s): upstream_model is required", i, u.Name)
+		}
+		if len(u.ModelAlias) == 0 {
+			return fmt.Errorf("gateway config: upstreams[%d] (%s): model_alias must list at least one alias", i, u.Name)
+		}
+		if !supportedVendors[u.Vendor] {
+			return fmt.Errorf("gateway config: upstreams[%d] (%s): vendor %q is not supported by gateway v1 (supported: deepseek, openai, moonshot; anthropic needs format conversion, later milestone)", i, u.Name, u.Vendor)
+		}
+		for _, alias := range u.ModelAlias {
+			if prev, dup := seenModel[alias]; dup {
+				return fmt.Errorf("gateway config: model alias %q is declared by both %q and %q", alias, prev, u.Name)
+			}
+			seenModel[alias] = u.Name
+		}
+	}
+	return nil
+}
+
+func validScope(s string) bool {
+	switch s {
+	case "session", "project", "user":
+		return true
+	}
+	return false
+}
+
+// DefaultConfig returns the built-in defaults (for tests and docs).
+func DefaultConfig() *Config {
+	return &Config{
+		Server: ServerConfig{Addr: ":8080", GatewayKey: "dev-key"},
+		Store:  StoreConfig{DB: ".semantix/gateway.jsonl", Scope: "project", DepsRoot: "."},
+		Retrieval: RetrievalConfig{Retriever: "bm25", TopK: 5, Budget: 4096},
+		Cache:  CacheConfig{TTLSeconds: 86400},
+		Ingest: IngestConfig{SessionsDir: ".semantix/sessions", UsageLog: ".semantix/gateway-usage.jsonl"},
+	}
+}
+
+// ModelList returns every model alias the gateway can route, sorted.
+func (c *Config) ModelList() []string {
+	set := map[string]bool{}
+	for _, u := range c.Upstreams {
+		for _, a := range u.ModelAlias {
+			set[a] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for m := range set {
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// UpstreamFor resolves a client-visible model alias to its channel.
+func (c *Config) UpstreamFor(model string) (UpstreamConfig, bool) {
+	for _, u := range c.Upstreams {
+		for _, a := range u.ModelAlias {
+			if a == model {
+				return u, true
+			}
+		}
+	}
+	return UpstreamConfig{}, false
+}

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -1,0 +1,132 @@
+package gateway
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gateway.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const validConfig = `
+[server]
+addr = ":8080"
+gateway_key = "${GW_KEY}"
+
+[store]
+db = "~/.semantix/gw.jsonl"
+scope = "project"
+deps_root = "."
+
+[retrieval]
+retriever = "bm25"
+top_k = 5
+budget = 4096
+
+[cache]
+ttl_seconds = 86400
+
+[ingest]
+sessions_dir = "~/.semantix/sessions"
+usage_log = "~/.semantix/gw-usage.jsonl"
+
+[[upstreams]]
+name = "deepseek"
+base_url = "https://api.deepseek.com/v1"
+api_key = "${DS_KEY}"
+model_alias = ["deepseek-chat", "ds-chat"]
+upstream_model = "deepseek-chat"
+vendor = "deepseek"
+`
+
+func TestLoadExpandsEnvAndHome(t *testing.T) {
+	t.Setenv("GW_KEY", "k1")
+	t.Setenv("DS_KEY", "k2")
+	cfg, err := Load(writeConfig(t, validConfig))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.GatewayKey != "k1" || cfg.Upstreams[0].APIKey != "k2" {
+		t.Errorf("env expansion failed: key=%q upkey=%q", cfg.Server.GatewayKey, cfg.Upstreams[0].APIKey)
+	}
+	home, _ := os.UserHomeDir()
+	wantDB := filepath.Join(home, ".semantix", "gw.jsonl")
+	if cfg.Store.DB != wantDB {
+		t.Errorf("db = %q, want %q", cfg.Store.DB, wantDB)
+	}
+	if cfg.Upstreams[0].UpstreamModel != "deepseek-chat" || cfg.Upstreams[0].Vendor != "deepseek" {
+		t.Errorf("upstream fields = %#v", cfg.Upstreams[0])
+	}
+}
+
+func TestLoadFailsOnUnresolvedEnv(t *testing.T) {
+	os.Unsetenv("GW_KEY")
+	os.Unsetenv("DS_KEY")
+	_, err := Load(writeConfig(t, validConfig))
+	if err == nil || !strings.Contains(err.Error(), "GW_KEY") {
+		t.Fatalf("want unresolved-env error naming GW_KEY, got %v", err)
+	}
+}
+
+func TestLoadValidation(t *testing.T) {
+	cases := []struct {
+		name  string
+		mut   func(*Config)
+		msg   string
+	}{
+		{"missing addr", func(c *Config) { c.Server.Addr = "" }, "addr"},
+		{"missing key", func(c *Config) { c.Server.GatewayKey = "" }, "gateway_key"},
+		{"missing db", func(c *Config) { c.Store.DB = "" }, "db"},
+		{"no upstreams", func(c *Config) { c.Upstreams = nil }, "upstreams"},
+		{"bad scope", func(c *Config) { c.Store.Scope = "all" }, "scope"},
+		{"anthropic vendor", func(c *Config) { c.Upstreams[0].Vendor = "anthropic" }, "vendor"},
+		{"dup alias", func(c *Config) {
+			c.Upstreams = append(c.Upstreams, c.Upstreams[0])
+			c.Upstreams[1].Name = "second"
+		}, "alias"},
+		{"missing api_key", func(c *Config) { c.Upstreams[0].APIKey = "" }, "api_key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := DefaultConfig()
+			c.Server.GatewayKey = "k"
+			c.Store.DB = "x.jsonl"
+			c.Upstreams = []UpstreamConfig{{
+				Name: "ds", BaseURL: "https://u/v1", APIKey: "k",
+				ModelAlias: []string{"m"}, UpstreamModel: "m", Vendor: "deepseek",
+			}}
+			tc.mut(c)
+			err := c.validate()
+			if err == nil || !strings.Contains(err.Error(), tc.msg) {
+				t.Fatalf("want error containing %q, got %v", tc.msg, err)
+			}
+		})
+	}
+}
+
+func TestModelListAndUpstreamFor(t *testing.T) {
+	c := DefaultConfig()
+	c.Upstreams = []UpstreamConfig{
+		{Name: "a", ModelAlias: []string{"b-model", "a-model"}},
+		{Name: "b", ModelAlias: []string{"c-model"}},
+	}
+	got := c.ModelList()
+	want := []string{"a-model", "b-model", "c-model"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("ModelList = %v, want %v", got, want)
+	}
+	if u, ok := c.UpstreamFor("b-model"); !ok || u.Name != "a" {
+		t.Errorf("UpstreamFor(b-model) = %#v, %v", u, ok)
+	}
+	if _, ok := c.UpstreamFor("nope"); ok {
+		t.Error("UpstreamFor(nope) must be false")
+	}
+}

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -159,10 +159,11 @@ func TestE2EL3HitZeroUpstreamCalls(t *testing.T) {
 	srv := httptest.NewServer(g)
 	defer srv.Close()
 
+	chash, _ := contextHash([]chatMessage{msg("user", "hello world")})
 	seed(t, g, &slice.Slice{
 		ID: "l3-a", Type: slice.Result, Scope: slice.Project,
 		Content: []byte("hello world hello world cached answer"),
-		Meta:    slice.SliceMeta{L3Safe: true},
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
 	})
 
 	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
@@ -305,10 +306,11 @@ func TestE2EL3StreamingReplay(t *testing.T) {
 	srv := httptest.NewServer(g)
 	defer srv.Close()
 
+	chash, _ := contextHash([]chatMessage{msg("user", "widgets cached")})
 	seed(t, g, &slice.Slice{
 		ID: "l3-s", Type: slice.Result, Scope: slice.Project,
 		Content: []byte("widgets cached widgets cached stream answer"),
-		Meta:    slice.SliceMeta{L3Safe: true},
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
 	})
 
 	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "widgets cached", true))
@@ -423,3 +425,99 @@ func TestE2EScopeHeader(t *testing.T) {
 }
 
 var _ = fmt.Sprintf
+
+// ---------------------------------------------------------------------------
+// model alias mapping (review fix: upstream_model must reach the upstream)
+
+func TestE2EAliasMapping(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"mapped"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	g.cfg.Upstreams[0].ModelAlias = []string{"client-model"}
+	g.cfg.Upstreams[0].UpstreamModel = "real-model"
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, out := postChat(t, srv, "test-key", chatBody("client-model", "hi", false))
+	if respContent(t, out) != "mapped" {
+		t.Fatalf("unexpected: %s", out)
+	}
+	up.mu.Lock()
+	model, _ := up.lastBody["model"].(string)
+	up.mu.Unlock()
+	if model != "real-model" {
+		t.Errorf("forwarded model = %q, want real-model (alias must be mapped)", model)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// L3 context isolation (review fix: different history must not reuse)
+
+func TestE2ECrossContextIsolation(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	messagesA := []chatMessage{msg("system", "project alpha"), msg("user", "hello world cached")}
+	chashA, _ := contextHash(messagesA)
+	seed(t, g, &slice.Slice{
+		ID: "l3-ctx", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("hello world cached answer from context A"),
+		Meta: slice.SliceMeta{
+			L3Safe: true, ContextHash: chashA, Model: "deepseek-chat",
+		},
+	})
+
+	body := func(messages []chatMessage) string {
+		raw, _ := json.Marshal(map[string]any{
+			"model": "deepseek-chat", "messages": messages,
+		})
+		return string(raw)
+	}
+
+	// same context → hit, zero upstream calls
+	resp, out := postChat(t, srv, "test-key", body(messagesA))
+	if resp.Header.Get("x-semantix-cache") != "hit" {
+		t.Errorf("same context: cache = %q, want hit (%s)", resp.Header.Get("x-semantix-cache"), out)
+	}
+
+	// different system prompt (different context) → miss, upstream called
+	other := []chatMessage{msg("system", "project beta"), msg("user", "hello world cached")}
+	resp2, out2 := postChat(t, srv, "test-key", body(other))
+	if resp2.Header.Get("x-semantix-cache") != "miss" {
+		t.Errorf("different context: cache = %q, want miss (%s)", resp2.Header.Get("x-semantix-cache"), out2)
+	}
+	if n := up.callCount(); n != 1 {
+		t.Errorf("upstream calls = %d, want exactly 1 (only the different-context request)", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// L3Safe=false rejection (design §3.5: gateway results are not L3 by default)
+
+func TestE2EL3SafeFalseRejected(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"not cached"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	seed(t, g, &slice.Slice{
+		ID: "l3-unsafe", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("hello world hello world unsafe answer"),
+		Meta:    slice.SliceMeta{L3Safe: false}, // no deps + not opted in
+	})
+
+	resp, _ := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if resp.Header.Get("x-semantix-cache") != "miss" {
+		t.Errorf("cache = %q, want miss (L3Safe=false must not be served)", resp.Header.Get("x-semantix-cache"))
+	}
+	if n := up.callCount(); n != 1 {
+		t.Errorf("upstream calls = %d, want 1", n)
+	}
+}

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -1,0 +1,425 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"semantix/kernel/slice"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+
+// testUpstream simulates an OpenAI-compatible upstream LLM: it counts calls,
+// captures the last forwarded body, and answers with a canned response.
+type testUpstream struct {
+	mu       sync.Mutex
+	calls    int
+	lastBody map[string]any
+	stream   string // canned SSE body when the request asked for stream
+	plain    string // canned JSON body otherwise
+}
+
+func (u *testUpstream) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		u.mu.Lock()
+		u.calls++
+		u.lastBody = parsed
+		u.mu.Unlock()
+		if stream, _ := parsed["stream"].(bool); stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, u.stream)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, u.plain)
+	}
+}
+
+func (u *testUpstream) callCount() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.calls
+}
+
+func (u *testUpstream) forwardedMessages() []map[string]any {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	m, _ := u.lastBody["messages"].([]any)
+	out := make([]map[string]any, 0, len(m))
+	for _, item := range m {
+		if mm, ok := item.(map[string]any); ok {
+			out = append(out, mm)
+		}
+	}
+	return out
+}
+
+// newTestGateway builds a gateway wired to the fake upstream in a temp dir.
+func newTestGateway(t *testing.T, upURL string) *Gateway {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.Server.GatewayKey = "test-key"
+	cfg.Store.DB = filepath.Join(dir, "db.jsonl")
+	cfg.Store.DepsRoot = dir
+	cfg.Ingest.SessionsDir = filepath.Join(dir, "sessions")
+	cfg.Ingest.UsageLog = filepath.Join(dir, "usage.jsonl")
+	cfg.Upstreams = []UpstreamConfig{{
+		Name: "deepseek", BaseURL: upURL, APIKey: "up-key",
+		ModelAlias: []string{"deepseek-chat"}, UpstreamModel: "deepseek-chat",
+		Vendor: "deepseek",
+	}}
+	g, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = g.Close() })
+	return g
+}
+
+// seed puts a slice into the store and index directly.
+func seed(t *testing.T, g *Gateway, s *slice.Slice) {
+	t.Helper()
+	if s.CreatedAt == 0 {
+		s.CreatedAt = time.Now().Unix()
+	}
+	if err := g.store.Put(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.index.Insert(s); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func chatBody(model, user string, stream bool) string {
+	raw, _ := json.Marshal(map[string]any{
+		"model":    model,
+		"stream":   stream,
+		"messages": []map[string]string{{"role": "user", "content": user}},
+	})
+	return string(raw)
+}
+
+func postChat(t *testing.T, srv *httptest.Server, key, body string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp, out
+}
+
+func respContent(t *testing.T, body []byte) string {
+	t.Helper()
+	var r struct {
+		Choices []struct {
+			Message struct{ Content string `json:"content"` } `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Fatalf("unmarshal response %s: %v", body, err)
+	}
+	if len(r.Choices) == 0 {
+		t.Fatalf("no choices in %s", body)
+	}
+	return r.Choices[0].Message.Content
+}
+
+// ---------------------------------------------------------------------------
+// L3 hit: zero upstream calls (issue acceptance #1)
+
+func TestE2EL3HitZeroUpstreamCalls(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"unused"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	seed(t, g, &slice.Slice{
+		ID: "l3-a", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("hello world hello world cached answer"),
+		Meta:    slice.SliceMeta{L3Safe: true},
+	})
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if resp.Header.Get("x-semantix-cache") != "hit" {
+		t.Errorf("x-semantix-cache = %q, want hit", resp.Header.Get("x-semantix-cache"))
+	}
+	if got := respContent(t, out); got != "hello world hello world cached answer" {
+		t.Errorf("content = %q, want cached answer", got)
+	}
+	if n := up.callCount(); n != 0 {
+		t.Errorf("upstream calls = %d, want 0 (L3 must not reach upstream)", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// L2 injection: forwarded request carries the reuse block (acceptance #2)
+
+func TestE2EL2InjectionForwarded(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"upstream reply"}}],"usage":{"prompt_tokens":5,"completion_tokens":3}}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	seed(t, g, &slice.Slice{
+		ID: "l2-a", Type: slice.Prompt, Scope: slice.Project,
+		Content: []byte("prior knowledge about widgets"),
+	})
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "widgets", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if resp.Header.Get("x-semantix-cache") != "miss" {
+		t.Errorf("x-semantix-cache = %q, want miss", resp.Header.Get("x-semantix-cache"))
+	}
+	if got := respContent(t, out); got != "upstream reply" {
+		t.Errorf("content = %q, want upstream reply (passthrough)", got)
+	}
+	if n := up.callCount(); n != 1 {
+		t.Fatalf("upstream calls = %d, want 1", n)
+	}
+	msgs := up.forwardedMessages()
+	if len(msgs) == 0 {
+		t.Fatal("no messages forwarded")
+	}
+	sys, _ := msgs[0]["content"].(string)
+	if msgs[0]["role"] != "system" || !strings.Contains(sys, "[semantix-reuse]") {
+		t.Errorf("injection block not prepended as system message: %#v", msgs[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSE passthrough (design §3.4)
+
+func TestE2EStreamPassthrough(t *testing.T) {
+	up := &testUpstream{stream: "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"b\"}}]}\n\ndata: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "stream me", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	if !strings.Contains(string(out), "[DONE]") || !strings.Contains(string(out), `"content":"a"`) {
+		t.Errorf("stream not relayed verbatim: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// auth + errors
+
+func TestE2EAuthAndErrors(t *testing.T) {
+	upSrv := httptest.NewServer((&testUpstream{plain: `{}`}).handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	// no key
+	resp, out := postChat(t, srv, "", chatBody("deepseek-chat", "hi", false))
+	if resp.StatusCode != http.StatusUnauthorized || !strings.Contains(string(out), "authentication_error") {
+		t.Errorf("no key: status=%d body=%s", resp.StatusCode, out)
+	}
+	// wrong key
+	resp, out = postChat(t, srv, "wrong", chatBody("deepseek-chat", "hi", false))
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("wrong key: status=%d", resp.StatusCode)
+	}
+	// unknown model
+	resp, out = postChat(t, srv, "test-key", chatBody("nope", "hi", false))
+	if resp.StatusCode != http.StatusNotFound || !strings.Contains(string(out), "model_not_found") {
+		t.Errorf("unknown model: status=%d body=%s", resp.StatusCode, out)
+	}
+	// bad request
+	resp, out = postChat(t, srv, "test-key", `{"model":"deepseek-chat","messages":[]}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("empty messages: status=%d body=%s", resp.StatusCode, out)
+	}
+	// healthz is unauthenticated
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(out), `"status":"ok"`) {
+		t.Errorf("healthz: status=%d body=%s", resp.StatusCode, out)
+	}
+	// models endpoint lists the routed model
+	resp, err = http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _ = io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("/v1/models without key: status=%d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// L3 streaming replay (design §3.4)
+
+func TestE2EL3StreamingReplay(t *testing.T) {
+	up := &testUpstream{stream: "data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	seed(t, g, &slice.Slice{
+		ID: "l3-s", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("widgets cached widgets cached stream answer"),
+		Meta:    slice.SliceMeta{L3Safe: true},
+	})
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "widgets cached", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	body := string(out)
+	if resp.Header.Get("x-semantix-cache") != "hit" {
+		t.Errorf("x-semantix-cache = %q, want hit", resp.Header.Get("x-semantix-cache"))
+	}
+	if !strings.Contains(body, "cached stream answer") || !strings.Contains(body, "[DONE]") {
+		t.Errorf("replay stream missing content or terminator: %s", body)
+	}
+	if n := up.callCount(); n != 0 {
+		t.Errorf("upstream calls = %d, want 0", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sidecar write memory (design §3.7)
+
+func TestE2ESidecarWrittenAndIngested(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh reply"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "brand new topic", false))
+	if respContent(t, out) != "fresh reply" {
+		t.Fatalf("unexpected passthrough: %s", out)
+	}
+
+	// sidecar JSONL exists with the request + response turns
+	dir := g.cfg.Ingest.SessionsDir
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("no sidecar files in %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, entries[0].Name())
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "brand new topic") || !strings.Contains(string(raw), "fresh reply") {
+		t.Errorf("sidecar missing turns: %s", raw)
+	}
+
+	// async ingest eventually extracts slices into the store
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		items, err := g.store.ListAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range items {
+			if s.ID == "l3-a" || s.ID == "l2-a" { // seeds of other tests
+				continue
+			}
+			if bytes.Contains(s.Content, []byte("brand new topic")) {
+				return // ingested
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Error("async ingest did not extract the session into the store within 3s")
+}
+
+// ---------------------------------------------------------------------------
+// scope header override
+
+func TestE2EScopeHeader(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions",
+		strings.NewReader(chatBody("deepseek-chat", "scope test", false)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("x-semantix-scope", "user")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("scope header: status=%d body=%s", resp.StatusCode, out)
+	}
+	if sc, err := g.resolveScope(req); err != nil || sc != slice.User {
+		t.Errorf("scope not resolved to user: %v (%v)", sc, err)
+	}
+
+	// invalid scope header is rejected
+	req2, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions",
+		strings.NewReader(chatBody("deepseek-chat", "scope test", false)))
+	req2.Header.Set("Authorization", "Bearer test-key")
+	req2.Header.Set("x-semantix-scope", "bogus")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	out2, _ := io.ReadAll(resp2.Body)
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Errorf("bad scope header: status=%d body=%s", resp2.StatusCode, out2)
+	}
+}
+
+var _ = fmt.Sprintf

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
 
@@ -36,6 +37,8 @@ type Gateway struct {
 	sessionsMu sync.Mutex // serializes sidecar JSONL appends
 	ingestMu   sync.Mutex // serializes the async ingest writes
 	ingestWG   sync.WaitGroup
+	shutdownMu sync.Mutex // guards closing flag vs recordSession's Add
+	closing    bool
 	disabled   bool       // SEMANTIX_GATEWAY_DISABLE ablation switch
 
 	now func() time.Time
@@ -97,9 +100,13 @@ func New(cfg *Config) (*Gateway, error) {
 	return g, nil
 }
 
-// Close waits for in-flight sidecar ingestion (write memory is best-effort
-// but must not be silently dropped on shutdown), then releases the store.
+// Close stops accepting new sidecar writes, waits for in-flight ingestion
+// (write memory is best-effort but must not be silently dropped on
+// shutdown), then releases the store.
 func (g *Gateway) Close() error {
+	g.shutdownMu.Lock()
+	g.closing = true
+	g.shutdownMu.Unlock()
 	g.ingestWG.Wait()
 	return closeStore(g.store)
 }
@@ -175,16 +182,30 @@ func randomID() string {
 // ---------------------------------------------------------------------------
 // session sidecar (write memory, design §3.7)
 
+// sessionIDPattern bounds the client-supplied session id so it can only
+// name a sidecar file inside the sessions dir (no path traversal).
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
 // recordSession appends this request/response pair to a session JSONL file
 // (0600, ingest.JSONLSource-compatible lines) and asynchronously extracts it
 // into the slice library. Best-effort: failures are logged, never returned
-// to the client.
-func (g *Gateway) recordSession(sessionID string, turns []map[string]any) {
-	if sessionID == "" {
+// to the client. ctxHash/model are stamped onto extracted Result slices so
+// the L3 gate can isolate outcomes per context and model.
+func (g *Gateway) recordSession(sessionID string, ctxHash, model string, turns []map[string]any) {
+	g.shutdownMu.Lock()
+	if g.closing {
+		g.shutdownMu.Unlock()
+		return
+	}
+	g.ingestWG.Add(1)
+	g.shutdownMu.Unlock()
+
+	if sessionID == "" || !sessionIDPattern.MatchString(sessionID) {
 		sessionID = "gw-" + randomID()
 	}
 	dir := g.cfg.Ingest.SessionsDir
 	if dir == "" {
+		g.ingestWG.Done()
 		return
 	}
 	path := filepath.Join(dir, sessionID+".jsonl")
@@ -193,21 +214,22 @@ func (g *Gateway) recordSession(sessionID string, turns []map[string]any) {
 	err := appendJSONLLines(path, turns)
 	g.sessionsMu.Unlock()
 	if err != nil {
+		g.ingestWG.Done()
 		log.Printf("gateway: write session %s: %v", path, err)
 		return
 	}
-	g.ingestWG.Add(1)
 	go func() {
 		defer g.ingestWG.Done()
-		g.ingestSession(path)
+		g.ingestSession(path, ctxHash, model)
 	}()
 }
 
 // ingestSession drains one sidecar file into the slice library via the
-// kernel ingest pipeline, wrapping the extractor so gateway-generated
-// dependency-free Result slices honor the configured L3-safe default
-// (design §3.5: gateway entries are NOT L3-eligible unless opted in).
-func (g *Gateway) ingestSession(path string) {
+// kernel ingest pipeline. Result slices are stamped with the producing
+// request's context hash and model (through metaStore) so the L3 gate can
+// isolate outcomes per context and model; the L3-safe default adapter keeps
+// gateway entries out of L3 unless explicitly configured.
+func (g *Gateway) ingestSession(path, ctxHash, model string) {
 	g.ingestMu.Lock()
 	defer g.ingestMu.Unlock()
 	src, err := ingest.NewJSONLSource(path)
@@ -217,7 +239,7 @@ func (g *Gateway) ingestSession(path string) {
 	}
 	p := ingest.Pipeline{
 		Extractor: l3SafeExtractor{inner: slice.NewExtractor(), l3Safe: g.cfg.Ingest.L3SafeDefault},
-		Store:     g.store,
+		Store:     metaStore{inner: g.store, ctxHash: ctxHash, model: model},
 		Index:     g.index,
 		Scope:     g.injector.Scope,
 		Project:   filepath.Base(path),
@@ -226,6 +248,31 @@ func (g *Gateway) ingestSession(path string) {
 		log.Printf("gateway: ingest %s: %v", path, err)
 	}
 }
+
+// metaStore stamps the producing request's context/model onto Result slices
+// as they are persisted (the only type the L3 gate ever serves). Non-Result
+// slices pass through untouched.
+type metaStore struct {
+	inner   slice.Store
+	ctxHash string
+	model   string
+}
+
+func (m metaStore) Put(s *slice.Slice) error {
+	if s.Type == slice.Result {
+		s.Meta.ContextHash = m.ctxHash
+		s.Meta.Model = m.model
+	}
+	return m.inner.Put(s)
+}
+
+func (m metaStore) Get(id string) (*slice.Slice, error)      { return m.inner.Get(id) }
+func (m metaStore) List(scope slice.Scope) ([]*slice.Slice, error) { return m.inner.List(scope) }
+func (m metaStore) UpdateStats(id string, delta slice.SliceStats) error {
+	return m.inner.UpdateStats(id, delta)
+}
+func (m metaStore) ListAll() ([]*slice.Slice, error) { return m.inner.ListAll() }
+func (m metaStore) Delete(id string) error           { return m.inner.Delete(id) }
 
 // l3SafeExtractor delegates to the kernel extractor, then applies the
 // configured L3-safe default to dependency-free Result slices (the only

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1,0 +1,273 @@
+package gateway
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/cache"
+	"semantix/kernel/ingest"
+	"semantix/kernel/inject"
+	"semantix/kernel/slice"
+	"semantix/kernel/usage"
+	"semantix/kernel/zone"
+)
+
+// Gateway is the assembled Semantix Gateway v1. All semantic behavior is
+// delegated to kernel packages (cache / inject / slice / ingest / usage);
+// this type only wires them together and owns the HTTP transport.
+type Gateway struct {
+	cfg      *Config
+	store    slice.Store
+	index    slice.Index
+	decider  *cache.L3Decider
+	injector *inject.Injector
+	usageLog *usage.Recorder
+	client   *http.Client
+
+	sessionsMu sync.Mutex // serializes sidecar JSONL appends
+	ingestMu   sync.Mutex // serializes the async ingest writes
+	ingestWG   sync.WaitGroup
+	disabled   bool       // SEMANTIX_GATEWAY_DISABLE ablation switch
+
+	now func() time.Time
+}
+
+// New assembles the gateway from config: opens the slice store, rebuilds the
+// in-memory BM25 index from it, and wires the L2 injector + L3 decider. It
+// never starts network listeners — the caller (cmd/semantix-gateway) does.
+func New(cfg *Config) (*Gateway, error) {
+	root := cfg.Store.DepsRoot
+	if root == "" {
+		root = "."
+	}
+	store, err := slice.NewFileStore(cfg.Store.DB)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: open store %s: %w", cfg.Store.DB, err)
+	}
+	idx := bm25.New()
+	if err := loadIndex(store, idx); err != nil {
+		_ = closeStore(store)
+		return nil, fmt.Errorf("gateway: rebuild index: %w", err)
+	}
+
+	scope, err := parseScope(cfg.Store.Scope)
+	if err != nil {
+		_ = closeStore(store)
+		return nil, err
+	}
+	topK := cfg.Retrieval.TopK
+	if topK <= 0 {
+		topK = 5
+	}
+	budget := cfg.Retrieval.Budget
+	if budget <= 0 {
+		budget = inject.DefaultBudget
+	}
+	z := zone.Default()
+
+	var rec *usage.Recorder
+	if cfg.Ingest.UsageLog != "" {
+		rec, err = usage.NewRecorder(cfg.Ingest.UsageLog)
+		if err != nil {
+			_ = closeStore(store)
+			return nil, fmt.Errorf("gateway: usage recorder: %w", err)
+		}
+	}
+
+	g := &Gateway{
+		cfg:      cfg,
+		store:    store,
+		index:    idx,
+		decider:  &cache.L3Decider{Index: idx, Store: store, Root: root, K: topK},
+		injector: &inject.Injector{Index: idx, Store: store, Scope: scope, K: topK, Budget: budget, Zones: &z},
+		usageLog: rec,
+		client:   &http.Client{Timeout: 120 * time.Second},
+		disabled: os.Getenv("SEMANTIX_GATEWAY_DISABLE") != "",
+		now:      time.Now,
+	}
+	return g, nil
+}
+
+// Close waits for in-flight sidecar ingestion (write memory is best-effort
+// but must not be silently dropped on shutdown), then releases the store.
+func (g *Gateway) Close() error {
+	g.ingestWG.Wait()
+	return closeStore(g.store)
+}
+
+func closeStore(store slice.Store) error {
+	if closer, ok := store.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// loadIndex rebuilds the in-memory index from the persisted store so L2/L3
+// retrieval sees previously extracted slices (same pattern as the CLI's
+// lookup/search command assembly).
+func loadIndex(store slice.Store, idx slice.Index) error {
+	items, err := store.ListAll()
+	if err != nil {
+		return err
+	}
+	for _, s := range items {
+		if err := idx.Insert(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseScope maps the configured scope name to the kernel scope enum.
+func parseScope(s string) (slice.Scope, error) {
+	switch s {
+	case "", "project":
+		return slice.Project, nil
+	case "session":
+		return slice.Session, nil
+	case "user":
+		return slice.User, nil
+	default:
+		return 0, fmt.Errorf("gateway config: [store] scope %q must be session, project, or user", s)
+	}
+}
+
+// resolveScope picks the request scope: an optional x-semantix-scope header
+// overrides the configured default (design §4.4 方案 B hook; the header is
+// injected by the New API channel config, clients never touch it).
+func (g *Gateway) resolveScope(r *http.Request) (slice.Scope, error) {
+	v := r.Header.Get("x-semantix-scope")
+	if v == "" {
+		return g.injector.Scope, nil
+	}
+	return parseScope(v)
+}
+
+// cacheFresh applies the configured TTL window over Slice.CreatedAt.
+// ttl_seconds<=0 or unknown age (CreatedAt==0) never expire (kernel gc
+// semantics); the kernel dep-fingerprint chain stays the staleness authority.
+func (g *Gateway) cacheFresh(s *slice.Slice) bool {
+	ttl := g.cfg.Cache.TTLSeconds
+	if ttl <= 0 || s.CreatedAt == 0 {
+		return true
+	}
+	return g.now().Unix()-s.CreatedAt <= ttl
+}
+
+// randomID returns a hex id for sidecar session files.
+func randomID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
+}
+
+// ---------------------------------------------------------------------------
+// session sidecar (write memory, design §3.7)
+
+// recordSession appends this request/response pair to a session JSONL file
+// (0600, ingest.JSONLSource-compatible lines) and asynchronously extracts it
+// into the slice library. Best-effort: failures are logged, never returned
+// to the client.
+func (g *Gateway) recordSession(sessionID string, turns []map[string]any) {
+	if sessionID == "" {
+		sessionID = "gw-" + randomID()
+	}
+	dir := g.cfg.Ingest.SessionsDir
+	if dir == "" {
+		return
+	}
+	path := filepath.Join(dir, sessionID+".jsonl")
+
+	g.sessionsMu.Lock()
+	err := appendJSONLLines(path, turns)
+	g.sessionsMu.Unlock()
+	if err != nil {
+		log.Printf("gateway: write session %s: %v", path, err)
+		return
+	}
+	g.ingestWG.Add(1)
+	go func() {
+		defer g.ingestWG.Done()
+		g.ingestSession(path)
+	}()
+}
+
+// ingestSession drains one sidecar file into the slice library via the
+// kernel ingest pipeline, wrapping the extractor so gateway-generated
+// dependency-free Result slices honor the configured L3-safe default
+// (design §3.5: gateway entries are NOT L3-eligible unless opted in).
+func (g *Gateway) ingestSession(path string) {
+	g.ingestMu.Lock()
+	defer g.ingestMu.Unlock()
+	src, err := ingest.NewJSONLSource(path)
+	if err != nil {
+		log.Printf("gateway: ingest %s: %v", path, err)
+		return
+	}
+	p := ingest.Pipeline{
+		Extractor: l3SafeExtractor{inner: slice.NewExtractor(), l3Safe: g.cfg.Ingest.L3SafeDefault},
+		Store:     g.store,
+		Index:     g.index,
+		Scope:     g.injector.Scope,
+		Project:   filepath.Base(path),
+	}
+	if _, err := p.Run(src); err != nil {
+		log.Printf("gateway: ingest %s: %v", path, err)
+	}
+}
+
+// l3SafeExtractor delegates to the kernel extractor, then applies the
+// configured L3-safe default to dependency-free Result slices (the only
+// case where L3Safe is consulted — slices with captured Deps are inherently
+// safe, kernel-side).
+type l3SafeExtractor struct {
+	inner  slice.Extractor
+	l3Safe bool
+}
+
+func (e l3SafeExtractor) Extract(tr []byte, meta slice.SliceMeta) ([]*slice.Slice, error) {
+	items, err := e.inner.Extract(tr, meta)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range items {
+		if s.Type == slice.Result && len(s.Meta.Deps) == 0 {
+			s.Meta.L3Safe = e.l3Safe
+		}
+	}
+	return items, nil
+}
+
+// appendJSONLLines appends JSON objects as lines, creating the file with
+// 0600 and the parent directory with 0700 (kernel permission convention).
+func appendJSONLLines(path string, lines []map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, line := range lines {
+		raw, err := json.Marshal(line)
+		if err != nil {
+			return err
+		}
+		if _, err := f.Write(append(raw, '\n')); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/gateway/normalize.go
+++ b/gateway/normalize.go
@@ -1,0 +1,108 @@
+package gateway
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// chatRequest is the OpenAI-compatible subset the gateway consumes. Unknown
+// fields are ignored and forwarded verbatim upstream (the upstream is the
+// protocol authority; the gateway only rewrites what it must).
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Stream      bool          `json:"stream"`
+	Temperature *float64      `json:"temperature"`
+}
+
+// chatMessage is one OpenAI chat message. Content may be a plain string or
+// a multimodal part array (text/image urls); the gateway only reads text
+// parts for query extraction and fingerprints the raw structure.
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+}
+
+// textParts renders a message content value as its text form: a string is
+// used as-is, an array keeps the text parts of each part. Non-text parts
+// (image_url etc.) are skipped — they carry no reusable query semantics.
+func textParts(content any) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []any:
+		var b strings.Builder
+		for _, part := range v {
+			m, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			if m["type"] != "text" {
+				continue
+			}
+			if s, ok := m["text"].(string); ok {
+				b.WriteString(s)
+			}
+		}
+		return b.String()
+	default:
+		return ""
+	}
+}
+
+var whitespace = regexp.MustCompile(`\s+`)
+
+// normalizeQuery trims and collapses whitespace so semantically identical
+// user turns map to the same cache key (same discipline as kernel sanitize).
+func normalizeQuery(s string) string {
+	return strings.TrimSpace(whitespace.ReplaceAllString(s, " "))
+}
+
+// lastUserText returns the normalized text of the last user message, which
+// is the L2/L3 retrieval query (design §3.3 step 2).
+func lastUserText(messages []chatMessage) (string, bool) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role != "user" {
+			continue
+		}
+		if q := normalizeQuery(textParts(messages[i].Content)); q != "" {
+			return q, true
+		}
+	}
+	return "", false
+}
+
+// contextHash fingerprints the full messages array (role + content) so the
+// same query under a different conversation history never reuses another
+// session's cached outcome (design §3.5: messages-context fingerprint).
+func contextHash(messages []chatMessage) (string, error) {
+	raw, err := json.Marshal(messages)
+	if err != nil {
+		return "", fmt.Errorf("gateway: fingerprint messages: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// parseChatRequest decodes the request body and runs the required structural
+// checks (model present, non-empty messages, last user text available).
+func parseChatRequest(body []byte) (*chatRequest, error) {
+	var req chatRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("invalid request body: %w", err)
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	if len(req.Messages) == 0 {
+		return nil, fmt.Errorf("messages must not be empty")
+	}
+	if _, ok := lastUserText(req.Messages); !ok {
+		return nil, fmt.Errorf("no user message with text content found")
+	}
+	return &req, nil
+}

--- a/gateway/normalize_test.go
+++ b/gateway/normalize_test.go
@@ -1,0 +1,135 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func msg(role, content string) chatMessage {
+	return chatMessage{Role: role, Content: content}
+}
+
+func TestLastUserText(t *testing.T) {
+	cases := []struct {
+		name     string
+		messages []chatMessage
+		want     string
+		ok       bool
+	}{
+		{"plain", []chatMessage{msg("user", "  hello   world  ")}, "hello world", true},
+		{"last user wins", []chatMessage{
+			msg("user", "first"),
+			msg("assistant", "reply"),
+			msg("user", "second"),
+		}, "second", true},
+		{"empty user skipped", []chatMessage{
+			msg("user", "   "),
+			msg("assistant", "r"),
+			msg("user", "final"),
+		}, "final", true},
+		{"no user", []chatMessage{msg("system", "s"), msg("assistant", "a")}, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := lastUserText(tc.messages)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("lastUserText = (%q, %v), want (%q, %v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestLastUserTextMultimodal(t *testing.T) {
+	m := chatMessage{Role: "user", Content: []any{
+		map[string]any{"type": "text", "text": "describe"},
+		map[string]any{"type": "image_url", "image_url": map[string]any{"url": "http://x"}},
+		map[string]any{"type": "text", "text": "  the chart "},
+	}}
+	got, ok := lastUserText([]chatMessage{m})
+	if !ok || got != "describe the chart" {
+		t.Errorf("multimodal = (%q, %v), want (\"describe the chart\", true)", got, ok)
+	}
+}
+
+func TestContextHash(t *testing.T) {
+	a := []chatMessage{msg("system", "sys"), msg("user", "hi")}
+	b := []chatMessage{msg("system", "sys"), msg("user", "hi")}
+	c := []chatMessage{msg("system", "different"), msg("user", "hi")}
+	ha, _ := contextHash(a)
+	hb, _ := contextHash(b)
+	hc, _ := contextHash(c)
+	if ha != hb {
+		t.Error("identical contexts must hash identically")
+	}
+	if ha == hc {
+		t.Error("different contexts must hash differently")
+	}
+}
+
+func TestParseChatRequestErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"bad json", `{`},
+		{"no model", `{"messages":[{"role":"user","content":"x"}]}`},
+		{"no messages", `{"model":"m"}`},
+		{"no user text", `{"model":"m","messages":[{"role":"assistant","content":"x"}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseChatRequest([]byte(tc.body)); err == nil {
+				t.Errorf("parseChatRequest(%s) must fail", tc.body)
+			}
+		})
+	}
+}
+
+func TestParseChatRequestOK(t *testing.T) {
+	req, err := parseChatRequest([]byte(`{"model":"ds","messages":[{"role":"system","content":"s"},{"role":"user","content":"hello"}],"temperature":0.5}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Model != "ds" || len(req.Messages) != 2 || req.Temperature == nil || *req.Temperature != 0.5 {
+		t.Errorf("req = %#v", req)
+	}
+}
+
+func TestAttachBlock(t *testing.T) {
+	// appended to the first system message
+	in := []chatMessage{msg("system", "sys1"), msg("user", "u")}
+	out := attachBlock(in, "[semantix-reuse]\nblock\n[/semantix-reuse]")
+	if s, ok := out[0].Content.(string); !ok || !strings.Contains(s, "[semantix-reuse]") {
+		t.Errorf("block not appended to system: %#v", out[0])
+	}
+	// prepended when no system message exists
+	in = []chatMessage{msg("user", "u")}
+	out = attachBlock(in, "[semantix-reuse]\nblock\n[/semantix-reuse]")
+	if len(out) != 2 || out[0].Role != "system" || out[0].Content != "[semantix-reuse]\nblock\n[/semantix-reuse]" {
+		t.Errorf("system not prepended: %#v", out)
+	}
+	// multimodal system message untouched, block prepended instead
+	in = []chatMessage{{Role: "system", Content: []any{}}, msg("user", "u")}
+	out = attachBlock(in, "block")
+	if out[0].Role != "system" || out[0].Content != "block" {
+		t.Errorf("multimodal system handling wrong: %#v", out)
+	}
+}
+
+func TestExtractAssistantContent(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"answer text"}}]}`)
+	if got := extractAssistantContent(body); got != "answer text" {
+		t.Errorf("extract = %q", got)
+	}
+	if got := extractAssistantContent([]byte(`{broken`)); got != "" {
+		t.Errorf("broken body must yield empty, got %q", got)
+	}
+}
+
+func TestTurns(t *testing.T) {
+	req := &chatRequest{Messages: []chatMessage{msg("user", "q"), msg("assistant", "a")}}
+	turns := turns(req, "answer")
+	if len(turns) != 3 || turns[2]["role"] != "assistant" || turns[2]["content"] != "answer" {
+		t.Errorf("turns = %#v", turns)
+	}
+}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -1,0 +1,368 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"semantix/kernel/cache"
+	"semantix/kernel/inject"
+	"semantix/kernel/usage"
+)
+
+// handleChat runs the full pipeline for POST /v1/chat/completions
+// (design §3.3): auth is done in the router; here: normalize → L3 → L2 →
+// forward upstream → passthrough/SSE → sidecar + usage.
+func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte) {
+	req, err := parseChatRequest(body)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+	up, ok := g.cfg.UpstreamFor(req.Model)
+	if !ok {
+		writeAPIError(w, http.StatusNotFound, "model_not_found",
+			fmt.Sprintf("model %q is not routed by this gateway", req.Model))
+		return
+	}
+	query, _ := lastUserText(req.Messages)
+	chash, err := contextHash(req.Messages)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+	scope, err := g.resolveScope(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+	sessionID := r.Header.Get("x-semantix-session")
+	ctx := r.Context()
+	q := cache.Query{UserInput: query, ContextHash: chash, Scope: scope}
+
+	// L3: verified reuse — zero upstream calls (design §3.3 step 3).
+	if !g.disabled {
+		if res, lerr := g.decider.DecideL3(ctx, q); lerr == nil && res != nil && g.l3Eligible(res.SliceID) {
+			g.recordUsage(usage.Event{
+				SessionID: sessionID, TokensIn: int64(len(query)/4) + int64(len(res.Response)/4),
+				TokensOut: 0, CacheHitToken: int64(len(res.Response) / 4),
+				L3Reuse: true, At: g.now().Unix(),
+			})
+			g.replyFromCache(w, r, req, res)
+			return
+		}
+	}
+
+	// L2: inject reuse context, then forward (design §3.3 steps 4-5).
+	var injectedTokens int64
+	inj, ierr := g.injector.Build(query)
+	if ierr != nil {
+		log.Printf("gateway: inject: %v", ierr) // never blocks the main path
+	}
+	if inj != nil {
+		injectedTokens = int64(inj.Bytes / 4)
+		body = g.attachInjection(body, req, inj)
+	}
+
+	resp, ferr := g.forward(ctx, up, body)
+	if ferr != nil {
+		writeAPIError(w, http.StatusBadGateway, "upstream_error",
+			fmt.Sprintf("upstream request failed: %v", ferr))
+		return
+	}
+	defer resp.Body.Close()
+
+	if req.Stream {
+		g.streamThrough(w, resp, sessionID, req, query, injectedTokens)
+		return
+	}
+	g.passthrough(w, resp, sessionID, req, query, injectedTokens)
+}
+
+// l3Eligible applies the gateway-side TTL window on top of the kernel
+// verification chain. A slice that disappeared from the store also fails
+// closed.
+func (g *Gateway) l3Eligible(id string) bool {
+	s, err := g.store.Get(id)
+	if err != nil {
+		return false
+	}
+	return g.cacheFresh(s)
+}
+
+// attachInjection rewrites the outgoing body: the injection block is
+// appended to the first system message (byte-stable prefix tail, L1) or
+// prepended as a new system message when none exists. All other request
+// fields pass through untouched.
+func (g *Gateway) attachInjection(body []byte, req *chatRequest, inj *inject.Injection) []byte {
+	if inj == nil || inj.Text == "" {
+		return body
+	}
+	messages := append([]chatMessage(nil), req.Messages...)
+	messages = attachBlock(messages, inj.Text)
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return body
+	}
+	raw["messages"] = messages
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// attachBlock appends block to the first string-content system message, or
+// prepends a system message when none exists (design §3.6 injection slot).
+func attachBlock(messages []chatMessage, block string) []chatMessage {
+	for i := range messages {
+		if messages[i].Role != "system" {
+			continue
+		}
+		if s, ok := messages[i].Content.(string); ok {
+			messages[i].Content = s + "\n\n" + block
+			return messages
+		}
+	}
+	return append([]chatMessage{{Role: "system", Content: block}}, messages...)
+}
+
+// forward posts the (rewritten) body to the upstream OpenAI-compatible
+// endpoint with the upstream API key.
+func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (*http.Response, error) {
+	url := strings.TrimRight(up.BaseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+up.APIKey)
+	return g.client.Do(req)
+}
+
+// passthrough relays a non-streaming upstream response, records usage and
+// writes the session sidecar (request turns + assistant reply).
+func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, query string, injectedTokens int64) {
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		writeAPIError(w, http.StatusBadGateway, "upstream_error",
+			fmt.Sprintf("read upstream response: %v", err))
+		return
+	}
+	content := extractAssistantContent(out)
+	g.recordSession(sessionID, turns(req, content))
+
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.Header().Set("x-semantix-cache", "miss")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(out)
+
+	if resp.StatusCode >= 400 {
+		return // upstream error: nothing reusable happened
+	}
+	g.recordUsage(usage.Event{
+		SessionID: sessionID,
+		TokensIn:  int64(len(query)/4) + injectedTokens,
+		TokensOut: int64(len(out) / 4),
+		CacheHitToken: 0,
+		InjectedTokens: injectedTokens,
+		At: g.now().Unix(),
+	})
+}
+
+// streamThrough relays a streaming upstream response chunk by chunk (SSE),
+// preserving events verbatim (design §3.4: never reorder/rewrite the
+// upstream stream). Sidecar records the request turns only — parsing the
+// assistant content out of the SSE chunks is deferred (documented debt).
+func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, query string, injectedTokens int64) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("x-semantix-cache", "miss")
+	w.WriteHeader(resp.StatusCode)
+	flusher, _ := w.(http.Flusher)
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			_, _ = w.Write(buf[:n])
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	if resp.StatusCode < 400 {
+		g.recordSession(sessionID, turns(req, ""))
+		g.recordUsage(usage.Event{
+			SessionID: sessionID,
+			TokensIn:  int64(len(query)/4) + injectedTokens,
+			InjectedTokens: injectedTokens,
+			At: g.now().Unix(),
+		})
+	}
+}
+
+// turns renders the request messages plus the assistant reply as the
+// ingest.JSONLSource-compatible sidecar lines.
+func turns(req *chatRequest, assistant string) []map[string]any {
+	out := make([]map[string]any, 0, len(req.Messages)+1)
+	for _, m := range req.Messages {
+		out = append(out, map[string]any{"role": m.Role, "content": textParts(m.Content)})
+	}
+	if assistant != "" {
+		out = append(out, map[string]any{"role": "assistant", "content": assistant})
+	}
+	return out
+}
+
+// extractAssistantContent pulls choices[0].message.content out of a
+// non-streaming OpenAI response (best-effort; empty on parse failure).
+func extractAssistantContent(body []byte) string {
+	var resp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil || len(resp.Choices) == 0 {
+		return ""
+	}
+	return resp.Choices[0].Message.Content
+}
+
+// recordUsage appends one kernel/usage event (best-effort).
+func (g *Gateway) recordUsage(e usage.Event) {
+	if g.usageLog == nil {
+		return
+	}
+	if err := g.usageLog.Append(e); err != nil {
+		log.Printf("gateway: usage append: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// L3 hit responses (design §3.4)
+
+// chatCompletion is the synthetic non-streaming response for an L3 hit.
+type chatCompletion struct {
+	ID      string          `json:"id"`
+	Object  string          `json:"object"`
+	Created int64           `json:"created"`
+	Model   string          `json:"model"`
+	Choices []choicePayload `json:"choices"`
+	Usage   usagePayload    `json:"usage"`
+}
+
+type choicePayload struct {
+	Index        int           `json:"index"`
+	Message      messagePayload `json:"message"`
+	FinishReason string        `json:"finish_reason"`
+}
+
+type messagePayload struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type usagePayload struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+	PromptDetails    struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+}
+
+// replyFromCache serves a verified L3 hit: a plain JSON response, or a
+// reconstructed SSE stream for stream=true (design §3.4 streaming replay).
+func (g *Gateway) replyFromCache(w http.ResponseWriter, r *http.Request, req *chatRequest, res *cache.L3Result) {
+	w.Header().Set("x-semantix-cache", "hit")
+	if req.Stream {
+		g.replayStream(w, r, req, res)
+		return
+	}
+	cached := len(res.Response) / 4
+	query, _ := lastUserText(req.Messages)
+	prompt := len(query) / 4
+	body := chatCompletion{
+		ID:      "chatcmpl-" + res.SliceID,
+		Object:  "chat.completion",
+		Created: g.now().Unix(),
+		Model:   req.Model,
+		Choices: []choicePayload{{
+			Index:        0,
+			Message:      messagePayload{Role: "assistant", Content: res.Response},
+			FinishReason: "stop",
+		}},
+		Usage: usagePayload{
+			PromptTokens:     prompt + cached,
+			CompletionTokens: 0,
+			TotalTokens:      prompt + cached,
+		},
+	}
+	body.Usage.PromptDetails.CachedTokens = cached
+	raw, _ := json.Marshal(body)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(raw)
+}
+
+// replayStream rebuilds an SSE stream from the cached response, chunking the
+// content into deltas (design §3.4 streaming replay; MVP chunk size 256B).
+func (g *Gateway) replayStream(w http.ResponseWriter, r *http.Request, req *chatRequest, res *cache.L3Result) {
+	flusher, _ := w.(http.Flusher)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	base := struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Created int64  `json:"created"`
+		Model   string `json:"model"`
+	}{"chatcmpl-" + res.SliceID, "chat.completion.chunk", g.now().Unix(), req.Model}
+
+	writeChunk := func(delta map[string]any, finish any) {
+		evt := map[string]any{
+			"id": base.ID, "object": base.Object, "created": base.Created, "model": base.Model,
+			"choices": []map[string]any{{
+				"index": 0, "delta": delta, "finish_reason": finish,
+			}},
+		}
+		raw, _ := json.Marshal(evt)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", raw)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+
+	writeChunk(map[string]any{"role": "assistant"}, nil)
+	content := res.Response
+	for len(content) > 0 {
+		n := 256
+		if len(content) < n {
+			n = len(content)
+		}
+		writeChunk(map[string]any{"content": content[:n]}, nil)
+		content = content[n:]
+	}
+	writeChunk(map[string]any{}, "stop")
+	_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
+}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -43,9 +43,11 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	}
 	sessionID := r.Header.Get("x-semantix-session")
 	ctx := r.Context()
-	q := cache.Query{UserInput: query, ContextHash: chash, Scope: scope}
+	q := cache.Query{UserInput: query, ContextHash: chash, Scope: scope, Model: req.Model}
 
-	// L3: verified reuse — zero upstream calls (design §3.3 step 3).
+	// L3: verified reuse — zero upstream calls (design §3.3 step 3). The
+	// kernel gate enforces context/model isolation (fail closed) on top of
+	// the dep-fingerprint chain.
 	if !g.disabled {
 		if res, lerr := g.decider.DecideL3(ctx, q); lerr == nil && res != nil && g.l3Eligible(res.SliceID) {
 			g.recordUsage(usage.Event{
@@ -66,8 +68,8 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	}
 	if inj != nil {
 		injectedTokens = int64(inj.Bytes / 4)
-		body = g.attachInjection(body, req, inj)
 	}
+	body = g.rewriteOutgoing(body, req, up, inj)
 
 	resp, ferr := g.forward(ctx, up, body)
 	if ferr != nil {
@@ -78,10 +80,10 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	defer resp.Body.Close()
 
 	if req.Stream {
-		g.streamThrough(w, resp, sessionID, req, query, injectedTokens)
+		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens)
 		return
 	}
-	g.passthrough(w, resp, sessionID, req, query, injectedTokens)
+	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens)
 }
 
 // l3Eligible applies the gateway-side TTL window on top of the kernel
@@ -95,22 +97,21 @@ func (g *Gateway) l3Eligible(id string) bool {
 	return g.cacheFresh(s)
 }
 
-// attachInjection rewrites the outgoing body: the injection block is
-// appended to the first system message (byte-stable prefix tail, L1) or
-// prepended as a new system message when none exists. All other request
-// fields pass through untouched.
-func (g *Gateway) attachInjection(body []byte, req *chatRequest, inj *inject.Injection) []byte {
-	if inj == nil || inj.Text == "" {
-		return body
-	}
-	messages := append([]chatMessage(nil), req.Messages...)
-	messages = attachBlock(messages, inj.Text)
-
+// rewriteOutgoing rewrites the outgoing body in place: the client model
+// alias is mapped to the upstream model name, and (when an injection block
+// was assembled) the block is appended to the first system message
+// (byte-stable prefix tail, L1) or prepended as a new system message. All
+// other request fields pass through untouched.
+func (g *Gateway) rewriteOutgoing(body []byte, req *chatRequest, up UpstreamConfig, inj *inject.Injection) []byte {
 	var raw map[string]any
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return body
 	}
-	raw["messages"] = messages
+	raw["model"] = up.UpstreamModel
+	if inj != nil && inj.Text != "" {
+		messages := append([]chatMessage(nil), req.Messages...)
+		raw["messages"] = attachBlock(messages, inj.Text)
+	}
 	out, err := json.Marshal(raw)
 	if err != nil {
 		return body
@@ -147,16 +148,23 @@ func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (
 }
 
 // passthrough relays a non-streaming upstream response, records usage and
-// writes the session sidecar (request turns + assistant reply).
-func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, query string, injectedTokens int64) {
-	out, err := io.ReadAll(resp.Body)
+// writes the session sidecar (request turns + assistant reply) — only for
+// successful exchanges, so failed requests never enter the reuse library.
+func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64) {
+	out, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		writeAPIError(w, http.StatusBadGateway, "upstream_error",
 			fmt.Sprintf("read upstream response: %v", err))
 		return
 	}
+	if resp.StatusCode >= 400 {
+		// upstream error: relay the OpenAI error envelope, nothing reusable
+		writeAPIError(w, resp.StatusCode, "upstream_error",
+			fmt.Sprintf("upstream returned %d: %s", resp.StatusCode, strings.TrimSpace(string(out))))
+		return
+	}
 	content := extractAssistantContent(out)
-	g.recordSession(sessionID, turns(req, content))
+	g.recordSession(sessionID, ctxHash, req.Model, turns(req, content))
 
 	for k, vs := range resp.Header {
 		for _, v := range vs {
@@ -167,16 +175,12 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(out)
 
-	if resp.StatusCode >= 400 {
-		return // upstream error: nothing reusable happened
-	}
 	g.recordUsage(usage.Event{
-		SessionID: sessionID,
-		TokensIn:  int64(len(query)/4) + injectedTokens,
-		TokensOut: int64(len(out) / 4),
-		CacheHitToken: 0,
+		SessionID:      sessionID,
+		TokensIn:       int64(len(query)/4) + injectedTokens,
+		TokensOut:      int64(len(out) / 4),
 		InjectedTokens: injectedTokens,
-		At: g.now().Unix(),
+		At:             g.now().Unix(),
 	})
 }
 
@@ -184,7 +188,13 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 // preserving events verbatim (design §3.4: never reorder/rewrite the
 // upstream stream). Sidecar records the request turns only — parsing the
 // assistant content out of the SSE chunks is deferred (documented debt).
-func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, query string, injectedTokens int64) {
+func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64) {
+	if resp.StatusCode >= 400 {
+		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		writeAPIError(w, resp.StatusCode, "upstream_error",
+			fmt.Sprintf("upstream returned %d: %s", resp.StatusCode, strings.TrimSpace(string(out))))
+		return
+	}
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("x-semantix-cache", "miss")
@@ -204,15 +214,13 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 			break
 		}
 	}
-	if resp.StatusCode < 400 {
-		g.recordSession(sessionID, turns(req, ""))
-		g.recordUsage(usage.Event{
-			SessionID: sessionID,
-			TokensIn:  int64(len(query)/4) + injectedTokens,
-			InjectedTokens: injectedTokens,
-			At: g.now().Unix(),
-		})
-	}
+	g.recordSession(sessionID, ctxHash, req.Model, turns(req, ""))
+	g.recordUsage(usage.Event{
+		SessionID:      sessionID,
+		TokensIn:       int64(len(query)/4) + injectedTokens,
+		InjectedTokens: injectedTokens,
+		At:             g.now().Unix(),
+	})
 }
 
 // turns renders the request messages plus the assistant reply as the

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -49,7 +49,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 			return
 		}
-		body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBodyBytes))
 		if err != nil {
 			writeAPIError(w, http.StatusBadRequest, "invalid_request_error", "read body: "+err.Error())
 			return

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1,0 +1,126 @@
+package gateway
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+// maxBodyBytes caps the request body (bounding memory; OpenAI chat bodies
+// are far smaller).
+const maxBodyBytes = 10 << 20
+
+// ServeHTTP routes the OpenAI-compatible surface: /v1/models, the core
+// /v1/chat/completions pipeline, and the New API health probe /healthz.
+// Every /v1/* request is authenticated against the gateway key (the key
+// New API attaches as the channel credential — clients never see it).
+func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	defer func() {
+		log.Printf("gateway: %s %s (%s)", r.Method, r.URL.Path, time.Since(start).Round(time.Millisecond))
+	}()
+
+	switch r.URL.Path {
+	case "/healthz":
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		g.handleHealth(w)
+		return
+	case "/v1/models":
+		if !g.authenticate(w, r) {
+			return
+		}
+		if r.Method != http.MethodGet {
+			writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		g.handleModels(w)
+		return
+	case "/v1/chat/completions":
+		if !g.authenticate(w, r) {
+			return
+		}
+		if r.Method != http.MethodPost {
+			writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+		if err != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_request_error", "read body: "+err.Error())
+			return
+		}
+		g.handleChat(w, r, body)
+		return
+	default:
+		writeAPIError(w, http.StatusNotFound, "not_found", "no such endpoint: "+r.URL.Path)
+	}
+}
+
+// authenticate checks the Authorization: Bearer header against the gateway
+// key using a constant-time compare. /healthz deliberately skips this — New
+// API's channel health check does not carry the channel key.
+func (g *Gateway) authenticate(w http.ResponseWriter, r *http.Request) bool {
+	const prefix = "Bearer "
+	auth := r.Header.Get("Authorization")
+	if len(auth) <= len(prefix) || auth[:len(prefix)] != prefix {
+		writeAPIError(w, http.StatusUnauthorized, "authentication_error", "missing bearer token")
+		return false
+	}
+	token := auth[len(prefix):]
+	want := g.cfg.Server.GatewayKey
+	if len(token) != len(want) || subtle.ConstantTimeCompare([]byte(token), []byte(want)) != 1 {
+		writeAPIError(w, http.StatusUnauthorized, "authentication_error", "invalid gateway key")
+		return false
+	}
+	return true
+}
+
+// handleHealth answers the New API channel probe: the store is already open
+// by construction (New failed otherwise), so 200 means "ready".
+func (g *Gateway) handleHealth(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, `{"status":"ok"}`)
+}
+
+// handleModels lists every routable model alias (design §3.2).
+func (g *Gateway) handleModels(w http.ResponseWriter) {
+	list := g.cfg.ModelList()
+	models := make([]map[string]any, 0, len(list))
+	for _, m := range list {
+		models = append(models, map[string]any{
+			"id": m, "object": "model", "created": 0, "owned_by": "semantix-gateway",
+		})
+	}
+	body := map[string]any{"object": "list", "data": models}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(raw)
+}
+
+// apiErrorBody is the OpenAI error envelope New API and clients parse.
+type apiErrorBody struct {
+	Error apiError `json:"error"`
+}
+
+type apiError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code,omitempty"`
+}
+
+// writeAPIError writes an OpenAI-format error response.
+func writeAPIError(w http.ResponseWriter, status int, typ, message string) {
+	raw, _ := json.Marshal(apiErrorBody{Error: apiError{Message: message, Type: typ}})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(raw)
+}

--- a/kernel/cache/cache.go
+++ b/kernel/cache/cache.go
@@ -13,6 +13,10 @@ type Query struct {
 	Intent      string // from the intent classifier (later milestone)
 	ContextHash string // stable hash of the current context fingerprint
 	Scope       slice.Scope
+	// Model is the client-visible model alias. The L3 gate requires the
+	// cached slice to carry the same Model (cross-model reuse is never
+	// allowed, Issue #133). Empty disables the check for legacy entries.
+	Model string
 }
 
 // L3Result is a reusable cached outcome (verified, fail-closed).

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -74,6 +74,18 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 		if z.Classify(h.Score, top1) != zone.Hit {
 			continue // grey/miss: not clearly the same task
 		}
+		// Context/model isolation (Issue #133 gateway): a cached outcome
+		// produced under a different conversation history or model must
+		// never be served. When the query carries a context/model (gateway
+		// always does), entries without a matching stamp — including
+		// unstamped legacy slices — fail closed; empty query fields keep
+		// the legacy CLI behavior.
+		if q.ContextHash != "" && s.Meta.ContextHash != q.ContextHash {
+			continue
+		}
+		if q.Model != "" && s.Meta.Model != q.Model {
+			continue
+		}
 		if !d.verified(ctx, s) {
 			continue // deps changed: stale, reject this candidate
 		}

--- a/kernel/cache/l3_test.go
+++ b/kernel/cache/l3_test.go
@@ -313,3 +313,77 @@ func TestDecideL2FiltersGrey(t *testing.T) {
 		}
 	}
 }
+
+// TestDecideL3ContextIsolation (Issue #133): a cached outcome stamped with a
+// different messages-context hash or model must never be served — the same
+// query under another history or model fails closed.
+func TestDecideL3ContextIsolation(t *testing.T) {
+	root, idx, _, _ := buildTestLib(t)
+	d := &L3Decider{Index: idx, Root: root}
+	ctx := context.Background()
+
+	// legacy entry (no stamp) with a context/model-carrying query is
+	// rejected: the gateway must never serve an outcome whose provenance
+	// is unknown (fail closed).
+	res, err := d.DecideL3(ctx, Query{
+		UserInput: "修复 go 测试失败", Scope: slice.Project,
+		ContextHash: "ctx-a", Model: "ds",
+	})
+	if err != nil || res != nil {
+		t.Fatalf("unstamped entry must fail closed under context query: %v %v", res, err)
+	}
+
+	// stamped with matching context+model → reuse
+	stamped := &slice.Slice{
+		ID: "l3-ctx", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("修复 go 测试失败 的缓存答案"),
+		Meta: slice.SliceMeta{
+			Deps: idxDep(t, root), Mtimes: idxMtimes(t, root),
+			ContextHash: "ctx-a", Model: "ds",
+		},
+	}
+	idx.Insert(stamped)
+	res, err = d.DecideL3(ctx, Query{
+		UserInput: "修复 go 测试失败", Scope: slice.Project,
+		ContextHash: "ctx-a", Model: "ds",
+	})
+	if err != nil || res == nil || res.SliceID != "l3-ctx" {
+		t.Fatalf("matching context/model must reuse: %v %v", res, err)
+	}
+
+	// different context → rejected
+	res, err = d.DecideL3(ctx, Query{
+		UserInput: "修复 go 测试失败", Scope: slice.Project,
+		ContextHash: "ctx-b", Model: "ds",
+	})
+	if err != nil || res != nil {
+		t.Fatalf("different context must fail closed: %v %v", res, err)
+	}
+
+	// different model → rejected
+	res, err = d.DecideL3(ctx, Query{
+		UserInput: "修复 go 测试失败", Scope: slice.Project,
+		ContextHash: "ctx-a", Model: "claude",
+	})
+	if err != nil || res != nil {
+		t.Fatalf("different model must fail closed: %v %v", res, err)
+	}
+}
+
+func idxDep(t *testing.T, root string) fingerprint.Deps {
+	t.Helper()
+	deps, err := fingerprint.Capture(root, []string{"dep.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return deps
+}
+
+func idxMtimes(t *testing.T, root string) map[string]int64 {
+	t.Helper()
+	st, err := os.Stat(filepath.Join(root, "dep.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string]int64{"dep.txt": st.ModTime().Unix()}
+}

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -93,6 +93,16 @@ type SliceMeta struct {
 	// silently skipping dimension-mismatched vectors.
 	EmbedModel string `json:"embed_model,omitempty"`
 	EmbedDim   int    `json:"embed_dim,omitempty"`
+	// ContextHash records the messages-context fingerprint of the request
+	// that produced this slice (Issue #133 gateway). The L3 gate compares
+	// it against the live request so the same query under a different
+	// conversation history never reuses another session's outcome. Empty
+	// means unknown/legacy — the L3 gate skips the check then.
+	ContextHash string `json:"context_hash,omitempty"`
+	// Model records the client-visible model alias that produced this
+	// slice (Issue #133 gateway). Cross-model reuse is never allowed, so
+	// the L3 gate requires a match when non-empty.
+	Model string `json:"model,omitempty"`
 }
 
 // Slice is the core semantic slice value.


### PR DESCRIPTION
## 概述

Semantix Gateway v1（M2-GW1）：OpenAI 兼容 HTTP 网关（`/v1/*`），复用一个已验收的 kernel 三层语义缓存，让任意 OpenAI 兼容客户端（Claude Code / chatbox / IDE 插件等）的请求在到达上游 LLM 前先过语义缓存：L3 命中零上游调用、L2 注入跳过重复探索。

## 变更（15 文件 +2626 行）

- `docs/specs/newapi-gateway-design.md` — 设计文档（issue 要求提交）
- `gateway/`（8 文件）— 核心：`pipeline.go`（L3 命中 → L2 注入 → 上游转发 → 会话旁路写记忆）、`server.go`（OpenAI 兼容 + SSE 透传 + L3 流式回放）、`normalize.go`（alias 映射、错误信封）、`config.go`（${VAR} env 展开，未解析即报错）、e2e/单元测试
- `cmd/semantix-gateway/` — 入口（优雅关闭）
- `kernel/cache` + `kernel/slice` — 增补 2 个隔离字段（`SliceMeta.ContextHash/Model`），`L3Decider` fail-closed 隔离（审查修复，附测试）

## 验收（issue checklist 5/5）

- 设计文档已提交、OpenAI 兼容 `/v1/*` 流水线实现、kernel 复用零新增核心逻辑、New API HTTP 上游对接（alias 映射）
- 独立 subagent 审查：2 个阻断项（L3 缓存键缺 context/model 隔离、upstream_model 未应用）与 3 个应修项均已修复并复验
- `go test ./...` 16 包全绿（`cmd/semantix/kernel/slice` 3 项失败经基线 9cf3d53 对照验证为既有 Windows 问题）；`go vet ./...` 通过；e2e 实测 9 场景全过
- `-race` 本机无 CGO 无法运行，由 CI 承担（`.github/workflows/ci.yml:36` 已跑 `go test ./... -race`）

## 未闭合

M1/M2 项（Claude 格式转换、流式 usage trailer、计费对账）与债务记录于 `docs/reports/issue-133-acceptance.md` §6，另行开 issue。

Closes #133
