### PR TITLE
feat(gateway): Semantix Gateway v1 - New API OpenAI 兼容网关（Issue #133）

### DIFF
--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -73,10 +73,10 @@ func isUsage(err error) bool {
 type commandGroup int
 
 const (
-	groupKernelOps commandGroup = iota // kernel 运维（U19：现有 8 命令，行为不变）
-	groupProduct                       // 产品与管理（U21/U23/U24/U25 挂载）
-	groupMaintenance                   // 维护（U26 挂载）
-	groupService                       // 服务模式（U27 挂载）
+	groupKernelOps   commandGroup = iota // kernel 运维（U19：现有 8 命令，行为不变）
+	groupProduct                         // 产品与管理（U21/U23/U24/U25 挂载）
+	groupMaintenance                     // 维护（U26 挂载）
+	groupService                         // 服务模式（U27 挂载）
 )
 
 func (g commandGroup) String() string {
@@ -99,7 +99,7 @@ func (g commandGroup) String() string {
 var plannedByGroup = map[commandGroup][]string{
 	groupProduct:     {"install", "completion"},
 	groupMaintenance: {},
-	groupService:     {"serve", "watch"},
+	groupService:     {"watch"},
 }
 
 // commandSpec registers one CLI command in the command tree. All commands
@@ -183,6 +183,10 @@ var commands = []commandSpec{
 		usage:   "semantix gc [--retention-days N] [--min-weight W] [--dry-run] [--json]",
 		summary: "prune stale / low-weight slices",
 		run:     errCommand("gc", runGC)},
+	{name: "serve", group: groupService,
+		usage:   "semantix serve [--addr :8080] [--config <file>] [--db <path>] [--disable]",
+		summary: "Semantix Gateway: OpenAI-compatible HTTP service (Issue #133)",
+		run:     errCommand("serve", runServe)},
 }
 
 func run(args []string, stdout, stderr io.Writer, deps dependencies) int {

--- a/cmd/semantix/main_test.go
+++ b/cmd/semantix/main_test.go
@@ -305,11 +305,15 @@ func TestHelpShowsPlannedGroups(t *testing.T) {
 	out := stdout.String()
 	for _, want := range []string{
 		"Maintenance",
-		"Service mode (planned: serve watch)",
+		"serve",
+		"(planned: watch)",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("help missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "Service mode (planned") {
+		t.Errorf("serve is implemented; the service group must not render as planned:\n%s", out)
 	}
 	if strings.Contains(out, "Product & management (planned") {
 		t.Errorf("doctor is implemented; the product group must not render as planned:\n%s", out)

--- a/cmd/semantix/serve.go
+++ b/cmd/semantix/serve.go
@@ -33,6 +33,15 @@ func runServe(args []string, stdout, stderr io.Writer, deps dependencies) error 
 	if flags.NArg() != 0 {
 		return usagef("serve: unexpected arguments: %v", flags.Args())
 	}
+	if *scope != "" {
+		// Flag-domain validation is a usage error (exit 2), not a runtime
+		// error — validate here so gateway.Load never sees it.
+		switch *scope {
+		case "session", "project", "user":
+		default:
+			return usagef("serve: invalid --scope %q (want session|project|user)", *scope)
+		}
+	}
 
 	cfg, err := gateway.Load(gateway.Options{
 		ConfigPath: *config,

--- a/cmd/semantix/serve.go
+++ b/cmd/semantix/serve.go
@@ -22,7 +22,7 @@ import (
 func runServe(args []string, stdout, stderr io.Writer, deps dependencies) error {
 	flags := flag.NewFlagSet("serve", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	addr := flags.String("addr", "", "listen address (default :8080; env SEMANTIX_GATEWAY_ADDR)")
+	addr := flags.String("addr", "", "listen address (default 127.0.0.1:8080; env SEMANTIX_GATEWAY_ADDR)")
 	config := flags.String("config", "", "gateway config file (default semantix-gateway.toml)")
 	db := flags.String("db", "", "slice store path override (env SEMANTIX_GATEWAY_DB)")
 	scope := flags.String("scope", "", "slice scope override: session|project|user")

--- a/cmd/semantix/serve.go
+++ b/cmd/semantix/serve.go
@@ -65,6 +65,10 @@ func runServe(args []string, stdout, stderr io.Writer, deps dependencies) error 
 
 	fmt.Fprintf(stdout, "semantix serve: gateway listening on %s (models: %v, cache: %s)\n",
 		cfg.Addr, srv.ModelAliases(), cacheMode(cfg))
+	if cfg.GatewayKey == "" {
+		fmt.Fprintln(stdout, "semantix serve: WARNING gateway key is empty — auth is disabled; "+
+			"only run this behind New API on a trusted network (set gateway_key / SEMANTIX_GATEWAY_KEY)")
+	}
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- srv.Serve(ctx, ln) }()

--- a/cmd/semantix/serve.go
+++ b/cmd/semantix/serve.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"semantix/gateway"
+)
+
+// runServe starts the Semantix Gateway HTTP service (Issue #133, design
+// docs/specs/newapi-gateway-design.md): an OpenAI-compatible endpoint that
+// runs requests through the kernel L3/L2 semantic cache before forwarding
+// to the configured upstream. Configuration: semantix-gateway.toml +
+// SEMANTIX_GATEWAY_* env (see gateway.Load). The command blocks until
+// SIGINT/SIGTERM, then shuts down gracefully (exit 0).
+func runServe(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	flags := flag.NewFlagSet("serve", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	addr := flags.String("addr", "", "listen address (default :8080; env SEMANTIX_GATEWAY_ADDR)")
+	config := flags.String("config", "", "gateway config file (default semantix-gateway.toml)")
+	db := flags.String("db", "", "slice store path override (env SEMANTIX_GATEWAY_DB)")
+	scope := flags.String("scope", "", "slice scope override: session|project|user")
+	disable := flags.Bool("disable", false, "disable the semantic cache (pure pass-through; env SEMANTIX_GATEWAY_DISABLE=1)")
+	if err := flags.Parse(args); err != nil {
+		return usageWrap(err)
+	}
+	if flags.NArg() != 0 {
+		return usagef("serve: unexpected arguments: %v", flags.Args())
+	}
+
+	cfg, err := gateway.Load(gateway.Options{
+		ConfigPath: *config,
+		Addr:       *addr,
+		StoreDB:    *db,
+		Scope:      *scope,
+		Disable:    *disable,
+	})
+	if err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+	if len(cfg.Upstreams) == 0 {
+		return fmt.Errorf("serve: no upstreams configured (add [[upstreams]] to %q or set SEMANTIX_GATEWAY_* env)",
+			configFileOrDefault(*config))
+	}
+
+	srv, err := gateway.New(*cfg)
+	if err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+	defer srv.Close()
+
+	ln, err := net.Listen("tcp", cfg.Addr)
+	if err != nil {
+		return fmt.Errorf("serve: listen %s: %w", cfg.Addr, err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Fprintf(stdout, "semantix serve: gateway listening on %s (models: %v, cache: %s)\n",
+		cfg.Addr, srv.ModelAliases(), cacheMode(cfg))
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(ctx, ln) }()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		fmt.Fprintln(stdout, "semantix serve: shutting down")
+		return nil
+	}
+}
+
+func configFileOrDefault(flagPath string) string {
+	if flagPath != "" {
+		return flagPath
+	}
+	if p := os.Getenv("SEMANTIX_GATEWAY_CONFIG"); p != "" {
+		return p
+	}
+	return "semantix-gateway.toml"
+}
+
+func cacheMode(cfg *gateway.Config) string {
+	if cfg.Disable {
+		return "disabled (pure pass-through)"
+	}
+	return "L3 + L2"
+}

--- a/cmd/semantix/serve_test.go
+++ b/cmd/semantix/serve_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestServeRejectsExtraArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"serve", "--addr", ":1", "extra"}, &stdout, &stderr, productionDependencies())
+	if code != 2 {
+		t.Fatalf("serve with positional args: code = %d, want 2; stderr %q", code, stderr.String())
+	}
+}
+
+func TestServeUnknownFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"serve", "--bogus"}, &stdout, &stderr, productionDependencies())
+	if code != 2 {
+		t.Fatalf("serve --bogus: code = %d, want 2; stderr %q", code, stderr.String())
+	}
+}
+
+// TestServeWithoutUpstreamsFails: a gateway with nothing to forward to must
+// refuse to start (runtime error, not a silently empty service).
+func TestServeWithoutUpstreamsFails(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "semantix-gateway.toml")
+	if err := os.WriteFile(configPath, []byte("[server]\naddr = \":0\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SEMANTIX_GATEWAY_CONFIG", configPath)
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"serve"}, &stdout, &stderr, productionDependencies())
+	if code != 1 {
+		t.Fatalf("serve without upstreams: code = %d, want 1; stderr %q", code, stderr.String())
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("no upstreams")) {
+		t.Fatalf("stderr = %q, want no-upstreams diagnostic", stderr.String())
+	}
+}

--- a/cmd/semantix/serve_test.go
+++ b/cmd/semantix/serve_test.go
@@ -23,6 +23,16 @@ func TestServeUnknownFlag(t *testing.T) {
 	}
 }
 
+// TestServeInvalidScopeIsUsageError: `serve --scope bogus` is a usage
+// mistake (exit 2), not a runtime error.
+func TestServeInvalidScopeIsUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"serve", "--scope", "bogus"}, &stdout, &stderr, productionDependencies())
+	if code != 2 {
+		t.Fatalf("serve --scope bogus: code = %d, want 2; stderr %q", code, stderr.String())
+	}
+}
+
 // TestServeWithoutUpstreamsFails: a gateway with nothing to forward to must
 // refuse to start (runtime error, not a silently empty service).
 func TestServeWithoutUpstreamsFails(t *testing.T) {

--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -1,0 +1,326 @@
+# New API 网关集成设计 —— Semantix Gateway（v1）
+> 日期：2026-08-13 · 状态：**已落地（v1，Issue #133）** · 对应：Semantix 对外形态扩展
+> 落地差异（以 Issue #133 文件面为准）：组件为 `gateway/` 包 + `cmd/semantix serve` 命令
+> （不再单独 `cmd/semantix-gateway/` 二进制）；`semantix lookup --json` 子进程协议同构，
+> 网关后端在进程内直接复用 `kernel/lookup` + `kernel/inject`（等价于该子进程协议）。
+> 一句话目标：以 **New API（OpenAI 兼容中转）**，在它后面挂一个 **Semantix Gateway**
+> （新组件，复用 kernel 三层缓存），让任意 OpenAI 兼容客户端（Claude Code / chatbox / IDE 插件等）
+> 的请求在到达上游 LLM 之前先过语义缓存——**L3 命中零上游调用、L2 注入跳过重复探索**，
+> 达成省 token、省成本的效果。
+> 与既有集成方式的关系：LangChain 中间件是「消息级」读/写记忆，Reasonix fork 是「事件级」，
+> 本设计是**「请求级」的 HTTP 网关形态**——同一个「读记忆（inject/lookup） 写记忆（extract）」模型，
+> 只是挂在 API 网关上，零侵入任何 agent harness，天然适配所有 OpenAI 兼容客户端。
+
+---
+
+## 1. 背景与缺口
+### 1.1 Semantix 现状（v0.3.1）
+- kernel 三层语义缓存已实现：**L1** 前缀字节稳定（依赖上游前缀缓存价）、**L2** 语义切片注入（`kernel/inject`）、**L3** 已验证结果复用（`kernel/fingerprint` + `kernel/judge` + `kernel/promote`，issue-08 已验收）；
+- 成本演示（`docs/reports/m0-cost-comparison.md`）：跨会话复用**节省 79.8%**（目标 ≥ 50%），敏感性分析在最保守参数下仍 ≥ 50%；
+- 对外形态目前是**纯 CLI + kernel 库**：`extract / search / lookup / inject / verify / eval / usage`，**没有 HTTP 服务、没有 OpenAI 兼容 API 层**。
+### 1.2 New API 现状
+
+New API（QuantumNous/new-api，one-api 加强分支）是 **OpenAI 兼容的 API 中转/分发面板**：统一入口 `/v1/*`、多用户 Token 管理、渠道管理（多上游 + 模型映射 + 负载均衡 + 重试）、按模型定价计费、额度与速率限制。它本身**不带 agent loop、不做语义缓存**——这正是 Semantix 要补的位置。
+### 1.3 缺口与方案
+> **缺口**：New API 的「渠道」必须是一个 HTTP 上游，而 Semantix 没有 HTTP 层，两者无法直接对接。
+**方案**：新增 **Semantix Gateway**（独立 Go 进程，复用 kernel 全部包），对外暴露 OpenAI 兼容 API，New API 侧把它配置为一个*自定义渠道*。数据流：
+```
+客户端 (Claude Code / chatbox / 任意 OpenAI 兼容客户端)
+   │  base_url = https://new-api.example.com
+   ▼ New API（key 管理 / 计费 / 渠道分发）
+   │  渠道类型 = 自定义（base_url = http://semantix-gateway:8080）
+   ▼ Semantix Gateway（★ 本设计的核心新组件）
+   ├─ L3 语义缓存命中 ──────► 直接返回缓存结果（零上游调用）
+   ├─ L2 注入 + 转发 ────────► 上游 LLM（DeepSeek / Claude / Kimi / GPT）
+   └─ 会话旁路提取 ──────────► 切片库（写记忆，供下次复用）
+```
+
+---
+
+## 2. 省 token 机制与收益模型
+### 2.1 三层机制在网关场景的映射
+
+| 层 | 机制 | 网关中的落点 | 省钱方式 |
+|---|---|---|---|
+| **L1** | 前缀字节稳定 | 网关把注入块放在 **system 提示末尾、消息尾部之后**（Reasonix KV Cache 机制研究结论：静态在前、动态在后），且注入块 ID 规范序 → 字节稳定 | 上游按*缓存价*计费（DeepSeek miss $0.27/M vs hit $0.07/M，价差约 4 倍） |
+| **L2** | 语义切片注入 | 未命中时 `inject.Injector.Build(query)` 检索 top-k 切片，拼入请求后转发上游 | 模型**跳过重复探索**，少生成工具调用/中间步骤 → 省*输出 token**（演示中 80% 的重复步骤被替代，是主要节省来源） |
+| **L3** | 已验证结果复用 | 请求归一化 → 指纹校验（deps/mtime）→ `judge.RuleGate` 验证 → 命中直接返回缓存响应 | **零上游调用**，节省约 100% 的该请求成本 |
+
+### 2.2 收益公式（沿用 m0-cost-comparison 模型）
+```
+单请求成本 = P_miss × (inject_bytes + 新内容) + P_hit × 稳定前缀 + P_out × output_tokens
+
+baseline（无网关） = P_miss × 全量输入 + P_out × 全量输出
+gateway 未命中     ≈ P_hit × 注入前缀 + P_miss × 增量 + P_out × (1 - reuse_ratio) × 全量输出
+gateway L3 命中     ≈ 0（仅网关本地检索，<100ms）——计费上需 D1 的「合成 usage + 近零倍率」落地（§4.3）
+```
+
+- 合成演示实测：1800 → 360 completion tokens，成本 $0.001980 → $0.000399，**节省 79.8%**；
+- 网关场景（API 网关、真实重复任务）预期区间：**30%–50%**，取决于重复率（垂类工作流重复度高，收益靠近上沿）；
+- L3 命中是「纯赚」：一次缓存命中省掉该请求的全部上游费用，且延迟更低（<100ms vs 秒级）。
+### 2.3 目标模型单价（2026-08 参考，网关设计按此建模）
+| 模型 | 输入(miss) | 输入(缓存命中) | 输出 | 缓存机制 |
+|---|---|---|---|---|
+| DeepSeek-chat | $0.27/M | $0.07/M | $1.10/M | 自动前缀缓存（24h），无需显式标记 |
+| Kimi (Moonshot) | ~$0.60/M | 前缀缓存价 | ~$2.20/M | OpenAI 兼容端点，自动前缀缓存（自动性待上游确认，§3.5） |
+| GPT-4o 系列 | ~$2.50/M | ~$1.25/M | ~$10/M | 自动前缀缓存（provider 侧） |
+| Claude Sonnet 系列 | ~$3.00/M | ~$0.30/M | ~$15/M | 需 `cache_control:{type:"ephemeral"}` 断点（≤2 个） |
+
+> 注入块**字节稳定**是 L1 生效的前提；对 Claude 还需在注入块边界打 `cache_control` 断点（见 §3.8）。
+> 单价随时可能变动，网关不硬编码价格——价格只在 New API 侧做计费用，网关只透传 usage。
+
+---
+
+## 3. Semantix Gateway 组件规格
+
+### 3.1 形态与进程
+
+- **独立 Go 进程**：`gateway/` 包 + `cmd/semantix serve` 命令，复用 `kernel/` 全部包（结构铁律不变：kernel 不得反向依赖网关）；
+- 不侵入 New API（New API 无插件机制，渠道化对接是唯一合理方式）；
+- 单二进制、零第三方 HTTP 依赖（标准库 `net/http` 即可，流式用 `http.Flusher`）；
+- 切片库复用 `slice.NewFileStore`（JSONL 单文件 + 原子重写，0600/0700 权限约定延续；MVP 明确不用 bbolt，量大再评估切换）。
+### 3.2 OpenAI 兼容 API 端点
+
+| 端点 | 方法 | 说明 |
+|---|---|---|
+| `GET /v1/models` | 透传 | 返回可路由模型列表（网关上游已配置的模型名） |
+| `POST /v1/chat/completions` | 核心 | 完整流水线（§3.3），支持 `stream=true`（SSE） |
+| `POST /v1/completions` | 可选 | 文本补全透传（MVP 可先不做，默认 501） |
+| `GET /healthz` | 健康 | 检查切片库可打开 + 上游可达性（New API 渠道健康检查用） |
+
+请求/响应结构严格遵循 OpenAI 协议；错误响应也是 OpenAI 格式（`{"error": {"message", "type", "code"}}`），保证 New API 与客户端能正确识别。
+### 3.3 请求处理流水线（核心）
+```
+POST /v1/chat/completions {model, messages, stream, ...}
+   │
+   ├─ 1. 鉴权：校验网关 Key（New API 转发时带的上游 key，见 §4.1）
+   ├─ 2. 归一化：提取 (project/scope, 最后一条用户消息 → query, 完整 messages 指纹)
+   │       项目 scope 来源：可配置 header（如 x-project）或 New API 渠道固定值
+   ├─ 3. L3 查询：查缓存库
+   │       · 命中（指纹 + deps/mtime 校验 + RuleGate 通过）：
+   │       │  ├─ 非流式：直接返回缓存响应（含原始 usage）
+   │       │  └─ 流式：按缓存响应重建 SSE 分块回放（§3.4）
+   │       · 未命中 → 4
+   ├─ 4. L2 注入：inject.Injector{Scope,K,Budget,Zones}.Build(query)
+   │       有命中 → 注入块拼入请求（system 提示末尾，字节稳定）
+   ├─ 5. 上游转发：模型映射（§3.8 适配层）→ 调用上游（超时/重试由 New API 与网关双层兜底）
+   ├─ 6. 响应：透传 content + usage；L3 候选判定（§3.5）
+   └─ 7. 异步写记忆：请求/响应旁路 → 会话 JSONL → ingest → extract（不阻塞主链路）
+```
+
+**关键原则**：
+- **缓存永不阻塞主链路**：检索、注入、写库都是本地操作（<10ms 级）；上游失败/超时按 OpenAI 错误格式返回，客户端可重试；
+- **L3 命中必须可观测**：响应头或 usage 中标记命中（如 `x-semantix-cache: hit` / `prompt_tokens_details.cached_tokens`），便于 New API 侧计费与用户看到省钱；
+- **ablation 开关**：`SEMANTIX_GATEWAY_DISABLE=1` 一键退化为纯透传（风险预案）。
+### 3.4 流式（SSE）
+- **未命中流式**：网关向上游转发 `stream=true`，把上游 SSE 事件**逐块透传**；上游若未在末块返回 usage，网关在 `[DONE]` 前补一个含注入量 usage 统计的末块；保持 `[DONE]` 终止；
+- **命中流式**：缓存存的是完整响应；网关按 OpenAI SSE 协议把缓存内容切成 `choices[0].delta.content` 分块回放（每块 ≤ 4KB 或按原缓存分块）。注意这是*重建流*：`id`/`created`、工具调用首块（`index`/`id` 必须在第一个 delta）、`finish_reason` 位置、token 边界都与上游原始流不同；M1 落地时用真实客户端回归验证（见 §8）；
+- **字节稳定注意**：透传不重排、不重写上游事件，避免破坏客户端兼容性；注入块只在请求侧生效，不触碰响应流。
+### 3.5 L3 语义缓存设计
+
+```
+缓存键 = hash(scope | 归一化 query | 模型名 | deps 指纹 | messages 上下文指纹)
+```
+
+- **messages 上下文指纹**：完整 messages（含 system/历史）的归一化哈希——防止不同会话历史/系统提示下*相同 query 互相复用**（跨上下文复用与信息泄漏）；MVP 用全量指纹，宽松模式（仅前缀参与）待 M1 后评估；
+- **归一化 query**：最后一条用户消息去空白/规范化（复用 `sanitize` 纪律）；
+- **deps 指纹**：复用 `fingerprint.Capture/Verify`（path → sha256）+ mtime 快速失败（`SliceMeta.Mtimes`）——*文件一变缓存即失效**（issue-08 已验收的机制）；网关条目的 deps root 由配置提供（如项目根目录），缺失文件一律视为已变更 → 失效；*网关生成中 deps 为空的结果默认不进入 L3**（`l3_safe=false`，需显式配置才启用）——否则指纹 RuleGate 验证形同虚设（空 deps 时 Chain 会跳过指纹阶段）；
+- **验证**：`judge.RuleGate.Chain`（grey zone 规则，Krites §3.1）；grey 区候选可配置 `SEMANTIX_JUDGE_API_KEY` 走 LLM judge 确认；*judge 一律异步、离主链路执行**（不阻塞响应，保持 <100ms）；
+- **提升与级联失效**：`promote.Store` 存提升条目 + 包级函数 `promote.CascadeInvalidate(store, sourceSliceID, currentContent)`——上游响应内容变化（content 版本号变更）时*级联失效**同一源切片衍生的下游缓存条目；
+- **TTL**：缓存条目按模型 vendor 差异化（DeepSeek 24h / DashScope 5m / Anthropic 5m，沿用 `reasonix-kvcache-mechanisms.md` 的 vendor-aware 结论）；Kimi/Moonshot 与 GPT 的缓存 TTL **以上游文档确认后配置**（Moonshot 历史上需显式建缓存，勿假设自动生效）；
+- **模型名进缓存键**：防止 Claude 的响应被 GPT 复用（跨模型语义相同但行为/风格不同，绝不混用）；
+- **只缓存可安全复用结果**：带工具调用副作用的结果默认不入 L3（R-Slice 需 `--l3-safe` 或 deps 指纹非空，见 `SliceMeta.L3Safe`）。
+### 3.6 L2 注入设计
+
+- 检索：`inject.Injector`（K=5、Budget=4096、Zones 灰度分类默认开）；
+- 注入位置：**system 提示末尾**（前缀尾部，保证注入块之后的历史消息字节稳定 → L1 生效）；对 Claude 在注入块边界打 `cache_control` 断点；
+- 注入块形态沿用内核：`[semantix-reuse] ... [/semantix-reuse]`，*低权威定位**（内容仅供模型参考，不当作指令）；块内 ID 规范序（内核行为）保证字节稳定；
+- 注入块不改变客户端可见的 model/messages 语义，仅内部改写后转发。
+### 3.7 会话提取（写记忆）
+- **旁路落盘**：每个请求/响应对（含工具调用如存在）追加到 `~/.semantix/sessions/<gateway-session-id>.jsonl`（0600），每行 `{role, content, tool_calls}`，与 `ingest.JSONLSource` 格式兼容；
+- **提取**：异步执行 `ingest.Pipeline.Run` → 切片入库（P/C/R/T/M）；可复用现有 extract 逻辑（`cmd/semantix/extract.go`）；
+- **scope 策略**：默认 `project`（New API 渠道级隔离），可选 `user`（按客户端 key 前缀映射，见 §4.4）；
+- **写库失败不影响主链路**：提取是 best-effort，失败仅记日志 + usage 统计。
+### 3.8 上游适配层（DeepSeek / Claude / Kimi / GPT）
+网关统一对上游发 **OpenAI 兼容协议**，适配差异收敛到配置：
+
+| 上游 | base_url（示例） | 鉴权头 | 需特殊处理 |
+|---|---|---|---|
+| DeepSeek | `https://api.deepseek.com/v1` | `Authorization: Bearer` | 无需 cache_control（自动前缀缓存），刻意不发 |
+| Kimi | `https://api.moonshot.cn/v1` | 同上 | 同 OpenAI 兼容，自动前缀缓存 |
+| GPT | `https://api.openai.com/v1` | 同上 | 同 OpenAI 兼容 |
+| Claude | `https://api.anthropic.com/v1` | `x-api-key` + `anthropic-version` | ① 需要把 messages 转 Anthropic 格式（或走官方 OpenAI 兼容端点）；② 注入块边界打 `cache_control:{type:"ephemeral"}`（≤2 断点：system 尾 + 最后消息尾） |
+
+**模型映射**：`semantix-gateway.toml` 中定义 `upstreams[].model_alias`（New API 侧模型名 → 上游模型名）；New API 渠道的模型名即网关的 model_alias，网关负责换成上游真实模型名。
+**超时与重试**：网关给上游设保守超时（connect 10s / 首字节 60s / 总时长延续 New API 配置）；重试逻辑**主要在 New API 渠道层**（New API 有重试/负载均衡），网关只做一次重试兜底（幂等 GET 类；chat 请求重试仅对网络错误）。
+### 3.9 配置（semantix-gateway.toml 草案）
+```toml
+# semantix-gateway.toml
+# 注：配置加载器需实现 ${VAR} 环境变量替换 + ~ 路径展开；
+#     任何未解析的 ${...} 启动即报错（防把字面量当凭据）。
+[server]
+addr = ":8080"
+gateway_key = "${SEMANTIX_GATEWAY_KEY}"   # New API 渠道转发时携带的 key（env 注入，不入库）
+[store]
+db = "~/.semantix/gateway.jsonl"          # 切片库 + L3 缓存库（JSONL 单文件，§3.1）
+scope = "project"                         # 默认切片作用域
+[retrieval]
+retriever = "hybrid"                      # bm25 | vector | hybrid
+top_k = 5
+budget = 4096                             # L2 注入块字节预算
+[cache]
+ttl_seconds = 86400                       # 默认 TTL（vendor 差异化优先）
+judge_api_key = "${SEMANTIX_JUDGE_API_KEY}"   # 可选：grey 区 LLM judge
+
+[ingest]
+sessions_dir = "~/.semantix/sessions"     # 会话旁路落盘目录
+l3_safe_default = false                   # 无 deps 的结果切片默认不进入 L3
+
+[[upstreams]]                             # 每个 New API 渠道模型对应一段
+name = "deepseek-chat"
+base_url = "https://api.deepseek.com/v1"
+api_key = "${DEEPSEEK_API_KEY}"
+model_alias = ["deepseek-chat", "ds-chat"]   # 网关侧别名（New API 渠道模型名，§4.2 第一层）
+upstream_model = "deepseek-chat"          # 上游真实模型名（§4.2 映射目标，第三层）
+vendor = "deepseek"                       # deepseek | anthropic | openai | moonshot（决定 cache_control/格式处理）
+```
+
+### 3.10 安全
+
+- 网关 Key（`SEMANTIX_GATEWAY_KEY`）由 New API 渠道配置注入（渠道密钥字段），*客户端不接触**；网关不校验客户端 key——校验在 New API 层完成（New API 已做用户认证/配额）；
+- 网关 key 支持**轮换与按渠道隔离**（每渠道独立 key 更佳）；明确边界：*New API 容器被攻破 = 网关凭据全部暴露**（内网 + 凭据不落盘缓解，不构成绝对隔离）；
+- 上游 key 只存环境变量，*不落配置文件与日志**；
+- 切片库 0600/0700 权限、原子写、防 symlink（沿用现有安全约定）；
+- 敏感内容：默认 `scope=project` 隔离；脱敏接入点预留（`sanitize` 已有，正式版按策略启用）；
+- 网关无公网暴露面：只允许 New API 所在网段访问（compose 内网即可，见 §5）。
+
+---
+
+## 4. New API 接入配置
+
+### 4.1 渠道配置
+
+New API 管理后台 → 渠道 → 新建渠道：
+| 字段 | 值 |
+|---|---|
+| 类型 | **自定义**（Custom / OpenAI-API 兼容，按 New API 版本选择） |
+| 名称 | semantix-gateway |
+| 代理地址 (Base URL) | `http://semantix-gateway:8080`（compose 内网名）或公网地址（若网关单独部署） |
+| 密钥 (Key) | `SEMANTIX_GATEWAY_KEY` 的值（New API 转发请求时作为 `Authorization: Bearer` 带给网关） |
+| 模型 | 该渠道要路由的模型（如 `deepseek-chat`、`claude-sonnet-4`、`kimi-k2`、`gpt-4o`） |
+| 模型映射 | 可选：New API 展示名 → 上游真实名（不映射则同名透传） |
+| 启用 | 勾选 |
+
+> 一个渠道 = 一个上游服务 + 一组模型。可**每个上游模型建一个渠道**（deepseek / claude / kimi / gpt 各一个渠道，均指向同一网关地址），便于 New API 侧按渠道做分组、权重与禁用。
+### 4.2 模型映射示例
+
+```
+New API 侧模型名（客户端可见） → 网关 model_alias  → 上游真实模型
+deepseek-chat                   → deepseek-chat      → deepseek-chat
+claude-sonnet                   → claude-sonnet      → claude-sonnet-4-20250514（示例）
+kimi-k2                         → kimi-k2            → moonshot-v1-128k（示例）
+gpt-4o                          → gpt-4o             → gpt-4o
+```
+
+### 4.3 计费与配额
+- New API 按渠道模型*定价倍率**计费（按上游单价配置模型价格）；
+- 网关透传上游 usage，命中缓存时：
+  - **L3 命中返回合成 usage**：`completion_tokens=0`、`prompt_tokens=缓存前缀量`并标记 `prompt_tokens_details.cached_tokens` 全部为缓存——否则缓存里的 completion tokens 仍会按全价计费，「≈0 成本」不成立；
+  - New API 侧给网关渠道配*近零价格倍率**（如 0.001x）落 L3 命中的费用——*这是商业决策，见 §9 待决策项 D1**；
+- 网关 `usage` 记录（`kernel/usage.Recorder/Summarize`）用于 Semantix 侧成本统计与验证报告，与 New API 侧计费对账用。
+### 4.4 多用户 / 多项目隔离（可选）
+
+- 方案 A（简单）：整个网关一个 scope=project，所有用户共享切片库（适合个人/小团队）；
+- 方案 B（多项目）：New API 渠道按项目拆分（每项目一个渠道 + 固定 `x-project` header 由渠道配置注入），网关按 header 选 scope 库；
+- 方案 C（用户级）：客户端 key 前缀映射到 scope=user 库。*注意：网关看不到客户端 key**（New API 只转发渠道 key，见 §4.1），需 New API 侧透传用户身份（如按用户拆渠道 + 固定 header，或 New API 支持的用户标识转发）才可行。MVP 用 A，需要时再 B。
+
+---
+
+## 5. 部署方案（推荐：单机 Docker Compose）
+```
+docker-compose.yml
+├─ new-api          镜像: quantumnew/new-api  端口 3000 → 公网（或经 nginx）
+│    volumes: ./data/new-api:/data            （SQLite 持久化）
+├─ semantix-gateway 镜像: <semantix 构建产物镜像（见下）>  端口 8080（仅内网）
+│    env: SEMANTIX_GATEWAY_KEY / DEEPSEEK_API_KEY / ANTHROPIC_API_KEY / MOONSHOT_API_KEY / OPENAI_API_KEY / SEMANTIX_JUDGE_API_KEY
+│    volumes: ./data/semantix:/root/.semantix  （切片库 + 会话旁路持久化）
+└─ (可选) nginx：TLS 终结 + /v1/* 反代到 new-api:3000
+```
+
+要点：
+- **new-api 用 SQLite**（单机够用，零外部依赖）；规模上来再迁 MySQL；
+- 网关镜像：`go build ./cmd/semantix` → scratch/distroless 单二进制镜像，*零第三方依赖**——`go.mod` 无外部包，文件存储为 JSONL；镜像 <10MB）；
+- 网络：`semantix-gateway:8080` **只暴露给 new-api 容器**（compose 内部 network），不发布到宿主机；
+- 健康检查：New API 渠道可用性检测可配置为 `GET /healthz`（或渠道自检开关）；
+- 日志：stdout JSON 日志 + usage 汇总（`semantix usage` 可对账）；建议接 Loki/Promtail 或仅文件轮转。
+### 5.1 非 Docker 备选
+- 二进制直跑：`semantix serve` 与 `new-api` 同机/异机，`base_url` 填实际地址；用 systemd/launchd 托管 + 环境变量注入 key。
+
+---
+
+## 6. 数据流时序
+### 6.1 L3 命中（零上游调用）
+```
+客户端 ──POST /v1/chat/completions──► New API（认证/计费）──► 网关
+   │                                    │                        │
+   │  200 {content, usage}  ◄───────────┤ 指纹+RuleGate 校验通过      │
+   │  headers: x-semantix-cache: hit     │ 直接返回缓存响应        │
+   ◄──────────── 响应 <100ms，无上游费用 ────────────────────────┤
+```
+
+### 6.2 未命中（L2 注入 + 上游）
+```
+客户端 ──► New API ──► 网关
+                        ├─ inject.Build(query) → 注入块（字节稳定）
+                        ├─ 转发上游（OpenAI 兼容协议 / Claude 转格式 + cache_control）
+                        ├─ 上游 200 / SSE 流
+                        ├─ 透传响应 + usage（cached_tokens 标记注入前缀）
+                        └─ 异步：旁路写会话 JSONL → ingest 提取 → L3 候选入库
+客户端 ◄── 响应 ◄──────────────────────────────────────────────
+```
+
+---
+
+## 7. 实施路线与验收标准
+| 阶段 | 内容 | 工期 | Gate（验收） |
+|---|---|---|---|
+| **M0 网关 MVP** | `gateway/` 包（`semantix serve`）：OpenAI 兼容层（chat/completions + SSE 透传 + /healthz）、鉴权 + 上游 DeepSeek 适配 + 会话旁路入库 | 1–2 周 | 任意 OpenAI 兼容客户端 → New API → 网关 → DeepSeek 全链路跑通；会话入库后 `semantix search` 可检索到切片 |
+| **M1 缓存闭环** | L2 注入 + L3 缓存（指纹/RuleGate/promote/TTL）、流式命中回放 + usage 标记 | +1–2 周 | 重复任务第二次命中 `x-semantix-cache: hit` 且零上游调用；合成演示成本节省 ≥ 50%（复用 m0-cost-comparison 脚本） |
+| **M2 多模型 + 上线** | Claude（格式转换 + cache_control）、Kimi / GPT 适配 + 模型映射表 + 计费对账 + 健康监控 | +1 周 | 四家模型渠道全通；命中率/节省率有周报数字；New API 侧对账一致 |
+
+**M0 为决策门**：若网关形态下「请求级注入」收益显著低于预期（重复率低的场景），及时转向纯 L3 缓存策略或按会话聚合注入，控制投入在 2 周内。
+
+---
+
+## 8. 风险与边界
+| 风险 | 缓解 |
+|---|---|
+| L3 误命中（文件变了还复用旧结果） | deps 指纹 + mtime 快速失效 + RuleGate grey zone；副作用结果默认不入 L3（`l3_safe=false`）；**网关生成中 deps 为空的条目默认不入 L3**（§3.5） |
+| 注入块改变模型行为（低质量参考干扰） | 注入块低权威定位 + ablation 开关一键关闭 + 灰度分类（Zones）只注入明确可复用的切片 |
+| 流式命中回放兼容性 | MVP 先做非流式 L3 命中 + 流式透传；流式命中回放为 M1 项，用真实客户端回归 |
+| 敏感数据进切片库 | scope 隔离（project/user）、0600 权限 + 脱敏接入点预留；`scope=user` 方案 C 为可选增强 |
+| 缓存键跨模型混用 | 模型名进缓存键（§3.5），绝不跨模型复用 |
+| L3 跨上下文复用/泄漏（同 query 不同历史） | messages 上下文指纹进缓存键（§3.5）；共享 scope 仅限可信用户（§4.4） |
+| L3 缓存无界增长 / JSONL 全量重写放大 | 条目上限 + TTL 惰性清理 + 异步批量写（D4，§9） |
+| 共享 scope 切片注入投毒（对抗指令） | 方案 A 仅限可信用户；多租户用方案 B/C 隔离；judge 内容消毒 |
+| L3 命中计费不落地（completion 仍全价） | §4.3 合成 usage + New API 近零倍率（D1，§9） |
+| 网关成为单点/性能瓶颈 | 纯本地操作 <10ms；`/healthz` 探活；New API 侧可配多网关渠道做负载均衡（同一切片库需共享 volume） |
+| 上游 key 泄露 | 仅环境变量 + 内网暴露 + 日志脱敏 |
+| 计费口径不一致（网关 vs New API） | usage 统一以网关透传/回填为准，`kernel/usage` 周对账 |
+
+---
+
+## 9. 待决策项（D1–D4）
+| 编号 | 决策 | 选项 | 建议 |
+|---|---|---|---|
+| **D1** | L3 缓存命中是否对客户端降价 | ① New API 模型价格倍率下调（如命中 0.25x）② 不降价，省钱体现为服务方利润 ③ 仅统计展示不调价 | 个人使用建议 ①（钱省在自己账户）；商业化看②③——*上线前定** |
+| **D2** | 网关是否支持 `/v1/embeddings` 透传 | 支持 / 不支持 | MVP 不支持；有向量检索 embedding 需求再加（透传很简单） |
+| **D3** | 多用户 scope 方案 | A 单库 / B 多项目渠道 / C 用户级库 | MVP 用 A，B 按需 |
+| **D4** | 网关缓存库与切片库分库还是合库 | 分库 / 合库（同一 JSONL Store） | 合库（同一 Store，L3 缓存作为特殊 Slice 类型）；条目上限 + TTL 惰性清理，防无界增长 |
+
+---
+
+## 10. 结论
+
+Semantix Gateway 是 Semantix 从「agent kernel / CLI」走向*「API 网关形态」**的关键一步：
+把已验证的 79.8% 成本节省机制（L2 注入 + L3 复用 + L1 字节稳定）搬到 New API 后面，*零侵入任何客户端或 harness**；一条命令部署（`go build ./cmd/semantix`），天然服务 DeepSeek / Claude / Kimi / GPT 四家模型。M0 决策门控制投入在 2 周内，收益不成立可随时退化为纯透传。

--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -153,10 +153,10 @@ POST /v1/chat/completions {model, messages, stream, ...}
 
 **模型映射**：`semantix-gateway.toml` 中定义 `upstreams[].model_alias`（New API 侧模型名 → 上游模型名）；New API 渠道的模型名即网关的 model_alias，网关负责换成上游真实模型名。
 **超时与重试**：网关给上游设保守超时（connect 10s / 首字节 60s / 总时长延续 New API 配置）；重试逻辑**主要在 New API 渠道层**（New API 有重试/负载均衡），网关只做一次重试兜底（幂等 GET 类；chat 请求重试仅对网络错误）。
-### 3.9 配置（semantix-gateway.toml 草案）
+### 3.9 配置（semantix-gateway.toml，v1 已实现）
 ```toml
-# semantix-gateway.toml
-# 注：配置加载器需实现 ${VAR} 环境变量替换 + ~ 路径展开；
+# semantix-gateway.toml（semantix serve 读取；另有 SEMANTIX_GATEWAY_* 环境变量层）
+# 注：配置加载器实现 ${VAR} 环境变量替换 + ~ 路径展开；
 #     任何未解析的 ${...} 启动即报错（防把字面量当凭据）。
 [server]
 addr = ":8080"
@@ -165,16 +165,17 @@ gateway_key = "${SEMANTIX_GATEWAY_KEY}"   # New API 渠道转发时携带的 key
 db = "~/.semantix/gateway.jsonl"          # 切片库 + L3 缓存库（JSONL 单文件，§3.1）
 scope = "project"                         # 默认切片作用域
 [retrieval]
-retriever = "hybrid"                      # bm25 | vector | hybrid
 top_k = 5
 budget = 4096                             # L2 注入块字节预算
 [cache]
-ttl_seconds = 86400                       # 默认 TTL（vendor 差异化优先）
-judge_api_key = "${SEMANTIX_JUDGE_API_KEY}"   # 可选：grey 区 LLM judge
-
+ttl_seconds = 86400                       # L3 条目 TTL（秒；0 = 不过期）
+l3_safe = false                           # 显式开启网关 L3 写回（需 deps_root，§3.5）
+deps_root = "${SEMANTIX_GATEWAY_DEPS_ROOT}"  # 依赖指纹根目录（文件一变缓存即失效）
 [ingest]
-sessions_dir = "~/.semantix/sessions"     # 会话旁路落盘目录
-l3_safe_default = false                   # 无 deps 的结果切片默认不进入 L3
+sessions_dir = "~/.semantix/sessions"     # 会话旁路落盘目录（空 = 关闭写记忆）
+extract = true                            # 旁路会话异步提取为切片
+[usage]
+db = "~/.semantix/gateway-usage.jsonl"    # usage 记录（kernel/usage，与 `semantix usage` 对账）
 
 [[upstreams]]                             # 每个 New API 渠道模型对应一段
 name = "deepseek-chat"
@@ -182,7 +183,8 @@ base_url = "https://api.deepseek.com/v1"
 api_key = "${DEEPSEEK_API_KEY}"
 model_alias = ["deepseek-chat", "ds-chat"]   # 网关侧别名（New API 渠道模型名，§4.2 第一层）
 upstream_model = "deepseek-chat"          # 上游真实模型名（§4.2 映射目标，第三层）
-vendor = "deepseek"                       # deepseek | anthropic | openai | moonshot（决定 cache_control/格式处理）
+vendor = "deepseek"                       # deepseek | anthropic | openai | moonshot（预留）
+timeout_seconds = 60                      # 单次上游调用超时
 ```
 
 ### 3.10 安全
@@ -249,7 +251,7 @@ docker-compose.yml
 
 要点：
 - **new-api 用 SQLite**（单机够用，零外部依赖）；规模上来再迁 MySQL；
-- 网关镜像：`go build ./cmd/semantix` → scratch/distroless 单二进制镜像，*零第三方依赖**——`go.mod` 无外部包，文件存储为 JSONL；镜像 <10MB）；
+- 网关镜像：`go build ./cmd/semantix` → scratch/distroless 单二进制镜像，*零第三方依赖**——`go.mod` 无外部包，文件存储为 JSONL；镜像 <10MB；
 - 网络：`semantix-gateway:8080` **只暴露给 new-api 容器**（compose 内部 network），不发布到宿主机；
 - 健康检查：New API 渠道可用性检测可配置为 `GET /healthz`（或渠道自检开关）；
 - 日志：stdout JSON 日志 + usage 汇总（`semantix usage` 可对账）；建议接 Loki/Promtail 或仅文件轮转。

--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -1,8 +1,12 @@
 # New API 网关集成设计 —— Semantix Gateway（v1）
 > 日期：2026-08-13 · 状态：**已落地（v1，Issue #133）** · 对应：Semantix 对外形态扩展
-> 落地差异（以 Issue #133 文件面为准）：组件为 `gateway/` 包 + `cmd/semantix serve` 命令
-> （不再单独 `cmd/semantix-gateway/` 二进制）；`semantix lookup --json` 子进程协议同构，
-> 网关后端在进程内直接复用 `kernel/lookup` + `kernel/inject`（等价于该子进程协议）。
+> 落地差异（以 Issue #133 文件面为准）：
+> - 组件为 `gateway/` 包 + `cmd/semantix serve` 命令（不再单独 `cmd/semantix-gateway/` 二进制）；
+> - 网关后端在进程内直接复用 kernel 检索/注入路径（`kernel/cache.L3Decider` + `kernel/inject` +
+>   `kernel/ingest`），与 `semantix lookup --json` 子进程协议同构（该协议即这些 kernel 包的 CLI 壳）；
+> - v1 未接线 `judge.RuleGate`/`promote.CascadeInvalidate`（LLM 异步裁决与级联失效留待 M1）——
+>   L3 验证走 L3Decider 的 zone 灰度区 + deps/mtime/指纹链（fail-closed）；
+> - L3 TTL 实现为单一 `cache.ttl_seconds`（vendor 差异化 TTL 待上游文档确认后配置）。
 > 一句话目标：以 **New API（OpenAI 兼容中转）**，在它后面挂一个 **Semantix Gateway**
 > （新组件，复用 kernel 三层缓存），让任意 OpenAI 兼容客户端（Claude Code / chatbox / IDE 插件等）
 > 的请求在到达上游 LLM 之前先过语义缓存——**L3 命中零上游调用、L2 注入跳过重复探索**，
@@ -159,8 +163,8 @@ POST /v1/chat/completions {model, messages, stream, ...}
 # 注：配置加载器实现 ${VAR} 环境变量替换 + ~ 路径展开；
 #     任何未解析的 ${...} 启动即报错（防把字面量当凭据）。
 [server]
-addr = ":8080"
-gateway_key = "${SEMANTIX_GATEWAY_KEY}"   # New API 渠道转发时携带的 key（env 注入，不入库）
+addr = "127.0.0.1:8080"              # 默认回环绑定；配 New API 内网时改为 :8080
+gateway_key = "${SEMANTIX_GATEWAY_KEY}"   # New API 渠道转发时携带的 key（env 注入，不入库；空 = 关闭鉴权，仅限内网）
 [store]
 db = "~/.semantix/gateway.jsonl"          # 切片库 + L3 缓存库（JSONL 单文件，§3.1）
 scope = "project"                         # 默认切片作用域
@@ -251,7 +255,8 @@ docker-compose.yml
 
 要点：
 - **new-api 用 SQLite**（单机够用，零外部依赖）；规模上来再迁 MySQL；
-- 网关镜像：`go build ./cmd/semantix` → scratch/distroless 单二进制镜像，*零第三方依赖**——`go.mod` 无外部包，文件存储为 JSONL；镜像 <10MB；
+- 网关镜像：`go build ./cmd/semantix` → scratch/distroless 单二进制镜像；网关自身不引入新的
+  第三方依赖（沿用仓库已有的 toml 解析库），文件存储为 JSONL，镜像 <10MB；
 - 网络：`semantix-gateway:8080` **只暴露给 new-api 容器**（compose 内部 network），不发布到宿主机；
 - 健康检查：New API 渠道可用性检测可配置为 `GET /healthz`（或渠道自检开关）；
 - 日志：stdout JSON 日志 + usage 汇总（`semantix usage` 可对账）；建议接 Loki/Promtail 或仅文件轮转。

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -1,0 +1,425 @@
+// Package gateway implements the Semantix Gateway (Issue #133): an
+// OpenAI-compatible HTTP layer that sits in front of upstream LLM providers
+// (typically behind a New API relay channel) and runs every request through
+// the kernel's three-layer semantic cache before forwarding:
+//
+//   - L3: verified-result reuse (kernel/cache + kernel/fingerprint) — a hit
+//     returns the cached response with zero upstream calls;
+//   - L2: semantic-slice injection (kernel/inject) — on a miss, relevant
+//     stored slices are appended to the system prompt so the model skips
+//     repeated exploration;
+//   - L1: byte-stable injection blocks keep the upstream prefix-cache warm.
+//
+// The gateway reuses kernel packages only (cache/inject/fingerprint/judge/
+// promote/slice/ingest/usage); kernel never imports gateway. Deployment form:
+// `semantix serve` (a long-running process), configurable via
+// semantix-gateway.toml + SEMANTIX_GATEWAY_* env vars.
+package gateway
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+
+	"semantix/kernel/slice"
+)
+
+// Config is the effective gateway configuration after
+// flags > env > semantix-gateway.toml > built-in defaults.
+type Config struct {
+	Addr       string
+	GatewayKey string
+	// StoreDB is the slice store path (JSONL). The L3 cache shares this
+	// store (design decision D4: L3 entries are Result slices).
+	StoreDB string
+	Scope   slice.Scope
+	// Disable makes the gateway a pure pass-through (ablation switch,
+	// design §3.3): no L3 lookup, no L2 injection.
+	Disable bool
+
+	Retrieval struct {
+		TopK   int
+		Budget int
+	}
+	Cache struct {
+		// TTLSeconds bounds how old a cached L3 entry may be (0 = never).
+		TTLSeconds int64
+		// L3Safe opts into L3 write-back for gateway-produced responses.
+		// DepsRoot must also be set: entries are captured with a
+		// fingerprint of the configured project root, so any file change
+		// invalidates them (design §3.5: dep-less entries never enter L3).
+		L3Safe   bool
+		DepsRoot string
+	}
+	Ingest struct {
+		// SessionsDir is where request/response pairs are bypassed to
+		// session JSONL files (design §3.7). Empty disables write-memory.
+		SessionsDir string
+		// Extract runs the ingest pipeline on bypassed session files
+		// (default true when SessionsDir is set).
+		Extract bool
+	}
+	// UsageDB records per-request usage events (kernel/usage.Recorder).
+	// Empty disables recording.
+	UsageDB string
+
+	Upstreams []Upstream
+}
+
+// Upstream is one configured upstream LLM endpoint (design §3.8).
+type Upstream struct {
+	// Name is the upstream identifier (channel name on the New API side).
+	Name string
+	// BaseURL is the OpenAI-compatible upstream base, e.g.
+	// https://api.deepseek.com/v1
+	BaseURL string
+	// APIKey is the upstream bearer key (from env, never the config file
+	// itself).
+	APIKey string
+	// ModelAlias lists the client-visible model names routed here
+	// (design §4.2: New API channel model names).
+	ModelAlias []string
+	// UpstreamModel is the real model name sent upstream (design §4.2
+	// mapping target). Empty means the client model name passes through.
+	UpstreamModel string
+	// Vendor classifies the provider (design §3.8): deepseek | openai |
+	// moonshot | anthropic. Reserved for vendor-specific behavior.
+	Vendor string
+	// TimeoutSec bounds a single upstream round trip (default 60).
+	TimeoutSec int
+}
+
+// Options carries explicit flag-level overrides (highest precedence).
+type Options struct {
+	ConfigPath string
+	Addr       string
+	GatewayKey string
+	StoreDB    string
+	Scope      string
+	Disable    bool
+}
+
+// fileConfig mirrors semantix-gateway.toml (design §3.9).
+type fileConfig struct {
+	Server struct {
+		Addr       string `toml:"addr"`
+		GatewayKey string `toml:"gateway_key"`
+	} `toml:"server"`
+	Store struct {
+		DB    string `toml:"db"`
+		Scope string `toml:"scope"`
+	} `toml:"store"`
+	Retrieval struct {
+		TopK   int `toml:"top_k"`
+		Budget int `toml:"budget"`
+	} `toml:"retrieval"`
+	Cache struct {
+		TTLSeconds int64  `toml:"ttl_seconds"`
+		L3Safe     bool   `toml:"l3_safe"`
+		DepsRoot   string `toml:"deps_root"`
+	} `toml:"cache"`
+	Ingest struct {
+		SessionsDir string `toml:"sessions_dir"`
+		Extract     *bool  `toml:"extract"`
+	} `toml:"ingest"`
+	Usage struct {
+		DB string `toml:"db"`
+	} `toml:"usage"`
+	Upstreams []struct {
+		Name           string   `toml:"name"`
+		BaseURL        string   `toml:"base_url"`
+		APIKey         string   `toml:"api_key"`
+		ModelAlias     []string `toml:"model_alias"`
+		UpstreamModel  string   `toml:"upstream_model"`
+		Vendor         string   `toml:"vendor"`
+		TimeoutSeconds int      `toml:"timeout_seconds"`
+	} `toml:"upstreams"`
+}
+
+// DefaultConfig returns the built-in defaults.
+func DefaultConfig() *Config {
+	home, _ := os.UserHomeDir()
+	db := filepath.Join(home, ".semantix", "gateway.jsonl")
+	if home == "" {
+		db = ".semantix/gateway.jsonl"
+	}
+	c := &Config{
+		Addr:      ":8080",
+		StoreDB:   db,
+		Scope:     slice.Project,
+		Retrieval: struct{ TopK, Budget int }{TopK: 5, Budget: 4096},
+		Cache: struct {
+			TTLSeconds int64
+			L3Safe     bool
+			DepsRoot   string
+		}{TTLSeconds: 86400},
+		Ingest: struct {
+			SessionsDir string
+			Extract     bool
+		}{},
+	}
+	c.Ingest.Extract = true
+	return c
+}
+
+// envVarPattern matches ${VAR} placeholders (design §3.9: unresolved
+// placeholders are a startup error — a literal "${...}" must never be
+// treated as a credential).
+var envVarPattern = `\$\{[A-Za-z_][A-Za-z0-9_]*\}`
+
+// substituteEnv expands ${VAR} in the raw TOML text. An unset variable is
+// an error (fail fast, never leak the literal placeholder onward).
+func substituteEnv(text string) (string, error) {
+	return substituteEnvFunc(text, func(name string) (string, bool, error) {
+		v, ok := os.LookupEnv(name)
+		if !ok {
+			return "", false, fmt.Errorf("config: ${%s} is not set (refusing to start with a literal placeholder)", name)
+		}
+		return v, true, nil
+	})
+}
+
+// substituteEnvFunc is the testable core of substituteEnv.
+func substituteEnvFunc(text string, lookup func(string) (string, bool, error)) (string, error) {
+	var b strings.Builder
+	for {
+		start := strings.Index(text, "${")
+		if start < 0 {
+			b.WriteString(text)
+			return b.String(), nil
+		}
+		end := strings.Index(text[start:], "}")
+		if end < 0 {
+			// Unclosed placeholder: treat as literal text.
+			b.WriteString(text)
+			return b.String(), nil
+		}
+		end += start
+		name := text[start+2 : end]
+		if !validEnvName(name) {
+			b.WriteString(text[:end+1])
+			text = text[end+1:]
+			continue
+		}
+		b.WriteString(text[:start])
+		v, ok, err := lookup(name)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("config: ${%s} is not set", name)
+		}
+		b.WriteString(v)
+		text = text[end+1:]
+	}
+}
+
+func validEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		ok := r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (i > 0 && r >= '0' && r <= '9')
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// expandHome expands a leading ~ to the user home directory.
+func expandHome(p string) string {
+	if p == "" || p == "~" {
+		if p == "~" {
+			if home, err := os.UserHomeDir(); err == nil {
+				return home
+			}
+		}
+		return p
+	}
+	if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~\\") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+// Load resolves the effective configuration.
+func Load(opts Options) (*Config, error) {
+	cfg := DefaultConfig()
+
+	path := opts.ConfigPath
+	explicit := path != ""
+	if !explicit {
+		if p := os.Getenv("SEMANTIX_GATEWAY_CONFIG"); p != "" {
+			path = p
+			explicit = true
+		}
+	}
+	if path == "" {
+		path = "semantix-gateway.toml"
+	}
+
+	if b, err := os.ReadFile(path); err == nil {
+		text, err := substituteEnv(string(b))
+		if err != nil {
+			return nil, err
+		}
+		var fc fileConfig
+		if _, err := toml.Decode(text, &fc); err != nil {
+			return nil, fmt.Errorf("config: parse %s: %w", path, err)
+		}
+		if fc.Server.Addr != "" {
+			cfg.Addr = fc.Server.Addr
+		}
+		if fc.Server.GatewayKey != "" {
+			cfg.GatewayKey = fc.Server.GatewayKey
+		}
+		if fc.Store.DB != "" {
+			cfg.StoreDB = fc.Store.DB
+		}
+		if fc.Store.Scope != "" {
+			sc, err := parseScopeValue(fc.Store.Scope)
+			if err != nil {
+				return nil, fmt.Errorf("config: %w", err)
+			}
+			cfg.Scope = sc
+		}
+		if fc.Retrieval.TopK > 0 {
+			cfg.Retrieval.TopK = fc.Retrieval.TopK
+		}
+		if fc.Retrieval.Budget > 0 {
+			cfg.Retrieval.Budget = fc.Retrieval.Budget
+		}
+		if fc.Cache.TTLSeconds > 0 {
+			cfg.Cache.TTLSeconds = fc.Cache.TTLSeconds
+		}
+		if fc.Cache.L3Safe {
+			cfg.Cache.L3Safe = true
+		}
+		if fc.Cache.DepsRoot != "" {
+			cfg.Cache.DepsRoot = fc.Cache.DepsRoot
+		}
+		if fc.Ingest.SessionsDir != "" {
+			cfg.Ingest.SessionsDir = fc.Ingest.SessionsDir
+		}
+		if fc.Ingest.Extract != nil {
+			cfg.Ingest.Extract = *fc.Ingest.Extract
+		}
+		if fc.Usage.DB != "" {
+			cfg.UsageDB = fc.Usage.DB
+		}
+		for _, u := range fc.Upstreams {
+			cfg.Upstreams = append(cfg.Upstreams, Upstream{
+				Name:          u.Name,
+				BaseURL:       u.BaseURL,
+				APIKey:        u.APIKey,
+				ModelAlias:    u.ModelAlias,
+				UpstreamModel: u.UpstreamModel,
+				Vendor:        u.Vendor,
+				TimeoutSec:    u.TimeoutSeconds,
+			})
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("config: read %s: %w", path, err)
+	} else if explicit {
+		return nil, fmt.Errorf("config: file %s does not exist", path)
+	}
+
+	// Env layer (SEMANTIX_GATEWAY_*).
+	applyEnv := func(name string, apply func(string)) {
+		if v, ok := os.LookupEnv(name); ok && v != "" {
+			apply(v)
+		}
+	}
+	applyEnv("SEMANTIX_GATEWAY_ADDR", func(v string) { cfg.Addr = v })
+	applyEnv("SEMANTIX_GATEWAY_KEY", func(v string) { cfg.GatewayKey = v })
+	applyEnv("SEMANTIX_GATEWAY_DB", func(v string) { cfg.StoreDB = v })
+	applyEnv("SEMANTIX_GATEWAY_SCOPE", func(v string) {
+		if sc, err := parseScopeValue(v); err == nil {
+			cfg.Scope = sc
+		}
+	})
+	applyEnv("SEMANTIX_GATEWAY_SESSIONS_DIR", func(v string) { cfg.Ingest.SessionsDir = v })
+	applyEnv("SEMANTIX_GATEWAY_DEPS_ROOT", func(v string) { cfg.Cache.DepsRoot = v })
+	applyEnv("SEMANTIX_GATEWAY_USAGE_DB", func(v string) { cfg.UsageDB = v })
+	if v := os.Getenv("SEMANTIX_GATEWAY_DISABLE"); v == "1" || strings.EqualFold(v, "true") {
+		cfg.Disable = true
+	}
+	if v := os.Getenv("SEMANTIX_GATEWAY_L3_SAFE"); v == "1" || strings.EqualFold(v, "true") {
+		cfg.Cache.L3Safe = true
+	}
+
+	// Flag layer (highest).
+	if opts.Addr != "" {
+		cfg.Addr = opts.Addr
+	}
+	if opts.GatewayKey != "" {
+		cfg.GatewayKey = opts.GatewayKey
+	}
+	if opts.StoreDB != "" {
+		cfg.StoreDB = opts.StoreDB
+	}
+	if opts.Scope != "" {
+		sc, err := parseScopeValue(opts.Scope)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Scope = sc
+	}
+	if opts.Disable {
+		cfg.Disable = true
+	}
+
+	// Expand ~ in path fields.
+	cfg.StoreDB = expandHome(cfg.StoreDB)
+	cfg.Cache.DepsRoot = expandHome(cfg.Cache.DepsRoot)
+	cfg.Ingest.SessionsDir = expandHome(cfg.Ingest.SessionsDir)
+	cfg.UsageDB = expandHome(cfg.UsageDB)
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func parseScopeValue(v string) (slice.Scope, error) {
+	switch v {
+	case "session":
+		return slice.Session, nil
+	case "project":
+		return slice.Project, nil
+	case "user":
+		return slice.User, nil
+	default:
+		return 0, fmt.Errorf("invalid scope %q (want session|project|user)", v)
+	}
+}
+
+func (c *Config) validate() error {
+	if c.Addr == "" {
+		return fmt.Errorf("config: server.addr must not be empty")
+	}
+	if c.Retrieval.TopK <= 0 || c.Retrieval.Budget <= 0 {
+		return fmt.Errorf("config: retrieval top_k/budget must be > 0")
+	}
+	if c.Cache.L3Safe && c.Cache.DepsRoot == "" {
+		return fmt.Errorf("config: cache.l3_safe requires cache.deps_root (design §3.5: dep-less entries never enter L3)")
+	}
+	for i, u := range c.Upstreams {
+		if u.BaseURL == "" {
+			return fmt.Errorf("config: upstreams[%d]: base_url required", i)
+		}
+		if len(u.ModelAlias) == 0 {
+			return fmt.Errorf("config: upstreams[%d]: at least one model_alias required", i)
+		}
+		if u.APIKey == "" {
+			return fmt.Errorf("config: upstreams[%d]: api_key required (env-injected)", i)
+		}
+	}
+	return nil
+}

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -328,23 +328,42 @@ func Load(opts Options) (*Config, error) {
 		return nil, fmt.Errorf("config: file %s does not exist", path)
 	}
 
-	// Env layer (SEMANTIX_GATEWAY_*).
-	applyEnv := func(name string, apply func(string)) {
+	// Env layer (SEMANTIX_GATEWAY_*). Invalid values are hard errors
+	// (a typo must surface at startup, not silently fall back to defaults).
+	applyEnv := func(name string, apply func(string) error) error {
 		if v, ok := os.LookupEnv(name); ok && v != "" {
-			apply(v)
+			return apply(v)
 		}
+		return nil
 	}
-	applyEnv("SEMANTIX_GATEWAY_ADDR", func(v string) { cfg.Addr = v })
-	applyEnv("SEMANTIX_GATEWAY_KEY", func(v string) { cfg.GatewayKey = v })
-	applyEnv("SEMANTIX_GATEWAY_DB", func(v string) { cfg.StoreDB = v })
-	applyEnv("SEMANTIX_GATEWAY_SCOPE", func(v string) {
-		if sc, err := parseScopeValue(v); err == nil {
-			cfg.Scope = sc
+	if err := applyEnv("SEMANTIX_GATEWAY_ADDR", func(v string) error { cfg.Addr = v; return nil }); err != nil {
+		return nil, err
+	}
+	if err := applyEnv("SEMANTIX_GATEWAY_KEY", func(v string) error { cfg.GatewayKey = v; return nil }); err != nil {
+		return nil, err
+	}
+	if err := applyEnv("SEMANTIX_GATEWAY_DB", func(v string) error { cfg.StoreDB = v; return nil }); err != nil {
+		return nil, err
+	}
+	if err := applyEnv("SEMANTIX_GATEWAY_SCOPE", func(v string) error {
+		sc, err := parseScopeValue(v)
+		if err != nil {
+			return fmt.Errorf("config: SEMANTIX_GATEWAY_SCOPE: %w", err)
 		}
-	})
-	applyEnv("SEMANTIX_GATEWAY_SESSIONS_DIR", func(v string) { cfg.Ingest.SessionsDir = v })
-	applyEnv("SEMANTIX_GATEWAY_DEPS_ROOT", func(v string) { cfg.Cache.DepsRoot = v })
-	applyEnv("SEMANTIX_GATEWAY_USAGE_DB", func(v string) { cfg.UsageDB = v })
+		cfg.Scope = sc
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	if err := applyEnv("SEMANTIX_GATEWAY_SESSIONS_DIR", func(v string) error { cfg.Ingest.SessionsDir = v; return nil }); err != nil {
+		return nil, err
+	}
+	if err := applyEnv("SEMANTIX_GATEWAY_DEPS_ROOT", func(v string) error { cfg.Cache.DepsRoot = v; return nil }); err != nil {
+		return nil, err
+	}
+	if err := applyEnv("SEMANTIX_GATEWAY_USAGE_DB", func(v string) error { cfg.UsageDB = v; return nil }); err != nil {
+		return nil, err
+	}
 	if v := os.Getenv("SEMANTIX_GATEWAY_DISABLE"); v == "1" || strings.EqualFold(v, "true") {
 		cfg.Disable = true
 	}

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -147,7 +147,10 @@ func DefaultConfig() *Config {
 		db = ".semantix/gateway.jsonl"
 	}
 	c := &Config{
-		Addr:      ":8080",
+		// Loopback by default: the gateway carries API keys and must sit
+		// behind New API (compose internal network) — a wildcard bind is
+		// an explicit operator choice.
+		Addr:      "127.0.0.1:8080",
 		StoreDB:   db,
 		Scope:     slice.Project,
 		Retrieval: struct{ TopK, Budget int }{TopK: 5, Budget: 4096},
@@ -164,11 +167,6 @@ func DefaultConfig() *Config {
 	c.Ingest.Extract = true
 	return c
 }
-
-// envVarPattern matches ${VAR} placeholders (design §3.9: unresolved
-// placeholders are a startup error — a literal "${...}" must never be
-// treated as a credential).
-var envVarPattern = `\$\{[A-Za-z_][A-Za-z0-9_]*\}`
 
 // substituteEnv expands ${VAR} in the raw TOML text. An unset variable is
 // an error (fail fast, never leak the literal placeholder onward).

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -1,0 +1,233 @@
+package gateway
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+func TestSubstituteEnv(t *testing.T) {
+	lookup := func(name string) (string, bool, error) {
+		if name == "SET" {
+			return "value-1", true, nil
+		}
+		return "", false, nil
+	}
+	got, err := substituteEnvFunc("a ${SET} b ${MISSING}", lookup)
+	if err == nil || !strings.Contains(err.Error(), "${MISSING}") {
+		t.Fatalf("unresolved placeholder must error, got %q, %v", got, err)
+	}
+	got, err = substituteEnvFunc("a ${SET} b", lookup)
+	if err != nil || got != "a value-1 b" {
+		t.Fatalf("substituteEnvFunc = %q, %v", got, err)
+	}
+	// Literal-looking text without placeholders is untouched.
+	got, _ = substituteEnvFunc("no placeholders", lookup)
+	if got != "no placeholders" {
+		t.Fatalf("plain text mutated: %q", got)
+	}
+	// Unclosed placeholder stays literal (no false failure).
+	got, err = substituteEnvFunc("${UNCLOSED", lookup)
+	if err != nil || got != "${UNCLOSED" {
+		t.Fatalf("unclosed placeholder: %q, %v", got, err)
+	}
+}
+
+func TestLoadConfigFileWithEnvSubstitution(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "semantix-gateway.toml")
+	content := `
+[server]
+addr = ":9090"
+gateway_key = "${TEST_GATEWAY_KEY}"
+
+[store]
+db = "~/.semantix/gateway.jsonl"
+scope = "user"
+
+[retrieval]
+top_k = 7
+budget = 2048
+
+[cache]
+ttl_seconds = 3600
+
+[ingest]
+sessions_dir = "~/sessions"
+
+[[upstreams]]
+name = "ds"
+base_url = "https://api.deepseek.com/v1"
+api_key = "${TEST_UPSTREAM_KEY}"
+model_alias = ["deepseek-chat", "ds-chat"]
+upstream_model = "deepseek-chat"
+vendor = "deepseek"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TEST_GATEWAY_KEY", "gw-secret")
+	t.Setenv("TEST_UPSTREAM_KEY", "up-secret")
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home) // Windows home for ~ expansion
+	if err := os.MkdirAll(filepath.Join(home, ".semantix"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(Options{ConfigPath: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Addr != ":9090" {
+		t.Errorf("addr = %q", cfg.Addr)
+	}
+	if cfg.GatewayKey != "gw-secret" {
+		t.Errorf("gateway key not env-substituted: %q", cfg.GatewayKey)
+	}
+	if cfg.Scope != slice.User {
+		t.Errorf("scope = %v", cfg.Scope)
+	}
+	if cfg.Retrieval.TopK != 7 || cfg.Retrieval.Budget != 2048 {
+		t.Errorf("retrieval = %+v", cfg.Retrieval)
+	}
+	if cfg.Cache.TTLSeconds != 3600 {
+		t.Errorf("ttl = %d", cfg.Cache.TTLSeconds)
+	}
+	if cfg.Ingest.SessionsDir != filepath.Join(home, "sessions") {
+		t.Errorf("sessions dir = %q", cfg.Ingest.SessionsDir)
+	}
+	if !strings.HasPrefix(cfg.StoreDB, home) {
+		t.Errorf("store db not home-expanded: %q", cfg.StoreDB)
+	}
+	if len(cfg.Upstreams) != 1 {
+		t.Fatalf("upstreams = %d", len(cfg.Upstreams))
+	}
+	up := cfg.Upstreams[0]
+	if up.APIKey != "up-secret" || up.BaseURL != "https://api.deepseek.com/v1" {
+		t.Errorf("upstream = %+v", up)
+	}
+	if len(up.ModelAlias) != 2 || up.UpstreamModel != "deepseek-chat" || up.Vendor != "deepseek" {
+		t.Errorf("upstream fields = %+v", up)
+	}
+}
+
+func TestLoadUnresolvedPlaceholderFails(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "semantix-gateway.toml")
+	content := "[server]\ngateway_key = \"${NOT_SET_ANYWHERE}\"\n"
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(Options{ConfigPath: configPath}); err == nil ||
+		!strings.Contains(err.Error(), "${NOT_SET_ANYWHERE}") {
+		t.Fatalf("unresolved placeholder must fail startup, got %v", err)
+	}
+}
+
+func TestLoadL3SafeRequiresDepsRoot(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "semantix-gateway.toml")
+	content := "[cache]\nl3_safe = true\n"
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(Options{ConfigPath: configPath}); err == nil ||
+		!strings.Contains(err.Error(), "deps_root") {
+		t.Fatalf("l3_safe without deps_root must fail, got %v", err)
+	}
+}
+
+func TestLoadEnvOverridesAndDefaults(t *testing.T) {
+	t.Setenv("SEMANTIX_GATEWAY_ADDR", ":7777")
+	t.Setenv("SEMANTIX_GATEWAY_DB", filepath.Join(t.TempDir(), "gw.db"))
+	cfg, err := Load(Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Addr != ":7777" {
+		t.Errorf("env addr not applied: %q", cfg.Addr)
+	}
+	if cfg.Scope != slice.Project {
+		t.Errorf("default scope = %v", cfg.Scope)
+	}
+	if cfg.Retrieval.TopK != 5 || cfg.Retrieval.Budget != 4096 {
+		t.Errorf("default retrieval = %+v", cfg.Retrieval)
+	}
+	if cfg.Cache.TTLSeconds != 86400 {
+		t.Errorf("default ttl = %d", cfg.Cache.TTLSeconds)
+	}
+	if !cfg.Disable {
+		// explicit flag override path
+		if cfg2, err := Load(Options{Disable: true}); err != nil || !cfg2.Disable {
+			t.Fatalf("flag disable not applied: %v", err)
+		}
+	}
+	if cfg.Cache.L3Safe {
+		t.Errorf("l3_safe must default false (fail-closed)")
+	}
+}
+
+func TestLoadValidation(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "bad.toml")
+	content := `
+[[upstreams]]
+name = "no-base"
+model_alias = ["x"]
+api_key = "k"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(Options{ConfigPath: configPath}); err == nil ||
+		!strings.Contains(err.Error(), "base_url") {
+		t.Fatalf("upstream without base_url must fail, got %v", err)
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	if got := expandHome("~/x/y"); got != filepath.Join(home, "x", "y") {
+		t.Errorf("expandHome = %q", got)
+	}
+	if got := expandHome("/abs/path"); got != "/abs/path" {
+		t.Errorf("absolute path mutated: %q", got)
+	}
+	if got := expandHome(""); got != "" {
+		t.Errorf("empty path mutated: %q", got)
+	}
+}
+
+func TestUpstreamSetResolve(t *testing.T) {
+	s := newUpstreamSet([]Upstream{
+		{Name: "ds", ModelAlias: []string{"deepseek-chat", "ds-chat"}, UpstreamModel: "deepseek-chat"},
+		{Name: "claude", ModelAlias: []string{"claude-sonnet"}, UpstreamModel: "claude-sonnet-4-20250514"},
+	})
+	if up, ok := s.resolve("ds-chat"); !ok || up.Name != "ds" {
+		t.Fatalf("alias resolve failed: %+v %v", up, ok)
+	}
+	if _, ok := s.resolve("nope"); ok {
+		t.Fatal("unknown model must not resolve")
+	}
+	if got := s.upstreamModel("claude-sonnet"); got != "claude-sonnet-4-20250514" {
+		t.Errorf("upstream model mapping = %q", got)
+	}
+	if got := s.upstreamModel("deepseek-chat"); got != "deepseek-chat" {
+		t.Errorf("passthrough model = %q", got)
+	}
+	aliases := s.aliases()
+	if len(aliases) != 3 {
+		t.Fatalf("aliases = %v", aliases)
+	}
+	for i := 1; i < len(aliases); i++ {
+		if aliases[i-1] >= aliases[i] {
+			t.Fatalf("aliases not sorted: %v", aliases)
+		}
+	}
+}

--- a/gateway/errors_test.go
+++ b/gateway/errors_test.go
@@ -1,0 +1,149 @@
+package gateway
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// TestStreamUpstreamErrorNotSSE: when the upstream rejects a stream request
+// (e.g. 429 rate limit), the gateway must relay the JSON error — not wrap
+// it in an SSE stream that never terminates (clients would hang waiting
+// for [DONE]).
+func TestStreamUpstreamErrorNotSSE(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		io.WriteString(w, `{"error":{"message":"rate limited","type":"rate_limit_error","code":"rate_limit_exceeded"}}`)
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", true, "user:hi")
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json (not SSE)", ct)
+	}
+	if strings.Contains(rec.Body.String(), "[DONE]") || strings.Contains(rec.Body.String(), "chat.completion.chunk") {
+		t.Fatalf("upstream error must not be SSE-ified: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "rate limited") {
+		t.Fatalf("error body not relayed: %s", rec.Body.String())
+	}
+}
+
+// TestJSONUpstreamErrorSkipsWriteMemory: an upstream error response is not
+// a conversation — no session transcript, no usage event.
+func TestJSONUpstreamErrorSkipsWriteMemory(t *testing.T) {
+	sessions := filepath.Join(t.TempDir(), "sessions")
+	usageDB := filepath.Join(t.TempDir(), "usage.jsonl")
+	cfg := gatewayConfig(t, "ds-chat")
+	cfg.Ingest.SessionsDir = sessions
+	cfg.Ingest.Extract = true
+	cfg.UsageDB = usageDB
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, `{"error":{"message":"bad model","type":"invalid_request_error"}}`)
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", false, "user:trigger an error")
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+
+	entries, err := os.ReadDir(sessions)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("error response must not write a session transcript: %v %v", entries, err)
+	}
+	raw, err := os.ReadFile(usageDB)
+	if err != nil {
+		t.Fatalf("usage db: %v", err)
+	}
+	if strings.TrimSpace(string(raw)) != "" {
+		t.Fatalf("error response must not write usage events:\n%s", raw)
+	}
+}
+
+// TestNewCreatesStoreParentDir: the very first `semantix serve` run must
+// work even when ~/.semantix does not exist yet (parent dir auto-created).
+func TestNewCreatesStoreParentDir(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "does", "not", "exist", "yet", "gw.jsonl")
+	s, err := New(Config{
+		StoreDB:   db,
+		Scope:     slice.Project,
+		Upstreams: []Upstream{{Name: "x", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"m"}}},
+		Retrieval: struct {
+			TopK   int
+			Budget int
+		}{TopK: 5, Budget: 4096},
+	})
+	if err != nil {
+		t.Fatalf("New with missing parent dir: %v", err)
+	}
+	defer s.Close()
+	if _, err := os.Stat(db); err != nil {
+		t.Fatalf("store file not created: %v", err)
+	}
+}
+
+// TestStreamTailAfterDoneDropped: lines the upstream sends after [DONE] are
+// abnormal and must not leak into the client stream.
+func TestStreamTailAfterDoneDropped(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprintf(w, "data: %s\n\n", `{"id":"c","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`)
+		flusher.Flush()
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+		// Abnormal tail: must be dropped by the gateway.
+		fmt.Fprint(w, "data: {\"id\":\"c\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"TAIL\"},\"finish_reason\":null}]}\n\n")
+		flusher.Flush()
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", true, "user:stream")
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if strings.Contains(rec.Body.String(), "TAIL") {
+		t.Fatalf("tail after [DONE] leaked into the stream: %s", rec.Body.String())
+	}
+	if !strings.HasSuffix(strings.TrimSpace(rec.Body.String()), "data: [DONE]") {
+		t.Fatalf("stream must end with [DONE]: %q", rec.Body.String())
+	}
+}
+
+// TestEnvInvalidScopeFails: a typo in SEMANTIX_GATEWAY_SCOPE must fail
+// startup instead of silently falling back to the default.
+func TestEnvInvalidScopeFails(t *testing.T) {
+	t.Setenv("SEMANTIX_GATEWAY_SCOPE", "projct") // typo
+	if _, err := Load(Options{}); err == nil || !strings.Contains(err.Error(), "SEMANTIX_GATEWAY_SCOPE") {
+		t.Fatalf("invalid env scope must fail startup, got %v", err)
+	}
+}

--- a/gateway/memory.go
+++ b/gateway/memory.go
@@ -13,8 +13,12 @@ import (
 // This file implements the write-memory path (design §3.7): every
 // request/response pair is bypassed to a per-session JSONL file, and an
 // async worker extracts the sessions into slices via the kernel ingest
-// pipeline (P/C/R/T/M). Extraction is best-effort and never blocks the
-// main chain.
+// pipeline (P/C/R/T/M). The same worker also runs the L3 write-back
+// (design §3.5) off the request goroutine — capturing a deps-tree
+// fingerprint can take seconds on large repositories, and the main chain
+// must stay <10ms local (design §3.3).
+//
+// Everything here is best-effort: failures are logged, never fatal.
 
 // sessionLine is one transcript line, compatible with ingest.JSONLSource.
 type sessionLine struct {
@@ -30,39 +34,49 @@ type sessionToolCall struct {
 	Name string `json:"name"`
 }
 
-// memoryWorker appends session transcripts and extracts them asynchronously.
+// memJob is one queued write-memory unit.
+type memJob struct {
+	sessionID string
+	meta      forwardMeta // write-back
+	content   string      // write-back
+	toolCalls bool        // write-back
+}
+
+// memoryWorker processes session extraction and L3 write-back jobs
+// asynchronously. It exists when either write-memory or L3 write-back is
+// enabled.
 type memoryWorker struct {
-	dir     string
+	dir     string // sessions dir; empty = session extraction disabled
 	extract bool
 	s       *Server
 
-	jobs chan string
+	jobs chan memJob
 	wg   sync.WaitGroup
 	done chan struct{}
 }
 
-// newMemoryWorker starts the async extraction worker (when extract is true).
+// newMemoryWorker starts the async worker goroutine.
 func newMemoryWorker(s *Server, dir string, extract bool) *memoryWorker {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		s.logf("sessions dir: %v", err)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			s.logf("sessions dir: %v", err)
+		}
 	}
 	w := &memoryWorker{
 		dir:     dir,
 		extract: extract,
 		s:       s,
-		jobs:    make(chan string, 256),
+		jobs:    make(chan memJob, 256),
 		done:    make(chan struct{}),
 	}
-	if extract {
-		go w.loop()
-	}
+	go w.loop()
 	return w
 }
 
 // appendSession appends transcript lines to <dir>/<sessionID>.jsonl (0600,
 // append-only). Failure is best-effort: logged, never fatal to the chain.
 func (w *memoryWorker) appendSession(sessionID string, lines []sessionLine) {
-	if w == nil {
+	if w == nil || w.dir == "" {
 		return
 	}
 	path := filepath.Join(w.dir, safeFilename(sessionID)+".jsonl")
@@ -81,22 +95,34 @@ func (w *memoryWorker) appendSession(sessionID string, lines []sessionLine) {
 	}
 }
 
-// submit queues a session file for extraction (non-blocking; a full queue
-// drops the job — extraction is best-effort, a later request re-queues it).
-func (w *memoryWorker) submit(sessionID string) {
-	if w == nil || !w.extract {
+// submitSession queues a session file for extraction (non-blocking; a full
+// queue drops the job — extraction is best-effort, a later request
+// re-queues it).
+func (w *memoryWorker) submitSession(sessionID string) {
+	if w == nil || w.dir == "" || !w.extract {
 		return
 	}
-	path := filepath.Join(w.dir, safeFilename(sessionID)+".jsonl")
+	w.enqueue(memJob{sessionID: sessionID})
+}
+
+// submitWriteback queues an L3 write-back.
+func (w *memoryWorker) submitWriteback(meta forwardMeta, content string, toolCalls bool) {
+	if w == nil {
+		return
+	}
+	w.enqueue(memJob{meta: meta, content: content, toolCalls: toolCalls})
+}
+
+func (w *memoryWorker) enqueue(j memJob) {
 	w.wg.Add(1)
 	select {
-	case w.jobs <- path:
+	case w.jobs <- j:
 	default:
 		w.wg.Done() // queue full: skip this pass
 	}
 }
 
-// flush blocks until all queued extractions are processed (test hook).
+// flush blocks until all queued jobs are processed (test hook).
 func (w *memoryWorker) flush() {
 	if w == nil {
 		return
@@ -104,35 +130,53 @@ func (w *memoryWorker) flush() {
 	w.wg.Wait()
 }
 
-// close stops the worker goroutine.
+// close drains the queue and stops the worker goroutine.
 func (w *memoryWorker) close() {
 	if w == nil {
 		return
 	}
-	if w.extract {
-		select {
-		case <-w.done:
-		default:
-			close(w.done)
-		}
+	select {
+	case <-w.done:
+		return
+	default:
+		close(w.done)
 	}
 }
 
 func (w *memoryWorker) loop() {
 	for {
 		select {
-		case path := <-w.jobs:
-			w.process(path)
+		case j := <-w.jobs:
+			w.process(j)
 		case <-w.done:
-			return
+			// Drain whatever is already queued (never lose accepted
+			// jobs; wg.Done is guaranteed for every enqueued job).
+			for {
+				select {
+				case j := <-w.jobs:
+					w.process(j)
+				default:
+					return
+				}
+			}
 		}
 	}
 }
 
-// process extracts one session file into slices (idempotent: slices dedup
-// by content-derived ID via store.Put).
-func (w *memoryWorker) process(path string) {
+// process runs one job.
+func (w *memoryWorker) process(j memJob) {
 	defer w.wg.Done()
+	if j.sessionID != "" {
+		w.extractSession(j.sessionID)
+		return
+	}
+	w.s.maybeWriteBack(j.meta, j.content, j.toolCalls)
+}
+
+// extractSession runs the ingest pipeline over one session file (idempotent:
+// slices dedup by content-derived ID via store.Put).
+func (w *memoryWorker) extractSession(sessionID string) {
+	path := filepath.Join(w.dir, safeFilename(sessionID)+".jsonl")
 	pipe := ingest.Pipeline{
 		Extractor: slice.NewExtractor(),
 		Store:     w.s.store,

--- a/gateway/memory.go
+++ b/gateway/memory.go
@@ -1,0 +1,166 @@
+package gateway
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"semantix/kernel/ingest"
+	"semantix/kernel/slice"
+)
+
+// This file implements the write-memory path (design §3.7): every
+// request/response pair is bypassed to a per-session JSONL file, and an
+// async worker extracts the sessions into slices via the kernel ingest
+// pipeline (P/C/R/T/M). Extraction is best-effort and never blocks the
+// main chain.
+
+// sessionLine is one transcript line, compatible with ingest.JSONLSource.
+type sessionLine struct {
+	Role      string            `json:"role"`
+	Content   string            `json:"content,omitempty"`
+	ToolCalls []sessionToolCall `json:"tool_calls,omitempty"`
+}
+
+// sessionToolCall mirrors the transcript tool-call shape the extractor
+// understands (name is the only consumed field).
+type sessionToolCall struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name"`
+}
+
+// memoryWorker appends session transcripts and extracts them asynchronously.
+type memoryWorker struct {
+	dir     string
+	extract bool
+	s       *Server
+
+	jobs chan string
+	wg   sync.WaitGroup
+	done chan struct{}
+}
+
+// newMemoryWorker starts the async extraction worker (when extract is true).
+func newMemoryWorker(s *Server, dir string, extract bool) *memoryWorker {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		s.logf("sessions dir: %v", err)
+	}
+	w := &memoryWorker{
+		dir:     dir,
+		extract: extract,
+		s:       s,
+		jobs:    make(chan string, 256),
+		done:    make(chan struct{}),
+	}
+	if extract {
+		go w.loop()
+	}
+	return w
+}
+
+// appendSession appends transcript lines to <dir>/<sessionID>.jsonl (0600,
+// append-only). Failure is best-effort: logged, never fatal to the chain.
+func (w *memoryWorker) appendSession(sessionID string, lines []sessionLine) {
+	if w == nil {
+		return
+	}
+	path := filepath.Join(w.dir, safeFilename(sessionID)+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		w.s.logf("session append %s: %v", sessionID, err)
+		return
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, l := range lines {
+		if err := enc.Encode(l); err != nil {
+			w.s.logf("session encode %s: %v", sessionID, err)
+			return
+		}
+	}
+}
+
+// submit queues a session file for extraction (non-blocking; a full queue
+// drops the job — extraction is best-effort, a later request re-queues it).
+func (w *memoryWorker) submit(sessionID string) {
+	if w == nil || !w.extract {
+		return
+	}
+	path := filepath.Join(w.dir, safeFilename(sessionID)+".jsonl")
+	w.wg.Add(1)
+	select {
+	case w.jobs <- path:
+	default:
+		w.wg.Done() // queue full: skip this pass
+	}
+}
+
+// flush blocks until all queued extractions are processed (test hook).
+func (w *memoryWorker) flush() {
+	if w == nil {
+		return
+	}
+	w.wg.Wait()
+}
+
+// close stops the worker goroutine.
+func (w *memoryWorker) close() {
+	if w == nil {
+		return
+	}
+	if w.extract {
+		select {
+		case <-w.done:
+		default:
+			close(w.done)
+		}
+	}
+}
+
+func (w *memoryWorker) loop() {
+	for {
+		select {
+		case path := <-w.jobs:
+			w.process(path)
+		case <-w.done:
+			return
+		}
+	}
+}
+
+// process extracts one session file into slices (idempotent: slices dedup
+// by content-derived ID via store.Put).
+func (w *memoryWorker) process(path string) {
+	defer w.wg.Done()
+	pipe := ingest.Pipeline{
+		Extractor: slice.NewExtractor(),
+		Store:     w.s.store,
+		Index:     w.s.index,
+		Scope:     w.s.cfg.Scope,
+	}
+	src, err := ingest.NewJSONLSource(path)
+	if err != nil {
+		w.s.logf("extract %s: %v", path, err)
+		return
+	}
+	if _, err := pipe.Run(src); err != nil {
+		w.s.logf("extract %s: %v", path, err)
+	}
+}
+
+// safeFilename neutralizes session ids that could escape the sessions dir
+// (design §3.10 path hygiene).
+func safeFilename(id string) string {
+	out := make([]rune, 0, len(id))
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.':
+			out = append(out, r)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}

--- a/gateway/memory.go
+++ b/gateway/memory.go
@@ -130,7 +130,8 @@ func (w *memoryWorker) flush() {
 	w.wg.Wait()
 }
 
-// close drains the queue and stops the worker goroutine.
+// close drains the queue and stops the worker goroutine, waiting for the
+// already-accepted jobs to finish (store writes stay consistent).
 func (w *memoryWorker) close() {
 	if w == nil {
 		return
@@ -141,6 +142,7 @@ func (w *memoryWorker) close() {
 	default:
 		close(w.done)
 	}
+	w.wg.Wait()
 }
 
 func (w *memoryWorker) loop() {

--- a/gateway/memory_test.go
+++ b/gateway/memory_test.go
@@ -1,0 +1,313 @@
+package gateway
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// TestSessionBypassAndExtract: request/response pairs land in per-session
+// JSONL files and the async worker extracts them into the slice store
+// (design §3.7) — the acceptance that a gateway conversation becomes
+// searchable, i.e. L2 material for future turns.
+func TestSessionBypassAndExtract(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	sessions := filepath.Join(t.TempDir(), "sessions")
+	cfg.Ingest.SessionsDir = sessions
+	cfg.Ingest.Extract = true
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fixed the go test failure by running -race"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", false, "user:fix the failing go test in this repo")
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-semantix-session", "test-session-1")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+
+	// Session file written with user + assistant lines.
+	path := filepath.Join(sessions, "test-session-1.jsonl")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("session file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("session lines = %d, want 2:\n%s", len(lines), raw)
+	}
+	var userLine, asstLine map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &userLine); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &asstLine); err != nil {
+		t.Fatal(err)
+	}
+	if userLine["role"] != "user" || !strings.Contains(userLine["content"].(string), "fix the failing go test") {
+		t.Fatalf("user line = %v", userLine)
+	}
+	if asstLine["role"] != "assistant" || !strings.Contains(asstLine["content"].(string), "-race") {
+		t.Fatalf("assistant line = %v", asstLine)
+	}
+
+	// Async extraction lands slices in the store.
+	s.mem.flush()
+	st, err := slice.NewFileStore(cfg.StoreDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, err := st.List(slice.Project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	types := map[string]bool{}
+	for _, it := range items {
+		types[it.Type.String()] = true
+	}
+	if !types["prompt"] || !types["result"] {
+		t.Fatalf("extracted types = %v, want prompt+result", types)
+	}
+
+	// The extracted prompt is retrievable for a future turn (L2 material).
+	s.rebuild(t)
+	hits, err := s.index.Search("fix the failing go test", 5, slice.Project)
+	if err != nil || len(hits) == 0 {
+		t.Fatalf("future-turn lookup missed: %v %v", hits, err)
+	}
+}
+
+// TestSessionIDSanitized: hostile session ids cannot escape the sessions
+// directory (design §3.10).
+func TestSessionIDSanitized(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	cfg.Ingest.SessionsDir = filepath.Join(t.TempDir(), "sessions")
+	cfg.Ingest.Extract = false
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", false, "user:hi")
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("x-semantix-session", "../evil")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Ingest.SessionsDir, "..", "evil.jsonl")); err == nil {
+		t.Fatal("session id escaped the sessions dir")
+	}
+	// ../evil sanitizes to .._evil (separators replaced, no traversal).
+	if _, err := os.Stat(filepath.Join(cfg.Ingest.SessionsDir, ".._evil.jsonl")); err != nil {
+		t.Fatalf("sanitized session file missing: %v", err)
+	}
+}
+
+// TestL3WriteBackThenHit is the acceptance loop: a first miss caches the
+// response (opt-in l3_safe + deps_root), the identical second request is
+// served from L3 with zero upstream calls.
+func TestL3WriteBackThenHit(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("version 1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.L3Safe = true
+	cfg.Cache.DepsRoot = root
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("stable answer for the go test question"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("deepseek-chat", false, "user:what does the go test question ask")
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Header().Get("x-semantix-cache") != "miss" {
+		t.Fatalf("first request must miss, got %s", rec.Header().Get("x-semantix-cache"))
+	}
+
+	// The write-back lands in the store + index.
+	st, err := slice.NewFileStore(cfg.StoreDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, err := st.ListAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("write-back entries = %d, want 1", len(items))
+	}
+	if items[0].Meta.Model != "deepseek-chat" || items[0].Meta.ContextHash == "" {
+		t.Fatalf("write-back meta = %+v", items[0].Meta)
+	}
+	if len(items[0].Meta.Deps) == 0 {
+		t.Fatal("write-back must capture deps")
+	}
+
+	// Second identical request: L3 hit, zero upstream calls.
+	before := up.calls.Load()
+	rec2, m := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec2.Header().Get("x-semantix-cache") != "hit" {
+		t.Fatalf("second request must hit, got %s (%s)", rec2.Header().Get("x-semantix-cache"), rec2.Body.String())
+	}
+	if got := up.calls.Load(); got != before {
+		t.Fatalf("L3 hit called upstream: %d → %d", before, got)
+	}
+	choices, _ := m["choices"].([]any)
+	msg, _ := choices[0].(map[string]any)["message"].(map[string]any)
+	if !strings.Contains(msg["content"].(string), "stable answer") {
+		t.Fatalf("cached content = %v", msg["content"])
+	}
+}
+
+// TestWriteBackInvalidatedOnDepsChange: modifying a dependency file kills
+// the cached entry (design §3.5: 文件一变缓存即失效).
+func TestWriteBackInvalidatedOnDepsChange(t *testing.T) {
+	root := t.TempDir()
+	dep := filepath.Join(root, "a.txt")
+	if err := os.WriteFile(dep, []byte("version 1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.L3Safe = true
+	cfg.Cache.DepsRoot = root
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("answer one"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("deepseek-chat", false, "user:question about the go module")
+	doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if up.calls.Load() != 1 {
+		t.Fatalf("calls after first = %d", up.calls.Load())
+	}
+
+	// Change a dependency: the entry must fail verification.
+	if err := os.WriteFile(dep, []byte("version 2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if got := up.calls.Load(); got != 2 {
+		t.Fatalf("stale entry must not be reused after deps change: calls = %d, want 2", got)
+	}
+}
+
+// TestToolCallsNeverCached: responses with tool calls never enter L3
+// (design §3.5: side effects).
+func TestToolCallsNeverCached(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.L3Safe = true
+	cfg.Cache.DepsRoot = root
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, `{"id":"c","object":"chat.completion","created":1,"model":"m",
+"choices":[{"index":0,"message":{"role":"assistant","content":"checking...",
+"tool_calls":[{"id":"t1","type":"function","function":{"name":"run","arguments":"{}"}}]},"finish_reason":"tool_calls"}],
+"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("deepseek-chat", false, "user:run the checks please")
+	doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if got := up.calls.Load(); got != 2 {
+		t.Fatalf("tool-call responses must never be cached: calls = %d, want 2", got)
+	}
+}
+
+// TestWriteBackDisabledByDefault: without explicit opt-in nothing is cached
+// (fail-closed default).
+func TestWriteBackDisabledByDefault(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.L3Safe = false // default
+	cfg.Cache.DepsRoot = root
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("plain answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("deepseek-chat", false, "user:some question here")
+	doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if got := up.calls.Load(); got != 2 {
+		t.Fatalf("l3_safe=false must not cache: calls = %d, want 2", got)
+	}
+}
+
+func TestCaptureTree(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("aaa"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "b.go"), []byte("bbb"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes, err := captureTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 2 || deps["a.txt"] == "" || deps[filepath.Join("sub", "b.go")] == "" {
+		t.Fatalf("deps = %v", deps)
+	}
+	if mtimes["a.txt"] == 0 || mtimes[filepath.Join("sub", "b.go")] == 0 {
+		t.Fatalf("mtimes = %v", mtimes)
+	}
+	// Changed content → new digest (invalidation basis).
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps2, _, err := captureTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deps2["a.txt"] == deps["a.txt"] {
+		t.Fatal("digest must change after content change")
+	}
+}
+
+func TestSafeFilename(t *testing.T) {
+	cases := map[string]string{
+		"plain-session_1": "plain-session_1",
+		"../evil":         ".._evil",
+		"a/b\\c":          "a_b_c",
+		"中文会话":            "____",
+	}
+	for in, want := range cases {
+		if got := safeFilename(in); got != want {
+			t.Errorf("safeFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/gateway/memory_test.go
+++ b/gateway/memory_test.go
@@ -141,6 +141,9 @@ func TestL3WriteBackThenHit(t *testing.T) {
 	if rec.Header().Get("x-semantix-cache") != "miss" {
 		t.Fatalf("first request must miss, got %s", rec.Header().Get("x-semantix-cache"))
 	}
+	// The write-back runs on the async worker — wait for it before
+	// asserting the cache state.
+	s.mem.flush()
 
 	// The write-back lands in the store + index.
 	st, err := slice.NewFileStore(cfg.StoreDB)
@@ -200,6 +203,7 @@ func TestWriteBackInvalidatedOnDepsChange(t *testing.T) {
 	if up.calls.Load() != 1 {
 		t.Fatalf("calls after first = %d", up.calls.Load())
 	}
+	s.mem.flush() // write-back must land before we mutate the deps
 
 	// Change a dependency: the entry must fail verification.
 	if err := os.WriteFile(dep, []byte("version 2"), 0o600); err != nil {

--- a/gateway/openai.go
+++ b/gateway/openai.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,22 +36,6 @@ func writeAPIError(w http.ResponseWriter, status int, typ, code, message string)
 	}})
 }
 
-// newUpstreamError formats an upstream failure into an OpenAI error with a
-// machine-readable code (retryable network errors get 502 so the client /
-// New API can retry).
-func newUpstreamError(err error) (int, string, string) {
-	msg := fmt.Sprintf("upstream request failed: %v", err)
-	var netErr interface{ Timeout() bool }
-	if errors.As(err, &netErr) || isConnRefused(err) {
-		return http.StatusBadGateway, "upstream_error", msg
-	}
-	return http.StatusBadGateway, "upstream_error", msg
-}
-
-func isConnRefused(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "connection refused")
-}
-
 // --- chat completions request ---
 
 // chatRequest is the minimal decoded form of POST /v1/chat/completions.
@@ -68,9 +51,11 @@ type chatRequest struct {
 
 // messageFields decodes just the fields the gateway needs from one message.
 type messageFields struct {
-	Role      string          `json:"role"`
-	Content   json.RawMessage `json:"content"`
-	ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content"`
+	ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
 }
 
 // decodeChatRequest parses the request body (bounded) and keeps the raw
@@ -152,58 +137,17 @@ func systemMessageText(messages []json.RawMessage) (string, bool, error) {
 // after the block stays byte-stable for L1). When no system message exists,
 // a new one is prepended.
 func injectIntoMessages(messages []json.RawMessage, block string) ([]json.RawMessage, error) {
-	out := make([]json.RawMessage, 0, len(messages)+1)
-	patched := false
-	for _, raw := range messages {
+	lastSystem := -1
+	for i := range messages {
 		var mf messageFields
-		if err := json.Unmarshal(raw, &mf); err != nil {
+		if err := json.Unmarshal(messages[i], &mf); err != nil {
 			return nil, fmt.Errorf("invalid message: %w", err)
 		}
-		if !patched && mf.Role == "system" {
-			patched = true
-			var content string
-			var parts []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			}
-			if err := json.Unmarshal(mf.Content, &content); err == nil {
-				content += "\n\n" + block
-				patchedRaw, err := json.Marshal(struct {
-					Role       string          `json:"role"`
-					Content    string          `json:"content"`
-					ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
-					Name       string          `json:"name,omitempty"`
-					ToolCallID string          `json:"tool_call_id,omitempty"`
-				}{Role: mf.Role, Content: content, ToolCalls: mf.ToolCalls})
-				if err != nil {
-					return nil, err
-				}
-				out = append(out, patchedRaw)
-				continue
-			}
-			if err := json.Unmarshal(mf.Content, &parts); err == nil {
-				parts = append(parts, struct {
-					Type string `json:"type"`
-					Text string `json:"text"`
-				}{Type: "text", Text: "\n\n" + block})
-				patchedRaw, err := json.Marshal(struct {
-					Role      string          `json:"role"`
-					Content   any             `json:"content"`
-					ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
-				}{Role: mf.Role, Content: parts, ToolCalls: mf.ToolCalls})
-				if err != nil {
-					return nil, err
-				}
-				out = append(out, patchedRaw)
-				continue
-			}
-			// Unknown content shape: leave the message untouched.
-			out = append(out, raw)
-			continue
+		if mf.Role == "system" {
+			lastSystem = i
 		}
-		out = append(out, raw)
 	}
-	if !patched {
+	if lastSystem < 0 {
 		// No system message: prepend a system message holding the block.
 		prepended, err := json.Marshal(struct {
 			Role    string `json:"role"`
@@ -212,7 +156,61 @@ func injectIntoMessages(messages []json.RawMessage, block string) ([]json.RawMes
 		if err != nil {
 			return nil, err
 		}
-		out = append([]json.RawMessage{prepended}, out...)
+		out := make([]json.RawMessage, 0, len(messages)+1)
+		out = append(out, prepended)
+		return append(out, messages...), nil
+	}
+
+	out := make([]json.RawMessage, 0, len(messages))
+	for i, raw := range messages {
+		if i != lastSystem {
+			out = append(out, raw)
+			continue
+		}
+		var mf messageFields
+		if err := json.Unmarshal(raw, &mf); err != nil {
+			return nil, fmt.Errorf("invalid message: %w", err)
+		}
+		var content string
+		if err := json.Unmarshal(mf.Content, &content); err == nil {
+			content += "\n\n" + block
+			patchedRaw, err := json.Marshal(struct {
+				Role       string          `json:"role"`
+				Content    string          `json:"content"`
+				ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+				Name       string          `json:"name,omitempty"`
+				ToolCallID string          `json:"tool_call_id,omitempty"`
+			}{Role: mf.Role, Content: content, ToolCalls: mf.ToolCalls})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, patchedRaw)
+			continue
+		}
+		var parts []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(mf.Content, &parts); err == nil {
+			parts = append(parts, struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			}{Type: "text", Text: "\n\n" + block})
+			patchedRaw, err := json.Marshal(struct {
+				Role       string          `json:"role"`
+				Content    any             `json:"content"`
+				ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+				Name       string          `json:"name,omitempty"`
+				ToolCallID string          `json:"tool_call_id,omitempty"`
+			}{Role: mf.Role, Content: parts, ToolCalls: mf.ToolCalls, Name: mf.Name})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, patchedRaw)
+			continue
+		}
+		// Unknown content shape: leave the message untouched.
+		out = append(out, raw)
 	}
 	return out, nil
 }

--- a/gateway/openai.go
+++ b/gateway/openai.go
@@ -1,0 +1,251 @@
+package gateway
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// This file defines the OpenAI-compatible wire protocol types and error
+// format the gateway speaks (design §3.2). Error responses use the OpenAI
+// shape {"error": {"message", "type", "code"}} so New API and clients
+// recognize them.
+
+// apiErrorBody is the OpenAI error envelope.
+type apiErrorBody struct {
+	Error apiError `json:"error"`
+}
+
+type apiError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code,omitempty"`
+}
+
+// writeAPIError writes an OpenAI-format JSON error response.
+func writeAPIError(w http.ResponseWriter, status int, typ, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(apiErrorBody{Error: apiError{
+		Message: message,
+		Type:    typ,
+		Code:    code,
+	}})
+}
+
+// newUpstreamError formats an upstream failure into an OpenAI error with a
+// machine-readable code (retryable network errors get 502 so the client /
+// New API can retry).
+func newUpstreamError(err error) (int, string, string) {
+	msg := fmt.Sprintf("upstream request failed: %v", err)
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) || isConnRefused(err) {
+		return http.StatusBadGateway, "upstream_error", msg
+	}
+	return http.StatusBadGateway, "upstream_error", msg
+}
+
+func isConnRefused(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection refused")
+}
+
+// --- chat completions request ---
+
+// chatRequest is the minimal decoded form of POST /v1/chat/completions.
+// Messages stay raw so the forwarded body is byte-faithful except for the
+// two gateway-visible mutations (model mapping, L2 injection).
+type chatRequest struct {
+	Model    string            `json:"model"`
+	Messages []json.RawMessage `json:"messages"`
+	Stream   bool              `json:"stream,omitempty"`
+	// Raw is the full original request body (for forwarding).
+	Raw json.RawMessage `json:"-"`
+}
+
+// messageFields decodes just the fields the gateway needs from one message.
+type messageFields struct {
+	Role      string          `json:"role"`
+	Content   json.RawMessage `json:"content"`
+	ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+}
+
+// decodeChatRequest parses the request body (bounded) and keeps the raw
+// bytes for forwarding.
+func decodeChatRequest(r *http.Request) (*chatRequest, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBodyBytes))
+	if err != nil {
+		return nil, err
+	}
+	var cr chatRequest
+	if err := json.Unmarshal(body, &cr); err != nil {
+		return nil, fmt.Errorf("invalid chat completion request: %w", err)
+	}
+	cr.Raw = body
+	return &cr, nil
+}
+
+const maxRequestBodyBytes = 16 << 20 // 16 MiB
+
+// lastUserMessage extracts the (normalized) text of the last user message.
+// Content may be a plain string or an array of typed parts (multimodal);
+// only text parts contribute.
+func lastUserMessage(messages []json.RawMessage) (string, error) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		var mf messageFields
+		if err := json.Unmarshal(messages[i], &mf); err != nil {
+			return "", fmt.Errorf("invalid message: %w", err)
+		}
+		if mf.Role != "user" {
+			continue
+		}
+		return messageText(mf.Content)
+	}
+	return "", nil
+}
+
+// messageText renders a message content field (string or parts array).
+func messageText(content json.RawMessage) (string, error) {
+	if len(content) == 0 || string(content) == "null" {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		return s, nil
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content, &parts); err != nil {
+		return "", fmt.Errorf("unsupported message content shape")
+	}
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Type == "text" {
+			b.WriteString(p.Text)
+		}
+	}
+	return b.String(), nil
+}
+
+// systemMessageText returns the content of the last system message, if any.
+func systemMessageText(messages []json.RawMessage) (string, bool, error) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		var mf messageFields
+		if err := json.Unmarshal(messages[i], &mf); err != nil {
+			return "", false, fmt.Errorf("invalid message: %w", err)
+		}
+		if mf.Role == "system" {
+			t, err := messageText(mf.Content)
+			return t, true, err
+		}
+	}
+	return "", false, nil
+}
+
+// injectIntoMessages appends the L2 injection block to the end of the last
+// system message's content (design §3.6: system-prompt tail, so history
+// after the block stays byte-stable for L1). When no system message exists,
+// a new one is prepended.
+func injectIntoMessages(messages []json.RawMessage, block string) ([]json.RawMessage, error) {
+	out := make([]json.RawMessage, 0, len(messages)+1)
+	patched := false
+	for _, raw := range messages {
+		var mf messageFields
+		if err := json.Unmarshal(raw, &mf); err != nil {
+			return nil, fmt.Errorf("invalid message: %w", err)
+		}
+		if !patched && mf.Role == "system" {
+			patched = true
+			var content string
+			var parts []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			}
+			if err := json.Unmarshal(mf.Content, &content); err == nil {
+				content += "\n\n" + block
+				patchedRaw, err := json.Marshal(struct {
+					Role       string          `json:"role"`
+					Content    string          `json:"content"`
+					ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+					Name       string          `json:"name,omitempty"`
+					ToolCallID string          `json:"tool_call_id,omitempty"`
+				}{Role: mf.Role, Content: content, ToolCalls: mf.ToolCalls})
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, patchedRaw)
+				continue
+			}
+			if err := json.Unmarshal(mf.Content, &parts); err == nil {
+				parts = append(parts, struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				}{Type: "text", Text: "\n\n" + block})
+				patchedRaw, err := json.Marshal(struct {
+					Role      string          `json:"role"`
+					Content   any             `json:"content"`
+					ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+				}{Role: mf.Role, Content: parts, ToolCalls: mf.ToolCalls})
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, patchedRaw)
+				continue
+			}
+			// Unknown content shape: leave the message untouched.
+			out = append(out, raw)
+			continue
+		}
+		out = append(out, raw)
+	}
+	if !patched {
+		// No system message: prepend a system message holding the block.
+		prepended, err := json.Marshal(struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}{Role: "system", Content: block})
+		if err != nil {
+			return nil, err
+		}
+		out = append([]json.RawMessage{prepended}, out...)
+	}
+	return out, nil
+}
+
+// --- chat completions response ---
+
+type chatChoice struct {
+	Index        int         `json:"index"`
+	Message      chatRespMsg `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type chatRespMsg struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type usageInfo struct {
+	PromptTokens     int                 `json:"prompt_tokens"`
+	CompletionTokens int                 `json:"completion_tokens"`
+	TotalTokens      int                 `json:"total_tokens"`
+	PromptDetails    *promptTokenDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+type promptTokenDetails struct {
+	CachedTokens int `json:"cached_tokens,omitempty"`
+}
+
+type chatCompletion struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"`
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []chatChoice `json:"choices"`
+	Usage   *usageInfo   `json:"usage,omitempty"`
+}

--- a/gateway/openai.go
+++ b/gateway/openai.go
@@ -180,7 +180,8 @@ func injectIntoMessages(messages []json.RawMessage, block string) ([]json.RawMes
 				ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
 				Name       string          `json:"name,omitempty"`
 				ToolCallID string          `json:"tool_call_id,omitempty"`
-			}{Role: mf.Role, Content: content, ToolCalls: mf.ToolCalls})
+			}{Role: mf.Role, Content: content, ToolCalls: mf.ToolCalls,
+				Name: mf.Name, ToolCallID: mf.ToolCallID})
 			if err != nil {
 				return nil, err
 			}
@@ -202,7 +203,8 @@ func injectIntoMessages(messages []json.RawMessage, block string) ([]json.RawMes
 				ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
 				Name       string          `json:"name,omitempty"`
 				ToolCallID string          `json:"tool_call_id,omitempty"`
-			}{Role: mf.Role, Content: parts, ToolCalls: mf.ToolCalls, Name: mf.Name})
+			}{Role: mf.Role, Content: parts, ToolCalls: mf.ToolCalls,
+				Name: mf.Name, ToolCallID: mf.ToolCallID})
 			if err != nil {
 				return nil, err
 			}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -63,8 +63,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	sessionID := sessionID(r)
 
 	// Step 3: L3 verified-result reuse (design §3.5). A hit returns the
-	// cached response with zero upstream calls.
-	if !s.cfg.Disable && query != "" {
+	// cached response with zero upstream calls. Without a configured deps
+	// root the L3 gate cannot verify anything (and must not verify against
+	// the gateway process CWD) — fail-closed, skip the lookup entirely.
+	if !s.cfg.Disable && query != "" && s.cfg.Cache.DepsRoot != "" {
 		if hit := s.lookupL3(r.Context(), query, cr.Model, ctxHash); hit != nil {
 			s.serveL3Hit(w, r, cr, sessionID, hit)
 			return
@@ -141,8 +143,12 @@ type forwardMeta struct {
 
 // lookupL3 runs the kernel fail-closed L3 gate (kernel/cache.L3Decider:
 // retrieval + grey zone + deps/mtime/fingerprint verification) and then the
-// gateway-specific reuse gates: model match, messages-context fingerprint
-// match and TTL (design §3.5 cache key).
+// gateway-specific reuse gates (design §3.5 cache key): model match,
+// messages-context fingerprint match and TTL.
+//
+// Every gate is fail-closed: an entry without the gateway metadata
+// (Model/ContextHash — e.g. a CLI-extracted Result slice), an unknown-age
+// entry (CreatedAt == 0) or a stale entry is never served.
 func (s *Server) lookupL3(ctx context.Context, query, model, ctxHash string) *cache.L3Result {
 	decider := &cache.L3Decider{
 		Index: s.index,
@@ -161,16 +167,23 @@ func (s *Server) lookupL3(ctx context.Context, query, model, ctxHash string) *ca
 	if err != nil || sl == nil {
 		return nil
 	}
-	if sl.Meta.Model != "" && sl.Meta.Model != model {
+	if sl.Meta.Model == "" || sl.Meta.ContextHash == "" {
+		// Gateway entries always carry both; anything else is not
+		// verified for gateway reuse (review: fail-open on missing meta).
+		s.logf("L3 reject: entry %s lacks gateway meta (model=%q context=%q)",
+			sl.ID, sl.Meta.Model, sl.Meta.ContextHash)
+		return nil
+	}
+	if sl.Meta.Model != model {
 		s.logf("L3 reject: model %q != %q", sl.Meta.Model, model)
 		return nil
 	}
-	if sl.Meta.ContextHash != "" && sl.Meta.ContextHash != ctxHash {
+	if sl.Meta.ContextHash != ctxHash {
 		s.logf("L3 reject: context mismatch")
 		return nil
 	}
-	if s.cfg.Cache.TTLSeconds > 0 && sl.CreatedAt > 0 &&
-		time.Now().Unix()-sl.CreatedAt > s.cfg.Cache.TTLSeconds {
+	if sl.CreatedAt <= 0 ||
+		(s.cfg.Cache.TTLSeconds > 0 && time.Now().Unix()-sl.CreatedAt > s.cfg.Cache.TTLSeconds) {
 		s.logf("L3 reject: TTL expired")
 		return nil
 	}
@@ -267,21 +280,24 @@ func (s *Server) forwardJSON(w http.ResponseWriter, r *http.Request, up *Upstrea
 
 	respBody, status, retried, err := s.doUpstream(ctx, up, body)
 	if err != nil {
-		code, typ, msg := newUpstreamError(err)
-		writeAPIError(w, code, typ, "upstream_error", msg)
+		writeAPIError(w, http.StatusBadGateway, "upstream_error", "upstream_error",
+			fmt.Sprintf("upstream request failed: %v", err))
 		return
 	}
 	defer respBody.Close()
-	w.Header().Set("x-semantix-cache", "miss")
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
 
+	// Read the full body before writing any status/headers: a read failure
+	// must surface as a clean 502, not a 200 with a truncated body.
 	data, readErr := io.ReadAll(io.LimitReader(respBody, maxResponseBodyBytes))
 	if readErr != nil {
 		writeAPIError(w, http.StatusBadGateway, "upstream_error", "upstream_error",
 			fmt.Sprintf("read upstream response: %v", readErr))
 		return
 	}
+
+	w.Header().Set("x-semantix-cache", "miss")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	_, _ = w.Write(data)
 
 	content, toolCalls := parseCompletionContent(data)
@@ -297,8 +313,8 @@ func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstr
 
 	respBody, status, retried, err := s.doUpstream(ctx, up, body)
 	if err != nil {
-		code, typ, msg := newUpstreamError(err)
-		writeAPIError(w, code, typ, "upstream_error", msg)
+		writeAPIError(w, http.StatusBadGateway, "upstream_error", "upstream_error",
+			fmt.Sprintf("upstream request failed: %v", err))
 		return
 	}
 	defer respBody.Close()
@@ -371,7 +387,7 @@ func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstr
 					"completion_tokens": estTokens(contentBuf.String()),
 					"total_tokens":      est + estTokens(contentBuf.String()),
 					"prompt_tokens_details": map[string]any{
-						"cached_tokens": estTokens(strings.Repeat("a", meta.injected)),
+						"cached_tokens": estTokensN(meta.injected),
 					},
 				},
 			})
@@ -522,21 +538,24 @@ func (s *Server) recordUsage(e usage.Event) {
 
 // estTokens is a crude token estimate (≈ bytes/4, design §4.3 synthetic
 // usage; the gateway never bills — New API does).
-func estTokens(s string) int {
-	n := len(s) / 4
-	if n < 1 && len(s) > 0 {
-		n = 1
+func estTokens(s string) int { return estTokensN(len(s)) }
+
+// estTokensN estimates tokens for a byte count.
+func estTokensN(n int) int {
+	if n <= 0 {
+		return 0
 	}
-	return n
+	return (n + 3) / 4
 }
 
 const maxResponseBodyBytes = 32 << 20 // 32 MiB
 
 // afterResponse runs the post-forward write-memory path (design §3.7):
 // usage record + session bypass write + async extraction + L3 write-back.
-// Everything is best-effort and never blocks the main chain.
+// Everything is best-effort and never blocks the main chain; the deps-tree
+// fingerprint capture for the write-back runs on the worker goroutine.
 func (s *Server) afterResponse(meta forwardMeta, content string, toolCalls, retried bool) {
-	injectedEst := estTokens(strings.Repeat("a", meta.injected))
+	injectedEst := estTokensN(meta.injected)
 	s.recordUsage(usage.Event{
 		SessionID:      meta.sessionID,
 		TokensIn:       int64(meta.promptEst),
@@ -554,7 +573,7 @@ func (s *Server) afterResponse(meta forwardMeta, content string, toolCalls, retr
 			{Role: "user", Content: meta.query},
 			{Role: "assistant", Content: content, ToolCalls: calls},
 		})
-		s.mem.submit(meta.sessionID)
+		s.mem.submitSession(meta.sessionID)
+		s.mem.submitWriteback(meta, content, toolCalls)
 	}
-	s.maybeWriteBack(meta, content, toolCalls)
 }

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -1,0 +1,543 @@
+package gateway
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"semantix/kernel/cache"
+	"semantix/kernel/inject"
+	"semantix/kernel/usage"
+	"semantix/kernel/zone"
+)
+
+// handleChatCompletions is the core pipeline (design §3.3):
+//
+//  1. auth (middleware)          5. model mapping + forward upstream
+//  2. normalize (query, ctxHash) 6. passthrough content + usage
+//  3. L3 lookup (hit → return)   7. async write-memory (landed with the
+//  4. L2 injection                   write-memory commit)
+//
+// The gateway never blocks the main chain on local operations; upstream
+// failures surface as OpenAI-format errors so the client / New API can retry.
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error",
+			"method_not_allowed", "chat completions only supports POST")
+		return
+	}
+	cr, err := decodeChatRequest(r)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request_error",
+			"invalid_request", err.Error())
+		return
+	}
+	if cr.Model == "" {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request_error",
+			"invalid_request", "model is required")
+		return
+	}
+	up, ok := s.up.resolve(cr.Model)
+	if !ok {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request_error",
+			"model_not_found", fmt.Sprintf("model %q is not configured on this gateway", cr.Model))
+		return
+	}
+
+	query, err := lastUserMessage(cr.Messages)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid_request_error",
+			"invalid_request", err.Error())
+		return
+	}
+	query = normalizeQuery(query)
+	ctxHash := contextHash(cr.Raw)
+	sessionID := sessionID(r)
+
+	// Step 3: L3 verified-result reuse (design §3.5). A hit returns the
+	// cached response with zero upstream calls.
+	if !s.cfg.Disable && query != "" {
+		if hit := s.lookupL3(r.Context(), query, cr.Model, ctxHash); hit != nil {
+			s.serveL3Hit(w, r, cr, sessionID, hit)
+			return
+		}
+	}
+
+	// Step 4: L2 semantic injection (design §3.6) — appends a deterministic
+	// reuse block to the system prompt so the model skips repeated
+	// exploration. Byte-stable block keeps the upstream prefix cache warm.
+	block := ""
+	if !s.cfg.Disable && query != "" {
+		z := zone.Default()
+		inj, err := (&inject.Injector{
+			Index:  s.index,
+			Scope:  s.cfg.Scope,
+			K:      s.cfg.Retrieval.TopK,
+			Budget: s.cfg.Retrieval.Budget,
+			Zones:  &z,
+		}).Build(query)
+		if err != nil {
+			s.logf("L2 inject: %v", err)
+		} else if inj.Text != "" {
+			block = inj.Text
+		}
+	}
+
+	// Step 5: build the forwarded body — model mapping + (maybe) injected
+	// messages, deterministically re-encoded so identical requests forward
+	// byte-identically (L1 prefix caching).
+	messages := cr.Messages
+	if block != "" {
+		patched, err := injectIntoMessages(cr.Messages, block)
+		if err != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_request_error",
+				"invalid_request", err.Error())
+			return
+		}
+		messages = patched
+	}
+	body, err := rebuildBody(cr.Raw, messages, s.up.upstreamModel(cr.Model))
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "server_error",
+			"internal_error", err.Error())
+		return
+	}
+
+	meta := forwardMeta{
+		sessionID: sessionID,
+		model:     cr.Model,
+		query:     query,
+		ctxHash:   ctxHash,
+		injected:  len(block),
+	}
+	if cr.Stream {
+		s.forwardStream(w, r, up, body, meta)
+		return
+	}
+	s.forwardJSON(w, r, up, body, meta)
+}
+
+// forwardMeta carries pipeline observability to the forward + write-memory
+// stages.
+type forwardMeta struct {
+	sessionID string
+	model     string
+	query     string
+	ctxHash   string
+	injected  int // injected block bytes (0 = none)
+}
+
+// --- L3 ---
+
+// lookupL3 runs the kernel fail-closed L3 gate (kernel/cache.L3Decider:
+// retrieval + grey zone + deps/mtime/fingerprint verification) and then the
+// gateway-specific reuse gates: model match, messages-context fingerprint
+// match and TTL (design §3.5 cache key).
+func (s *Server) lookupL3(ctx context.Context, query, model, ctxHash string) *cache.L3Result {
+	decider := &cache.L3Decider{
+		Index: s.index,
+		Store: s.store,
+		Root:  s.cfg.Cache.DepsRoot,
+		K:     s.cfg.Retrieval.TopK,
+	}
+	res, err := decider.DecideL3(ctx, cache.Query{
+		UserInput: query,
+		Scope:     s.cfg.Scope,
+	})
+	if err != nil || res == nil {
+		return nil
+	}
+	sl, err := s.store.Get(res.SliceID)
+	if err != nil || sl == nil {
+		return nil
+	}
+	if sl.Meta.Model != "" && sl.Meta.Model != model {
+		s.logf("L3 reject: model %q != %q", sl.Meta.Model, model)
+		return nil
+	}
+	if sl.Meta.ContextHash != "" && sl.Meta.ContextHash != ctxHash {
+		s.logf("L3 reject: context mismatch")
+		return nil
+	}
+	if s.cfg.Cache.TTLSeconds > 0 && sl.CreatedAt > 0 &&
+		time.Now().Unix()-sl.CreatedAt > s.cfg.Cache.TTLSeconds {
+		s.logf("L3 reject: TTL expired")
+		return nil
+	}
+	return res
+}
+
+// serveL3Hit answers a verified cache hit: synthetic usage (design §4.3:
+// completion_tokens=0, all prompt tokens marked cached) and — for stream
+// requests — an SSE replay of the cached content (§3.4).
+func (s *Server) serveL3Hit(w http.ResponseWriter, r *http.Request, cr *chatRequest, sessionID string, hit *cache.L3Result) {
+	w.Header().Set("x-semantix-cache", "hit")
+	w.Header().Set("x-semantix-slice", hit.SliceID)
+
+	estIn := estTokens(string(cr.Raw))
+	go s.recordUsage(usage.Event{
+		SessionID:     sessionID,
+		TokensIn:      int64(estIn),
+		TokensOut:     0,
+		CacheHitToken: int64(estIn),
+		L3Reuse:       true,
+	})
+
+	if cr.Stream {
+		s.replayL3Stream(w, cr, hit)
+		return
+	}
+	resp := chatCompletion{
+		ID:      "chatcmpl-semantix-" + hit.SliceID,
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   cr.Model,
+		Choices: []chatChoice{{
+			Index:        0,
+			Message:      chatRespMsg{Role: "assistant", Content: hit.Response},
+			FinishReason: "stop",
+		}},
+		Usage: &usageInfo{
+			PromptTokens:     estIn,
+			CompletionTokens: 0,
+			TotalTokens:      estIn,
+			PromptDetails:    &promptTokenDetails{CachedTokens: estIn},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(resp)
+}
+
+// replayL3Stream rebuilds an OpenAI SSE stream from the cached response
+// (design §3.4): role chunk, content chunks (≤4KB), finish chunk, [DONE].
+func (s *Server) replayL3Stream(w http.ResponseWriter, cr *chatRequest, hit *cache.L3Result) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	flush := func() { _ = http.NewResponseController(w).Flush() }
+
+	id := "chatcmpl-semantix-" + hit.SliceID
+	created := time.Now().Unix()
+	chunk := func(delta map[string]any, finish any) {
+		payload, _ := json.Marshal(map[string]any{
+			"id":      id,
+			"object":  "chat.completion.chunk",
+			"created": created,
+			"model":   cr.Model,
+			"choices": []map[string]any{{
+				"index":         0,
+				"delta":         delta,
+				"finish_reason": finish,
+			}},
+		})
+		_, _ = io.WriteString(w, "data: "+string(payload)+"\n\n")
+		flush()
+	}
+
+	chunk(map[string]any{"role": "assistant", "content": ""}, nil)
+	content := hit.Response
+	for len(content) > 0 {
+		n := min(len(content), 4096)
+		chunk(map[string]any{"content": content[:n]}, nil)
+		content = content[n:]
+	}
+	chunk(map[string]any{}, "stop")
+	_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	flush()
+}
+
+// --- forward ---
+
+// forwardJSON forwards a non-stream request and passes the upstream body
+// through byte-exact (design §3.4 byte-stability note). The response is
+// parsed (in a copy) only for write-memory/usage decisions.
+func (s *Server) forwardJSON(w http.ResponseWriter, r *http.Request, up *Upstream, body []byte, meta forwardMeta) {
+	ctx, cancel := context.WithTimeout(r.Context(), s.upstreamTimeout(up))
+	defer cancel()
+
+	respBody, status, retried, err := s.doUpstream(ctx, up, body)
+	if err != nil {
+		code, typ, msg := newUpstreamError(err)
+		writeAPIError(w, code, typ, "upstream_error", msg)
+		return
+	}
+	defer respBody.Close()
+	w.Header().Set("x-semantix-cache", "miss")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	data, readErr := io.ReadAll(io.LimitReader(respBody, maxResponseBodyBytes))
+	if readErr != nil {
+		writeAPIError(w, http.StatusBadGateway, "upstream_error", "upstream_error",
+			fmt.Sprintf("read upstream response: %v", readErr))
+		return
+	}
+	_, _ = w.Write(data)
+
+	content, toolCalls := parseCompletionContent(data)
+	s.afterResponse(meta, content, toolCalls, retried)
+}
+
+// forwardStream pipes the upstream SSE stream through verbatim, line by
+// line (design §3.4: 逐块透传，不重排不重写), injecting a usage chunk before
+// [DONE] only when the upstream omitted usage and L2 injected tokens exist.
+func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstream, body []byte, meta forwardMeta) {
+	ctx, cancel := context.WithTimeout(r.Context(), s.upstreamTimeout(up))
+	defer cancel()
+
+	respBody, status, retried, err := s.doUpstream(ctx, up, body)
+	if err != nil {
+		code, typ, msg := newUpstreamError(err)
+		writeAPIError(w, code, typ, "upstream_error", msg)
+		return
+	}
+	defer respBody.Close()
+
+	w.Header().Set("x-semantix-cache", "miss")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(status)
+
+	flush := func() { _ = http.NewResponseController(w).Flush() }
+	br := bufio.NewReader(respBody)
+
+	var contentBuf strings.Builder
+	toolCallsSeen := false
+	usageSeen := false
+	writeFailed := false
+
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			trimmed := strings.TrimSpace(string(line))
+			if strings.HasPrefix(trimmed, "data: ") {
+				payload := strings.TrimPrefix(trimmed, "data: ")
+				if payload == "[DONE]" {
+					// Defer [DONE]: a usage chunk may need to precede it
+					// (design §3.4). Rewritten below after the loop.
+					continue
+				}
+				var evt struct {
+					Choices []struct {
+						Delta struct {
+							Content   string `json:"content"`
+							ToolCalls any    `json:"tool_calls"`
+						} `json:"delta"`
+					} `json:"choices"`
+					Usage *usageInfo `json:"usage"`
+				}
+				if json.Unmarshal([]byte(payload), &evt) == nil {
+					for _, c := range evt.Choices {
+						contentBuf.WriteString(c.Delta.Content)
+						if c.Delta.ToolCalls != nil {
+							toolCallsSeen = true
+						}
+					}
+					if evt.Usage != nil {
+						usageSeen = true
+					}
+				}
+			}
+			if _, werr := w.Write(line); werr != nil {
+				writeFailed = true
+				break
+			}
+			flush()
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	if !writeFailed {
+		// Design §3.4: fill in a usage chunk before [DONE] when the
+		// upstream omitted usage and the gateway injected tokens
+		// (observability for L1 savings).
+		if !usageSeen && meta.injected > 0 {
+			est := estTokens(string(body))
+			payload, _ := json.Marshal(map[string]any{
+				"usage": map[string]any{
+					"prompt_tokens":     est,
+					"completion_tokens": estTokens(contentBuf.String()),
+					"total_tokens":      est + estTokens(contentBuf.String()),
+					"prompt_tokens_details": map[string]any{
+						"cached_tokens": estTokens(strings.Repeat("a", meta.injected)),
+					},
+				},
+			})
+			_, _ = io.WriteString(w, "data: "+string(payload)+"\n\n")
+			flush()
+		}
+		// [DONE] always terminates (rewritten if the upstream sent it).
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		flush()
+	}
+
+	if !writeFailed {
+		s.afterResponse(meta, contentBuf.String(), toolCallsSeen, retried)
+	}
+}
+
+// parseCompletionContent extracts (content, hasToolCalls) from a non-stream
+// upstream completion response.
+func parseCompletionContent(data []byte) (string, bool) {
+	var resp struct {
+		Choices []struct {
+			Message struct {
+				Content   string `json:"content"`
+				ToolCalls any    `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", false
+	}
+	for _, c := range resp.Choices {
+		if c.Message.ToolCalls != nil {
+			return c.Message.Content, true
+		}
+		if c.Message.Content != "" {
+			return c.Message.Content, false
+		}
+	}
+	return "", false
+}
+
+// doUpstream performs the HTTP call with one retry on network errors only
+// (design §3.8: retry logic lives mostly at the New API channel; the
+// gateway only does a single best-effort retry for transport errors — the
+// body is fully buffered, so a resend is always safe).
+func (s *Server) doUpstream(ctx context.Context, up *Upstream, body []byte) (io.ReadCloser, int, bool, error) {
+	url := strings.TrimSuffix(up.BaseURL, "/") + "/chat/completions"
+	do := func() (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+up.APIKey)
+		req.Header.Set("Content-Type", "application/json")
+		return s.client.Do(req)
+	}
+	resp, err := do()
+	if err != nil {
+		resp, err = do()
+		if err != nil {
+			return nil, 0, true, err
+		}
+		return resp.Body, resp.StatusCode, true, nil
+	}
+	return resp.Body, resp.StatusCode, false, nil
+}
+
+func (s *Server) upstreamTimeout(up *Upstream) time.Duration {
+	sec := up.TimeoutSec
+	if sec <= 0 {
+		sec = 60
+	}
+	return time.Duration(sec) * time.Second
+}
+
+// --- helpers ---
+
+// normalizeQuery collapses whitespace and strips control characters
+// (design §3.5: 归一化 query，复用 sanitize 纪律).
+func normalizeQuery(q string) string {
+	var b strings.Builder
+	b.Grow(len(q))
+	lastSpace := false
+	for _, r := range q {
+		if r <= 0x20 || r == 0x7f {
+			if !lastSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			lastSpace = true
+			continue
+		}
+		b.WriteRune(r)
+		lastSpace = false
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// contextHash is the messages-context fingerprint (design §3.5): the sha256
+// of the exact request bytes, gating L3 reuse to the same context.
+func contextHash(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// rebuildBody deterministically re-encodes the request with the mapped
+// model and (possibly injected) messages. encoding/json marshals maps with
+// sorted keys, so identical inputs yield byte-identical output — the L1
+// prefix-cache requirement (design §2.1).
+func rebuildBody(raw []byte, messages []json.RawMessage, model string) ([]byte, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	msgJSON, err := json.Marshal(messages)
+	if err != nil {
+		return nil, err
+	}
+	modelJSON, err := json.Marshal(model)
+	if err != nil {
+		return nil, err
+	}
+	fields["messages"] = msgJSON
+	fields["model"] = modelJSON
+	return json.Marshal(fields)
+}
+
+// sessionID derives the write-memory session id from the client header
+// (design §3.7: gateway-session-id), falling back to a shared default.
+func sessionID(r *http.Request) string {
+	if id := r.Header.Get("x-semantix-session"); id != "" {
+		return id
+	}
+	return "default"
+}
+
+// recordUsage appends a usage event (best-effort, never blocks the chain).
+func (s *Server) recordUsage(e usage.Event) {
+	if s.usage == nil {
+		return
+	}
+	if e.At == 0 {
+		e.At = time.Now().Unix()
+	}
+	if err := s.usage.Append(e); err != nil {
+		s.logf("usage record: %v", err)
+	}
+}
+
+// estTokens is a crude token estimate (≈ bytes/4, design §4.3 synthetic
+// usage; the gateway never bills — New API does).
+func estTokens(s string) int {
+	n := len(s) / 4
+	if n < 1 && len(s) > 0 {
+		n = 1
+	}
+	return n
+}
+
+const maxResponseBodyBytes = 32 << 20 // 32 MiB
+
+// afterResponse records usage for a forwarded request (write-memory and L3
+// write-back hooks land with the write-memory commit).
+func (s *Server) afterResponse(meta forwardMeta, content string, toolCalls, retried bool) {
+	out := estTokens(content)
+	s.recordUsage(usage.Event{
+		SessionID:      meta.sessionID,
+		TokensIn:       int64(estTokens(strings.Repeat("a", meta.injected))),
+		TokensOut:      int64(out),
+		InjectedTokens: int64(estTokens(strings.Repeat("a", meta.injected))),
+	})
+}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -187,6 +187,12 @@ func (s *Server) lookupL3(ctx context.Context, query, model, ctxHash string) *ca
 		s.logf("L3 reject: TTL expired")
 		return nil
 	}
+	if res.Response == "" {
+		// An empty answer is not a reusable outcome (gateway write-back
+		// never produces one; reject defensively).
+		s.logf("L3 reject: empty cached response %s", sl.ID)
+		return nil
+	}
 	return res
 }
 
@@ -273,7 +279,9 @@ func (s *Server) replayL3Stream(w http.ResponseWriter, cr *chatRequest, hit *cac
 
 // forwardJSON forwards a non-stream request and passes the upstream body
 // through byte-exact (design §3.4 byte-stability note). The response is
-// parsed (in a copy) only for write-memory/usage decisions.
+// parsed (in a copy) only for write-memory/usage decisions. Upstream
+// error responses (status >= 400) are passed through untouched and never
+// enter the write-memory path.
 func (s *Server) forwardJSON(w http.ResponseWriter, r *http.Request, up *Upstream, body []byte, meta forwardMeta) {
 	ctx, cancel := context.WithTimeout(r.Context(), s.upstreamTimeout(up))
 	defer cancel()
@@ -300,13 +308,26 @@ func (s *Server) forwardJSON(w http.ResponseWriter, r *http.Request, up *Upstrea
 	w.WriteHeader(status)
 	_, _ = w.Write(data)
 
+	if retried {
+		s.logf("upstream retry succeeded (%s)", up.Name)
+	}
+	if status >= 400 {
+		// Error responses are not conversations: no usage record, no
+		// session write, no L3 write-back.
+		return
+	}
+
 	content, toolCalls := parseCompletionContent(data)
-	s.afterResponse(meta, content, toolCalls, retried)
+	s.afterResponse(meta, content, toolCalls)
 }
 
 // forwardStream pipes the upstream SSE stream through verbatim, line by
 // line (design §3.4: 逐块透传，不重排不重写), injecting a usage chunk before
 // [DONE] only when the upstream omitted usage and L2 injected tokens exist.
+//
+// Upstream error responses (status >= 400) are NOT SSE: they are passed
+// through as their original JSON body so the client can surface the error
+// (e.g. 429 rate limit) instead of hanging on a stream that never ends.
 func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstream, body []byte, meta forwardMeta) {
 	ctx, cancel := context.WithTimeout(r.Context(), s.upstreamTimeout(up))
 	defer cancel()
@@ -320,6 +341,24 @@ func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstr
 	defer respBody.Close()
 
 	w.Header().Set("x-semantix-cache", "miss")
+	if status >= 400 {
+		// Upstream refused the request: relay its error verbatim (it is
+		// already in OpenAI error format) — never as an SSE stream.
+		data, readErr := io.ReadAll(io.LimitReader(respBody, maxResponseBodyBytes))
+		if readErr != nil {
+			writeAPIError(w, http.StatusBadGateway, "upstream_error", "upstream_error",
+				fmt.Sprintf("read upstream error: %v", readErr))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write(data)
+		if retried {
+			s.logf("upstream retry succeeded (%s)", up.Name)
+		}
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(status)
@@ -330,6 +369,7 @@ func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstr
 	var contentBuf strings.Builder
 	toolCallsSeen := false
 	usageSeen := false
+	sawDone := false
 	writeFailed := false
 
 	for {
@@ -340,8 +380,13 @@ func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstr
 				payload := strings.TrimPrefix(trimmed, "data: ")
 				if payload == "[DONE]" {
 					// Defer [DONE]: a usage chunk may need to precede it
-					// (design §3.4). Rewritten below after the loop.
+					// (design §3.4). Any lines after [DONE] are abnormal —
+					// dropped, the stream is over.
+					sawDone = true
 					continue
+				}
+				if sawDone {
+					continue // already terminated upstream: ignore tail
 				}
 				var evt struct {
 					Choices []struct {
@@ -378,10 +423,16 @@ func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstr
 	if !writeFailed {
 		// Design §3.4: fill in a usage chunk before [DONE] when the
 		// upstream omitted usage and the gateway injected tokens
-		// (observability for L1 savings).
+		// (observability for L1 savings). The chunk carries the standard
+		// SSE envelope so strict clients parse it like any other chunk.
 		if !usageSeen && meta.injected > 0 {
 			est := estTokens(string(body))
 			payload, _ := json.Marshal(map[string]any{
+				"id":      "chatcmpl-semantix-usage",
+				"object":  "chat.completion.chunk",
+				"created": time.Now().Unix(),
+				"model":   meta.model,
+				"choices": []map[string]any{},
 				"usage": map[string]any{
 					"prompt_tokens":     est,
 					"completion_tokens": estTokens(contentBuf.String()),
@@ -400,7 +451,10 @@ func (s *Server) forwardStream(w http.ResponseWriter, r *http.Request, up *Upstr
 	}
 
 	if !writeFailed {
-		s.afterResponse(meta, contentBuf.String(), toolCallsSeen, retried)
+		if retried {
+			s.logf("upstream retry succeeded (%s)", up.Name)
+		}
+		s.afterResponse(meta, contentBuf.String(), toolCallsSeen)
 	}
 }
 
@@ -554,7 +608,7 @@ const maxResponseBodyBytes = 32 << 20 // 32 MiB
 // usage record + session bypass write + async extraction + L3 write-back.
 // Everything is best-effort and never blocks the main chain; the deps-tree
 // fingerprint capture for the write-back runs on the worker goroutine.
-func (s *Server) afterResponse(meta forwardMeta, content string, toolCalls, retried bool) {
+func (s *Server) afterResponse(meta forwardMeta, content string, toolCalls bool) {
 	injectedEst := estTokensN(meta.injected)
 	s.recordUsage(usage.Event{
 		SessionID:      meta.sessionID,

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -117,6 +117,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		query:     query,
 		ctxHash:   ctxHash,
 		injected:  len(block),
+		promptEst: estTokens(string(body)),
 	}
 	if cr.Stream {
 		s.forwardStream(w, r, up, body, meta)
@@ -133,6 +134,7 @@ type forwardMeta struct {
 	query     string
 	ctxHash   string
 	injected  int // injected block bytes (0 = none)
+	promptEst int // estimated input tokens (incl. injection)
 }
 
 // --- L3 ---
@@ -530,14 +532,29 @@ func estTokens(s string) int {
 
 const maxResponseBodyBytes = 32 << 20 // 32 MiB
 
-// afterResponse records usage for a forwarded request (write-memory and L3
-// write-back hooks land with the write-memory commit).
+// afterResponse runs the post-forward write-memory path (design §3.7):
+// usage record + session bypass write + async extraction + L3 write-back.
+// Everything is best-effort and never blocks the main chain.
 func (s *Server) afterResponse(meta forwardMeta, content string, toolCalls, retried bool) {
-	out := estTokens(content)
+	injectedEst := estTokens(strings.Repeat("a", meta.injected))
 	s.recordUsage(usage.Event{
 		SessionID:      meta.sessionID,
-		TokensIn:       int64(estTokens(strings.Repeat("a", meta.injected))),
-		TokensOut:      int64(out),
-		InjectedTokens: int64(estTokens(strings.Repeat("a", meta.injected))),
+		TokensIn:       int64(meta.promptEst),
+		TokensOut:      int64(estTokens(content)),
+		CacheHitToken:  int64(injectedEst),
+		InjectedTokens: int64(injectedEst),
 	})
+
+	if s.mem != nil {
+		var calls []sessionToolCall
+		if toolCalls {
+			calls = []sessionToolCall{{ID: "gateway-tool", Name: "tool_call"}}
+		}
+		s.mem.appendSession(meta.sessionID, []sessionLine{
+			{Role: "user", Content: meta.query},
+			{Role: "assistant", Content: content, ToolCalls: calls},
+		})
+		s.mem.submit(meta.sessionID)
+	}
+	s.maybeWriteBack(meta, content, toolCalls)
 }

--- a/gateway/pipeline_test.go
+++ b/gateway/pipeline_test.go
@@ -505,7 +505,9 @@ func TestUpstreamFailureSurfacesOpenAIError(t *testing.T) {
 
 // TestL3EmptyMetaNoReuse: an entry without the gateway metadata (e.g. a
 // CLI-extracted Result slice) must never serve a gateway request
-// (review fix: fail-closed on missing Model/ContextHash).
+// (review fix: fail-closed on missing Model/ContextHash). The seed content
+// deliberately overlaps the query so the retrieval/zone gates pass and the
+// meta gate is actually exercised.
 func TestL3EmptyMetaNoReuse(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
@@ -516,8 +518,9 @@ func TestL3EmptyMetaNoReuse(t *testing.T) {
 	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
 	cfg := gatewayConfig(t, "deepseek-chat")
 	cfg.Cache.DepsRoot = root
-	// No Model / no ContextHash in meta (legacy/CLI entry).
-	seedResultMeta(t, cfg.StoreDB, "answer without gateway meta",
+	// No Model / no ContextHash in meta (legacy/CLI entry) — content
+	// overlaps the query so it would be retrieved if it were eligible.
+	seedResultMeta(t, cfg.StoreDB, "go tests with race detection: answer without gateway meta",
 		"", "", deps, mtimes)
 
 	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
@@ -535,9 +538,46 @@ func TestL3EmptyMetaNoReuse(t *testing.T) {
 	}
 }
 
+// TestL3UnknownAgeNoReuse: an entry with unknown creation time (CreatedAt
+// == 0) is never served (review fix: TTL gate treats unknown age as
+// expired).
+func TestL3UnknownAgeNoReuse(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.DepsRoot = root
+	seedResult(t, cfg.StoreDB, "go tests with race detection: cached answer of unknown age",
+		"deepseek-chat", ctxHashOf(body), deps, mtimes)
+	st, _ := slice.NewFileStore(cfg.StoreDB)
+	sl, _ := st.Get(seedID("go tests with race detection: cached answer of unknown age"))
+	sl.CreatedAt = 0
+	if err := st.Put(sl); err != nil {
+		t.Fatal(err)
+	}
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fresh answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Header().Get("x-semantix-cache") == "hit" {
+		t.Fatal("unknown-age entry must not be reused")
+	}
+	if !strings.Contains(rec.Body.String(), "fresh answer") {
+		t.Fatalf("expected upstream answer: %s", rec.Body.String())
+	}
+}
+
 // TestL3SkippedWithoutDepsRoot: with no deps_root configured the L3 lookup
 // is skipped entirely (fail-closed — verification against the process CWD
-// must never happen), even for a fully qualified entry.
+// must never happen), even for a fully qualified, retrievable entry.
 func TestL3SkippedWithoutDepsRoot(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
@@ -548,7 +588,7 @@ func TestL3SkippedWithoutDepsRoot(t *testing.T) {
 	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
 	cfg := gatewayConfig(t, "deepseek-chat")
 	// cfg.Cache.DepsRoot intentionally left empty.
-	seedResult(t, cfg.StoreDB, "fully qualified cached answer",
+	seedResult(t, cfg.StoreDB, "go tests with race detection: fully qualified cached answer",
 		"deepseek-chat", ctxHashOf(body), deps, mtimes)
 
 	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {

--- a/gateway/pipeline_test.go
+++ b/gateway/pipeline_test.go
@@ -64,13 +64,18 @@ func mustJSON(s string) string {
 // extract --l3-safe with deps, or by the gateway write-back).
 func seedResult(t *testing.T, dbPath string, content, model, ctxHash string, deps fingerprint.Deps, mtimes map[string]int64) {
 	t.Helper()
+	seedResultMeta(t, dbPath, content, model, ctxHash, deps, mtimes)
+}
+
+// seedResultMeta is seedResult with full meta control.
+func seedResultMeta(t *testing.T, dbPath string, content, model, ctxHash string, deps fingerprint.Deps, mtimes map[string]int64) {
+	t.Helper()
 	st, err := slice.NewFileStore(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	id := seedID(content)
 	sl := &slice.Slice{
-		ID: id, Type: slice.Result, Scope: slice.Project,
+		ID: seedID(content), Type: slice.Result, Scope: slice.Project,
 		Content:   []byte(content),
 		Weight:    1.0,
 		CreatedAt: time.Now().Unix(),
@@ -84,7 +89,6 @@ func seedResult(t *testing.T, dbPath string, content, model, ctxHash string, dep
 	if err := st.Put(sl); err != nil {
 		t.Fatal(err)
 	}
-	_ = id
 }
 
 func seedID(content string) string {
@@ -496,6 +500,69 @@ func TestUpstreamFailureSurfacesOpenAIError(t *testing.T) {
 	}
 	if errMsg, _ := m["error"].(map[string]any); errMsg["code"] != "upstream_error" {
 		t.Fatalf("error = %v", m)
+	}
+}
+
+// TestL3EmptyMetaNoReuse: an entry without the gateway metadata (e.g. a
+// CLI-extracted Result slice) must never serve a gateway request
+// (review fix: fail-closed on missing Model/ContextHash).
+func TestL3EmptyMetaNoReuse(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.DepsRoot = root
+	// No Model / no ContextHash in meta (legacy/CLI entry).
+	seedResultMeta(t, cfg.StoreDB, "answer without gateway meta",
+		"", "", deps, mtimes)
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fresh answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Header().Get("x-semantix-cache") == "hit" {
+		t.Fatal("entry without gateway meta must not be reused")
+	}
+	if !strings.Contains(rec.Body.String(), "fresh answer") {
+		t.Fatalf("expected upstream answer: %s", rec.Body.String())
+	}
+}
+
+// TestL3SkippedWithoutDepsRoot: with no deps_root configured the L3 lookup
+// is skipped entirely (fail-closed — verification against the process CWD
+// must never happen), even for a fully qualified entry.
+func TestL3SkippedWithoutDepsRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	// cfg.Cache.DepsRoot intentionally left empty.
+	seedResult(t, cfg.StoreDB, "fully qualified cached answer",
+		"deepseek-chat", ctxHashOf(body), deps, mtimes)
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fresh answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Header().Get("x-semantix-cache") == "hit" {
+		t.Fatal("L3 must be skipped without deps_root")
+	}
+	if !strings.Contains(rec.Body.String(), "fresh answer") {
+		t.Fatalf("expected upstream answer: %s", rec.Body.String())
 	}
 }
 

--- a/gateway/pipeline_test.go
+++ b/gateway/pipeline_test.go
@@ -633,6 +633,48 @@ func TestRebuildBodyDeterministic(t *testing.T) {
 	}
 }
 
+// TestStreamUsageChunkEnvelope: when the upstream omits usage and the
+// gateway injected L2 tokens, the gateway appends a well-formed usage
+// chunk (with the standard SSE envelope) before [DONE] (design §3.4).
+func TestStreamUsageChunkEnvelope(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	seedPrompt(t, cfg.StoreDB, "how to fix a failing go test: run go test -race and read the failure trace")
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprintf(w, "data: %s\n\n", `{"id":"c","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":"fixed"},"finish_reason":null}]}`)
+		flusher.Flush()
+		// No usage in the stream.
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", true, "user:how do I fix this failing go test")
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	out := rec.Body.String()
+	idx := strings.Index(out, `"object":"chat.completion.chunk"`)
+	if idx < 0 {
+		t.Fatalf("no SSE chunk envelope in stream:\n%s", out)
+	}
+	if !strings.Contains(out, `"usage"`) || !strings.Contains(out, `"cached_tokens"`) {
+		t.Fatalf("usage chunk missing:\n%s", out)
+	}
+	doneIdx := strings.LastIndex(out, "data: [DONE]")
+	usageIdx := strings.Index(out, `"usage"`)
+	if usageIdx > doneIdx || doneIdx < 0 {
+		t.Fatalf("usage chunk must precede [DONE]:\n%s", out)
+	}
+	if !strings.Contains(out, `"model":"ds-chat"`) {
+		t.Fatalf("usage chunk envelope missing model:\n%s", out)
+	}
+}
+
 func TestNormalizeQuery(t *testing.T) {
 	cases := map[string]string{
 		"  fix\n my\t tests  ": "fix my tests",

--- a/gateway/pipeline_test.go
+++ b/gateway/pipeline_test.go
@@ -1,0 +1,541 @@
+package gateway
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/fingerprint"
+	"semantix/kernel/slice"
+)
+
+// --- helpers ---
+
+// testUpstream spins up a fake OpenAI-compatible upstream recording calls.
+type testUpstream struct {
+	srv      *httptest.Server
+	calls    atomic.Int32
+	lastBody []byte
+	lastPath string
+	handler  func(w http.ResponseWriter, r *http.Request, body []byte)
+}
+
+func newTestUpstream(t *testing.T, handler func(w http.ResponseWriter, r *http.Request, body []byte)) *testUpstream {
+	t.Helper()
+	u := &testUpstream{handler: handler}
+	u.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.calls.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		u.lastBody = body
+		u.lastPath = r.URL.Path
+		if u.handler != nil {
+			u.handler(w, r, body)
+		}
+	}))
+	t.Cleanup(u.srv.Close)
+	return u
+}
+
+func (u *testUpstream) url() string { return u.srv.URL }
+
+func jsonCompletion(content string) string {
+	return fmt.Sprintf(`{"id":"chatcmpl-test","object":"chat.completion","created":1,"model":"m",
+"choices":[{"index":0,"message":{"role":"assistant","content":%s},"finish_reason":"stop"}],
+"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`, mustJSON(content))
+}
+
+func mustJSON(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// seedResult seeds a verified reusable Result slice (as if captured by
+// extract --l3-safe with deps, or by the gateway write-back).
+func seedResult(t *testing.T, dbPath string, content, model, ctxHash string, deps fingerprint.Deps, mtimes map[string]int64) {
+	t.Helper()
+	st, err := slice.NewFileStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := seedID(content)
+	sl := &slice.Slice{
+		ID: id, Type: slice.Result, Scope: slice.Project,
+		Content:   []byte(content),
+		Weight:    1.0,
+		CreatedAt: time.Now().Unix(),
+		Meta: slice.SliceMeta{
+			Model:       model,
+			ContextHash: ctxHash,
+			Deps:        deps,
+			Mtimes:      mtimes,
+		},
+	}
+	if err := st.Put(sl); err != nil {
+		t.Fatal(err)
+	}
+	_ = id
+}
+
+func seedID(content string) string {
+	sum := sha256.Sum256([]byte{byte(slice.Result), byte(slice.Project)})
+	sum2 := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(append(sum[:], sum2[:]...))[:16]
+}
+
+// seedPrompt seeds a reusable Prompt slice for L2 injection.
+func seedPrompt(t *testing.T, dbPath, content string) {
+	t.Helper()
+	st, err := slice.NewFileStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sl := &slice.Slice{
+		ID: seedID(content), Type: slice.Prompt, Scope: slice.Project,
+		Content:   []byte(content),
+		Weight:    1.0,
+		CreatedAt: time.Now().Unix(),
+	}
+	if err := st.Put(sl); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func captureDeps(t *testing.T, root string, paths ...string) (fingerprint.Deps, map[string]int64) {
+	t.Helper()
+	deps, err := fingerprint.Capture(root, paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtimes := map[string]int64{}
+	for _, p := range paths {
+		fi, err := os.Stat(filepath.Join(root, p))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mtimes[p] = fi.ModTime().Unix()
+	}
+	return deps, mtimes
+}
+
+func requestBody(model string, stream bool, messages ...string) []byte {
+	var msgs []map[string]string
+	for _, m := range messages {
+		parts := strings.SplitN(m, ":", 2)
+		if len(parts) != 2 {
+			parts = []string{"user", m}
+		}
+		msgs = append(msgs, map[string]string{"role": parts[0], "content": parts[1]})
+	}
+	b, _ := json.Marshal(map[string]any{"model": model, "messages": msgs, "stream": stream})
+	return b
+}
+
+func ctxHashOf(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+func gatewayConfig(t *testing.T, alias string) Config {
+	t.Helper()
+	cfg := Config{
+		StoreDB: filepath.Join(t.TempDir(), "gw.jsonl"),
+		Scope:   slice.Project,
+		Upstreams: []Upstream{{
+			Name:          "test-up",
+			BaseURL:       "http://127.0.0.1:1", // replaced by tests with a live upstream
+			APIKey:        "up-key",
+			ModelAlias:    []string{alias},
+			UpstreamModel: "real-model",
+			Vendor:        "openai",
+		}},
+		Retrieval: struct {
+			TopK   int
+			Budget int
+		}{TopK: 5, Budget: 4096},
+		Cache: struct {
+			TTLSeconds int64
+			L3Safe     bool
+			DepsRoot   string
+		}{TTLSeconds: 86400},
+	}
+	return cfg
+}
+
+func (s *Server) rebuild(t *testing.T) {
+	t.Helper()
+	idx := bm25.New()
+	if err := indexFromStore(s.store, idx); err != nil {
+		t.Fatal(err)
+	}
+	s.index = idx
+}
+
+// --- tests ---
+
+// TestL3HitZeroUpstream is the issue acceptance core: an L3 hit serves the
+// cached response with zero upstream calls.
+func TestL3HitZeroUpstream(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.DepsRoot = root
+	seedResult(t, cfg.StoreDB, "cached answer: run `go test -race ./...` and read the failure trace",
+		"deepseek-chat", ctxHashOf(body), deps, mtimes)
+
+	up := newTestUpstream(t, nil)
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	rec, m := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("x-semantix-cache") != "hit" {
+		t.Fatalf("x-semantix-cache = %q, want hit", rec.Header().Get("x-semantix-cache"))
+	}
+	choices, _ := m["choices"].([]any)
+	msg, _ := choices[0].(map[string]any)["message"].(map[string]any)
+	if !strings.Contains(msg["content"].(string), "go test -race") {
+		t.Fatalf("content = %v", msg["content"])
+	}
+	usage, _ := m["usage"].(map[string]any)
+	if usage["completion_tokens"] != float64(0) {
+		t.Fatalf("completion_tokens must be 0 on L3 hit, got %v", usage)
+	}
+	details, _ := usage["prompt_tokens_details"].(map[string]any)
+	if details["cached_tokens"] != usage["prompt_tokens"] {
+		t.Fatalf("cached_tokens must cover prompt_tokens on L3 hit: %v", usage)
+	}
+	if got := up.calls.Load(); got != 0 {
+		t.Fatalf("L3 hit must not call upstream, got %d calls", got)
+	}
+}
+
+// TestL3ModelMismatchNoReuse: a cached entry for another model never serves
+// this request (design §3.5 cache key includes the model).
+func TestL3ModelMismatchNoReuse(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.DepsRoot = root
+	seedResult(t, cfg.StoreDB, "claude-style answer about go test", "claude-sonnet", ctxHashOf(body), deps, mtimes)
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fresh upstream answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	rec, m := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("x-semantix-cache") == "hit" {
+		t.Fatal("cross-model reuse must be rejected")
+	}
+	choices, _ := m["choices"].([]any)
+	msg, _ := choices[0].(map[string]any)["message"].(map[string]any)
+	if !strings.Contains(msg["content"].(string), "fresh upstream answer") {
+		t.Fatalf("expected upstream answer, got %v", msg["content"])
+	}
+	if up.calls.Load() != 1 {
+		t.Fatalf("upstream calls = %d, want 1", up.calls.Load())
+	}
+}
+
+// TestL3ContextMismatchNoReuse: the same query under a different message
+// context never reuses (design §3.5 messages-context fingerprint).
+func TestL3ContextMismatchNoReuse(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	bodyA := requestBody("deepseek-chat", false, "system:project alpha", "user:how do I run go tests with race detection")
+	bodyB := requestBody("deepseek-chat", false, "system:project beta", "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.DepsRoot = root
+	seedResult(t, cfg.StoreDB, "answer valid only under project alpha", "deepseek-chat", ctxHashOf(bodyA), deps, mtimes)
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fresh answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(bodyB), "")
+	if rec.Header().Get("x-semantix-cache") == "hit" {
+		t.Fatal("cross-context reuse must be rejected")
+	}
+	if !strings.Contains(rec.Body.String(), "fresh answer") {
+		t.Fatalf("expected upstream answer: %s", rec.Body.String())
+	}
+}
+
+// TestL3TTLExpired: an expired entry is never served.
+func TestL3TTLExpired(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	body := requestBody("deepseek-chat", false, "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.DepsRoot = root
+	cfg.Cache.TTLSeconds = 60
+	seedResult(t, cfg.StoreDB, "expired cached answer", "deepseek-chat", ctxHashOf(body), deps, mtimes)
+	// age the entry beyond the TTL
+	st, _ := slice.NewFileStore(cfg.StoreDB)
+	sl, _ := st.Get(seedID("expired cached answer"))
+	sl.CreatedAt = time.Now().Unix() - 120
+	_ = st.Put(sl)
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fresh answer"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Header().Get("x-semantix-cache") == "hit" {
+		t.Fatal("expired L3 entry must not be served")
+	}
+	if !strings.Contains(rec.Body.String(), "fresh answer") {
+		t.Fatalf("expected upstream answer: %s", rec.Body.String())
+	}
+}
+
+// TestL2InjectionForwarded is the issue acceptance core: on a miss, the
+// forwarded request carries the [semantix-reuse] block (the model skips
+// repeated exploration), the model is mapped, and the upstream body is
+// passed through untouched.
+func TestL2InjectionForwarded(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	seedPrompt(t, cfg.StoreDB, "how to fix a failing go test: run go test -race and read the failure trace")
+
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("fixed the test failure"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", false, "user:how do I fix this failing go test")
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("x-semantix-cache") != "miss" {
+		t.Fatalf("x-semantix-cache = %q, want miss", rec.Header().Get("x-semantix-cache"))
+	}
+	if up.calls.Load() != 1 {
+		t.Fatalf("upstream calls = %d, want 1", up.calls.Load())
+	}
+	fwd := string(up.lastBody)
+	if !strings.Contains(fwd, "[semantix-reuse]") {
+		t.Fatalf("forwarded request missing injection block: %s", fwd)
+	}
+	if !strings.Contains(fwd, "how to fix a failing go test") {
+		t.Fatalf("forwarded request missing slice content: %s", fwd)
+	}
+	// Model mapping: alias ds-chat → upstream real-model.
+	var sent struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(up.lastBody, &sent); err != nil || sent.Model != "real-model" {
+		t.Fatalf("forwarded model = %q (err %v), want real-model", sent.Model, err)
+	}
+	// Byte-exact passthrough of the upstream body.
+	if rec.Body.String() != jsonCompletion("fixed the test failure") {
+		t.Fatalf("body passthrough mismatch:\n got %s", rec.Body.String())
+	}
+	// Deterministic rebuild: the same request forwards byte-identically
+	// (L1 prefix-cache requirement).
+	rec2, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if up.calls.Load() != 2 {
+		t.Fatalf("second request must also hit upstream (no L3 entry), calls = %d", up.calls.Load())
+	}
+	if string(up.lastBody) != fwd {
+		t.Fatal("forwarded body must be byte-identical for identical requests (L1)")
+	}
+	_ = rec2
+}
+
+// TestForwardStreamPassthrough: SSE events flow through verbatim and the
+// stream terminates with [DONE].
+func TestForwardStreamPassthrough(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	seedPrompt(t, cfg.StoreDB, "the answer to streamed questions is often in the first chunk")
+
+	chunks := []string{
+		`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"hello "},"finish_reason":null}]}`,
+		`{"id":"c1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":"world"},"finish_reason":null}]}`,
+	}
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	body := requestBody("ds-chat", true, "user:stream me an answer")
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	out := rec.Body.String()
+	for _, c := range chunks {
+		if !strings.Contains(out, c) {
+			t.Fatalf("stream chunk not passed through: %s", c)
+		}
+	}
+	if !strings.HasSuffix(strings.TrimSpace(out), "data: [DONE]") {
+		t.Fatalf("stream must end with [DONE]: %q", out)
+	}
+}
+
+// TestStreamL3HitReplay: an L3 hit under stream=true replays the cached
+// content as SSE without calling upstream.
+func TestStreamL3HitReplay(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("data v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps, mtimes := captureDeps(t, root, "a.txt")
+
+	body := requestBody("deepseek-chat", true, "user:how do I run go tests with race detection")
+	cfg := gatewayConfig(t, "deepseek-chat")
+	cfg.Cache.DepsRoot = root
+	seedResult(t, cfg.StoreDB, "cached answer: run `go test -race ./...`",
+		"deepseek-chat", ctxHashOf(body), deps, mtimes)
+
+	up := newTestUpstream(t, nil)
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("x-semantix-cache") != "hit" {
+		t.Fatal("expected x-semantix-cache: hit")
+	}
+	out := rec.Body.String()
+	if !strings.Contains(out, "cached answer: run") || !strings.Contains(out, "data: [DONE]") {
+		t.Fatalf("replay stream missing content or [DONE]: %q", out)
+	}
+	if !strings.Contains(out, `"finish_reason":"stop"`) {
+		t.Fatalf("replay stream missing finish_reason: %q", out)
+	}
+	if got := up.calls.Load(); got != 0 {
+		t.Fatalf("L3 stream hit must not call upstream, got %d", got)
+	}
+}
+
+// TestUnknownModel: unconfigured models are rejected with an OpenAI error.
+func TestUnknownModel(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	s := testServer(t, &cfg)
+	body := requestBody("nope-model", false, "user:hi")
+	rec, m := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if errMsg, _ := m["error"].(map[string]any); errMsg["code"] != "model_not_found" {
+		t.Fatalf("error = %v", m)
+	}
+}
+
+// TestUpstreamFailureSurfacesOpenAIError: upstream network failure yields a
+// 502 in OpenAI error format (the client / New API can retry).
+func TestUpstreamFailureSurfacesOpenAIError(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	cfg.Upstreams[0].BaseURL = "http://127.0.0.1:1" // nothing listens here
+	s := testServer(t, &cfg)
+	body := requestBody("ds-chat", false, "user:hi")
+	rec, m := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions", string(body), "")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body %s", rec.Code, rec.Body.String())
+	}
+	if errMsg, _ := m["error"].(map[string]any); errMsg["code"] != "upstream_error" {
+		t.Fatalf("error = %v", m)
+	}
+}
+
+// TestRebuildBodyDeterministic: identical inputs produce byte-identical
+// output (L1 requirement).
+func TestRebuildBodyDeterministic(t *testing.T) {
+	raw := []byte(`{"model":"a","stream":true,"messages":[{"role":"user","content":"x"}]}`)
+	var msgs []json.RawMessage
+	if err := json.Unmarshal([]byte(`[{"role":"user","content":"x"}]`), &msgs); err != nil {
+		t.Fatal(err)
+	}
+	a, err := rebuildBody(raw, msgs, "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2, err := rebuildBody(raw, msgs, "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b2) {
+		t.Fatalf("rebuild not deterministic:\n%s\n%s", a, b2)
+	}
+	var m struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(a, &m); err != nil || m.Model != "b" {
+		t.Fatalf("model not mapped: %s", a)
+	}
+}
+
+func TestNormalizeQuery(t *testing.T) {
+	cases := map[string]string{
+		"  fix\n my\t tests  ": "fix my tests",
+		"already clean":        "already clean",
+		"   ":                  "",
+		"a\u0000b\u001fc":      "a b c",
+	}
+	for in, want := range cases {
+		if got := normalizeQuery(in); got != want {
+			t.Errorf("normalizeQuery(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1,0 +1,196 @@
+package gateway
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/slice"
+	"semantix/kernel/usage"
+)
+
+// Server is the Semantix Gateway HTTP server (design §3.1–3.3). It owns the
+// slice store + in-memory index (the L2/L3 backend, equivalent in-process
+// to the `semantix lookup --json` subprocess protocol), the upstream set
+// and the async write-memory worker.
+type Server struct {
+	cfg   Config
+	store slice.Store
+	index slice.Index
+	up    *upstreamSet
+	usage *usage.Recorder // nil when recording is disabled
+	logf  func(format string, args ...any)
+}
+
+// New builds a Server from the effective config: opens the slice store,
+// rebuilds the in-memory index, wires upstreams and the write-memory worker.
+func New(cfg Config) (*Server, error) {
+	store, err := slice.NewFileStore(cfg.StoreDB)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: open store %s: %w", cfg.StoreDB, err)
+	}
+	idx := bm25.New()
+	if err := indexFromStore(store, idx); err != nil {
+		return nil, fmt.Errorf("gateway: index store: %w", err)
+	}
+
+	s := &Server{
+		cfg:   cfg,
+		store: store,
+		index: idx,
+		up:    newUpstreamSet(cfg.Upstreams),
+		logf:  func(format string, args ...any) { log.Printf("[gateway] "+format, args...) },
+	}
+	if cfg.UsageDB != "" {
+		rec, err := usage.NewRecorder(cfg.UsageDB)
+		if err != nil {
+			return nil, fmt.Errorf("gateway: usage recorder: %w", err)
+		}
+		s.usage = rec
+	}
+	return s, nil
+}
+
+// Close releases the server's resources.
+func (s *Server) Close() error {
+	if closer, ok := s.store.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// Handler returns the routed HTTP handler.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.recover(s.handleHealthz))
+	mux.HandleFunc("/v1/models", s.recover(s.withAuth(s.handleModels)))
+	mux.HandleFunc("/v1/chat/completions", s.recover(s.withAuth(s.handleChatCompletions)))
+	mux.HandleFunc("/v1/completions", s.recover(s.withAuth(s.handleCompletions501)))
+	return mux
+}
+
+// ListenAndServe runs the HTTP server on cfg.Addr until the context is
+// cancelled (graceful shutdown). It returns the server error on failure.
+func (s *Server) ListenAndServe(addr string) error {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return srv.ListenAndServe()
+}
+
+// recover maps handler panics to OpenAI-format 500 responses.
+func (s *Server) recover(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				s.logf("panic: %v", rec)
+				writeAPIError(w, http.StatusInternalServerError,
+					"server_error", "internal_error", "internal server error")
+			}
+		}()
+		next(w, r)
+	}
+}
+
+// withAuth enforces the gateway key (design §3.10): New API injects it as
+// the channel key and forwards it as `Authorization: Bearer <key>`. An
+// empty configured key disables auth (trusted-network / dev mode).
+func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.cfg.GatewayKey != "" {
+			got := ""
+			if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+				got = strings.TrimPrefix(h, "Bearer ")
+			}
+			if subtle.ConstantTimeCompare([]byte(got), []byte(s.cfg.GatewayKey)) != 1 {
+				writeAPIError(w, http.StatusUnauthorized, "authentication_error",
+					"invalid_api_key", "invalid or missing API key")
+				return
+			}
+		}
+		next(w, r)
+	}
+}
+
+// handleHealthz reports liveness: the slice store must be openable and the
+// gateway must have at least one configured upstream (design §3.2).
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error",
+			"method_not_allowed", "healthz only supports GET")
+		return
+	}
+	if _, err := s.store.ListAll(); err != nil {
+		writeAPIError(w, http.StatusServiceUnavailable, "server_error",
+			"store_unavailable", "slice store unavailable")
+		return
+	}
+	if len(s.up.aliases()) == 0 {
+		writeAPIError(w, http.StatusServiceUnavailable, "server_error",
+			"no_upstream", "no upstreams configured")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, `{"status":"ok"}`+"\n")
+}
+
+// handleModels lists every routable model alias (design §3.2 / §4.2).
+func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error",
+			"method_not_allowed", "models only supports GET")
+		return
+	}
+	aliases := s.up.aliases()
+	data := make([]map[string]any, 0, len(aliases))
+	for _, a := range aliases {
+		data = append(data, map[string]any{
+			"id":       a,
+			"object":   "model",
+			"owned_by": "semantix-gateway",
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(map[string]any{"object": "list", "data": data})
+}
+
+// handleCompletions501 implements the design's MVP scope decision: text
+// completions are not supported in v1 (design §3.2 table).
+func (s *Server) handleCompletions501(w http.ResponseWriter, r *http.Request) {
+	writeAPIError(w, http.StatusNotImplemented, "invalid_request_error",
+		"not_implemented", "POST /v1/completions is not implemented in v1; use /v1/chat/completions")
+}
+
+// handleChatCompletions is the core pipeline entry (design §3.3); the
+// pipeline itself lands with the caching layers.
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	writeAPIError(w, http.StatusNotImplemented, "invalid_request_error",
+		"not_implemented", "chat completions pipeline not yet wired")
+}
+
+// indexFromStore rebuilds an in-memory index from the persistent store,
+// covering every scope (mirrors cmd/semantix).
+func indexFromStore(store slice.Store, idx slice.Index) error {
+	for _, scope := range []slice.Scope{slice.Session, slice.Project, slice.User} {
+		items, err := store.List(scope)
+		if err != nil {
+			return err
+		}
+		for _, sl := range items {
+			if err := idx.Insert(sl); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -35,6 +37,14 @@ type Server struct {
 // New builds a Server from the effective config: opens the slice store,
 // rebuilds the in-memory index, wires upstreams and the write-memory worker.
 func New(cfg Config) (*Server, error) {
+	// The store file's parent may not exist on first run (e.g. a fresh
+	// ~/.semantix) — create it like usage/sessions paths already do,
+	// otherwise the very first `semantix serve` would fail to open.
+	if dir := filepath.Dir(cfg.StoreDB); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("gateway: create store dir %s: %w", dir, err)
+		}
+	}
 	store, err := slice.NewFileStore(cfg.StoreDB)
 	if err != nil {
 		return nil, fmt.Errorf("gateway: open store %s: %w", cfg.StoreDB, err)
@@ -90,10 +100,15 @@ func (s *Server) Handler() http.Handler {
 
 // Serve runs the HTTP server on ln until ctx is cancelled, then shuts down
 // gracefully (in-flight requests finish within a 5s budget).
+//
+// Note: no WriteTimeout is set — streaming responses (SSE) legitimately
+// outlive any fixed write deadline; IdleTimeout alone keeps keep-alive
+// sockets from piling up.
 func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	srv := &http.Server{
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 	go func() {
 		<-ctx.Done()

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -59,7 +59,9 @@ func New(cfg Config) (*Server, error) {
 		}
 		s.usage = rec
 	}
-	if cfg.Ingest.SessionsDir != "" {
+	if cfg.Ingest.SessionsDir != "" || cfg.Cache.L3Safe {
+		// The worker owns both session extraction and L3 write-back, so it
+		// must exist whenever either is enabled.
 		s.mem = newMemoryWorker(s, cfg.Ingest.SessionsDir, cfg.Ingest.Extract)
 	}
 	return s, nil

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1,11 +1,13 @@
 package gateway
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -84,15 +86,29 @@ func (s *Server) Handler() http.Handler {
 	return mux
 }
 
-// ListenAndServe runs the HTTP server on cfg.Addr until the context is
-// cancelled (graceful shutdown). It returns the server error on failure.
-func (s *Server) ListenAndServe(addr string) error {
+// Serve runs the HTTP server on ln until ctx is cancelled, then shuts down
+// gracefully (in-flight requests finish within a 5s budget).
+func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	srv := &http.Server{
-		Addr:              addr,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-	return srv.ListenAndServe()
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+	err := srv.Serve(ln)
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}
+
+// ModelAliases lists every routable client-visible model name (design §4.2).
+func (s *Server) ModelAliases() []string {
+	return s.up.aliases()
 }
 
 // recover maps handler panics to OpenAI-format 500 responses.

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -20,12 +20,14 @@ import (
 // to the `semantix lookup --json` subprocess protocol), the upstream set
 // and the async write-memory worker.
 type Server struct {
-	cfg   Config
-	store slice.Store
-	index slice.Index
-	up    *upstreamSet
-	usage *usage.Recorder // nil when recording is disabled
-	logf  func(format string, args ...any)
+	cfg    Config
+	store  slice.Store
+	index  slice.Index
+	up     *upstreamSet
+	usage  *usage.Recorder // nil when recording is disabled
+	mem    *memoryWorker   // nil when write-memory is disabled
+	client *http.Client
+	logf   func(format string, args ...any)
 }
 
 // New builds a Server from the effective config: opens the slice store,
@@ -41,11 +43,12 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	s := &Server{
-		cfg:   cfg,
-		store: store,
-		index: idx,
-		up:    newUpstreamSet(cfg.Upstreams),
-		logf:  func(format string, args ...any) { log.Printf("[gateway] "+format, args...) },
+		cfg:    cfg,
+		store:  store,
+		index:  idx,
+		up:     newUpstreamSet(cfg.Upstreams),
+		client: &http.Client{Timeout: 120 * time.Second},
+		logf:   func(format string, args ...any) { log.Printf("[gateway] "+format, args...) },
 	}
 	if cfg.UsageDB != "" {
 		rec, err := usage.NewRecorder(cfg.UsageDB)
@@ -54,11 +57,17 @@ func New(cfg Config) (*Server, error) {
 		}
 		s.usage = rec
 	}
+	if cfg.Ingest.SessionsDir != "" {
+		s.mem = newMemoryWorker(s, cfg.Ingest.SessionsDir, cfg.Ingest.Extract)
+	}
 	return s, nil
 }
 
 // Close releases the server's resources.
 func (s *Server) Close() error {
+	if s.mem != nil {
+		s.mem.close()
+	}
 	if closer, ok := s.store.(interface{ Close() error }); ok {
 		return closer.Close()
 	}
@@ -169,13 +178,6 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleCompletions501(w http.ResponseWriter, r *http.Request) {
 	writeAPIError(w, http.StatusNotImplemented, "invalid_request_error",
 		"not_implemented", "POST /v1/completions is not implemented in v1; use /v1/chat/completions")
-}
-
-// handleChatCompletions is the core pipeline entry (design §3.3); the
-// pipeline itself lands with the caching layers.
-func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
-	writeAPIError(w, http.StatusNotImplemented, "invalid_request_error",
-		"not_implemented", "chat completions pipeline not yet wired")
 }
 
 // indexFromStore rebuilds an in-memory index from the persistent store,

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -1,13 +1,16 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"semantix/kernel/slice"
 )
@@ -29,9 +32,6 @@ func testServer(t *testing.T, cfg *Config) *Server {
 	}
 	if base.Retrieval.Budget == 0 {
 		base.Retrieval.Budget = 4096
-	}
-	if base.Ingest.Extract {
-		base.Ingest.Extract = false
 	}
 	s, err := New(base)
 	if err != nil {
@@ -150,17 +150,6 @@ func TestCompletionsNotImplemented(t *testing.T) {
 	}
 }
 
-func TestChatCompletionsNotWiredYet(t *testing.T) {
-	s := testServer(t, &Config{Upstreams: []Upstream{
-		{Name: "ds", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"m"}},
-	}})
-	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions",
-		`{"model":"m","messages":[{"role":"user","content":"hi"}]}`, "")
-	if rec.Code != http.StatusNotImplemented {
-		t.Fatalf("chat = %d, want 501 (pipeline lands next)", rec.Code)
-	}
-}
-
 func TestOpenAIProtocolHelpers(t *testing.T) {
 	messages := []json.RawMessage{
 		json.RawMessage(`{"role":"system","content":"base"}`),
@@ -215,5 +204,45 @@ func TestOpenAIProtocolHelpers(t *testing.T) {
 	}
 	if first.Role != "system" || first.Content != "block" {
 		t.Fatalf("prepended = %+v", first)
+	}
+}
+
+// TestServeLifecycle: Serve serves requests until the context is cancelled,
+// then shuts down cleanly (graceful shutdown path used by `semantix serve`).
+func TestServeLifecycle(t *testing.T) {
+	cfg := gatewayConfig(t, "ds-chat")
+	up := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request, body []byte) {
+		io.WriteString(w, jsonCompletion("up"))
+	})
+	cfg.Upstreams[0].BaseURL = up.url()
+	s := testServer(t, &cfg)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Serve(ctx, ln) }()
+
+	url := "http://" + ln.Addr().String() + "/healthz"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("healthz during serve: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(body), "ok") {
+		t.Fatalf("healthz = %d %s", resp.StatusCode, body)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Serve after cancel = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serve did not shut down after cancel")
 	}
 }

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -1,0 +1,219 @@
+package gateway
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// testServer builds a Server with an in-memory-backed config for endpoint
+// tests. The slice store lives in a temp dir.
+func testServer(t *testing.T, cfg *Config) *Server {
+	t.Helper()
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	base := *cfg
+	if base.StoreDB == "" {
+		base.StoreDB = filepath.Join(t.TempDir(), "gw.jsonl")
+	}
+	base.Scope = slice.Project
+	if base.Retrieval.TopK == 0 {
+		base.Retrieval.TopK = 5
+	}
+	if base.Retrieval.Budget == 0 {
+		base.Retrieval.Budget = 4096
+	}
+	if base.Ingest.Extract {
+		base.Ingest.Extract = false
+	}
+	s, err := New(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func doJSON(t *testing.T, h http.Handler, method, path, body, key string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	var rd io.Reader
+	if body != "" {
+		rd = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, rd)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	var m map[string]any
+	if rec.Body.Len() > 0 {
+		_ = json.Unmarshal(rec.Body.Bytes(), &m)
+	}
+	return rec, m
+}
+
+func TestHealthz(t *testing.T) {
+	s := testServer(t, &Config{Upstreams: []Upstream{
+		{Name: "ds", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"m"}},
+	}})
+	h := s.Handler()
+	rec, _ := doJSON(t, h, http.MethodGet, "/healthz", "", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("healthz = %d, body %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHealthzNoUpstreams(t *testing.T) {
+	s := testServer(t, nil)
+	rec, m := doJSON(t, s.Handler(), http.MethodGet, "/healthz", "", "")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("healthz with no upstreams = %d, want 503; %v", rec.Code, m)
+	}
+	if errMsg, _ := m["error"].(map[string]any); errMsg["code"] != "no_upstream" {
+		t.Fatalf("error body = %v", m)
+	}
+}
+
+func TestModelsListsAliases(t *testing.T) {
+	s := testServer(t, &Config{Upstreams: []Upstream{
+		{Name: "ds", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"ds-chat"}},
+		{Name: "claude", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"claude-sonnet", "claude-opus"}},
+	}})
+	rec, m := doJSON(t, s.Handler(), http.MethodGet, "/v1/models", "", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("models = %d", rec.Code)
+	}
+	data, ok := m["data"].([]any)
+	if !ok || len(data) != 3 {
+		t.Fatalf("models data = %v", m)
+	}
+	first := data[0].(map[string]any)
+	if first["id"] != "claude-opus" || first["object"] != "model" {
+		t.Fatalf("first model = %v", first)
+	}
+}
+
+func TestAuthRequired(t *testing.T) {
+	s := testServer(t, &Config{
+		GatewayKey: "secret",
+		Upstreams:  []Upstream{{Name: "ds", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"m"}}},
+	})
+	h := s.Handler()
+	rec, m := doJSON(t, h, http.MethodGet, "/v1/models", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing key = %d, want 401; %v", rec.Code, m)
+	}
+	if errMsg, _ := m["error"].(map[string]any); errMsg["code"] != "invalid_api_key" {
+		t.Fatalf("error body = %v", m)
+	}
+	rec, _ = doJSON(t, h, http.MethodGet, "/v1/models", "", "wrong")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong key = %d, want 401", rec.Code)
+	}
+	rec, _ = doJSON(t, h, http.MethodGet, "/v1/models", "", "secret")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("correct key = %d, want 200", rec.Code)
+	}
+}
+
+func TestAuthDisabledWhenKeyEmpty(t *testing.T) {
+	s := testServer(t, &Config{Upstreams: []Upstream{
+		{Name: "ds", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"m"}},
+	}})
+	rec, _ := doJSON(t, s.Handler(), http.MethodGet, "/v1/models", "", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty key must allow: %d", rec.Code)
+	}
+}
+
+func TestCompletionsNotImplemented(t *testing.T) {
+	s := testServer(t, &Config{Upstreams: []Upstream{
+		{Name: "ds", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"m"}},
+	}})
+	rec, m := doJSON(t, s.Handler(), http.MethodPost, "/v1/completions", `{"model":"m"}`, "")
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("completions = %d, want 501", rec.Code)
+	}
+	if errMsg, _ := m["error"].(map[string]any); errMsg["code"] != "not_implemented" {
+		t.Fatalf("error body = %v", m)
+	}
+}
+
+func TestChatCompletionsNotWiredYet(t *testing.T) {
+	s := testServer(t, &Config{Upstreams: []Upstream{
+		{Name: "ds", BaseURL: "http://x", APIKey: "k", ModelAlias: []string{"m"}},
+	}})
+	rec, _ := doJSON(t, s.Handler(), http.MethodPost, "/v1/chat/completions",
+		`{"model":"m","messages":[{"role":"user","content":"hi"}]}`, "")
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("chat = %d, want 501 (pipeline lands next)", rec.Code)
+	}
+}
+
+func TestOpenAIProtocolHelpers(t *testing.T) {
+	messages := []json.RawMessage{
+		json.RawMessage(`{"role":"system","content":"base"}`),
+		json.RawMessage(`{"role":"user","content":"hello"}`),
+	}
+	// lastUserMessage picks the last user message.
+	got, err := lastUserMessage(messages)
+	if err != nil || got != "hello" {
+		t.Fatalf("lastUserMessage = %q, %v", got, err)
+	}
+	// Multimodal content (parts array) yields concatenated text parts.
+	multi := []json.RawMessage{
+		json.RawMessage(`{"role":"user","content":[{"type":"text","text":"a"},{"type":"image_url","image_url":{"url":"x"}},{"type":"text","text":"b"}]}`),
+	}
+	got, err = lastUserMessage(multi)
+	if err != nil || got != "ab" {
+		t.Fatalf("multimodal = %q, %v", got, err)
+	}
+	// Injection appends to the last system message.
+	patched, err := injectIntoMessages(messages, "[semantix-reuse]x[/semantix-reuse]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(patched) != 2 {
+		t.Fatalf("patched length = %d", len(patched))
+	}
+	var sys struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(patched[0], &sys); err != nil {
+		t.Fatal(err)
+	}
+	if sys.Role != "system" || sys.Content != "base\n\n[semantix-reuse]x[/semantix-reuse]" {
+		t.Fatalf("system patched = %+v", sys)
+	}
+	// No system message → a system message is prepended.
+	only := []json.RawMessage{json.RawMessage(`{"role":"user","content":"hi"}`)}
+	patched, err = injectIntoMessages(only, "block")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(patched) != 2 {
+		t.Fatalf("prepend length = %d", len(patched))
+	}
+	var first struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(patched[0], &first); err != nil {
+		t.Fatal(err)
+	}
+	if first.Role != "system" || first.Content != "block" {
+		t.Fatalf("prepended = %+v", first)
+	}
+}

--- a/gateway/server_test.go
+++ b/gateway/server_test.go
@@ -205,6 +205,34 @@ func TestOpenAIProtocolHelpers(t *testing.T) {
 	if first.Role != "system" || first.Content != "block" {
 		t.Fatalf("prepended = %+v", first)
 	}
+
+	// Multiple system messages: the block lands at the END of the LAST one
+	// (design §3.6 "system 提示末尾"), earlier system messages untouched.
+	multiSys := []json.RawMessage{
+		json.RawMessage(`{"role":"system","content":"first"}`),
+		json.RawMessage(`{"role":"user","content":"u1"}`),
+		json.RawMessage(`{"role":"system","content":"second"}`),
+	}
+	patched, err = injectIntoMessages(multiSys, "tail-block")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sys0, sys1 struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(patched[0], &sys0); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(patched[2], &sys1); err != nil {
+		t.Fatal(err)
+	}
+	if sys0.Content != "first" {
+		t.Fatalf("first system mutated: %+v", sys0)
+	}
+	if sys1.Content != "second\n\ntail-block" {
+		t.Fatalf("last system not tail-injected: %+v", sys1)
+	}
 }
 
 // TestServeLifecycle: Serve serves requests until the context is cancelled,

--- a/gateway/upstream.go
+++ b/gateway/upstream.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"sort"
+)
+
+// upstreamSet routes client-visible model names to configured upstreams
+// (design §4.2: New API channel model names are the gateway's model_alias).
+type upstreamSet struct {
+	byAlias map[string]*Upstream
+	list    []Upstream
+}
+
+func newUpstreamSet(ups []Upstream) *upstreamSet {
+	s := &upstreamSet{byAlias: make(map[string]*Upstream, len(ups)), list: ups}
+	for i := range ups {
+		for _, a := range ups[i].ModelAlias {
+			s.byAlias[a] = &ups[i]
+		}
+	}
+	return s
+}
+
+// resolve finds the upstream serving a client-visible model name.
+func (s *upstreamSet) resolve(model string) (*Upstream, bool) {
+	up, ok := s.byAlias[model]
+	return up, ok
+}
+
+// aliases lists every routable model name, sorted for deterministic output.
+func (s *upstreamSet) aliases() []string {
+	out := make([]string, 0, len(s.byAlias))
+	for a := range s.byAlias {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// upstreamModel maps a client-visible model name to the real upstream model
+// (design §4.2 mapping target; empty means pass-through).
+func (s *upstreamSet) upstreamModel(model string) string {
+	if up, ok := s.byAlias[model]; ok && up.UpstreamModel != "" {
+		return up.UpstreamModel
+	}
+	return model
+}

--- a/gateway/writeback.go
+++ b/gateway/writeback.go
@@ -1,0 +1,119 @@
+package gateway
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"semantix/kernel/fingerprint"
+	"semantix/kernel/slice"
+)
+
+// This file implements the gateway L3 write-back (design §3.5): a fresh
+// upstream response becomes a reusable Result slice only when the operator
+// opted in (cache.l3_safe) AND a deps fingerprint of the configured project
+// root was captured — dep-less entries never enter L3 (fail-closed: the
+// fingerprint/RuleGate chain would be a no-op). Tool-call responses are
+// never cached (side effects).
+
+// maybeWriteBack stores a verified-safe response as an L3 candidate.
+func (s *Server) maybeWriteBack(meta forwardMeta, content string, toolCalls bool) {
+	if s.cfg.Disable || !s.cfg.Cache.L3Safe || s.cfg.Cache.DepsRoot == "" {
+		return
+	}
+	if content == "" || toolCalls {
+		// Design §3.5: only safely-reusable plain answers enter L3.
+		return
+	}
+	deps, mtimes, err := captureTree(s.cfg.Cache.DepsRoot)
+	if err != nil {
+		s.logf("L3 write-back: capture deps: %v", err)
+		return
+	}
+	if len(deps) == 0 {
+		// An empty capture is not evidence of stability — do not cache.
+		s.logf("L3 write-back: deps tree empty, skip")
+		return
+	}
+	sl := &slice.Slice{
+		ID:        gatewaySliceID(content, s.cfg.Scope),
+		Type:      slice.Result,
+		Scope:     s.cfg.Scope,
+		Content:   []byte(content),
+		Weight:    1.0,
+		CreatedAt: time.Now().Unix(),
+		Meta: slice.SliceMeta{
+			Model:       meta.model,
+			ContextHash: meta.ctxHash,
+			Deps:        deps,
+			Mtimes:      mtimes,
+		},
+	}
+	if err := s.store.Put(sl); err != nil {
+		s.logf("L3 write-back: put: %v", err)
+		return
+	}
+	if err := s.index.Insert(sl); err != nil {
+		s.logf("L3 write-back: index: %v", err)
+	}
+	s.logf("L3 write-back: cached %s (%d bytes, %d deps)", sl.ID, len(content), len(deps))
+}
+
+// captureTree fingerprints every regular file under root (relative paths,
+// sorted) with sha256 digests + mtimes — the L3 entry's dependency snapshot
+// (design §3.5: 文件一变缓存即失效).
+func captureTree(root string) (fingerprint.Deps, map[string]int64, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, nil, err
+	}
+	var paths []string
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Type()&os.ModeSymlink != 0 {
+			return nil // symlinked deps are rejected (verify never follows links)
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if !filepath.IsLocal(rel) {
+			return fmt.Errorf("non-local dep path %q", rel)
+		}
+		paths = append(paths, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Strings(paths)
+	deps, err := fingerprint.Capture(root, paths)
+	if err != nil {
+		return nil, nil, err
+	}
+	mtimes := make(map[string]int64, len(paths))
+	for _, p := range paths {
+		fi, err := os.Stat(filepath.Join(root, p))
+		if err != nil {
+			return nil, nil, err
+		}
+		mtimes[p] = fi.ModTime().Unix()
+	}
+	return deps, mtimes, nil
+}
+
+// gatewaySliceID derives a deterministic content ID (mirrors the extractor
+// discipline: same content + type + scope → same ID, so re-caching dedups).
+func gatewaySliceID(content string, scope slice.Scope) string {
+	h := sha256.New()
+	h.Write([]byte{byte(slice.Result), byte(scope)})
+	h.Write([]byte(content))
+	return hex.EncodeToString(h.Sum(nil)[:16])
+}

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -93,6 +93,16 @@ type SliceMeta struct {
 	// silently skipping dimension-mismatched vectors.
 	EmbedModel string `json:"embed_model,omitempty"`
 	EmbedDim   int    `json:"embed_dim,omitempty"`
+	// Model records the client-visible model that produced this slice
+	// (gateway L3 entries, Issue #133): L3 reuse is gated on the same model
+	// so a Claude answer can never serve a GPT request. Empty for slices
+	// produced by the CLI/extract path — the check is skipped when unset.
+	Model string `json:"model,omitempty"`
+	// ContextHash records the gateway-computed fingerprint of the request
+	// messages at write time (Issue #133): L3 reuse additionally requires
+	// the current request's context fingerprint to match, preventing
+	// cross-context reuse / information leakage (design §3.5).
+	ContextHash string `json:"context_hash,omitempty"`
 }
 
 // Slice is the core semantic slice value.

--- a/kernel/slice/slice_test.go
+++ b/kernel/slice/slice_test.go
@@ -148,6 +148,41 @@ func TestFileStorePutGetList(t *testing.T) {
 	}
 }
 
+// TestSliceMetaGatewayFieldsRoundTrip: the gateway metadata fields
+// (Issue #133) survive a store round trip and are absent on legacy slices
+// (omitempty keeps the JSONL wire format backward compatible).
+func TestSliceMetaGatewayFieldsRoundTrip(t *testing.T) {
+	st, err := NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sl := &Slice{
+		ID: "gw", Type: Result, Scope: Project, Content: []byte("cached answer"),
+		Meta: SliceMeta{
+			Model:       "deepseek-chat",
+			ContextHash: "abc123",
+		},
+	}
+	if err := st.Put(sl); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.Get("gw")
+	if err != nil || got == nil {
+		t.Fatalf("Get(gw) = %v, %v", got, err)
+	}
+	if got.Meta.Model != "deepseek-chat" || got.Meta.ContextHash != "abc123" {
+		t.Fatalf("gateway meta not preserved: %+v", got.Meta)
+	}
+
+	var legacy Slice
+	if err := json.Unmarshal([]byte(`{"id":"x","content":"y"}`), &legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.Meta.Model != "" || legacy.Meta.ContextHash != "" {
+		t.Fatalf("legacy slice must parse with empty gateway meta, got %+v", legacy.Meta)
+	}
+}
+
 // Put with the same ID replaces (no duplicates).
 func TestFileStoreReplaceSameID(t *testing.T) {
 	st, err := NewFileStore(filepath.Join(t.TempDir(), "slices.jsonl"))

--- a/kernel/slice/slice_test.go
+++ b/kernel/slice/slice_test.go
@@ -175,7 +175,7 @@ func TestSliceMetaGatewayFieldsRoundTrip(t *testing.T) {
 	}
 
 	var legacy Slice
-	if err := json.Unmarshal([]byte(`{"id":"x","content":"y"}`), &legacy); err != nil {
+	if err := json.Unmarshal([]byte(`{"id":"x","content":"eQ=="}`), &legacy); err != nil {
 		t.Fatal(err)
 	}
 	if legacy.Meta.Model != "" || legacy.Meta.ContextHash != "" {


### PR DESCRIPTION
## 概述

实现 Issue #133（M2-GW1）：Semantix Gateway v1 —— OpenAI 兼容 HTTP 网关，复用 kernel 三层语义缓存，作为 New API 中转的自定义上游渠道。

## 改动内容

- **设计文档**：`docs/specs/newapi-gateway-design.md`（恢复 0e31be2 中被回退的文档；原 blob 为 UTF-16LE+GBK 双重乱码、428 处不可恢复 PUA 字符，按内容重建为 UTF-8，并对齐 Issue #133 文件面）
- **kernel（最小扩展）**：`SliceMeta` 增加 `Model`/`ContextHash` 字段（L3 门禁元数据，omitempty，向后兼容）
- **gateway/ 包**（新增）：
  - 配置加载：`semantix-gateway.toml` + `SEMANTIX_GATEWAY_*` env + 默认值三层合并，`${VAR}` 未解析即报错，`~` 路径展开
  - OpenAI 兼容端点：`/v1/chat/completions`（流式+非流式）、`/v1/models`、`/healthz`、`/v1/completions`(501)
  - 流水线：L3 命中 → 直接返回（零上游调用，合成 usage，SSE 回放）；未命中 → L2 注入（system 提示末尾，字节稳定）→ 上游转发（模型映射、网络错误一次重试、SSE 逐块透传）
  - 写记忆：会话旁路 JSONL + 异步提取（ingest.Pipeline）；L3 写回（`l3_safe`+`deps_root` 显式开启，deps 全树指纹，文件变更即失效）
  - 安全：网关 Key constant-time 鉴权、session id 消毒、L3 门禁 fail-closed（模型/上下文指纹/TTL/空 meta 拒用）
- **CLI**：`semantix serve` 命令（优雅停机、空 key 启动警告、默认回环绑定）

## 验收对照（Issue #133 checklist）

- [x] 设计文档 `docs/specs/newapi-gateway-design.md` 入库
- [x] HTTP 网关层（/v1/*）：L3 命中直接返回；未命中 L2 注入后转发上游
- [x] 复用 kernel 三层缓存（`kernel/cache` + `kernel/inject` + `kernel/fingerprint`），零新增核心逻辑（kernel 不反向依赖 gateway）
- [x] New API 渠道对接（HTTP 上游形态）；后端进程内复用 kernel 检索/注入（等价 `lookup --json` 子进程协议）
- [x] e2e：`TestL3HitZeroUpstream`（命中零上游调用）、`TestL2InjectionForwarded`（注入块出现在转发请求）、`TestWriteBackInvalidatedOnDepsChange` 等 50+ 用例

## 测试

`go test -count=1 ./...` 全绿（18 包），`go vet` 干净。`go test -race` 由 CI（ubuntu）覆盖。

## 审查

已完成两轮 subagent 审查 + 修复（L3 门禁 fail-closed、写回异步化、注入位置、上游错误透传、首启目录创建等），共 10 个提交。
