### PR TITLE
fix(gateway): 全链路复审修复 8 处 bug（工具调用保留/alias env/优雅停机/流终止）

### DIFF
--- a/cmd/semantix-gateway/main.go
+++ b/cmd/semantix-gateway/main.go
@@ -14,9 +14,14 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"semantix/gateway"
@@ -34,19 +39,41 @@ func main() {
 	if err != nil {
 		log.Fatalf("semantix-gateway: %v", err)
 	}
-	defer g.Close()
 
 	srv := &http.Server{
 		Addr:              cfg.Server.Addr,
 		Handler:           g,
 		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 	log.Printf("semantix-gateway: listening on %s (%d upstream(s): %s)",
 		cfg.Server.Addr, len(cfg.Upstreams), upstreamNames(cfg))
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("semantix-gateway: %v", err)
+
+	// Graceful shutdown on SIGINT/SIGTERM: stop accepting, drain in-flight
+	// requests, then Close() waits for the async write-memory to land —
+	// without this, Ctrl+C would kill the process before sidecars extract.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.ListenAndServe() }()
+
+	select {
+	case err := <-serveErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("semantix-gateway: %v", err)
+		}
+	case <-ctx.Done():
+		log.Print("semantix-gateway: shutting down")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("semantix-gateway: shutdown: %v", err)
+		}
 	}
-	_ = srv.Shutdown(nil) // graceful: let in-flight handlers finish
+	if err := g.Close(); err != nil {
+		log.Printf("semantix-gateway: close: %v", err)
+	}
 }
 
 func upstreamNames(cfg *gateway.Config) string {

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -119,9 +119,9 @@ func (c *Config) expand() error {
 		u := &c.Upstreams[i]
 		fields = append(fields, &u.Name, &u.BaseURL, &u.APIKey, &u.UpstreamModel, &u.Vendor)
 		for j := range u.ModelAlias {
-			alias := u.ModelAlias[j]
-			fields = append(fields, &alias)
-			u.ModelAlias[j] = alias
+			// Take the address of the slice element itself — a copy would
+			// make the ${VAR} substitution below a no-op.
+			fields = append(fields, &u.ModelAlias[j])
 		}
 	}
 	for _, f := range fields {

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -130,3 +130,22 @@ func TestModelListAndUpstreamFor(t *testing.T) {
 		t.Error("UpstreamFor(nope) must be false")
 	}
 }
+
+// TestModelAliasEnvSubstitution: ${VAR} references inside model_alias must
+// expand (regression: the old code took the address of a loop copy, making
+// the substitution a silent no-op).
+func TestModelAliasEnvSubstitution(t *testing.T) {
+	t.Setenv("GW_KEY", "k1")
+	t.Setenv("DS_KEY", "k2")
+	t.Setenv("ALIAS_EXTRA", "ds-chat")
+	body := strings.Replace(validConfig, `model_alias = ["deepseek-chat", "ds-chat"]`,
+		`model_alias = ["deepseek-chat", "${ALIAS_EXTRA}"]`, 1)
+	cfg, err := Load(writeConfig(t, body))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	aliases := cfg.Upstreams[0].ModelAlias
+	if len(aliases) != 2 || aliases[1] != "ds-chat" {
+		t.Fatalf("model_alias env substitution failed: %v", aliases)
+	}
+}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +43,17 @@ type Gateway struct {
 	disabled   bool       // SEMANTIX_GATEWAY_DISABLE ablation switch
 
 	now func() time.Time
+}
+
+// disableEnv reports the ablation switch SEMANTIX_GATEWAY_DISABLE. Only
+// truthy values disable ("1", "true", "yes", "on") — "0"/"false" must keep
+// the cache enabled, otherwise the escape hatch silently breaks caching.
+func disableEnv() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SEMANTIX_GATEWAY_DISABLE"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // New assembles the gateway from config: opens the slice store, rebuilds the
@@ -94,7 +106,7 @@ func New(cfg *Config) (*Gateway, error) {
 		injector: &inject.Injector{Index: idx, Store: store, Scope: scope, K: topK, Budget: budget, Zones: &z},
 		usageLog: rec,
 		client:   &http.Client{Timeout: 120 * time.Second},
-		disabled: os.Getenv("SEMANTIX_GATEWAY_DISABLE") != "",
+		disabled: disableEnv(),
 		now:      time.Now,
 	}
 	return g, nil

--- a/gateway/normalize.go
+++ b/gateway/normalize.go
@@ -21,10 +21,16 @@ type chatRequest struct {
 
 // chatMessage is one OpenAI chat message. Content may be a plain string or
 // a multimodal part array (text/image urls); the gateway only reads text
-// parts for query extraction and fingerprints the raw structure.
+// parts for query extraction and fingerprints the raw structure. Tool-call
+// fields must be preserved verbatim: they are re-marshaled into the
+// forwarded request when the L2 injection block rewrites the messages, so
+// dropping them would corrupt tool-calling conversations.
 type chatMessage struct {
-	Role    string `json:"role"`
-	Content any    `json:"content"`
+	Role       string `json:"role"`
+	Content    any    `json:"content"`
+	ToolCalls  any    `json:"tool_calls,omitempty"`
+	Name       string `json:"name,omitempty"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
 }
 
 // textParts renders a message content value as its text form: a string is

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -119,32 +120,50 @@ func (g *Gateway) rewriteOutgoing(body []byte, req *chatRequest, up UpstreamConf
 	return out
 }
 
-// attachBlock appends block to the first string-content system message, or
-// prepends a system message when none exists (design §3.6 injection slot).
+// attachBlock appends block to the last string-content system message (the
+// system-prompt tail, design §3.6), or prepends a system message when none
+// exists. Earlier system messages stay untouched.
 func attachBlock(messages []chatMessage, block string) []chatMessage {
+	last := -1
 	for i := range messages {
-		if messages[i].Role != "system" {
-			continue
+		if messages[i].Role == "system" {
+			if _, ok := messages[i].Content.(string); ok {
+				last = i
+			}
 		}
-		if s, ok := messages[i].Content.(string); ok {
-			messages[i].Content = s + "\n\n" + block
-			return messages
-		}
+	}
+	if last >= 0 {
+		messages[last].Content = messages[last].Content.(string) + "\n\n" + block
+		return messages
 	}
 	return append([]chatMessage{{Role: "system", Content: block}}, messages...)
 }
 
 // forward posts the (rewritten) body to the upstream OpenAI-compatible
-// endpoint with the upstream API key.
+// endpoint with the upstream API key. Transport errors are retried once
+// (design §3.8: the gateway does a single best-effort retry; the body is
+// fully buffered so a resend is always safe); HTTP status errors are not
+// retried — they carry the upstream's own verdict.
 func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (*http.Response, error) {
 	url := strings.TrimRight(up.BaseURL, "/") + "/chat/completions"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
+	do := func() (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+up.APIKey)
+		return g.client.Do(req)
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+up.APIKey)
-	return g.client.Do(req)
+	resp, err := do()
+	if err != nil {
+		log.Printf("gateway: upstream %s: %v (retrying once)", up.Name, err)
+		resp, err = do()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return resp, nil
 }
 
 // passthrough relays a non-streaming upstream response, records usage and
@@ -167,6 +186,9 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 	g.recordSession(sessionID, ctxHash, req.Model, turns(req, content))
 
 	for k, vs := range resp.Header {
+		if isHopByHopHeader(k) {
+			continue
+		}
 		for _, v := range vs {
 			w.Header().Add(k, v)
 		}
@@ -186,7 +208,9 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 
 // streamThrough relays a streaming upstream response chunk by chunk (SSE),
 // preserving events verbatim (design §3.4: never reorder/rewrite the
-// upstream stream). Sidecar records the request turns only — parsing the
+// upstream stream). If the upstream ends without a [DONE] marker (abnormal
+// disconnect), the gateway appends one so the client never hangs on an
+// unterminated stream. Sidecar records the request turns only — parsing the
 // assistant content out of the SSE chunks is deferred (documented debt).
 func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64) {
 	if resp.StatusCode >= 400 {
@@ -201,17 +225,32 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 	w.WriteHeader(resp.StatusCode)
 	flusher, _ := w.(http.Flusher)
 
-	buf := make([]byte, 32*1024)
+	// Scan lines rather than blind blocks: we must detect the [DONE]
+	// marker to guarantee stream termination even when the upstream
+	// disconnects early. Lines are still forwarded verbatim.
+	br := bufio.NewReader(resp.Body)
+	sawDone := false
 	for {
-		n, err := resp.Body.Read(buf)
-		if n > 0 {
-			_, _ = w.Write(buf[:n])
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			if bytes.HasPrefix(bytes.TrimSpace(line), []byte("data: [DONE]")) {
+				sawDone = true
+			}
+			_, _ = w.Write(line)
 			if flusher != nil {
 				flusher.Flush()
 			}
 		}
 		if err != nil {
 			break
+		}
+	}
+	if !sawDone {
+		// Abnormal termination: close the stream ourselves so the client
+		// does not hang (design §3.4: [DONE] always terminates).
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		if flusher != nil {
+			flusher.Flush()
 		}
 	}
 	g.recordSession(sessionID, ctxHash, req.Model, turns(req, ""))
@@ -221,6 +260,17 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 		InjectedTokens: injectedTokens,
 		At:             g.now().Unix(),
 	})
+}
+
+// isHopByHopHeader reports connection-scoped headers that must never be
+// relayed end-to-end (RFC 9110 §7.6.1): they describe the upstream hop.
+func isHopByHopHeader(name string) bool {
+	switch http.CanonicalHeaderKey(name) {
+	case "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
+		"Proxy-Connection", "Te", "Trailer", "Transfer-Encoding", "Upgrade":
+		return true
+	}
+	return false
 }
 
 // turns renders the request messages plus the assistant reply as the

--- a/gateway/review_test.go
+++ b/gateway/review_test.go
@@ -1,0 +1,202 @@
+package gateway
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// TestToolCallMessagesPreservedThroughInjection: an L2 injection rewrites
+// the messages array — tool_calls / name / tool_call_id fields must survive
+// the rewrite or tool-calling conversations break upstream (regression).
+func TestToolCallMessagesPreservedThroughInjection(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	seed(t, g, &slice.Slice{
+		ID: "l2-tools", Type: slice.Prompt, Scope: slice.Project,
+		Content: []byte("prior widgets knowledge to inject"),
+	})
+
+	body := `{"model":"deepseek-chat","messages":[
+		{"role":"user","content":"widgets please"},
+		{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"a\"}"}}]},
+		{"role":"tool","tool_call_id":"call_1","name":"read_file","content":"file contents"}
+	]}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	msgs := up.forwardedMessages()
+	if len(msgs) != 4 {
+		t.Fatalf("forwarded messages = %d, want 4 (injected system + 3 originals)", len(msgs))
+	}
+	// The tool message must keep its tool_call_id and name.
+	toolMsg := msgs[3]
+	if toolMsg["role"] != "tool" {
+		t.Fatalf("tool message role = %v", toolMsg["role"])
+	}
+	if toolMsg["tool_call_id"] != "call_1" {
+		t.Fatalf("tool_call_id lost in rewrite: %#v", toolMsg)
+	}
+	if toolMsg["name"] != "read_file" {
+		t.Fatalf("tool name lost in rewrite: %#v", toolMsg)
+	}
+	// The assistant message must keep its tool_calls array.
+	asstMsg := msgs[2]
+	calls, ok := asstMsg["tool_calls"].([]any)
+	if !ok || len(calls) != 1 {
+		t.Fatalf("tool_calls lost in rewrite: %#v", asstMsg)
+	}
+	first, ok := calls[0].(map[string]any)
+	if !ok || first["id"] != "call_1" {
+		t.Fatalf("tool call detail lost in rewrite: %#v", asstMsg)
+	}
+}
+
+// TestStreamAbnormalEndGetsDone: an upstream stream that dies without
+// [DONE] must still terminate the client stream (regression: clients hung
+// forever on abnormal upstream disconnects).
+func TestStreamAbnormalEndGetsDone(t *testing.T) {
+	up := &testUpstream{stream: "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "stream me", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	body := string(out)
+	if !strings.Contains(body, "partial") {
+		t.Fatalf("stream content missing: %s", body)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(body), "data: [DONE]") {
+		t.Fatalf("stream must be terminated with [DONE]: %q", body)
+	}
+}
+
+// TestDisableFalseKeepsCache: SEMANTIX_GATEWAY_DISABLE=0 must NOT disable
+// the semantic cache (regression: any non-empty value used to disable).
+func TestDisableFalseKeepsCache(t *testing.T) {
+	t.Setenv("SEMANTIX_GATEWAY_DISABLE", "0")
+	if disableEnv() {
+		t.Fatal("SEMANTIX_GATEWAY_DISABLE=0 must keep the cache enabled")
+	}
+	t.Setenv("SEMANTIX_GATEWAY_DISABLE", "false")
+	if disableEnv() {
+		t.Fatal("SEMANTIX_GATEWAY_DISABLE=false must keep the cache enabled")
+	}
+	t.Setenv("SEMANTIX_GATEWAY_DISABLE", "1")
+	if !disableEnv() {
+		t.Fatal("SEMANTIX_GATEWAY_DISABLE=1 must disable the cache")
+	}
+	t.Setenv("SEMANTIX_GATEWAY_DISABLE", "")
+	if disableEnv() {
+		t.Fatal("unset SEMANTIX_GATEWAY_DISABLE must keep the cache enabled")
+	}
+}
+
+// TestAttachBlockLastSystemMessage: with multiple system messages the
+// injection block lands at the END of the LAST one (design §3.6 system
+// prompt tail), earlier system messages untouched.
+func TestAttachBlockLastSystemMessage(t *testing.T) {
+	msgs := []chatMessage{
+		{Role: "system", Content: "first"},
+		{Role: "user", Content: "u"},
+		{Role: "system", Content: "second"},
+	}
+	out := attachBlock(msgs, "block")
+	if len(out) != 3 {
+		t.Fatalf("len = %d", len(out))
+	}
+	if out[0].Content != "first" {
+		t.Fatalf("first system mutated: %v", out[0].Content)
+	}
+	if out[2].Content != "second\n\nblock" {
+		t.Fatalf("last system = %v, want tail-injected", out[2].Content)
+	}
+}
+
+// TestForwardRetriesNetworkError: a transport failure is retried once and
+// the response succeeds (design §3.8 gateway best-effort retry).
+func TestForwardRetriesNetworkError(t *testing.T) {
+	var calls int
+	upSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			// Force a transport error: hijack and kill the connection.
+			if hj, ok := w.(http.Hijacker); ok {
+				conn, _, _ := hj.Hijack()
+				_ = conn.Close()
+				return
+			}
+		}
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"role":"assistant","content":"after retry"}}]}`)
+	}))
+	defer upSrv.Close()
+
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hi", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if got := respContent(t, out); got != "after retry" {
+		t.Fatalf("content = %q", got)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (first transport-failed, retried)", calls)
+	}
+}
+
+// TestHopByHopHeadersFiltered: connection-scoped headers from the upstream
+// must not leak to the client.
+func TestHopByHopHeadersFiltered(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`}
+	upSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("X-Upstream-Marker", "kept")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, up.plain)
+	}))
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, _ := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hi", false))
+	if resp.Header.Get("Connection") != "" {
+		t.Errorf("Connection header leaked: %q", resp.Header.Get("Connection"))
+	}
+	if resp.Header.Get("Keep-Alive") != "" {
+		t.Errorf("Keep-Alive header leaked: %q", resp.Header.Get("Keep-Alive"))
+	}
+	if resp.Header.Get("X-Upstream-Marker") != "kept" {
+		t.Errorf("end-to-end header dropped: %q", resp.Header.Get("X-Upstream-Marker"))
+	}
+}


### PR DESCRIPTION
## 概述

对上游已合入的 `gateway/` 实现（`feat/issue-133-gateway`，Issue #133）做从头到尾复审，修复 8 处 bug，全部带回归测试。

## 修复清单

| 严重度 | 问题 | 修复 |
|---|---|---|
| 高 | `rewriteOutgoing` 注入时用 `chatMessage{Role, Content}` 重建 messages，**丢弃 tool_calls / name / tool_call_id 字段**——带工具调用的对话在 L2 注入命中时被损坏，上游工具链断裂 | `chatMessage` 增加 `ToolCalls/Name/ToolCallID` 字段保留（`gateway/normalize.go`）；`contextHash` 指纹也随之更精确 |
| 高 | `config.expand()` 对 `ModelAlias` 取循环副本的地址，**`${VAR}` 替换永不生效** | 改为对切片元素直接取地址（`gateway/config.go`） |
| 中 | `cmd/semantix-gateway` 无信号处理：Ctrl+C 直接终止进程，`g.Close()`（等待异步写记忆）不执行；`srv.Shutdown(nil)` 传 nil context 有 panic 风险 | `signal.NotifyContext` + 10s 排水 `Shutdown` + 显式 `g.Close()`（`cmd/semantix-gateway/main.go`） |
| 中 | `streamThrough` 上游异常断流（未发 `[DONE]`）时客户端**永久挂起** | 逐行扫描 `[DONE]`，异常终止时补发（`gateway/pipeline.go`） |
| 中 | `passthrough` 透传上游全部 header，含 hop-by-hop（`Connection`/`Keep-Alive`/`Transfer-Encoding`/`Upgrade`） | 按 RFC 9110 §7.6.1 过滤（`gateway/pipeline.go`） |
| 低 | `SEMANTIX_GATEWAY_DISABLE=0`/`false` 也禁用缓存（`!= ""` 判断） | 解析 `1/true/yes/on`（`gateway/gateway.go`） |
| 低 | `attachBlock` 注入到**第一个** system 消息 | 改为**最后一个**（设计 §3.6 "system 提示末尾"） |
| 低 | `forward` 无重试 | 按设计 §3.8 补一次网络错误重试 |

## 测试

新增 8 个回归测试（`gateway/review_test.go` + `config_test.go`）：
- 工具调用字段经注入保留（tool_calls/tool_call_id/name 断言）
- `model_alias` 中 `${VAR}` 替换生效
- 异常流补 `[DONE]`、`DISABLE=0` 不禁用、多 system 注入位置、网络错误重试、hop-by-hop 过滤

`go test -count=1 ./...` 全绿（18 包），`go vet` 干净。`-race` 由 CI 覆盖。
