### PR TITLE
feat(usage): count injected slice hits + iconize text output (U28, Issue #152)

### DIFF
--- a/cmd/semantix/usage.go
+++ b/cmd/semantix/usage.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"semantix/kernel/evolve"
 	"semantix/kernel/usage"
@@ -21,6 +22,7 @@ type usageJSON struct {
 	CacheHitTokens int64   `json:"cache_hit_tokens"`
 	L3Reuses       int     `json:"l3_reuses"`
 	InjectedTokens int64   `json:"injected_tokens"`
+	SliceHits      int     `json:"slice_hits"`
 	CostPaidUSD    float64 `json:"cost_paid_usd"`
 	CostNoCacheUSD float64 `json:"cost_no_cache_usd"`
 	SavingsUSD     float64 `json:"savings_usd"`
@@ -54,6 +56,7 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 		data := usageJSON{
 			Events: s.Events, TokensIn: s.TokensIn, TokensOut: s.TokensOut,
 			CacheHitTokens: s.CacheHitTokens, L3Reuses: s.L3Reuses, InjectedTokens: s.InjectedTokens,
+			SliceHits: s.SliceHits,
 			CostPaidUSD: s.CostPaidUSD, CostNoCacheUSD: s.CostNoCacheUSD,
 			SavingsUSD: s.SavingsUSD, SavingsRate: s.SavingsRate,
 		}
@@ -64,12 +67,22 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 		return 0
 	}
 
+	// Iconic summary for humans (Issue #152 / U28: vibe-coder readable).
+	savingsBar := barChart(s.SavingsRate, 10)
+	fmt.Fprintf(stdout, "💰 节省成本  %s  $%.6f\n", savingsBar, s.SavingsUSD)
+	fmt.Fprintf(stdout, "📈 节省率    %.1f%%\n", s.SavingsRate*100)
+	fmt.Fprintf(stdout, "🧠 L3 复用   %d\n", s.L3Reuses)
+	fmt.Fprintf(stdout, "📦 命中切片  %d\n", s.SliceHits)
+	fmt.Fprintln(stdout)
+
+	// Raw counters keep the machine-readable key\tvalue shape.
 	fmt.Fprintf(stdout, "events\t%d\n", s.Events)
 	fmt.Fprintf(stdout, "tokens_in\t%d\n", s.TokensIn)
 	fmt.Fprintf(stdout, "tokens_out\t%d\n", s.TokensOut)
 	fmt.Fprintf(stdout, "cache_hit_tokens\t%d\n", s.CacheHitTokens)
 	fmt.Fprintf(stdout, "l3_reuses\t%d\n", s.L3Reuses)
 	fmt.Fprintf(stdout, "injected_tokens\t%d\n", s.InjectedTokens)
+	fmt.Fprintf(stdout, "slice_hits\t%d\n", s.SliceHits)
 	fmt.Fprintf(stdout, "cost_paid_usd\t%.6f\n", s.CostPaidUSD)
 	fmt.Fprintf(stdout, "cost_no_cache_usd\t%.6f\n", s.CostNoCacheUSD)
 	fmt.Fprintf(stdout, "savings_usd\t%.6f\n", s.SavingsUSD)
@@ -130,4 +143,19 @@ func feedEvolve(dir string, s *usage.Summary, stdout io.Writer) error {
 type evolveState struct {
 	Params evolve.Params `json:"params"`
 	Epoch  uint64        `json:"epoch"`
+}
+
+// barChart renders an ASCII bar (█ filled, ░ empty) for a ratio in [0,1].
+func barChart(ratio float64, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	filled := int(ratio*float64(width) + 0.5)
+	return strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
 }

--- a/cmd/semantix/usage_test.go
+++ b/cmd/semantix/usage_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,7 +20,7 @@ func TestRunUsageSummary(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, e := range []usage.Event{
-		{Turn: 1, TokensIn: 1000, TokensOut: 200, CacheHitToken: 600},
+		{Turn: 1, TokensIn: 1000, TokensOut: 200, CacheHitToken: 600, SliceHits: 2},
 		{Turn: 2, TokensIn: 800, TokensOut: 150, L3Reuse: true},
 	} {
 		if err := r.Append(e); err != nil {
@@ -34,6 +35,8 @@ func TestRunUsageSummary(t *testing.T) {
 	for _, want := range []string{
 		"events\t2", "tokens_in\t1800", "cache_hit_tokens\t600",
 		"l3_reuses\t1", "savings_usd\t", "savings_rate\t",
+		// Iconic summary (Issue #152).
+		"💰 节省成本", "📈 节省率", "🧠 L3 复用", "📦 命中切片", "slice_hits\t2", "█",
 	} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("output missing %q:\n%s", want, s)
@@ -45,6 +48,41 @@ func TestRunUsageMissingDB(t *testing.T) {
 	var out bytes.Buffer
 	if code := runUsage([]string{"--db", filepath.Join(t.TempDir(), "nope.jsonl")}, &out, productionDependencies()); code != 1 {
 		t.Fatalf("missing db is a runtime/IO error, must exit 1, got %d", code)
+	}
+}
+
+// TestRunUsageJSON verifies --json emits a jq-parseable envelope whose data
+// appends the new slice_hits field while keeping the older fields.
+func TestRunUsageJSON(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "usage.jsonl")
+	r, err := usage.NewRecorder(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Append(usage.Event{Turn: 1, TokensIn: 1000, TokensOut: 200, CacheHitToken: 600, SliceHits: 4}); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if code := runUsage([]string{"--db", logPath, "--json"}, &out, productionDependencies()); code != 0 {
+		t.Fatalf("usage --json exit code = %d, want 0", code)
+	}
+	var env struct {
+		OK      bool   `json:"ok"`
+		Command string `json:"command"`
+		Data    struct {
+			Events    int `json:"events"`
+			SliceHits int `json:"slice_hits"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("--json output not parseable: %v\n%s", err, out.String())
+	}
+	if !env.OK || env.Command != "usage" {
+		t.Fatalf("envelope = %+v", env)
+	}
+	if env.Data.SliceHits != 4 || env.Data.Events != 1 {
+		t.Fatalf("data = %+v, want slice_hits=4 events=1", env.Data)
 	}
 }
 

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"semantix/kernel/slice"
+	"semantix/kernel/usage"
 )
 
 // ---------------------------------------------------------------------------
@@ -196,6 +197,15 @@ func TestE2EL2InjectionForwarded(t *testing.T) {
 		ID: "l2-a", Type: slice.Prompt, Scope: slice.Project,
 		Content: []byte("prior knowledge about widgets"),
 	})
+	// Keep the target's BM25 score above the default absolute hit threshold.
+	// A single-document corpus scores too low and only produces an empty
+	// marker block, which is not an L2 slice hit.
+	for i, content := range []string{"alpha", "bravo", "charlie", "delta"} {
+		seed(t, g, &slice.Slice{
+			ID: fmt.Sprintf("distractor-%d", i), Type: slice.Prompt, Scope: slice.Project,
+			Content: []byte(content),
+		})
+	}
 
 	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "widgets", false))
 	if resp.StatusCode != http.StatusOK {
@@ -217,6 +227,13 @@ func TestE2EL2InjectionForwarded(t *testing.T) {
 	sys, _ := msgs[0]["content"].(string)
 	if msgs[0]["role"] != "system" || !strings.Contains(sys, "[semantix-reuse]") {
 		t.Errorf("injection block not prepended as system message: %#v", msgs[0])
+	}
+	summary, err := usage.Summarize(g.cfg.Ingest.UsageLog, usage.DefaultCostMissPerMTok, usage.DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.SliceHits != 1 {
+		t.Errorf("usage slice hits = %d, want 1", summary.SliceHits)
 	}
 }
 

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -62,12 +62,14 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 
 	// L2: inject reuse context, then forward (design §3.3 steps 4-5).
 	var injectedTokens int64
+	var sliceHits int
 	inj, ierr := g.injector.Build(query)
 	if ierr != nil {
 		log.Printf("gateway: inject: %v", ierr) // never blocks the main path
 	}
 	if inj != nil {
 		injectedTokens = int64(inj.Bytes / 4)
+		sliceHits = len(inj.Slices)
 	}
 	body = g.rewriteOutgoing(body, req, up, inj)
 
@@ -80,10 +82,10 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	defer resp.Body.Close()
 
 	if req.Stream {
-		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens)
+		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits)
 		return
 	}
-	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens)
+	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits)
 }
 
 // l3Eligible applies the gateway-side TTL window on top of the kernel
@@ -150,7 +152,7 @@ func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (
 // passthrough relays a non-streaming upstream response, records usage and
 // writes the session sidecar (request turns + assistant reply) — only for
 // successful exchanges, so failed requests never enter the reuse library.
-func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64) {
+func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
 	out, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		writeAPIError(w, http.StatusBadGateway, "upstream_error",
@@ -180,6 +182,7 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 		TokensIn:       int64(len(query)/4) + injectedTokens,
 		TokensOut:      int64(len(out) / 4),
 		InjectedTokens: injectedTokens,
+		SliceHits:      sliceHits,
 		At:             g.now().Unix(),
 	})
 }
@@ -188,7 +191,7 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 // preserving events verbatim (design §3.4: never reorder/rewrite the
 // upstream stream). Sidecar records the request turns only — parsing the
 // assistant content out of the SSE chunks is deferred (documented debt).
-func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64) {
+func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
 	if resp.StatusCode >= 400 {
 		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		writeAPIError(w, resp.StatusCode, "upstream_error",
@@ -219,6 +222,7 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 		SessionID:      sessionID,
 		TokensIn:       int64(len(query)/4) + injectedTokens,
 		InjectedTokens: injectedTokens,
+		SliceHits:      sliceHits,
 		At:             g.now().Unix(),
 	})
 }

--- a/kernel/usage/usage.go
+++ b/kernel/usage/usage.go
@@ -36,7 +36,11 @@ type Event struct {
 	L3Reuse bool `json:"l3_reuse,omitempty"`
 	// InjectedTokens is the L2 injection block size for this turn.
 	InjectedTokens int64 `json:"injected_tokens,omitempty"`
-	At             int64 `json:"at"` // unix seconds
+	// SliceHits is the number of semantic slices that hit and were injected
+	// this turn (L2 injected slice count). Omitted for older logs, which
+	// Summarize reads as 0.
+	SliceHits int `json:"slice_hits,omitempty"`
+	At        int64 `json:"at"` // unix seconds
 }
 
 // Recorder appends usage events to a JSONL file (0600, atomic rewrite via
@@ -84,6 +88,7 @@ type Summary struct {
 	CacheHitTokens  int64   // tokens served from the provider prefix cache
 	L3Reuses        int     // turns fully served by L3 reuse
 	InjectedTokens  int64   // total L2 injected tokens
+	SliceHits       int     // total slices hit and injected across turns
 	CostPaidUSD     float64 // what the user actually paid
 	CostNoCacheUSD  float64 // what it would cost without any cache
 	SavingsUSD      float64 // CostNoCache - CostPaid
@@ -121,6 +126,7 @@ func Summarize(path string, costMiss, costHit float64) (*Summary, error) {
 		s.TokensOut += e.TokensOut
 		s.CacheHitTokens += e.CacheHitToken
 		s.InjectedTokens += e.InjectedTokens
+		s.SliceHits += e.SliceHits
 		if e.L3Reuse {
 			s.L3Reuses++
 			l3In += e.TokensIn

--- a/kernel/usage/usage_test.go
+++ b/kernel/usage/usage_test.go
@@ -13,8 +13,8 @@ func TestRecorderAppendAndSummarize(t *testing.T) {
 		t.Fatal(err)
 	}
 	evs := []Event{
-		{SessionID: "s1", Turn: 1, TokensIn: 1000, TokensOut: 200, CacheHitToken: 600},
-		{SessionID: "s1", Turn: 2, TokensIn: 1200, TokensOut: 250, CacheHitToken: 1000, InjectedTokens: 300},
+		{SessionID: "s1", Turn: 1, TokensIn: 1000, TokensOut: 200, CacheHitToken: 600, SliceHits: 2},
+		{SessionID: "s1", Turn: 2, TokensIn: 1200, TokensOut: 250, CacheHitToken: 1000, InjectedTokens: 300, SliceHits: 3},
 		{SessionID: "s2", Turn: 1, TokensIn: 800, TokensOut: 150, L3Reuse: true},
 	}
 	for _, e := range evs {
@@ -37,6 +37,9 @@ func TestRecorderAppendAndSummarize(t *testing.T) {
 	}
 	if s.L3Reuses != 1 || s.InjectedTokens != 300 {
 		t.Fatalf("L3=%d injected=%d", s.L3Reuses, s.InjectedTokens)
+	}
+	if s.SliceHits != 5 {
+		t.Fatalf("slice hits = %d, want 5 (2+3)", s.SliceHits)
 	}
 	// Billed: in 3000-1600-800=600 miss + 1600 hit + out 600-150=450 miss.
 	// L3 turn (800 in + 150 out) excluded entirely.
@@ -73,6 +76,9 @@ func TestSummarizeToleratesBadLines(t *testing.T) {
 	}
 	if s.TokensIn != 500 {
 		t.Fatalf("tokens_in = %d, want 500", s.TokensIn)
+	}
+	if s.SliceHits != 0 {
+		t.Fatalf("slice_hits = %d, want 0 (older log without the field)", s.SliceHits)
 	}
 }
 


### PR DESCRIPTION
实现 Issue #152（U28）：usage 命中切片数统计 + 图标化输出。

## 内容

### kernel/usage
- `Event` 新增 `SliceHits int`（L2 注入的切片数，json `slice_hits,omitempty`，旧日志无该字段读为 0，向后兼容）
- `Summary` 新增 `SliceHits`，`Summarize` 逐行累加

### cmd/semantix usage
- `--json` 信封 data 只追加 `slice_hits` 字段（向后兼容，jq 可解析）
- 默认文本输出顶部图标化：💰 节省成本（█/░ ASCII 条形图 + 数值）、📈 节省率、🧠 L3 复用、📦 命中切片；下方保留原始 key<TAB>value 计数（含新 slice_hits），脚本友好

## 测试
- kernel/usage：SliceHits 汇总（2+3=5）+ 旧日志无字段向后兼容（=0）
- cmd/semantix：文本输出含 emoji + 条形图 + slice_hits；新增 TestRunUsageJSON 验证 --json 信封可 json.Unmarshal 且 slice_hits=4

## 验证
- go vet ./... 全绿
- go test -race ./kernel/usage/ ./cmd/semantix/ 全绿

Refs #152




## 审查修复
- gateway 将 `len(inj.Slices)` 接入非流式与流式 usage event，真实 L2 命中不再恒为 0
- gateway E2E 使用真实 BM25 命中并验证 usage log 汇总为 1
