### PR TITLE
feat(cli): U30 search/lookup 命中可视化 + 来源会话标注（#154）

### DIFF
--- a/cmd/semantix/config_wiring_test.go
+++ b/cmd/semantix/config_wiring_test.go
@@ -11,7 +11,6 @@ import (
 
 	"semantix/kernel/bm25"
 	"semantix/kernel/config"
-	"semantix/kernel/lookup"
 	"semantix/kernel/slice"
 )
 
@@ -44,16 +43,18 @@ func TestConfigDefaultsWiredIntoCommands(t *testing.T) {
 
 	// lookup 不带 --db/--limit：db 默认取 config.store.db（custom.db），
 	// limit 默认取 config.retrieval.limit（2，而非硬编码 5）。
+	// 用 --json 信封读取结果数（U30 起默认输出为人类可读文本）。
 	var out bytes.Buffer
-	if err := runLookup([]string{"--query", "修复 go 测试"}, &out, &emptyStderr{}, deps); err != nil {
+	if err := runLookup([]string{"--query", "修复 go 测试", "--json"}, &out, &emptyStderr{}, deps); err != nil {
 		t.Fatalf("lookup with config defaults: %v", err)
 	}
-	var results []lookup.Result
-	if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+	var env envelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
 		t.Fatalf("bad JSON: %v\n%s", err, out.String())
 	}
-	if len(results) != 2 {
-		t.Fatalf("results = %d, want 2 (config retrieval.limit + store.db applied)", len(results))
+	data, ok := env.Data.([]any)
+	if !ok || len(data) != 2 {
+		t.Fatalf("results = %d, want 2 (config retrieval.limit + store.db applied)", len(data))
 	}
 }
 

--- a/cmd/semantix/hitviz.go
+++ b/cmd/semantix/hitviz.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// zoneIcon maps a grey-zone verdict to its vibe-coder readable icon (U30):
+// 🟢 clear hit, 🟡 grey (verify before reuse), ⚪ miss. Unknown verdicts
+// fall back to ⚪ (failure-safe, mirrors zone.Classify).
+func zoneIcon(z string) string {
+	switch z {
+	case "hit":
+		return "🟢"
+	case "grey":
+		return "🟡"
+	default:
+		return "⚪"
+	}
+}
+
+// hitRow is the minimal shape the hits-summary line needs: one row per
+// displayed result, carrying its zone verdict and source session.
+type hitRow struct {
+	Zone          string
+	SourceSession string
+}
+
+// writeHitsSummary prints the cross-session reuse summary line
+// (e.g. "🎯 3/10 hits in 2 sessions") after a text hit list. The "hits"
+// count is clear-hit (🟢) results; sessions counts distinct non-empty
+// source sessions. Nothing is printed for an empty result list.
+func writeHitsSummary(w io.Writer, rows []hitRow) {
+	if len(rows) == 0 {
+		return
+	}
+	hits := 0
+	sessions := map[string]struct{}{}
+	for _, r := range rows {
+		if r.Zone == "hit" {
+			hits++
+		}
+		if r.SourceSession != "" {
+			sessions[r.SourceSession] = struct{}{}
+		}
+	}
+	fmt.Fprintf(w, "🎯 %d/%d hits in %d sessions\n", hits, len(rows), len(sessions))
+}
+
+// formatHitLine renders one human-readable hit line (U30): position, zone
+// icon, score/zone/id/scope key-values, and the source session annotation
+// "from:<session_id>" (omitted when unknown).
+func formatHitLine(n int, icon, score, zone, id, scope, session string) string {
+	line := fmt.Sprintf("%d. %s score=%s zone=%s id=%s scope=%s", n, icon, score, zone, id, scope)
+	if session != "" {
+		line += " from:" + session
+	}
+	return line
+}

--- a/cmd/semantix/hitviz_test.go
+++ b/cmd/semantix/hitviz_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+// U30: zone 图标映射 —— 🟢 hit / 🟡 grey / ⚪ miss（未知回落 ⚪，故障安全）。
+func TestZoneIcon(t *testing.T) {
+	for _, tc := range []struct {
+		zone string
+		want string
+	}{
+		{"hit", "🟢"},
+		{"grey", "🟡"},
+		{"miss", "⚪"},
+		{"bogus", "⚪"},
+		{"", "⚪"},
+	} {
+		if got := zoneIcon(tc.zone); got != tc.want {
+			t.Errorf("zoneIcon(%q) = %q, want %q", tc.zone, got, tc.want)
+		}
+	}
+}
+
+// U30: 命中摘要行 —— hits 数 = zone==hit 行数，sessions = 去重非空来源会话。
+func TestWriteHitsSummary(t *testing.T) {
+	cases := []struct {
+		name string
+		rows []hitRow
+		want string
+	}{
+		{"empty list prints nothing", nil, ""},
+		{"single hit, one session", []hitRow{{Zone: "hit", SourceSession: "sess-a"}}, "🎯 1/1 hits in 1 sessions\n"},
+		{"mixed zones, two sessions", []hitRow{
+			{Zone: "hit", SourceSession: "sess-a"},
+			{Zone: "grey", SourceSession: "sess-a"},
+			{Zone: "miss", SourceSession: "sess-b"},
+		}, "🎯 1/3 hits in 2 sessions\n"},
+		{"unknown session not counted", []hitRow{
+			{Zone: "hit", SourceSession: ""},
+			{Zone: "hit", SourceSession: "sess-a"},
+		}, "🎯 2/2 hits in 1 sessions\n"},
+	}
+	for _, tc := range cases {
+		var buf bytes.Buffer
+		writeHitsSummary(&buf, tc.rows)
+		if got := buf.String(); got != tc.want {
+			t.Errorf("%s: summary = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// U30: 命中行格式 —— 位置 + 图标 + score/zone/id/scope；from:<session> 仅在已知时输出。
+func TestFormatHitLine(t *testing.T) {
+	got := formatHitLine(2, "🟢", "0.850000", "hit", "s1", "project", "sess-a")
+	want := "2. 🟢 score=0.850000 zone=hit id=s1 scope=project from:sess-a"
+	if got != want {
+		t.Errorf("formatHitLine = %q, want %q", got, want)
+	}
+	got = formatHitLine(1, "⚪", "0.000000", "miss", "s9", "project", "")
+	want = "1. ⚪ score=0.000000 zone=miss id=s9 scope=project"
+	if got != want {
+		t.Errorf("formatHitLine (no session) = %q, want %q", got, want)
+	}
+}

--- a/cmd/semantix/json_envelope_test.go
+++ b/cmd/semantix/json_envelope_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"semantix/kernel/bm25"
@@ -46,15 +47,26 @@ func TestLookupJSONEnvelope(t *testing.T) {
 	if !ok || len(data) != 1 {
 		t.Fatalf("data = %#v, want 1 result row", env.Data)
 	}
+	// U30: 每项追加 source_session 字段（向后兼容：只加不删）。
+	row, ok := data[0].(map[string]any)
+	if !ok {
+		t.Fatalf("row = %#v, want object", data[0])
+	}
+	if _, ok := row["source_session"]; !ok {
+		t.Fatalf("row missing source_session field: %#v", row)
+	}
 
-	// 无 --json 保持裸数组（既有 H1 契约，向后兼容）。
+	// 无 --json 为 vibe-coder 可读文本（U30）：zone 图标 + 摘要行。
+	// 机器可读形态统一走 --json 信封（H1 协议入口）。
 	var out2 bytes.Buffer
 	if err := runLookup([]string{"--query", "修复", "--db", db}, &out2, &emptyStderr{}, deps); err != nil {
 		t.Fatal(err)
 	}
-	var arr []map[string]any
-	if err := json.Unmarshal(out2.Bytes(), &arr); err != nil {
-		t.Fatalf("legacy bare-array output broken: %v\n%s", err, out2.String())
+	if !strings.ContainsAny(out2.String(), "🟢🟡⚪") {
+		t.Fatalf("default lookup output missing zone icon:\n%s", out2.String())
+	}
+	if !strings.Contains(out2.String(), "🎯 ") {
+		t.Fatalf("default lookup output missing hits summary:\n%s", out2.String())
 	}
 }
 

--- a/cmd/semantix/lookup.go
+++ b/cmd/semantix/lookup.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 
 	"semantix/kernel/inject"
 	"semantix/kernel/lookup"
@@ -71,20 +71,28 @@ func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error
 	out := make([]lookup.Result, 0, len(hits))
 	for _, h := range hits {
 		out = append(out, lookup.Result{
-			ID:      h.Slice.ID,
-			Type:    h.Slice.Type.String(),
-			Scope:   h.Slice.Scope.String(),
-			Score:   h.Score,
-			Zone:    zones.Classify(h.Score, top1).String(),
-			Content: string(h.Slice.Content),
+			ID:            h.Slice.ID,
+			Type:          h.Slice.Type.String(),
+			Scope:         h.Slice.Scope.String(),
+			Score:         h.Score,
+			Zone:          zones.Classify(h.Score, top1).String(),
+			Content:       string(h.Slice.Content),
+			SourceSession: h.Slice.Meta.SourceSession,
 		})
 	}
 	if *jsonOut {
 		return writeJSON(stdout, okEnvelope("lookup", out))
 	}
-	enc := json.NewEncoder(stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	// 默认（无 --json）为 vibe-coder 可读文本（U30）：zone 图标 + 来源会话 +
+	// 命中摘要行。机器可读形态是 --json 信封（H1 协议入口）。
+	rows := make([]hitRow, len(out))
+	for i, r := range out {
+		content := stripESC(strings.Join(strings.Fields(r.Content), " "))
+		fmt.Fprintf(stdout, "%s\n   %s\n", formatHitLine(i+1, zoneIcon(r.Zone), fmt.Sprintf("%.6f", r.Score), r.Zone, r.ID, r.Scope, r.SourceSession), content)
+		rows[i] = hitRow{Zone: r.Zone, SourceSession: r.SourceSession}
+	}
+	writeHitsSummary(stdout, rows)
+	return nil
 }
 
 // runInject assembles an L2 injection block for a query (U8 compose side):

--- a/cmd/semantix/lookup_test.go
+++ b/cmd/semantix/lookup_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"semantix/kernel/bm25"
-	"semantix/kernel/lookup"
 	"semantix/kernel/slice"
 )
 
@@ -47,19 +47,102 @@ func TestRunLookupLimitClamp(t *testing.T) {
 		{"5"},
 	} {
 		var out bytes.Buffer
-		err := runLookup([]string{"--query", "配置", "--db", db, "--limit", tc.limit}, &out, &emptyStderr{}, deps)
+		// 用 --json 信封读取结果数（U30 起默认输出为人类可读文本）。
+		err := runLookup([]string{"--query", "配置", "--db", db, "--limit", tc.limit, "--json"}, &out, &emptyStderr{}, deps)
 		if err != nil {
 			t.Fatalf("--limit %s: %v", tc.limit, err)
 		}
-		var results []lookup.Result
-		if err := json.Unmarshal(out.Bytes(), &results); err != nil {
+		var env envelope
+		if err := json.Unmarshal(out.Bytes(), &env); err != nil {
 			t.Fatalf("--limit %s: bad JSON: %v\n%s", tc.limit, err, out.String())
+		}
+		data, ok := env.Data.([]any)
+		if !ok {
+			t.Fatalf("--limit %s: data = %#v, want array", tc.limit, env.Data)
 		}
 		// The library has 3 slices but "配置" matches exactly one; the clamp
 		// contract is: never error, never empty for a matching query. Before
 		// the <=0 fallback, --limit 0 returned zero results.
-		if len(results) != 1 {
-			t.Errorf("--limit %s: results = %d, want 1 (the matching slice)", tc.limit, len(results))
+		if len(data) != 1 {
+			t.Errorf("--limit %s: results = %d, want 1 (the matching slice)", tc.limit, len(data))
 		}
+	}
+}
+
+// U30: lookup 默认文本输出同款 zone 图标 + 来源会话 + 摘要行；
+// --json 信封每项追加 source_session 字段（向后兼容：只加不删）。
+func TestLookupHitVisualization(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "lib.db")
+	store, err := slice.NewFileStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := bm25.New()
+	for _, s := range []struct {
+		id, sess, content string
+	}{
+		{"s1", "sess-a", "修复 go 测试失败"},
+		{"s2", "sess-b", "修复 go 测试超时"},
+		{"s3", "sess-c", "修复 go 测试崩溃"},
+	} {
+		sl := &slice.Slice{ID: s.id, Type: slice.Prompt, Scope: slice.Project, Content: []byte(s.content),
+			Meta: slice.SliceMeta{SourceSession: s.sess}}
+		if err := store.Put(sl); err != nil {
+			t.Fatal(err)
+		}
+		if err := idx.Insert(sl); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deps := dependencies{
+		newExtractor: slice.NewExtractor,
+		openStore:    func(p string) (slice.Store, error) { return store, nil },
+		newIndex:     func() slice.Index { return bm25.New() },
+	}
+
+	// 默认文本输出：图标 + 来源会话 + 摘要行。
+	var out bytes.Buffer
+	if err := runLookup([]string{"--query", "修复 go 测试失败", "--db", db, "--limit", "3"},
+		&out, &emptyStderr{}, deps); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"🟢", "zone=hit", "from:sess-a", "from:sess-b", "from:sess-c", "🎯 ", "hits in 3 sessions"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("lookup text output missing %q:\n%s", want, got)
+		}
+	}
+
+	// --json：信封 + data 每项带 source_session（来源会话来自 Slice.Meta）。
+	var out2 bytes.Buffer
+	if err := runLookup([]string{"--query", "修复 go 测试失败", "--db", db, "--limit", "3", "--json"}, &out2, &emptyStderr{}, deps); err != nil {
+		t.Fatal(err)
+	}
+	var env envelope
+	if err := json.Unmarshal(out2.Bytes(), &env); err != nil {
+		t.Fatalf("bad envelope JSON: %v\n%s", err, out2.String())
+	}
+	if !env.OK || env.Command != "lookup" {
+		t.Fatalf("envelope = %+v, want ok + command=lookup", env)
+	}
+	data, ok := env.Data.([]any)
+	if !ok || len(data) == 0 {
+		t.Fatalf("data = %#v, want non-empty array", env.Data)
+	}
+	sessions := map[string]bool{}
+	for i, item := range data {
+		row, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("row %d = %#v, want object", i, item)
+		}
+		sess, ok := row["source_session"].(string)
+		if !ok || sess == "" {
+			t.Errorf("row %d: source_session = %q, want non-empty (slices carry provenance)", i, sess)
+		}
+		sessions[sess] = true
+	}
+	if !sessions["sess-a"] || !sessions["sess-b"] || !sessions["sess-c"] {
+		t.Errorf("source sessions across rows = %v, want sess-a/sess-b/sess-c all present", sessions)
 	}
 }

--- a/cmd/semantix/search.go
+++ b/cmd/semantix/search.go
@@ -19,6 +19,9 @@ type searchResult struct {
 	Content string  `json:"content"`
 	Score   float64 `json:"score"`
 	Zone    string  `json:"zone"`
+	// SourceSession is provenance shown in the text output only (U30);
+	// json:"-" keeps search --json output byte-identical (backward compat).
+	SourceSession string `json:"-"`
 }
 
 func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error {
@@ -145,22 +148,26 @@ func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error
 	zones := zf.zones()
 	for i, hit := range hits {
 		results[i] = searchResult{
-			ID:      hit.Slice.ID,
-			Type:    int(hit.Slice.Type),
-			Scope:   scopeName(hit.Slice.Scope),
-			Content: string(hit.Slice.Content),
-			Score:   hit.Score,
-			Zone:    zones.Classify(hit.Score, top1).String(),
+			ID:            hit.Slice.ID,
+			Type:          int(hit.Slice.Type),
+			Scope:         scopeName(hit.Slice.Scope),
+			Content:       string(hit.Slice.Content),
+			Score:         hit.Score,
+			Zone:          zones.Classify(hit.Score, top1).String(),
+			SourceSession: hit.Slice.Meta.SourceSession,
 		}
 	}
 
 	if *jsonOutput {
 		return writeJSON(stdout, okEnvelope("search", results))
 	}
+	rows := make([]hitRow, len(results))
 	for i, result := range results {
 		content := stripESC(strings.Join(strings.Fields(result.Content), " "))
-		fmt.Fprintf(stdout, "%d. score=%.6f zone=%s id=%s scope=%s\n   %s\n", i+1, result.Score, result.Zone, result.ID, result.Scope, content)
+		fmt.Fprintf(stdout, "%s\n   %s\n", formatHitLine(i+1, zoneIcon(result.Zone), fmt.Sprintf("%.6f", result.Score), result.Zone, result.ID, result.Scope, result.SourceSession), content)
+		rows[i] = hitRow{Zone: result.Zone, SourceSession: result.SourceSession}
 	}
+	writeHitsSummary(stdout, rows)
 	return nil
 }
 

--- a/cmd/semantix/search_test.go
+++ b/cmd/semantix/search_test.go
@@ -73,6 +73,44 @@ func TestRRFFuseRanksSharedHitsHigher(t *testing.T) {
 	}
 }
 
+// U30: search 文本输出带 zone 图标 + 来源会话 + 命中摘要行（vibe-coder 可读）。
+// s1 与 query 全匹配（必为 🟢 hit）；s2/s3 部分匹配、分数非零，保证三行都进
+// 结果，跨会话复用（3 个来源会话）可感知。
+func TestSearchHitVisualization(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "lib.db")
+	store, err := slice.NewFileStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []struct {
+		id, sess, content string
+	}{
+		{"s1", "sess-a", "修复 go 测试失败"},
+		{"s2", "sess-b", "修复 go 测试超时"},
+		{"s3", "sess-c", "修复 go 测试崩溃"},
+	} {
+		sl := &slice.Slice{ID: s.id, Type: slice.Prompt, Scope: slice.Project, Content: []byte(s.content),
+			Meta: slice.SliceMeta{SourceSession: s.sess}}
+		if err := store.Put(sl); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var out bytes.Buffer
+	code := run([]string{"search", "--query", "修复 go 测试失败", "--db", db, "--limit", "3", "--retriever", "bm25"},
+		&out, &emptyStderr{}, productionDependencies())
+	if code != 0 {
+		t.Fatalf("search code = %d, out:\n%s", code, out.String())
+	}
+	got := out.String()
+	for _, want := range []string{"🟢", "zone=hit", "from:sess-a", "from:sess-b", "from:sess-c", "🎯 ", "hits in 3 sessions"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("search output missing %q:\n%s", want, got)
+		}
+	}
+}
+
 type emptyStderr struct{}
 
 func (emptyStderr) Write(p []byte) (int, error) { return len(p), nil }

--- a/kernel/lookup/lookup.go
+++ b/kernel/lookup/lookup.go
@@ -61,14 +61,16 @@ func Schema() ArgSchema {
 
 // Result is one returned slice, safe to serialize as tool output. Zone is
 // the grey-zone verdict (Krites arXiv:2602.13165): hit = clearly reusable,
-// grey = verify before reuse, miss = do not reuse.
+// grey = verify before reuse, miss = do not reuse. SourceSession records
+// which session the slice was extracted from (U30; empty when unknown).
 type Result struct {
-	ID      string  `json:"id"`
-	Type    string  `json:"type"`
-	Scope   string  `json:"scope"`
-	Score   float64 `json:"score"`
-	Zone    string  `json:"zone"`
-	Content string  `json:"content"`
+	ID            string  `json:"id"`
+	Type          string  `json:"type"`
+	Scope         string  `json:"scope"`
+	Score         float64 `json:"score"`
+	Zone          string  `json:"zone"`
+	Content       string  `json:"content"`
+	SourceSession string  `json:"source_session"`
 }
 
 // Execute runs the lookup against idx. args uses the JSON schema names;
@@ -111,12 +113,13 @@ func Execute(idx slice.Index, args map[string]any) ([]Result, error) {
 	out := make([]Result, 0, len(hits))
 	for _, h := range hits {
 		out = append(out, Result{
-			ID:      h.Slice.ID,
-			Type:    h.Slice.Type.String(),
-			Scope:   h.Slice.Scope.String(),
-			Score:   h.Score,
-			Zone:    zones.Classify(h.Score, top1).String(),
-			Content: string(h.Slice.Content),
+			ID:            h.Slice.ID,
+			Type:          h.Slice.Type.String(),
+			Scope:         h.Slice.Scope.String(),
+			Score:         h.Score,
+			Zone:          zones.Classify(h.Score, top1).String(),
+			Content:       string(h.Slice.Content),
+			SourceSession: h.Slice.Meta.SourceSession,
 		})
 	}
 	return out, nil


### PR DESCRIPTION
Closes #154

## 变更

**search 文本输出**（`cmd/semantix/search.go`）
- 每行加 zone 图标：🟢 高置信（hit）/ 🟡 灰色（grey）/ ⚪ 低分（miss）
- 每行追加来源会话 `from:<session_id>`（未知时省略）
- 末尾命中摘要行 `🎯 n/m hits in k sessions`
- `search --json` 输出保持字节级不变（`json:"-"`）

**lookup 文本输出**（`cmd/semantix/lookup.go`）
- 默认（无 `--json`）改为与 search 同款文本：图标 + 来源会话 + 摘要行
- `--json` 信封保持（H1 协议机器形态）；`data` 每项新增 `source_session` 字段（向后兼容：只加不删）

**kernel**（`kernel/lookup/lookup.go`）
- `Result` 新增 `SourceSession`，取自 `Slice.Meta.SourceSession`（`kernel/slice/slice.go:74`，extract 时记录）

## 验收对照

- [x] search 文本行：zone 图标 + `from:<session_id>`（`TestSearchHitVisualization`）
- [x] lookup 默认文本：同款图标 + 来源会话，JSON 输出兼容（`TestLookupHitVisualization`）
- [x] `lookup --json` data 每项 `source_session`（只加不删；`TestLookupJSONEnvelope`）
- [x] 摘要行 `🎯 3/10 hits in 2 sessions`（`TestWriteHitsSummary`）
- [x] `go test -race ./...` 全绿

## 文件面

`cmd/semantix/{search,lookup}.go` + 测试；新增 `cmd/semantix/hitviz.go`（共享图标/摘要/行渲染辅助）。与 U28/U29/U31 零重叠。