### PR TITLE
feat(verify): iconize replay output with zone bar + gate verdict (U29, Issue #153)

### DIFF
--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -75,6 +75,23 @@ func zoneIcon(z zone.Zone) string {
 	}
 }
 
+// verifyBar renders an ASCII bar (█ filled, ░ empty) for a ratio in [0,1].
+// Kept local to verify so U29 stays file-disjoint from U28 (usage.go owns
+// its own barChart helper).
+func verifyBar(ratio float64, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	filled := int(ratio*float64(width) + 0.5)
+	return strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
+}
+
 // verifyExit maps the grey-zone alarm to the exit code contract (3 = gate).
 func verifyExit(greyTarget, greyRatio float64, strict bool) int {
 	if strict && greyTarget > 0 && greyRatio > greyTarget {
@@ -91,8 +108,11 @@ func verifyExit(greyTarget, greyRatio float64, strict bool) int {
 // (query → top-1 hit + score) for human relevance marking.
 //
 // Output columns (tab-separated, first line is a header):
-//   session turn score top1_content query
-// After marking each row ✅/❌, relevance rate = marked-correct / total.
+//   session turn score zone top1_content query
+// The zone cell is iconized (✅hit / 🟡grey / ❌miss) and the tail appends a
+// zone-distribution bar plus a gate verdict line. The verdict's relevance is
+// the AUTO-classified hit share (hit / replayed) — NOT the human-marked
+// relevance of #58, which requires offline labeling and is not computed here.
 // Target for M0-Gate: ≥70% of replayed turns find a "previously done similar"
 // top-1 hit.
 
@@ -374,6 +394,8 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 	relevance := 0.0
 	if replayed > 0 {
 		greyRatio = 100 * float64(zoneCount[int(zone.Grey)]) / float64(replayed)
+		// relevance is the auto-classified hit share (hit / replayed), not the
+		// human-marked relevance of #58 — see the runVerify doc comment.
 		relevance = float64(zoneCount[int(zone.Hit)]) / float64(replayed)
 	}
 	icon := verifyVerdict(relevance, greyRatio, *greyTarget)
@@ -400,9 +422,9 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 	// zone distribution bar (Issue #153 / U29).
 	if replayed > 0 {
 		fmt.Fprintf(stdout, "# zones: hit %s grey %s miss %s\n",
-			barChart(float64(zoneCount[int(zone.Hit)])/float64(replayed), 8),
-			barChart(float64(zoneCount[int(zone.Grey)])/float64(replayed), 8),
-			barChart(float64(zoneCount[int(zone.Miss)])/float64(replayed), 8))
+			verifyBar(float64(zoneCount[int(zone.Hit)])/float64(replayed), 8),
+			verifyBar(float64(zoneCount[int(zone.Grey)])/float64(replayed), 8),
+			verifyBar(float64(zoneCount[int(zone.Miss)])/float64(replayed), 8))
 	}
 	// gate verdict line (Issue #153 / U29).
 	switch icon {

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -43,9 +43,36 @@ type verifySummary struct {
 	ZonesMiss      int          `json:"zones_miss"`
 	GreyRatioPct   float64      `json:"grey_ratio_pct"`
 	GreyTargetPct  float64      `json:"grey_target_pct"`
+	RelevancePct   float64      `json:"relevance_pct"`
+	Icon           string       `json:"icon"`
 	WarnGrey       bool         `json:"warn_grey"`
 	Judge          *judge.Stats `json:"judge,omitempty"`
 	Rows           []verifyRow  `json:"rows"`
+}
+
+// verifyVerdict returns the one-line gate verdict icon (Issue #153 / U29):
+// "warn" when the grey-zone alarm fires, "fail" when relevance is under the
+// M0-Gate 70% bar, otherwise "pass".
+func verifyVerdict(relevance, greyRatio, greyTarget float64) string {
+	if greyTarget > 0 && greyRatio > greyTarget {
+		return "warn"
+	}
+	if relevance < 0.7 {
+		return "fail"
+	}
+	return "pass"
+}
+
+// zoneIcon prefixes a zone with a human-readable glyph for the replay table.
+func zoneIcon(z zone.Zone) string {
+	switch z {
+	case zone.Hit:
+		return "✅hit"
+	case zone.Grey:
+		return "🟡grey"
+	default:
+		return "❌miss"
+	}
 }
 
 // verifyExit maps the grey-zone alarm to the exit code contract (3 = gate).
@@ -339,20 +366,25 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 				})
 			} else {
 				fmt.Fprintf(stdout, "%s\t%d\t%.4f\t%s\t%s\t%s\n",
-					tabSafe(t.Session), t.Turn, score, z.String(), tabSafe(top1), tabSafe(t.Query))
+					tabSafe(t.Session), t.Turn, score, zoneIcon(z), tabSafe(top1), tabSafe(t.Query))
 			}
 		}
 	}
 	greyRatio := 0.0
+	relevance := 0.0
 	if replayed > 0 {
 		greyRatio = 100 * float64(zoneCount[int(zone.Grey)]) / float64(replayed)
+		relevance = float64(zoneCount[int(zone.Hit)]) / float64(replayed)
 	}
+	icon := verifyVerdict(relevance, greyRatio, *greyTarget)
 	if *jsonOut {
 		summary := verifySummary{
 			Sessions: len(files), TrainedTurns: trained, ReplaySessions: len(replay), ReplayedTurns: replayed,
 			ZonesHit: zoneCount[int(zone.Hit)], ZonesGrey: zoneCount[int(zone.Grey)], ZonesMiss: zoneCount[int(zone.Miss)],
-			GreyRatioPct: greyRatio, GreyTargetPct: *greyTarget, WarnGrey: *greyTarget > 0 && greyRatio > *greyTarget,
-			Rows: rows,
+			GreyRatioPct: greyRatio, GreyTargetPct: *greyTarget,
+			RelevancePct: relevance * 100, Icon: icon,
+			WarnGrey: *greyTarget > 0 && greyRatio > *greyTarget,
+			Rows:     rows,
 		}
 		if *judgeProtocol != "" {
 			summary.Judge = &jstats
@@ -365,6 +397,22 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 	}
 	fmt.Fprintf(stdout, "# done: %d replayed turns; zones hit=%d grey=%d miss=%d grey_ratio=%.1f%% (target %.1f%%)\n",
 		replayed, zoneCount[int(zone.Hit)], zoneCount[int(zone.Grey)], zoneCount[int(zone.Miss)], greyRatio, *greyTarget)
+	// zone distribution bar (Issue #153 / U29).
+	if replayed > 0 {
+		fmt.Fprintf(stdout, "# zones: hit %s grey %s miss %s\n",
+			barChart(float64(zoneCount[int(zone.Hit)])/float64(replayed), 8),
+			barChart(float64(zoneCount[int(zone.Grey)])/float64(replayed), 8),
+			barChart(float64(zoneCount[int(zone.Miss)])/float64(replayed), 8))
+	}
+	// gate verdict line (Issue #153 / U29).
+	switch icon {
+	case "pass":
+		fmt.Fprintf(stdout, "# ✅ PASS relevance=%.1f%% (≥70%%)\n", relevance*100)
+	case "fail":
+		fmt.Fprintf(stdout, "# ❌ FAIL relevance=%.1f%% (<70%%)\n", relevance*100)
+	default:
+		fmt.Fprintf(stdout, "# ⚠ WARN grey_ratio=%.1f%% exceeds target %.1f%%\n", greyRatio, *greyTarget)
+	}
 	if *judgeProtocol != "" {
 		fmt.Fprintf(stdout, "# judge: confirmed=%d rules_reject=%d fingerprint=%d judge_reject=%d judge_approved=%d waste=%d\n",
 			jstats.Confirmed, jstats.RulesReject, jstats.Fingerprint, jstats.JudgeReject, jstats.JudgeApproved,

--- a/cmd/semantix/verify_test.go
+++ b/cmd/semantix/verify_test.go
@@ -55,8 +55,8 @@ func TestVerifyReplayProducesEvaluationTable(t *testing.T) {
 		if len(cols) != 6 {
 			t.Fatalf("row %q: want 6 tab columns (session/turn/score/zone/top1/query), got %d", l, len(cols))
 		}
-		if cols[3] != "hit" && cols[3] != "grey" && cols[3] != "miss" {
-			t.Fatalf("row %q: zone column %q not a valid zone", l, cols[3])
+		if cols[3] != "✅hit" && cols[3] != "🟡grey" && cols[3] != "❌miss" {
+			t.Fatalf("row %q: zone column %q not an iconized zone", l, cols[3])
 		}
 	}
 	if rows != 2 {
@@ -76,6 +76,31 @@ func TestVerifyReplayProducesEvaluationTable(t *testing.T) {
 	}
 	if !foundScore {
 		t.Fatalf("replayed '修复 go 测试失败' turn did not get a scored top-1 hit:\n%s", out.String())
+	}
+}
+
+// TestVerifyIconicOutput verifies the Issue #153 / U29 human-readable output:
+// iconized zone cells, the zone distribution bar, and the gate verdict line.
+func TestVerifyIconicOutput(t *testing.T) {
+	dir := t.TempDir()
+	writeSession(t, dir, "s1.jsonl", []string{"修复 go 测试失败"})
+	writeSession(t, dir, "s2.jsonl", []string{"修复 go 测试失败"})
+
+	var out bytes.Buffer
+	db := filepath.Join(t.TempDir(), "v.db")
+	code := runVerify([]string{"--session", dir, "--db", db, "--holdout", "0.5"}, &out, productionDependencies())
+	if code != 0 {
+		t.Fatalf("runVerify = %d, want 0; out:\n%s", code, out.String())
+	}
+	s := out.String()
+	for _, want := range []string{
+		"✅hit",               // iconized zone cell
+		"# zones: hit",        // distribution bar line
+		"✅ PASS relevance=",  // gate verdict line
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("output missing %q:\n%s", want, s)
+		}
 	}
 }
 


### PR DESCRIPTION
实现 Issue #153（U29）：verify 回放结果图标化。

## 内容

### 回放表格
- 每行 zone 列加图标：✅hit / 🟡grey / ❌miss（表头不变，TSV 6 列结构保持）

### 结尾可视化
- zone 分布条形图：`# zones: hit ████████ grey █ miss ██`（Unicode 方块，零依赖）
- 门禁结论行醒目化：`# ✅ PASS relevance=78.6% (≥70%)` / `# ❌ FAIL relevance=62.0% (<70%)`；grey_ratio 超限时 `# ⚠ WARN`

### --json
- 信封 data 只追加 `relevance_pct` 与 `icon`（pass|fail|warn），向后兼容
- verdict 优先级：warn（grey_ratio 超限）> fail（relevance<70%）> pass

## 测试
- 更新 zone 单元格断言为图标化值
- 新增 TestVerifyIconicOutput 断言图标、条形图、PASS 结论行

## 验证
- go vet ./... 全绿
- go test -race ./cmd/semantix/ 全绿

Refs #153
