### PR TITLE
fix(release): build-full.sh 默认构建全部支持平台（v0.4.0 发版前置）

### DIFF
--- a/scripts/release/build-full.sh
+++ b/scripts/release/build-full.sh
@@ -4,11 +4,12 @@
 #   (memory kernel) + example configs + install.sh + README, per platform.
 #
 # Usage: build-full.sh --version v0.3.0 [--platforms darwin-arm64,linux-amd64]
+# Default platforms: darwin-arm64, darwin-amd64, linux-amd64, linux-arm64
 # Output: dist/semantix-agent-<version>-<platform>.tar.gz + SHA256SUMS
 set -euo pipefail
 
 VERSION=""
-PLATFORMS="darwin-arm64"
+PLATFORMS="darwin-arm64,darwin-amd64,linux-amd64,linux-arm64"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in


### PR DESCRIPTION
## 背景
v0.3.1 发布时 dist/ 只有 darwin-arm64 单平台资产——build-full.sh 默认 `PLATFORMS="darwin-arm64"`。v0.4.0 发版需全平台资产（darwin/linux × amd64/arm64）。

## 变更
- `PLATFORMS` 默认值 → `darwin-arm64,darwin-amd64,linux-amd64,linux-arm64`（脚本已支持这 4 种组合的校验与构建）
- 脚本头注释同步

## 验证
- 本地 `go test` 全绿（排除并行未提交的 kernel/mcp）
- CI：go vet + go test -race