### PR TITLE
fix(build): main 编译失败 — verify/hitviz zoneIcon 重复声明（U29 × U30）

### DIFF
--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -63,8 +63,10 @@ func verifyVerdict(relevance, greyRatio, greyTarget float64) string {
 	return "pass"
 }
 
-// zoneIcon prefixes a zone with a human-readable glyph for the replay table.
-func zoneIcon(z zone.Zone) string {
+// verifyZoneIcon prefixes a zone with a human-readable glyph for the replay
+// table. Named verifyZoneIcon (not zoneIcon) to stay clear of hitviz.go's
+// zoneIcon(string) — both live in package main (U29 × U30).
+func verifyZoneIcon(z zone.Zone) string {
 	switch z {
 	case zone.Hit:
 		return "✅hit"
@@ -386,7 +388,7 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 				})
 			} else {
 				fmt.Fprintf(stdout, "%s\t%d\t%.4f\t%s\t%s\t%s\n",
-					tabSafe(t.Session), t.Turn, score, zoneIcon(z), tabSafe(top1), tabSafe(t.Query))
+					tabSafe(t.Session), t.Turn, score, verifyZoneIcon(z), tabSafe(top1), tabSafe(t.Query))
 			}
 		}
 	}


### PR DESCRIPTION
## 问题

main 自 [#160](https://github.com/Gnosil/semantix/pull/160) 合入起**编译失败**：

```
cmd/semantix/verify.go:67:6: zoneIcon redeclared in this block
	cmd/semantix/hitviz.go:11:6: other declaration of zoneIcon
cmd/semantix/verify.go:389:50: cannot use z (variable of int type zone.Zone) as string value
```

#162（U29，`verify.go` 的 `zoneIcon(zone.Zone)`）与 #160（U30，`hitviz.go` 的 `zoneIcon(string)`）各自 CI 都绿——文件不相交、分别对旧 main 可编译——但两者都进 `package main` 后撞名。合并顺序 #162(10:02) → #160(10:05)，最后一个合入时没有针对新 base 的 CI 复跑。

## 修复

verify 侧改名 `zoneIcon` → `verifyZoneIcon`（与同文件 `verifyBar`/`verifyVerdict` 的 verify-local 命名一致），hitviz 的 `zoneIcon(string)` 保持不变（lookup/search 在用）。

## 验证

- `go build ./...` ✅（修复前在 main 上可复现上述报错）
- `go vet ./...` ✅
- `go test -race ./cmd/...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)