### PR TITLE
fix(cli): doctor --json 信封 version 与发布版本一致

### DIFF
--- a/cmd/semantix/doctor.go
+++ b/cmd/semantix/doctor.go
@@ -17,8 +17,9 @@ import (
 )
 
 // cliVersion is the semantix CLI release reported in the --json envelope
-// (docs/reports/cli-v2-architecture.md §4.2). Bump it with each release tag.
-const cliVersion = "0.3.1"
+// (docs/reports/cli-v2-architecture.md §4.2). It is injected at link time
+// via -ldflags "-X main.version=..." — keep in sync with `semantix version`.
+var cliVersion = version
 
 // doctorStatus is one health-check outcome.
 type doctorStatus string


### PR DESCRIPTION
## 背景
CLI 可用性检测（v0.4.0）发现：`semantix doctor --json` 信封顶层 `version` 为 **0.3.1**（doctor.go 硬编码 `const cliVersion = "0.3.1"`），而 `semantix version` 与其他命令的信封走 `-X main.version` 注入（v0.4.0）。同一二进制两个版本号，误导用户与 CI。

## 变更
- `doctor.go`: `const cliVersion = "0.3.1"` → `var cliVersion = version`（复用 ldflags 注入的包级 `version`）

## 验证
- `go build -ldflags "-X main.version=v0.4.0"` 后 `doctor --json` 与 `version --json` 信封 version 一致（均 v0.4.0）
- doctor/install/version 测试对 cliVersion 的断言在测试环境（version=dev）自洽，无需改