### PR TITLE
fix(cli): zoneIcon 同名冲突（main 编译不过，CI 红）

### DIFF
--- a/cmd/semantix/hitviz.go
+++ b/cmd/semantix/hitviz.go
@@ -5,10 +5,10 @@ import (
 	"io"
 )
 
-// zoneIcon maps a grey-zone verdict to its vibe-coder readable icon (U30):
+// verdictIcon maps a grey-zone verdict to its vibe-coder readable icon (U30):
 // 🟢 clear hit, 🟡 grey (verify before reuse), ⚪ miss. Unknown verdicts
 // fall back to ⚪ (failure-safe, mirrors zone.Classify).
-func zoneIcon(z string) string {
+func verdictIcon(z string) string {
 	switch z {
 	case "hit":
 		return "🟢"

--- a/cmd/semantix/hitviz_test.go
+++ b/cmd/semantix/hitviz_test.go
@@ -17,8 +17,8 @@ func TestZoneIcon(t *testing.T) {
 		{"bogus", "⚪"},
 		{"", "⚪"},
 	} {
-		if got := zoneIcon(tc.zone); got != tc.want {
-			t.Errorf("zoneIcon(%q) = %q, want %q", tc.zone, got, tc.want)
+		if got := verdictIcon(tc.zone); got != tc.want {
+			t.Errorf("verdictIcon(%q) = %q, want %q", tc.zone, got, tc.want)
 		}
 	}
 }

--- a/cmd/semantix/lookup.go
+++ b/cmd/semantix/lookup.go
@@ -88,7 +88,7 @@ func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error
 	rows := make([]hitRow, len(out))
 	for i, r := range out {
 		content := stripESC(strings.Join(strings.Fields(r.Content), " "))
-		fmt.Fprintf(stdout, "%s\n   %s\n", formatHitLine(i+1, zoneIcon(r.Zone), fmt.Sprintf("%.6f", r.Score), r.Zone, r.ID, r.Scope, r.SourceSession), content)
+		fmt.Fprintf(stdout, "%s\n   %s\n", formatHitLine(i+1, verdictIcon(r.Zone), fmt.Sprintf("%.6f", r.Score), r.Zone, r.ID, r.Scope, r.SourceSession), content)
 		rows[i] = hitRow{Zone: r.Zone, SourceSession: r.SourceSession}
 	}
 	writeHitsSummary(stdout, rows)

--- a/cmd/semantix/search.go
+++ b/cmd/semantix/search.go
@@ -164,7 +164,7 @@ func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error
 	rows := make([]hitRow, len(results))
 	for i, result := range results {
 		content := stripESC(strings.Join(strings.Fields(result.Content), " "))
-		fmt.Fprintf(stdout, "%s\n   %s\n", formatHitLine(i+1, zoneIcon(result.Zone), fmt.Sprintf("%.6f", result.Score), result.Zone, result.ID, result.Scope, result.SourceSession), content)
+		fmt.Fprintf(stdout, "%s\n   %s\n", formatHitLine(i+1, verdictIcon(result.Zone), fmt.Sprintf("%.6f", result.Score), result.Zone, result.ID, result.Scope, result.SourceSession), content)
 		rows[i] = hitRow{Zone: result.Zone, SourceSession: result.SourceSession}
 	}
 	writeHitsSummary(stdout, rows)


### PR DESCRIPTION
## 背景
PR #160（U30 hit-visualization）新增 `hitviz.go` 的 `zoneIcon(z string)`，与既有 `verify.go` 的 `zoneIcon(z zone.Zone)` 同名——Go 无重载，**main 当前编译不过**（任何 PR 的 CI 都会在 go vet 红）。

## 变更
- `hitviz.go`: U30 的 string 版 `zoneIcon` → `verdictIcon`（判定→emoji 映射，语义更准）
- 同步 `hitviz_test.go`、`lookup.go`、`search.go` 调用点
- `verify.go` 的 `zoneIcon(zone.Zone)` 保持不变（U29 verify 图标化）

## 验证
- `go build ./cmd/semantix/` + `go vet ./cmd/semantix/` 通过
- `go test ./cmd/semantix/ -run 'HitViz|ZoneIcon|Lookup|Search' ` 通过