### PR TITLE
docs: 中文项目介绍 README.zh-CN.md（双语切换）

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/Gnosil/semantix?style=flat-square\&logo=github)](https://github.com/Gnosil/semantix/graphs/contributors)
 [![Website](https://img.shields.io/badge/website-semantix.ensureok.ai-168b6d?style=flat-square)](https://semantix.ensureok.ai)
 
+**English** | [简体中文](./README.zh-CN.md)
+
 </div>
 
 <br/>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,257 @@
+<div align="center">
+
+# Semantix
+
+### 一个越用越懂你的自进化 Agent Kernel
+
+**语义缓存 · 自适应调度 · 投机预取 · 跨会话学习**
+
+[![License: FSL-1.1-MIT](https://img.shields.io/badge/License-FSL--1.1--MIT-blue.svg?style=flat-square)](./LICENSE)
+[![Status](https://img.shields.io/badge/status-v0.3.1-green?style=flat-square)](#项目状态)
+[![Version](https://img.shields.io/badge/release-0.3.1-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
+[![GitHub stars](https://img.shields.io/github/stars/Gnosil/semantix?style=flat-square\&logo=github)](https://github.com/Gnosil/semantix/stargazers)
+[![Website](https://img.shields.io/badge/website-semantix.ensureok.ai-168b6d?style=flat-square)](https://semantix.ensureok.ai)
+
+[English](./README.md) | **简体中文**
+
+</div>
+
+<br/>
+
+> **Agent 不应该每个会话都从零开始。**
+>
+> Semantix 架在 AI agent harness（如 DeepSeek-Reasonix、Claude Code 风格运行时）与其资源之间：它学习你复用什么、怎么干活、接下来可能需要什么——然后把这些知识变成语义缓存命中、更聪明的调度、安全的预取，和更低的 agent 执行成本。
+
+目标不只是省 token，而是：
+
+> **在保持甚至提升 agent 质量的前提下，避免不必要的计算。**
+
+---
+
+## 为什么需要 Semantix？
+
+现代 agent harness 已经很擅长管理单个长会话：维护上下文、调用工具、压缩历史、从失败中恢复、利用厂商的前缀缓存。但绝大多数优化都停在**会话边界**：
+
+- 新会话要重建项目上下文
+- 相似的工具调用被重复执行
+- 熟悉的指令被重新处理
+- 相同的文件被重新发现
+- 已经做过的工作被重新付费
+- 用户的历史工作模式被完全忽略
+
+```text
+传统 agent：
+
+会话 A ────────────X   上下文结束
+会话 B ────────────X   上下文重建
+会话 C ────────────X   相似工作重做
+
+Semantix：
+
+会话 A ───────┐
+会话 B ───────┼────► Semantix ────► 语义知识 / 行为模式 / 可复用结果
+会话 C ───────┘                          │
+                                         ▼
+                                   下一个会话更好
+```
+
+四个具体问题（详见 [docs/GEO.md](./docs/GEO.md)）：
+
+1. **字节级缓存是会话内、被动、静态的**——厂商前缀缓存靠字节完全一致命中，跨会话的语义相似任务无法复用
+2. **跨会话的相似工作每次从零开始**——同样的上下文重新读、同样的工具序列重新跑
+3. **调度是静态规则**——并发度、模型选择不会根据任务类型和用户习惯自适应
+4. **等待时间被浪费**——LLM 流式输出期间的数秒到数十秒墙钟时间空转
+
+---
+
+## 核心概念
+
+### 语义切片库（Semantic Slice Library）
+
+Semantix 从历史会话中提取可复用的语义单元（切片），持久化到本地库：
+
+| 切片 | 含义 | 用途 | 例子 |
+|---|---|---|---|
+| **P-Slice** | 任务模板 / 提示词模式 | L2 上下文注入 | `提交前先跑测试` |
+| **C-Slice** | 上下文知识 | L2 上下文注入 | 项目结构、构建命令 |
+| **T-Slice** | 工具调用模式 | 调度 / 预取 | `grep → readFile → editFile` |
+| **R-Slice** | 可复用结果 | L3 结果复用 | 重复的查询或解释 |
+| **M-Slice** | 记忆单元 | 检索 / 进化 | 用户或项目偏好 |
+
+切片不是永久的：按历史命中率、时效、意图相关度、用户反馈打分——低价值切片衰减，高价值切片更易检索。目标是让库**越来越准，而不是越来越大**。
+
+### 三级语义缓存
+
+```text
+┌────────────────────────────────────────┐
+│ L3 · 验证后结果复用                     │  只读任务带指纹验证直接复用，不调模型
+├────────────────────────────────────────┤
+│ L2 · 语义切片注入                       │  语义相似 → 稳定字节 → 喂养 L1
+├────────────────────────────────────────┤
+│ L1 · 厂商前缀 / 字节缓存                │  相同前缀字节的被动复用
+└────────────────────────────────────────┘
+```
+
+核心创新是「**语义层喂养字节层**」：两个会话的任务语义相似但字节不同（"跑一下 Go 测试" vs "确保 Go 测试全过"），普通前缀缓存视为无关；Semantix 检索出同一个规范切片、按固定顺序**原样注入**前缀区——语义命中就转化成了厂商字节缓存的真实命中。不改 harness，不依赖厂商新 API。
+
+配套机制：**冻结期**（参数变更后注入集 ≥1 小时不变，防止进化抖动摧毁自己喂养的字节缓存）、**污染检测**（注入内容被用户改掉/回滚会降权）、L3 **fail-closed**（验证不过不复用，正确性 > 命中率）。
+
+### 调度器与预取器
+
+- **内核调度器**（`kernel/sched`）：按任务 intent 联合决策工具并发分组、模型 tier、注入切片与预取目标，附带行为学习门
+- **投机预取器**（`kernel/prefetch`）：用 T-Slice 转移矩阵在 LLM 流式输出的等待期预取下一轮**只读**资源，waste/hit 比例自我惩罚
+- **自进化引擎**（`kernel/evolve`）：每轮采集命中/污染/延迟/成本信号，在线 EWMA 调参（带冻结期保护）+ 离线重训。参数不是人调的，是系统长出来的
+
+---
+
+## 复用可视化
+
+跨会话复用看得见——以下均为真实命令输出（演示库实录）：
+
+```text
+$ semantix dashboard
+
+  semantix dashboard — reuse snapshot
+  ------------------------------------------------
+
+  💰 Cost savings
+     paid        $ 0.0060
+     baseline    $ 0.0141
+     saved       $ 0.0080  (56.99%)
+     ██████████████░░░░░░░░░░
+
+  🎯 Cache hit rate (L3/L2)
+     4 / 5 turns  (80.00%)
+     L3 1 · L2 3
+     ███████████████████░░░░░
+
+  🗂 Zone distribution (library replay)
+     hit  ████ 4   grey ██████ 6   miss  0
+
+  📦 Slice library
+     10 slices · 3 cross-session sessions
+```
+
+检索命中带 zone 图标与来源会话标注：
+
+```text
+$ semantix search --query "fix failing go test"
+1. 🟢 score=4.331011 zone=hit id=619551c54af5437a scope=project from:2026-08-14-c9d4
+   fix failing go test after refactor
+2. 🟢 score=3.852740 zone=hit id=73b12bb117664106 scope=project from:2026-08-13-b7c2
+   fix failing go test in kernel slice extractor
+🎯 3/3 hits in 3 sessions
+```
+
+`verify` 回放门禁一眼可读（✅hit / 🟡grey / ❌miss + 分布条形 + 结论行）：
+
+```text
+# done: 4 replayed turns; zones hit=3 grey=0 miss=1 grey_ratio=0.0% (target 30.0%)
+# zones: hit ██████░░ grey ░░░░░░░░ miss ██░░░░░░
+# ✅ PASS relevance=75.0% (≥70%)
+```
+
+在合成回放对照实验中，跨会话复用节省了 **79.8%** 的成本（[docs/reports/m0-cost-comparison.md](./docs/reports/m0-cost-comparison.md)）。
+
+---
+
+## 快速上手
+
+### 安装
+
+**方式一：GitHub Release（推荐）**——[Releases](https://github.com/Gnosil/semantix/releases) 提供 6 平台二进制（macOS / Linux / Windows，amd64 + arm64），完整产品包含 reasonix（coding-agent harness）+ semantix（记忆内核）：
+
+```bash
+tar -xzf semantix-agent-<version>-<platform>.tar.gz
+cd semantix-agent-<version>-<platform>
+./semantix-install.sh   # 安装两个二进制 + 配置
+```
+
+**方式二：源码构建**（Go 1.26+）：
+
+```bash
+git clone https://github.com/Gnosil/semantix.git && cd semantix
+go build -o semantix ./cmd/semantix
+```
+
+### 30 秒体验
+
+```bash
+# 1. 从历史会话提取切片（Reasonix/Claude Code 风格 JSONL）
+semantix extract --input session.jsonl --db .semantix/project.db --project demo
+
+# 2. 语义检索（bm25 / vector / hybrid 三模式）
+semantix search --query "修复 go 测试失败" --db .semantix/project.db
+
+# 3. L2 注入块（会话 B 复用会话 A 的切片）
+semantix inject --query "修复 go 测试失败" --db .semantix/project.db
+
+# 4. 离线回放验证（门禁：命中率 ≥70%）
+semantix verify --session <会话目录> --project demo
+
+# 5. 一屏复用仪表盘
+semantix dashboard
+```
+
+### 接入你的 agent
+
+```bash
+semantix install --target claude-code   # 安装 agent skill 到 ~/.claude/skills/semantix/
+semantix install --target reasonix      # Reasonix fork 已内置集成
+```
+
+全部命令（`extract` / `search` / `verify` / `eval` / `eval-judge` / `usage` / `lookup` / `inject` / `doctor` / `install` / `completion` / `gc` / `export` / `import` / `dashboard` …）见 `semantix help`；CLI v2 起统一 `--json` 信封输出（`{ok, command, data, error, version}`），退出码契约统一（0 成功 / 1 运行错误 / 2 用法错误 / 3 门禁未达标）。详见 [docs/QUICKSTART.md](./docs/QUICKSTART.md)。
+
+另有 **Semantix Gateway**（`cmd/semantix-gateway`）：OpenAI 兼容网关，为任意支持自定义 base URL 的客户端透明加上跨会话复用层。
+
+---
+
+## 项目状态
+
+> **v0.3.1 已发布**，M2 CLI v2（命令树 / config / `--json` 信封 / completion / doctor / install / gc）已交付。规模化之前剩余的门槛是**真实数据的跨会话命中率验证**。
+
+| Agile | 里程碑 | 状态 |
+|---|---|---|
+| **1** | 首个可下载、可品牌化的 agent（v1.0） | 🚧 M0 ✅ · M1 接近完成（门禁 [#58](https://github.com/Gnosil/semantix/issues/58)）· CLI v2 ✅ · 复用可视化 CLI 侧 ✅ |
+| **2** | 自进化闭环——kernel 调配 harness 资源 | 🚧 kernel 侧 MVP 已落地（sched/prefetch/evolve）；harness 侧待接 |
+| **3** | 多 harness 生态 | ⏳ 路径已文档化，未开始 |
+
+技术阶段 P0（可观测）✅ · P1（切片库）🚧 · P2（语义缓存）🚧 · P3（调度）✅ MVP · P4（预取）✅ MVP · P5（进化）✅ MVP。完整路线图见 [docs/Agile路线图.md](./docs/Agile路线图.md)。
+
+### 参与验证（社区第一入口 👋）
+
+[Issue #58](https://github.com/Gnosil/semantix/issues/58) 是给每一位使用者的第一个任务，**不需要写代码**：下载 semantix → 用你自己的真实 agent 会话跑 `semantix verify` → 把命中率和 zone 分布贴回 issue。汇总结果将决定 M0-Gate 是否通过（≥70%）。
+
+---
+
+## 安全设计
+
+- 切片库文件权限 `0600`、目录 `0700`（原子写 + 防 symlink）
+- 所有输出经消毒：ANSI/C1 剥离、TSV 公式注入防护、注入块标记转义
+- L3 复用 fail-closed（指纹验证不过不复用）；缓存层故障 fail-open（不阻塞主循环）
+- 零第三方运行时依赖（单二进制，唯一外部依赖 bbolt）
+
+详见 [docs/Security-安全设计.md](./docs/Security-安全设计.md) 与 [SECURITY.md](./SECURITY.md)。
+
+---
+
+## 文档索引
+
+| 文档 | 内容 |
+|---|---|
+| [docs/QUICKSTART.md](./docs/QUICKSTART.md) | 安装、命令参考、shell 补全、配置 |
+| [docs/Agent-Infra-架构设计.md](./docs/Agent-Infra-架构设计.md) | 完整架构设计（问题、分层、组件、风险、指标） |
+| [docs/总体架构-流程树.md](./docs/总体架构-流程树.md) | 端到端流程树（含 mermaid） |
+| [docs/Agile路线图.md](./docs/Agile路线图.md) | Agile 1–3 路线图与 DoD |
+| [docs/GEO.md](./docs/GEO.md) / [GEO-guide.md](./docs/GEO-guide.md) | 面向 AI 引擎的项目语义档案与深度解读 |
+| [docs/Security-安全设计.md](./docs/Security-安全设计.md) | 威胁模型与安全机制 |
+
+官网：[semantix.ensureok.ai](https://semantix.ensureok.ai)
+
+---
+
+## 许可与致谢
+
+- 许可证：**FSL-1.1-MIT**（各版本发布两年后转为 MIT）
+- 设计基线：[DeepSeek-Reasonix](https://github.com/esengine/DeepSeek-Reasonix)（MIT）——算法参考其思路但按「参考不抄」原则独立实现，保留 attribution
+- 贡献：提 [issue](https://github.com/Gnosil/semantix/issues)、开 PR（分支命名 `feat/<unit>`，PR 需附 `go vet` + `go test -race` 全绿验证）


### PR DESCRIPTION
## 内容

新增根目录 [`README.zh-CN.md`](https://github.com/Gnosil/semantix/blob/docs/readme-zh/README.zh-CN.md)——不是英文 README 的逐行翻译，而是从 `docs/` 中文文档提炼的独立中文介绍：

- **定位与问题**：GEO.md 的一句话定义 + 四个具体问题（字节缓存会话内 / 跨会话从零开始 / 静态调度 / 等待浪费）
- **核心概念**：切片五类型表、三级缓存（含「语义层喂养字节层」核心创新 + 冻结期 / 污染检测 / fail-closed）、调度器 / 预取器 / 自进化引擎
- **复用可视化**：dashboard / search / verify 的**真实输出实录**（与 #164 英文版同源）
- **快速上手**：QUICKSTART 提炼（安装两方式 + 30 秒体验 + install 接入 + 退出码契约）
- **项目状态**：用当前真实进度（M0 ✅ / M1 门禁 #58 / M2 CLI v2 ✅ / U28-31 ✅），修正了 GEO.md 里过时的「M0 进行中」表述；**#58 社区第一入口**单独成段
- **安全设计 / 文档索引 / 许可**（FSL-1.1-MIT 两年转 MIT + Reasonix attribution）

英文 README 顶部加对称的语言切换行（`English | 简体中文`）。

## 验证

- 引用的全部 docs 路径逐一存在性校验 ✅
- site `npm run check` 全绿（lint / tsc / build / 35 内容测试）——README 改动无副作用 ✅
- 与 open PR #164 的 README 改动不同区域（顶部 badges vs 第 92 行起的 Reuse Visualization 段），任意顺序合并无冲突

## 备注

工作区里的 `kernel/mcp/` 等未跟踪文件是并行工作，未包含在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)