### PR TITLE
feat(cli): add responsive Semantix terminal intro

### DIFF
--- a/cmd/semantix/intro.go
+++ b/cmd/semantix/intro.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	semantixGreen = "\x1b[38;2;22;139;109m"
+	shadowGreen   = "\x1b[38;2;11;72;57m"
+	resetColor    = "\x1b[0m"
+	introVersion  = "v0.2.0"
+)
+
+var introGlyphs = map[rune][]string{
+	'S': {"11111", "10000", "10000", "11111", "00001", "00001", "11111"},
+	'E': {"11111", "10000", "10000", "11110", "10000", "10000", "11111"},
+	'M': {"10001", "11011", "10101", "10101", "10001", "10001", "10001"},
+	'A': {"01110", "10001", "10001", "11111", "10001", "10001", "10001"},
+	'N': {"10001", "11001", "10101", "10101", "10011", "10001", "10001"},
+	'T': {"11111", "00100", "00100", "00100", "00100", "00100", "00100"},
+	'I': {"11111", "00100", "00100", "00100", "00100", "00100", "11111"},
+	'X': {"10001", "10001", "01010", "00100", "01010", "10001", "10001"},
+}
+
+type introLayout struct {
+	block     string
+	letterGap string
+}
+
+var (
+	wideIntroLayout   = introLayout{block: "██", letterGap: "     "}
+	narrowIntroLayout = introLayout{block: "█", letterGap: "  "}
+	plainIntroLayout  = introLayout{}
+)
+
+func runIntro(args []string, stdout io.Writer) int {
+	fs := flag.NewFlagSet("intro", flag.ContinueOnError)
+	fs.SetOutput(stdout)
+	noAnimation := fs.Bool("no-animation", false, "render the final frame without animation")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	effects := supportsTerminalEffects(stdout)
+	color := effects && os.Getenv("NO_COLOR") == ""
+	columns, rows := terminalSize(stdout)
+	layout := introLayoutForSize(columns, rows)
+	if *noAnimation || !effects || layout.block == "" {
+		fmt.Fprint(stdout, renderIntroFrameWithLayout(1, color, layout))
+		return 0
+	}
+
+	const frameCount = 56
+	frames := make([]float64, frameCount)
+	for frame := range frames {
+		frames[frame] = float64(frame+1) / frameCount
+	}
+	renderIntroAnimation(stdout, frames, color, layout, 28*time.Millisecond)
+	return 0
+}
+
+func renderIntroAnimation(stdout io.Writer, frames []float64, color bool, layout introLayout, delay time.Duration) {
+	// Animate in the terminal's alternate screen buffer. Some terminals do not
+	// implement cursor save/restore consistently, especially after a long line
+	// wraps. The alternate buffer guarantees that every intermediate frame is
+	// discarded at once, then only the final wordmark enters normal scrollback.
+	fmt.Fprint(stdout, "\x1b[?1049h\x1b[?25l")
+	for _, progress := range frames {
+		fmt.Fprint(stdout, "\x1b[2J\x1b[H")
+		fmt.Fprint(stdout, renderIntroFrameWithLayout(progress, color, layout))
+		time.Sleep(delay)
+	}
+	fmt.Fprint(stdout, "\x1b[?25h\x1b[?1049l")
+	fmt.Fprint(stdout, renderIntroFrameWithLayout(1, color, layout))
+}
+
+func introLayoutForSize(columns, rows int) introLayout {
+	const (
+		safeMargin     = 2
+		minimumRows    = 13
+		letters        = len("SEMANTIX")
+		letterColumns  = letters * 5
+		letterGaps     = letters - 1
+		maximumSpacing = 6
+	)
+	if rows > 0 && rows < minimumRows {
+		return plainIntroLayout
+	}
+	if columns <= 0 {
+		return wideIntroLayout
+	}
+	available := columns - safeMargin
+	for blockWidth := 2; blockWidth >= 1; blockWidth-- {
+		remaining := available - letterColumns*blockWidth
+		if remaining < letterGaps {
+			continue
+		}
+		spacing := max(1, min(maximumSpacing, remaining/letterGaps)-1)
+		return introLayout{
+			block:     strings.Repeat("█", blockWidth),
+			letterGap: strings.Repeat(" ", spacing),
+		}
+	}
+	return plainIntroLayout
+}
+
+func introWidth(layout introLayout) int {
+	const letters = len("SEMANTIX")
+	return letters*5*utf8.RuneCountInString(layout.block) + (letters-1)*utf8.RuneCountInString(layout.letterGap)
+}
+
+func supportsTerminalEffects(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0 && os.Getenv("TERM") != "dumb"
+}
+
+func renderIntroFrame(progress float64, color bool) string {
+	return renderIntroFrameWithLayout(progress, color, wideIntroLayout)
+}
+
+func renderIntroFrameWithLayout(progress float64, color bool, layout introLayout) string {
+	const word = "SEMANTIX"
+	totalPixels := len(word) * 35
+	visiblePixels := int(progress * float64(totalPixels))
+	var out strings.Builder
+
+	if color {
+		out.WriteString(semantixGreen)
+	}
+	out.WriteString("╭──────────────────────────────╮\n")
+	out.WriteString("│ ")
+	if color {
+		out.WriteString(introStarColor(progress))
+	}
+	out.WriteString("✦")
+	if color {
+		out.WriteString(semantixGreen)
+	}
+	out.WriteString("  Semantix ")
+	out.WriteString(introVersion)
+	out.WriteString(strings.Repeat(" ", max(1, 17-len(introVersion))))
+	out.WriteString("│\n")
+	out.WriteString("╰──────────────────────────────╯")
+	if color {
+		out.WriteString(resetColor)
+	}
+	out.WriteString("\n\n")
+	if layout.block == "" {
+		if color {
+			out.WriteString(semantixGreen)
+		}
+		out.WriteString("SEMANTIX\n")
+		if color {
+			out.WriteString(resetColor)
+		}
+		return out.String()
+	}
+
+	for row := 0; row < 7; row++ {
+		for letterIndex, letter := range word {
+			glyph := introGlyphs[letter]
+			for column := 0; column < 5; column++ {
+				// Reveal each glyph from its top-left corner to its
+				// bottom-right corner, then continue into the next glyph.
+				// This creates the original diagonal sweep across the word.
+				pixelIndex := letterIndex*35 + row*5 + column
+				on := glyph[row][column] == '1'
+				visible := pixelIndex < visiblePixels
+				if on && visible {
+					if color && progress < 1 && pixelIndex+18 > visiblePixels {
+						out.WriteString(shadowGreen)
+					} else if color {
+						out.WriteString(semantixGreen)
+					}
+					out.WriteString(layout.block)
+				} else {
+					out.WriteString(strings.Repeat(" ", utf8.RuneCountInString(layout.block)))
+				}
+			}
+			if letterIndex < len(word)-1 {
+				out.WriteString(layout.letterGap)
+			}
+		}
+		if color {
+			out.WriteString(resetColor)
+		}
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+func introStarColor(progress float64) string {
+	// Two restrained pulses: one as the scan begins and one as it settles.
+	const pulseWidth = 0.22
+	strength := 0.0
+	if progress < pulseWidth {
+		strength = math.Sin(math.Pi * progress / pulseWidth)
+	} else if progress > 1-pulseWidth && progress < 1 {
+		strength = math.Sin(math.Pi * (progress - (1 - pulseWidth)) / pulseWidth)
+	}
+	base := [3]float64{22, 139, 109}
+	highlight := [3]float64{105, 255, 211}
+	r := int(base[0] + (highlight[0]-base[0])*strength)
+	g := int(base[1] + (highlight[1]-base[1])*strength)
+	b := int(base[2] + (highlight[2]-base[2])*strength)
+	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm", r, g, b)
+}

--- a/cmd/semantix/intro_test.go
+++ b/cmd/semantix/intro_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestIntroRendersStaticWordmarkForNonTerminalOutput(t *testing.T) {
+	var out bytes.Buffer
+	if code := runIntro(nil, &out); code != 0 {
+		t.Fatalf("runIntro() code = %d, want 0", code)
+	}
+	text := out.String()
+	if !strings.Contains(text, "Semantix v0.2.0") {
+		t.Fatalf("intro missing version: %q", text)
+	}
+	if strings.Contains(text, "\x1b[") {
+		t.Fatalf("non-terminal output contains ANSI escapes: %q", text)
+	}
+	if lines := strings.Count(text, "\n"); lines != 11 {
+		t.Fatalf("intro newline count = %d, want 11", lines)
+	}
+}
+
+func TestRunDispatchesIntro(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"intro", "--no-animation"}, &stdout, &stderr, dependencies{}); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Semantix v0.2.0") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestAnimationUsesDisposableAlternateScreen(t *testing.T) {
+	var out bytes.Buffer
+	frames := []float64{0.08, 1}
+	renderIntroAnimation(&out, frames, false, wideIntroLayout, 0)
+	text := out.String()
+	if !strings.Contains(text, "\x1b[?1049h") || !strings.Contains(text, "\x1b[?1049l") {
+		t.Fatalf("animation does not enter and leave alternate screen: %q", text)
+	}
+	if !strings.HasSuffix(text, renderIntroFrame(1, false)) {
+		t.Fatalf("normal scrollback does not end with one final frame: %q", text)
+	}
+}
+
+func TestIntroAdaptsContinuouslyToTerminalSize(t *testing.T) {
+	layout := introLayoutForSize(68, 19)
+	if got := introWidth(layout); got > 66 {
+		t.Fatalf("narrow intro width = %d, want <= 66", got)
+	}
+	if layout.block != narrowIntroLayout.block || layout.letterGap != narrowIntroLayout.letterGap {
+		t.Fatalf("68-column terminal selected layout %#v, want narrow layout %#v", layout, narrowIntroLayout)
+	}
+	if layout := introLayoutForSize(100, 20); utf8.RuneCountInString(layout.block) != 2 || len(layout.letterGap) != 1 {
+		t.Fatalf("100-column terminal selected layout %#v, want double blocks with 1-column gaps", layout)
+	}
+	if layout := introLayoutForSize(120, 20); len(layout.letterGap) != 4 {
+		t.Fatalf("120-column terminal selected gap %q, want 4 spaces", layout.letterGap)
+	}
+	if layout := introLayoutForSize(160, 20); layout.letterGap != wideIntroLayout.letterGap {
+		t.Fatalf("160-column terminal selected gap %q, want wide gap %q", layout.letterGap, wideIntroLayout.letterGap)
+	}
+	if layout := introLayoutForSize(40, 20); layout.block != "" {
+		t.Fatalf("40-column terminal selected block %q, want plain fallback", layout.block)
+	}
+	if layout := introLayoutForSize(100, 10); layout.block != "" {
+		t.Fatalf("10-row terminal selected block %q, want plain fallback", layout.block)
+	}
+}
+
+func TestAnimationSweepsFromTopLeftToBottomRight(t *testing.T) {
+	// 36 visible pixels completes S and reveals only the first pixel of E.
+	frame := renderIntroFrameWithLayout(36.0/280, false, narrowIntroLayout)
+	lines := strings.Split(frame, "\n")
+	wordmark := lines[4:11]
+
+	if !strings.Contains(wordmark[6], "█") {
+		t.Fatal("S did not finish before the sweep moved to E")
+	}
+	if !strings.Contains(wordmark[0], "█  █") {
+		t.Fatalf("sweep did not reach the top-left of E: %q", wordmark[0])
+	}
+	if blocks := strings.Count(wordmark[1], "█"); blocks != 1 {
+		t.Fatalf("E advanced downward before its top-left pixel: %q", wordmark[1])
+	}
+}
+
+func TestFinalFrameHasNoDarkScanTail(t *testing.T) {
+	frame := renderIntroFrameWithLayout(1, true, narrowIntroLayout)
+	if strings.Contains(frame, shadowGreen) {
+		t.Fatal("final frame retained the dark scan tail")
+	}
+}
+
+func TestStarPulseReturnsToBrandGreen(t *testing.T) {
+	if got := introStarColor(0.11); got == semantixGreen {
+		t.Fatal("star did not brighten during its opening pulse")
+	}
+	if got := introStarColor(1); got != semantixGreen {
+		t.Fatalf("final star color = %q, want brand green %q", got, semantixGreen)
+	}
+}

--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -234,6 +234,13 @@ func buildCommands() []commandSpec {
 			return runConfig(args, stdout, stderr)
 		},
 		completionFlags: []string{"--config", "--db", "--json"}},
+	{name: "intro", group: groupProduct,
+		usage:   "semantix intro [--no-animation]",
+		summary: "play the branded terminal startup animation",
+		run: func(args []string, stdout, stderr io.Writer, _ dependencies) int {
+			return runIntro(args, stdout)
+		},
+		completionFlags: []string{"--no-animation"}},
 	{name: "version", group: groupProduct,
 		usage:   "semantix version [--json]",
 		summary: "version + commit + build time",

--- a/cmd/semantix/terminal_width_other.go
+++ b/cmd/semantix/terminal_width_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package main
+
+import "io"
+
+func terminalSize(io.Writer) (columns, rows int) { return 0, 0 }

--- a/cmd/semantix/terminal_width_unix.go
+++ b/cmd/semantix/terminal_width_unix.go
@@ -1,0 +1,30 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+type terminalWindowSize struct {
+	rows    uint16
+	columns uint16
+	xpixel  uint16
+	ypixel  uint16
+}
+
+func terminalSize(w io.Writer) (columns, rows int) {
+	file, ok := w.(*os.File)
+	if !ok {
+		return 0, 0
+	}
+	var size terminalWindowSize
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, file.Fd(), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&size)))
+	if errno != 0 {
+		return 0, 0
+	}
+	return int(size.columns), int(size.rows)
+}


### PR DESCRIPTION
## What changed

- add a branded `SEMANTIX` pixel-wordmark intro in the official green
- add an explicit `semantix intro` command for previewing and future AI CLI startup integration
- animate through the terminal alternate screen so intermediate frames do not remain in scrollback
- adapt block size and letter spacing to the terminal dimensions
- support `--no-animation`, `NO_COLOR`, redirected output, and narrow-terminal fallbacks
- add tests for dispatch, terminal cleanup, responsive layout, diagonal reveal, final colors, and the title-star pulse

## Why

This prepares a reusable startup moment for the future Semantix AI CLI without changing the current CLI v2 no-argument contract. When the interactive AI CLI lands, it can invoke the intro immediately before entering its prompt loop.

## User impact

Users can run `semantix intro` now. Existing commands and the current no-argument help behavior remain unchanged. Redirected output receives a static, ANSI-free rendering, and motion can be disabled explicitly.

## Validation

- `go test ./...`
- manual checks in macOS Terminal at full and narrow window sizes
- verified the alternate-screen animation leaves only one final wordmark in normal scrollback