### PR TITLE
docs(specs): Agile 2 合体路线 spec（U37 先审后写）+ 路线图批次更新

### DIFF
--- a/docs/Agile路线图.md
+++ b/docs/Agile路线图.md
@@ -12,7 +12,9 @@
 - **U 编号**（GitHub issue 前缀，全仓库唯一）：
   - **M0 · U1-U10**（已全部完成）：kernel 骨架/切片/BM25/fork 适配/Gate
   - **M1 · U11-U18**（U11-U18 已实现，验收见各 issue）：真实数据/embedding/fork 闭环/evolve/L3/成本仪表。m0-gate 建议清单里的 U19/U20（灰色地带、LLM judge）已作为 M1 一部分实现，**编号作废不再使用**
-  - **M2 · U19-U27**（2026-08-14 起，issue #113-#121）：CLI v2 产品化（命令树/config/--json/completion/doctor/install/gc/serve）
+  - **M2 · U19-U27**（2026-08-14 起，issue #113-#121）：CLI v2 产品化（命令树/config/--json/completion/doctor/install/gc/serve）——✅ 全部完成（含补强 U28-U36）
+  - **GW 编号**（网关线，先例 #133 M2-GW1）：Semantix Gateway（New API 套壳）独立编号，不占 U 序列
+  - **Agile 2 · U37-U43**（2026-08-17 起）：H2/H3/H5 资源编排批次，契约 spec 见 `docs/specs/h2h3-resource-orchestration.md`
 
 ---
 
@@ -55,7 +57,7 @@
 | H3 编排 | kernel/sched 落地：意图 → 资源分配指令下发 + 反馈闭环（观测 → 决策 → 执行 → 进化） |
 | H5 预取/进化 | kernel/prefetch（Planner + MatrixPrefetcher + Runner）+ evolve 接入编排闭环 |
 
-### 当前状态（2026-08-14 更新）
+### 当前状态（2026-08-17 更新）
 
 **kernel 侧 MVP 已随 M1-U18b 提前落地**（合入 main，commit d8b0558）：
 
@@ -63,7 +65,20 @@
 - ✅ `kernel/prefetch`（Planner 离线转置矩阵 / MatrixPrefetcher 在线 hit-waste 学习 / Runner 串行只读执行 + 结果落 Result 切片）
 - ✅ `kernel/evolve` MVP（独立已实现）
 
-**harness 侧未开工**：H2 ResourceLayer（工具挂起/恢复/预算配额）、H3 编排指令下发、evolve 闭环接线均未开始。
+**fork 侧已有一截**（U13c/#123，`patches/semantix-sched-prefetch.patch`）：sched 的**本地移植版**已接线
+（并行分组生效、tier 记录、注入预热）——但决策不经 kernel，不构成「kernel 调配 harness」。
+
+**真正缺口**（issue 批次 U37-U43，契约 spec `docs/specs/h2h3-resource-orchestration.md` 先审后写）：
+
+| U | 内容 | 阶段 |
+|---|---|---|
+| U37 | H2/H3 资源编排契约 spec 评审（ResourceCatalog 事件 + `sched decide --json` + RoundPlan 扩展） | 门禁 |
+| U38 | harness ToolRegistry 可调度化（SuspendTools 挂起/恢复执行点） | H2 |
+| U39 | harness BudgetController（阶梯降级）+ 资源目录上报 | H2 |
+| U40 | kernel `sched decide` CLI 面 + fork 改为先问 kernel 软降级本地 | H3 |
+| U41 | 调度演示 + 可量化收益报告（DoD 证据） | H3 |
+| U42 | prefetch 闭环接线（PrefetchHit/Waste 发射 + 等待期 Runner） | H5 |
+| U43 | evolve 闭环接线（EvolutionTick + 参数生效）+ 自进化曲线报告（DoD 证据） | H5 |
 
 ### 验收标准（蓝图 §5）
 
@@ -121,9 +136,15 @@
 
 | Agile | 目标 | 当前状态 | DoD 摘要 |
 |---|---|---|---|
-| 1 | 首个可下载品牌化 agent | M0 ✅ · M1 遗留 #58 · CLI v2 进行中 | v1.0 发布 + 命中率 ≥70% + 复用可视化 |
-| 2 | 自进化闭环（kernel 调配 harness） | 🚧 kernel 侧 MVP 已合入（M1-U18b：RuleDecider/Planner/MatrixPrefetcher/Runner）；harness 侧（H2/H3）未开工 | 调度演示 + 自进化曲线 |
-| 3 | 多 harness 生态 | 路径已文档化 | ≥3 harness 正式接入 |
+| 1 | 首个可下载品牌化 agent | M0 ✅ · M1 遗留 #58（唯一 P0 门禁）· CLI v2 ✅（U19-U36）· TUI 可视化 ✅（U33/#168）· 桌面端 #158 | v1.0 发布 + 命中率 ≥70% + 复用可视化 |
+| 2 | 自进化闭环（kernel 调配 harness） | 🚧 kernel 侧 MVP ✅（M1-U18b）· fork 侧本地移植 ✅（U13c）· 控制通道/预算/闭环未开工 → 批次 U37-U43 已建，spec 待审 | 调度演示 + 自进化曲线 |
+| 3 | 多 harness 生态 | 路径已文档化；serve/watch ✅（U27/U36） | ≥3 harness 正式接入 |
+
+**网关线（套壳，GW 编号，独立于 Agile 主线）**：GW1 ✅（#133，主干可运行、29 测试绿）。
+剩余按 `docs/specs/newapi-gateway-design.md` §0 对账（2026-08-15 回写）：流式响应侧写记忆（GW2，
+不修则真实流式流量不积累 L3）→ 部署产物 + healthz 探活（GW3）→ **§7 M0/M1 验收门实录**（GW4，
+真实全链路 + 二次命中 + 成本节省 ≥30%，「套壳完成」的定义性门槛）→ Anthropic 适配（GW5，Spec-Required）
+→ 配置键对账（GW6）/ 计量口径收尾（GW7）。
 
 ---
 

--- a/docs/Agile路线图.md
+++ b/docs/Agile路线图.md
@@ -65,20 +65,25 @@
 - ✅ `kernel/prefetch`（Planner 离线转置矩阵 / MatrixPrefetcher 在线 hit-waste 学习 / Runner 串行只读执行 + 结果落 Result 切片）
 - ✅ `kernel/evolve` MVP（独立已实现）
 
-**fork 侧已有一截**（U13c/#123，`patches/semantix-sched-prefetch.patch`）：sched 的**本地移植版**已接线
-（并行分组生效、tier 记录、注入预热）——但决策不经 kernel，不构成「kernel 调配 harness」。
+**战略决策（2026-08-17，Song）**：停止在 DeepSeek-Reasonix fork 仓库改动。Reasonix agent 系统
+**vendor 进本仓 `harness/`**（MIT + attribution），在集成分支 `harness-integration` 上与 kernel
+**进程内**结合，换 Semantix Design 视觉。`patches/` 模式废弃（U13c 成果作迁移对照表）。
+这是蓝图 §6「停止跟随上游」风险项的正式落地；#158 桌面端随之重定位到本仓（等 U38 后续作）。
 
-**真正缺口**（issue 批次 U37-U43，契约 spec `docs/specs/h2h3-resource-orchestration.md` 先审后写）：
+**fork 侧已验证的能力**（U13c/#123，`patches/semantix-sched-prefetch.patch`）：sched 本地移植、
+并行分组、注入预热——按 spec §5 迁移进 `harness/`，移植副本删除（`kernel/sched` 成唯一实现）。
+
+**issue 批次 U37-U43**（合体路线，契约 spec `docs/specs/h2h3-resource-orchestration.md` 先审后写）：
 
 | U | 内容 | 阶段 |
 |---|---|---|
-| U37 | H2/H3 资源编排契约 spec 评审（ResourceCatalog 事件 + `sched decide --json` + RoundPlan 扩展） | 门禁 |
-| U38 | harness ToolRegistry 可调度化（SuspendTools 挂起/恢复执行点） | H2 |
-| U39 | harness BudgetController（阶梯降级）+ 资源目录上报 | H2 |
-| U40 | kernel `sched decide` CLI 面 + fork 改为先问 kernel 软降级本地 | H3 |
-| U41 | 调度演示 + 可量化收益报告（DoD 证据） | H3 |
-| U42 | prefetch 闭环接线（PrefetchHit/Waste 发射 + 等待期 Runner） | H5 |
-| U43 | evolve 闭环接线（EvolutionTick + 参数生效）+ 自进化曲线报告（DoD 证据） | H5 |
+| U37 | Harness 合体 + 资源编排契约 spec 评审（C0 vendor 方案 + ResourceCatalog + RoundPlan 扩展） | 门禁 |
+| U38 | C0：vendor Reasonix agent 系统进 `harness/`（模块改写 + 构建 + 冒烟） | 合体 |
+| U39 | C5：Semantix Design 视觉基线（主题 token + U33 复用面板迁移进程内化） | H4 |
+| U40 | C1/C2：kernel 进程内接线（Decider 直连 + ResourceCatalog + SuspendTools 执行点） | H2/H3 |
+| U41 | C3：BudgetController 阶梯降级（70/90/100 三阈值） | H2 |
+| U42 | 调度演示 + 可量化收益报告（DoD 证据） | H3 |
+| U43 | C4：prefetch/evolve 闭环接线 + 自进化曲线报告（DoD 证据） | H5 |
 
 ### 验收标准（蓝图 §5）
 
@@ -137,7 +142,7 @@
 | Agile | 目标 | 当前状态 | DoD 摘要 |
 |---|---|---|---|
 | 1 | 首个可下载品牌化 agent | M0 ✅ · M1 遗留 #58（唯一 P0 门禁）· CLI v2 ✅（U19-U36）· TUI 可视化 ✅（U33/#168）· 桌面端 #158 | v1.0 发布 + 命中率 ≥70% + 复用可视化 |
-| 2 | 自进化闭环（kernel 调配 harness） | 🚧 kernel 侧 MVP ✅（M1-U18b）· fork 侧本地移植 ✅（U13c）· 控制通道/预算/闭环未开工 → 批次 U37-U43 已建，spec 待审 | 调度演示 + 自进化曲线 |
+| 2 | 自进化闭环（kernel 调配 harness） | 🚧 kernel 侧 MVP ✅（M1-U18b）· 2026-08-17 转合体路线（harness vendor 进本仓，集成分支 `harness-integration`）→ 批次 U37-U43 已建，spec 待审 | 调度演示 + 自进化曲线 |
 | 3 | 多 harness 生态 | 路径已文档化；serve/watch ✅（U27/U36） | ≥3 harness 正式接入 |
 
 **网关线（套壳，GW 编号，独立于 Agile 主线）**：GW1 ✅（#133，主干可运行、29 测试绿）。

--- a/docs/specs/h2h3-resource-orchestration.md
+++ b/docs/specs/h2h3-resource-orchestration.md
@@ -1,0 +1,138 @@
+# Spec：H2/H3 资源编排契约（Agile 2 · U37）
+
+> 对应 Issue：U37（Agile 2 批次，见 `docs/Agile路线图.md` §2）
+> 真源约束：`kernel/sched/sched.go`（`RoundInput` / `ToolCallInfo` / `RoundPlan` / `Decider`，接口已冻结于 U1）、
+> `kernel/event/event.go`（12 种 Kind + `KindCount` 哨兵）、`patches/semantix-sched-prefetch.patch`（U13c 已接线现状）；
+> 架构基线：`docs/reports/harness-refactor-blueprint.md` §3（资源目录 / 控制通道 / 闭环反馈）、
+> `docs/Agent-Infra-架构设计.md` §5（调度决策输出）。
+>
+> **状态（2026-08-17）**：v1 草案，**先审后写**——本文档获批准前，U38-U43 不开工实现。
+> 判级：Spec-Required（wire 契约扩展 + 跨仓库改动，同时命中两条）。
+
+## 1. 背景与缺口
+
+Agile 2 验收三条（路线图 §2）：① 工具可挂起/恢复 + 预算配额生效（H2）；② 调度演示：kernel 决策改变
+harness 行为 + 可量化收益（H3）；③ 命中率/成本随使用提升曲线（H5）。
+
+U13c（#123）之后的真实现状，与蓝图的差距：
+
+| 能力 | 现状 | 缺口 |
+|---|---|---|
+| 观测上行 | ✅ 事件旁路（`internal/semantix/sink.go` 镜像 12 种事件） | 无资源目录——kernel 看不到 harness 有哪些工具/模型/预算 |
+| 调度决策 | ⚠️ fork 侧 `internal/semantix/sched.go` 是 `RuleDecider` 的**本地移植**，并行分组/tier 已生效 | 决策不经 kernel——不构成「kernel 调配 harness」，规则升级要两仓同步 |
+| 工具挂起/恢复 | ❌ | `RoundPlan` 无挂起语义；fork 侧无执行点 |
+| 预算配额 | ❌ | 配置有 `[semantix] budget` 键，无 Controller 强制执行 |
+| prefetch/evolve 闭环 | ⚠️ kernel 包已实现（U18/U18b） | `PrefetchHit`/`PrefetchWaste`/`EvolutionTick` 无人发射，参数更新不生效 |
+
+## 2. 范围
+
+**范围内**（本 spec 定义的契约）：
+
+- C1 资源目录上报（上行，新增 event Kind）
+- C2 调度指令通道（下行，`semantix sched decide --json` CLI 面 + `RoundPlan` 字段扩展）
+- C3 预算配额模型（fork 侧 BudgetController 行为语义）
+- C4 反馈闭环最小集（PrefetchHit/Waste + EvolutionTick 的发射点）
+
+**不在范围内**：serve/unix-socket 传输面（U27 已落地，作为 Agile 3 升级路径，本期一律 CLI 子进程）；
+会话级调度（蓝图 §6 決策：先工具级）；`kernel/sched.Decider` 接口签名变更（冻结，只加 `RoundPlan` 字段）；
+H4 UI（#158 并行）。
+
+## 3. C1 资源目录上报（上行）
+
+新增 event Kind（追加在 `EvolutionTick` 之后、`KindCount` 之前，保持既有序号不变——
+`ingest.JSONLSource` 按 int 反序列化，追加式演进不破坏旧会话文件）：
+
+```go
+// ResourceCatalog reports the harness resource inventory (tools/models/budget).
+ResourceCatalog
+
+type ResourceCatalogPayload struct {
+    Tools  []ResourceTool  `json:"tools"`  // name, readOnly, suspended
+    Models []ResourceModel `json:"models"` // id, tier ("flash"|"pro"), inputPrice, outputPrice
+    Budget ResourceBudget  `json:"budget"` // limitUSD, spentUSD, window ("session"|"day")
+}
+```
+
+发射时机：harness 启动后一次全量 + 目录变化时（工具注册/挂起状态变化）增量重发全量（幂等，
+kernel 以最新一条为准）。fork 侧落点：`internal/semantix/bridge.go` 聚合，boot 时发射。
+
+## 4. C2 调度指令通道（下行）
+
+### 4.1 传输面
+
+沿用 U13c 的既有模式（CLI 子进程 + JSON + 超时软降级），新增子命令：
+
+```
+echo '<RoundInput JSON>' | semantix sched decide --json
+→ stdout: {"ok":true,"data":<RoundPlan JSON>}   （--json 统一信封，U22 契约）
+```
+
+fork 侧 `internal/semantix/sched.go` 改为：**先问 kernel（3s 超时），失败/超时软降级回本地移植版**
+（fail-open 三铁律，与 inject/lookup 一致）。本地移植版从「权威实现」降级为「降级兜底」，
+消除两仓规则漂移。
+
+### 4.2 `RoundPlan` 字段扩展（契约演进，需批准）
+
+```go
+type RoundPlan struct {
+    ParallelGroups [][]string
+    Tier           string
+    InjectIDs      []string
+    PrefetchIDs    []string
+    // 新增（Go 加字段向后兼容，JSON 旧消费者忽略未知键）：
+    SuspendTools   []string `json:"suspendTools,omitempty"`   // 本轮起挂起的工具名；恢复 = 不再出现
+    MaxParallel    int      `json:"maxParallel,omitempty"`    // 0 = 不限（沿用 harness 配置）
+    BudgetAction   string   `json:"budgetAction,omitempty"`   // "" | "degrade_tier" | "halt_prefetch" | "hard_stop"
+}
+```
+
+挂起语义：`SuspendTools` 是**声明式全量**（每轮下发当前应挂起集合），不是增量指令——
+harness 无需维护指令历史，重启后由下一轮决策自然恢复。
+
+### 4.3 fork 侧执行点
+
+| 指令 | 执行点（Reasonix fork） |
+|---|---|
+| `ParallelGroups`/`MaxParallel` | `internal/agent/execute_batch.go`（U13c 已有，扩 MaxParallel 上限） |
+| `SuspendTools` | `executeBatch` 前过滤：被挂起工具的调用立即返回 tool error「suspended by scheduler」 |
+| `Tier` | `internal/agent/run_loop.go` `handleToolRound`（U13c 已记录，本期真正切模型） |
+| `BudgetAction` | BudgetController（§5） |
+
+## 5. C3 预算配额（BudgetController）
+
+fork 侧新增 `internal/semantix/budget.go`：从 `[semantix] budget` 读 `limitUSD`，
+以 `Usage` 事件累计 `spentUSD`。**阶梯降级**（正确性 > 缓存 > 并发 > 预取，架构 §5.1 优先级的反向裁剪）：
+
+| 阈值 | 行为 |
+|---|---|
+| ≥ 70% | `halt_prefetch`：停止预取（赌博先停） |
+| ≥ 90% | `degrade_tier`：强制 flash |
+| ≥ 100% | `hard_stop`：拒绝新工具轮，向用户显式报错（不静默） |
+
+预算状态随 C1 目录上报回流 kernel；kernel `RuleDecider` 读到后可在 `BudgetAction` 提前下发
+（kernel 决策优先，harness 本地阈值为兜底——两层同规则，谁先触发谁生效）。
+
+## 6. C4 反馈闭环最小集
+
+- `PrefetchHit`/`PrefetchWaste`：发射点在 fork 侧 `startInjectWarm` 结果消费处
+  （预热的注入块被本轮请求使用 = Hit，被丢弃/过期 = Waste）；payload 既有定义不变。
+- `EvolutionTick`：`kernel/evolve` 在参数更新时发射（发射代码在 kernel 侧，随 ingest 落库）；
+  本期参数生效面**只限** `RuleDecider` 的行为门阈值与 prefetch 信号源权重（架构 §6.2 在线层），
+  离线重训不在本期。
+
+## 7. 验收（对应 Agile 2 DoD）
+
+- [ ] `semantix sched decide --json`：golden 用例（输入 RoundInput → 输出含 SuspendTools/BudgetAction 的 RoundPlan）
+- [ ] fork 真实会话：kernel 下发挂起某工具 → 该工具调用被拒；恢复后可用（H2 门①）
+- [ ] 预算演示：压到 70%/90%/100% 三阈值，行为逐级降级且用户可见（H2 门①）
+- [ ] 调度演示报告：同一任务 kernel 决策 on/off 对比（延迟/成本/并发度量化），落 `docs/reports/`（H3 门②）
+- [ ] PrefetchHit/Waste 与 EvolutionTick 在真实会话 JSONL 中出现且 `semantix search` 可检索（H5 前置）
+- [ ] 两仓测试全绿：semantix `go test ./... -race`；fork `go build ./...` + patch 套用验证
+
+## 8. 风险
+
+- **wire 契约一旦发出即绑死下游**：Kind 只追加不重排；RoundPlan 只加 omitempty 字段；`--json` 信封不动。
+- **fork patch 冲突面**：改动集中 `internal/semantix/` + 4 个 agent 文件（U13c 同一批文件），
+  patch 更新走 `patches/` 惯例（U13c 先例）。
+- **子进程延迟**：每工具轮一次 decide 调用（3s 超时兜底）；若实测延迟不可接受，
+  升级路径是 serve 常驻（U27 已落地），契约不变只换传输。

--- a/docs/specs/h2h3-resource-orchestration.md
+++ b/docs/specs/h2h3-resource-orchestration.md
@@ -1,46 +1,89 @@
-# Spec：H2/H3 资源编排契约（Agile 2 · U37）
+# Spec：Harness 合体 + 资源编排契约（Agile 2 · U37）
 
 > 对应 Issue：U37（Agile 2 批次，见 `docs/Agile路线图.md` §2）
-> 真源约束：`kernel/sched/sched.go`（`RoundInput` / `ToolCallInfo` / `RoundPlan` / `Decider`，接口已冻结于 U1）、
-> `kernel/event/event.go`（12 种 Kind + `KindCount` 哨兵）、`patches/semantix-sched-prefetch.patch`（U13c 已接线现状）；
-> 架构基线：`docs/reports/harness-refactor-blueprint.md` §3（资源目录 / 控制通道 / 闭环反馈）、
-> `docs/Agent-Infra-架构设计.md` §5（调度决策输出）。
+> 真源约束：`kernel/sched/sched.go`（`RoundInput` / `ToolCallInfo` / `RoundPlan` / `Decider`，接口冻结于 U1）、
+> `kernel/event/event.go`（12 种 Kind + `KindCount` 哨兵）、`patches/semantix-sched-prefetch.patch`（U13c 成果，本期作迁移素材）；
+> 架构基线：`docs/reports/harness-refactor-blueprint.md` §3/§4/§6、`docs/Agent-Infra-架构设计.md` §5。
 >
 > **状态（2026-08-17）**：v1 草案，**先审后写**——本文档获批准前，U38-U43 不开工实现。
-> 判级：Spec-Required（wire 契约扩展 + 跨仓库改动，同时命中两条）。
+> 判级：Spec-Required（新顶层目录/包结构 + 事件契约扩展 + 新配置面，多条命中）。
+
+## 0. 战略决策（2026-08-17，Song）
+
+**停止在 DeepSeek-Reasonix fork 仓库上改动。** Reasonix 的 agent 系统（主循环/工具/TUI 骨架）
+直接**复用进 semantix 仓**（MIT 允许，保留 attribution），在 semantix 开长期集成分支，
+换上我们自己的视觉（Semantix Design，蓝图 §4），与 kernel **进程内**结合。
+
+这是蓝图 §6 风险项的正式落地（「fork 维护负担 → 评估后可能停止跟随上游，本项目自研方向已定」）。
+后果：
+
+- `patches/` 模式废弃（保留作历史与迁移素材，U13c 的接线成果按 §5 迁移）
+- 「跨仓库 wire 契约」降级为「单仓进程内接口」——控制通道不再需要 CLI 子进程与 3s 超时软降级
+- H4 视觉从「可并行的 UI 换肤」升级为集成分支的组成部分（#157 成果迁移、#158 重定位到本仓）
+- **集成分支**：`harness-integration`（从 main 切出；U38-U43 的实现 PR 全部以它为 base，
+  阶段验收后整体回合 main）
 
 ## 1. 背景与缺口
 
 Agile 2 验收三条（路线图 §2）：① 工具可挂起/恢复 + 预算配额生效（H2）；② 调度演示：kernel 决策改变
 harness 行为 + 可量化收益（H3）；③ 命中率/成本随使用提升曲线（H5）。
 
-U13c（#123）之后的真实现状，与蓝图的差距：
+现状与差距（U13c 已在 fork 验证过的能力按 §5 迁入本仓）：
 
 | 能力 | 现状 | 缺口 |
 |---|---|---|
-| 观测上行 | ✅ 事件旁路（`internal/semantix/sink.go` 镜像 12 种事件） | 无资源目录——kernel 看不到 harness 有哪些工具/模型/预算 |
-| 调度决策 | ⚠️ fork 侧 `internal/semantix/sched.go` 是 `RuleDecider` 的**本地移植**，并行分组/tier 已生效 | 决策不经 kernel——不构成「kernel 调配 harness」，规则升级要两仓同步 |
-| 工具挂起/恢复 | ❌ | `RoundPlan` 无挂起语义；fork 侧无执行点 |
-| 预算配额 | ❌ | 配置有 `[semantix] budget` 键，无 Controller 强制执行 |
-| prefetch/evolve 闭环 | ⚠️ kernel 包已实现（U18/U18b） | `PrefetchHit`/`PrefetchWaste`/`EvolutionTick` 无人发射，参数更新不生效 |
+| harness 代码 | 在 fork 仓（另一个 module） | 未进本仓：无 `harness/` 目录 |
+| 观测上行 | ✅ fork 侧 sink 镜像 12 种事件（U13c） | 迁移后改为进程内直发总线；资源目录缺失 |
+| 调度决策 | ⚠️ fork 侧 `internal/semantix/sched.go` 是 RuleDecider 的本地移植 | 迁移后直接 import `kernel/sched`，删除移植副本 |
+| 工具挂起/恢复 | ❌ | `RoundPlan` 无挂起语义；无执行点 |
+| 预算配额 | ❌ | 配置键存在，无 Controller 强制执行 |
+| prefetch/evolve 闭环 | ⚠️ kernel 包已实现（U18/U18b） | `PrefetchHit`/`PrefetchWaste`/`EvolutionTick` 无人发射，参数不生效 |
+| 视觉 | fork TUI 原样 + U33 复用面板（#168 已并入 fork） | Semantix Design（深色 + 语义绿 #2F967F）未落地 |
 
 ## 2. 范围
 
-**范围内**（本 spec 定义的契约）：
+**范围内**：
 
-- C1 资源目录上报（上行，新增 event Kind）
-- C2 调度指令通道（下行，`semantix sched decide --json` CLI 面 + `RoundPlan` 字段扩展）
-- C3 预算配额模型（fork 侧 BudgetController 行为语义）
-- C4 反馈闭环最小集（PrefetchHit/Waste + EvolutionTick 的发射点）
+- C0 Reasonix agent 系统 vendor 进本仓（目录/模块/构建/attribution）
+- C1 资源目录（进程内构造 + 新增 `ResourceCatalog` 事件 Kind 用于落盘观测）
+- C2 调度接线（harness 直接调用 `sched.Decider` + `RoundPlan` 字段扩展）
+- C3 预算配额模型（BudgetController 阶梯降级）
+- C4 反馈闭环最小集（PrefetchHit/Waste + EvolutionTick 发射点）
+- C5 视觉基线迁移（U33 复用面板 + Semantix Design 主题 token）
 
-**不在范围内**：serve/unix-socket 传输面（U27 已落地，作为 Agile 3 升级路径，本期一律 CLI 子进程）；
-会话级调度（蓝图 §6 決策：先工具级）；`kernel/sched.Decider` 接口签名变更（冻结，只加 `RoundPlan` 字段）；
-H4 UI（#158 并行）。
+**不在范围内**：桌面端 Wails 重画（#158，等 C0 落地后在本仓续作）；serve/JSON-RPC 对外协议
+（Agile 3）；会话级调度（蓝图 §6：先工具级）；`Decider` 接口签名变更（冻结，只加 `RoundPlan` 字段）；
+上游 Reasonix 的后续同步（正式脱钩）。
 
-## 3. C1 资源目录上报（上行）
+## 3. C0 Vendor 方案（新顶层目录）
 
-新增 event Kind（追加在 `EvolutionTick` 之后、`KindCount` 之前，保持既有序号不变——
-`ingest.JSONLSource` 按 int 反序列化，追加式演进不破坏旧会话文件）：
+```
+semantix/
+├── kernel/          # 既有，不动
+├── gateway/         # 既有，不动
+├── harness/         # 新增：Reasonix agent 系统落点（单 Go module 合并进本仓 module）
+│   ├── agent/       # 主循环（run_loop / execute_batch / turnruntime / sampling_request）
+│   ├── tool/        # 内置工具注册表
+│   ├── control/     # 单 Controller 多前端骨架（蓝图 §2.2「最大资产」）
+│   ├── tui/         # chatREPL/runAgent（bubbletea）→ Semantix Design 重画面
+│   ├── provider/    # DeepSeek 前缀缓存 provider
+│   └── ATTRIBUTION.md  # 上游 MIT 声明 + 脱钩 commit 记录
+└── cmd/semantix-agent/  # 新增：合体后的可执行入口（TUI 主力形态）
+```
+
+- **模块路径**：全部改写为 `semantix/harness/...`（进本仓 module，不留 `reasonix` module）；
+- **裁剪原则**：只搬 agent 系统运行必需（memory/skills/权限门控/事件流按需保留），
+  desktop/、ACP、serve 等前端本期不搬（#158 时再取）；搬运清单在 U38 实现 PR 中逐目录列出；
+- **fork 里的 semantix 桥**（`internal/semantix/`）**不搬**——它是跨进程时代的产物，
+  其职责由 §4 的进程内接线替代；U13c patch 中 agent 文件的改动点作为迁移对照表。
+
+## 4. C1/C2 编排契约（进程内）
+
+### 4.1 C1 资源目录
+
+harness 启动时与目录变化时（工具注册/挂起变化）构造全量目录，直发事件总线（幂等，以最新为准）。
+新增 event Kind（追加在 `EvolutionTick` 之后、`KindCount` 之前——`ingest.JSONLSource` 按 int
+反序列化，追加式演进不破坏旧会话文件）：
 
 ```go
 // ResourceCatalog reports the harness resource inventory (tools/models/budget).
@@ -53,25 +96,15 @@ type ResourceCatalogPayload struct {
 }
 ```
 
-发射时机：harness 启动后一次全量 + 目录变化时（工具注册/挂起状态变化）增量重发全量（幂等，
-kernel 以最新一条为准）。fork 侧落点：`internal/semantix/bridge.go` 聚合，boot 时发射。
+进程内已可直接读结构体，仍保留事件的原因：**落盘可观测**（会话 JSONL 回放）+ evolve 的信号源
++ 未来多 harness（Agile 3）时该 Kind 即外部上报契约。
 
-## 4. C2 调度指令通道（下行）
+### 4.2 C2 调度接线
 
-### 4.1 传输面
-
-沿用 U13c 的既有模式（CLI 子进程 + JSON + 超时软降级），新增子命令：
-
-```
-echo '<RoundInput JSON>' | semantix sched decide --json
-→ stdout: {"ok":true,"data":<RoundPlan JSON>}   （--json 统一信封，U22 契约）
-```
-
-fork 侧 `internal/semantix/sched.go` 改为：**先问 kernel（3s 超时），失败/超时软降级回本地移植版**
-（fail-open 三铁律，与 inject/lookup 一致）。本地移植版从「权威实现」降级为「降级兜底」，
-消除两仓规则漂移。
-
-### 4.2 `RoundPlan` 字段扩展（契约演进，需批准）
+- harness 每个工具轮直接调用 `sched.Decider.DecideRound`（默认注入 `RuleDecider`）；
+  错误时降级为静态 `ReadOnly()` 分组（fail-open 三铁律），不再有子进程与超时层；
+- 删除 fork 时代的本地移植副本（迁移后 `kernel/sched` 是唯一实现）；
+- `RoundPlan` 字段扩展（契约演进，需批准；Go 加字段向后兼容，JSON 旧消费者忽略未知键）：
 
 ```go
 type RoundPlan struct {
@@ -79,29 +112,30 @@ type RoundPlan struct {
     Tier           string
     InjectIDs      []string
     PrefetchIDs    []string
-    // 新增（Go 加字段向后兼容，JSON 旧消费者忽略未知键）：
-    SuspendTools   []string `json:"suspendTools,omitempty"`   // 本轮起挂起的工具名；恢复 = 不再出现
+    // 新增：
+    SuspendTools   []string `json:"suspendTools,omitempty"`   // 本轮应挂起的工具名（声明式全量）
     MaxParallel    int      `json:"maxParallel,omitempty"`    // 0 = 不限（沿用 harness 配置）
     BudgetAction   string   `json:"budgetAction,omitempty"`   // "" | "degrade_tier" | "halt_prefetch" | "hard_stop"
 }
 ```
 
 挂起语义：`SuspendTools` 是**声明式全量**（每轮下发当前应挂起集合），不是增量指令——
-harness 无需维护指令历史，重启后由下一轮决策自然恢复。
+harness 不维护指令历史，恢复 = 下一轮不在集合中。
 
-### 4.3 fork 侧执行点
+### 4.3 执行点（harness/ 内，对照 U13c patch 迁移）
 
-| 指令 | 执行点（Reasonix fork） |
+| 指令 | 执行点 |
 |---|---|
-| `ParallelGroups`/`MaxParallel` | `internal/agent/execute_batch.go`（U13c 已有，扩 MaxParallel 上限） |
-| `SuspendTools` | `executeBatch` 前过滤：被挂起工具的调用立即返回 tool error「suspended by scheduler」 |
-| `Tier` | `internal/agent/run_loop.go` `handleToolRound`（U13c 已记录，本期真正切模型） |
+| `ParallelGroups`/`MaxParallel` | `harness/agent/execute_batch.go`（U13c 已验证的替换点） |
+| `SuspendTools` | `executeBatch` 前过滤：被挂起工具立即返回 tool error「suspended by scheduler」 |
+| `Tier` | `harness/agent/run_loop.go` 工具轮末（U13c 记录 tier → 本期真正切模型） |
 | `BudgetAction` | BudgetController（§5） |
+| `InjectIDs`/预热 | `sampling_request.go` 注入块 + `startInjectWarm`（U13c 已验证，进程内化） |
 
 ## 5. C3 预算配额（BudgetController）
 
-fork 侧新增 `internal/semantix/budget.go`：从 `[semantix] budget` 读 `limitUSD`，
-以 `Usage` 事件累计 `spentUSD`。**阶梯降级**（正确性 > 缓存 > 并发 > 预取，架构 §5.1 优先级的反向裁剪）：
+`harness/agent/budget.go`：从配置读 `limitUSD`，以 `Usage` 事件累计 `spentUSD`。
+**阶梯降级**（正确性 > 缓存 > 并发 > 预取，架构 §5.1 优先级反向裁剪）：
 
 | 阈值 | 行为 |
 |---|---|
@@ -109,30 +143,39 @@ fork 侧新增 `internal/semantix/budget.go`：从 `[semantix] budget` 读 `limi
 | ≥ 90% | `degrade_tier`：强制 flash |
 | ≥ 100% | `hard_stop`：拒绝新工具轮，向用户显式报错（不静默） |
 
-预算状态随 C1 目录上报回流 kernel；kernel `RuleDecider` 读到后可在 `BudgetAction` 提前下发
-（kernel 决策优先，harness 本地阈值为兜底——两层同规则，谁先触发谁生效）。
+预算状态随 C1 目录进总线；`RuleDecider` 读到后可经 `BudgetAction` 提前下发
+（kernel 决策优先，harness 本地阈值兜底——两层同规则，谁先触发谁生效）。
 
 ## 6. C4 反馈闭环最小集
 
-- `PrefetchHit`/`PrefetchWaste`：发射点在 fork 侧 `startInjectWarm` 结果消费处
-  （预热的注入块被本轮请求使用 = Hit，被丢弃/过期 = Waste）；payload 既有定义不变。
-- `EvolutionTick`：`kernel/evolve` 在参数更新时发射（发射代码在 kernel 侧，随 ingest 落库）；
-  本期参数生效面**只限** `RuleDecider` 的行为门阈值与 prefetch 信号源权重（架构 §6.2 在线层），
-  离线重训不在本期。
+- `PrefetchHit`/`PrefetchWaste`：发射点在注入预热结果消费处（预热块被本轮请求使用 = Hit，
+  被丢弃/过期 = Waste）；payload 既有定义不变；
+- `EvolutionTick`：`kernel/evolve` 参数更新时发射；本期参数生效面**只限** RuleDecider 行为门阈值
+  与 prefetch 信号源权重（架构 §6.2 在线层），离线重训不在本期。
 
-## 7. 验收（对应 Agile 2 DoD）
+## 7. C5 视觉基线（Semantix Design 最小集）
 
-- [ ] `semantix sched decide --json`：golden 用例（输入 RoundInput → 输出含 SuspendTools/BudgetAction 的 RoundPlan）
-- [ ] fork 真实会话：kernel 下发挂起某工具 → 该工具调用被拒；恢复后可用（H2 门①）
+- 主题 token：深色基调 + 语义绿 `#2F967F`（蓝图 §4，与 landing page 一致）；
+- U33 复用面板（每 turn：📦 命中切片数 / 💰 节省成本 / 🗂 来源会话）从 fork 迁入 `harness/tui/`，
+  数据源从 CLI 子进程改为进程内直读；
+- 资源仪表（侧栏实时资源占用）**本期只留挂点不实现**（等 C1-C3 数据稳定后单独 issue）。
+
+## 8. 验收（对应 Agile 2 DoD）
+
+- [ ] `go build ./...` + `go test ./... -race` 单仓全绿（harness 并入后）
+- [ ] `cmd/semantix-agent` 真实会话跑通：注入/复用面板显示（C0+C5 冒烟）
+- [ ] 挂起演示：kernel 下发挂起某工具 → 调用被拒；恢复后可用（H2 门①）
 - [ ] 预算演示：压到 70%/90%/100% 三阈值，行为逐级降级且用户可见（H2 门①）
 - [ ] 调度演示报告：同一任务 kernel 决策 on/off 对比（延迟/成本/并发度量化），落 `docs/reports/`（H3 门②）
-- [ ] PrefetchHit/Waste 与 EvolutionTick 在真实会话 JSONL 中出现且 `semantix search` 可检索（H5 前置）
-- [ ] 两仓测试全绿：semantix `go test ./... -race`；fork `go build ./...` + patch 套用验证
+- [ ] PrefetchHit/Waste 与 EvolutionTick 出现在会话 JSONL 且 `semantix search` 可检索（H5 前置）
 
-## 8. 风险
+## 9. 风险
 
-- **wire 契约一旦发出即绑死下游**：Kind 只追加不重排；RoundPlan 只加 omitempty 字段；`--json` 信封不动。
-- **fork patch 冲突面**：改动集中 `internal/semantix/` + 4 个 agent 文件（U13c 同一批文件），
-  patch 更新走 `patches/` 惯例（U13c 先例）。
-- **子进程延迟**：每工具轮一次 decide 调用（3s 超时兜底）；若实测延迟不可接受，
-  升级路径是 serve 常驻（U27 已落地），契约不变只换传输。
+- **vendor 一次性成本**：模块路径改写 + 裁剪面判断失误会拖长 U38 → 对策：先最小可跑
+  （agent+tool+control+tui+provider），冒烟绿了再谈裁剪回补；
+- **wire 契约演进纪律不因进程内而放松**：事件 Kind 只追加不重排；`RoundPlan` 只加 omitempty 字段
+  ——会话 JSONL 是落盘契约，旧文件必须永远可回放；
+- **与上游脱钩**：Reasonix 后续修复不再自动获得 → `ATTRIBUTION.md` 记录脱钩 commit，
+  重大上游修复按需手工 cherry-pick；
+- **集成分支长期漂移**：`harness-integration` 与 main 的偏差随时间增大 → 每完成一个 U 即回合一次
+  main（小步合入，不攒大 PR）。


### PR DESCRIPTION
## 目的

启动 Agile 2 批次（路线图 §7 演进规则：开工前更新状态列 + 创建 issue 批次），并落实 Song 2026-08-17 战略决策：**停止在 DeepSeek-Reasonix fork 上改动，Reasonix agent 系统 vendor 进本仓，进程内结合 kernel，配 Semantix Design 视觉**。

## 内容

1. **新增 `docs/specs/h2h3-resource-orchestration.md`（U37，先审后写，Spec-Required）**：
   - §0 战略决策记录 + 集成分支 `harness-integration`（已从 main 开出）
   - C0 vendor 方案（`harness/` 目录结构、模块路径改写、裁剪原则、ATTRIBUTION）
   - C1 资源目录（新增 `ResourceCatalog` 事件 Kind，追加式演进）
   - C2 调度接线（harness 直调 `sched.Decider`，`RoundPlan` 加 `SuspendTools`/`MaxParallel`/`BudgetAction`）
   - C3 预算阶梯降级（70% 停预取 / 90% 降 tier / 100% 硬停）
   - C4 反馈闭环最小集（PrefetchHit/Waste + EvolutionTick 发射点）
   - C5 视觉基线（Semantix Design token + U33 面板迁移）
   - **批准本 spec 前 U38-U43 不开工。**
2. **路线图更新**：M2 全完成标注、GW 编号说明、合体路线决策注记、U37-U43 批次表、网关线对账状态。

## 配套 issue 批次（本 PR 推送后创建）

- 网关线 GW2-GW7：流式写记忆 → 部署产物 → §7 M0/M1 验收实录 → Anthropic 适配 → 配置键对账 → 计量口径
- Agile 2 线 U37-U43：spec 评审 → C0 vendor → 视觉基线 → 进程内编排 → 预算 → 调度演示 → 自进化闭环

## 备注

- 与 #175（网关 spec 对账回写）不冲突：本 PR 不动 `newapi-gateway-design.md`。
- #158（桌面端）目标仓库随决策变更为本仓，将在该 issue 评论说明；#157 已验收合入（#168 + acceptance report），建议关闭。
- SPEC-DRIVEN.md / 根 AGENTS.md 在 main 上尚不存在（08-15 已定制度）——若治理文件在某个未推送分支，请一并落仓。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
