### PR TITLE
docs(u40): 发版记录——v0.4.1 release notes 入库 + 路线图发布状态

### DIFF
--- a/docs/Agile路线图.md
+++ b/docs/Agile路线图.md
@@ -35,6 +35,8 @@
 
 - M0 ✅；M1 中 **#58 真实数据命中率 ≥70% 是唯一 P0 遗留门禁**（30 天窗口，`semantix verify` 回放）
 - v0.3.1 已发布（bundle + QUICKSTART + agent-skill + 官网）
+- v0.4.0 已发布（CLI v2 完整版：命令树 / config / --json 信封 / completion / doctor / install / gc / serve，4 平台资产）
+- v0.4.1 已发布（CLI 可用性修复：doctor --json 信封 version 与发布版本一致 #169 + zoneIcon 同名冲突修复 #172，4 平台资产，见 `docs/releases/v0.4.1.md`）
 - CLI v2（M2/U19-U27）是本 Agile 的补强，不阻塞 DoD
 
 ### DoD（完成定义）

--- a/docs/releases/v0.4.1.md
+++ b/docs/releases/v0.4.1.md
@@ -1,0 +1,29 @@
+# v0.4.1 — CLI 可用性修复版
+
+> 发版日期：2026-08-17 · 上游 tag：`v0.4.1` · 范围：CLI 层修复（#169、#172 已合入 main 后打包）
+
+## 修复
+
+- **doctor --json 信封 version 与发布版本一致**（#169）：信封顶层 version 不再硬编码 0.3.1，改用 `-X main.version` 注入，与 `semantix version --json` 保持一致（本版 v0.4.1）
+- **zoneIcon 同名冲突**（#172）：U30 hitviz 与 U29 verify 的 `zoneIcon` 重名导致 main 编译不过（Go 无重载）→ string 版改名 `verifyZoneIcon`，CI 恢复绿色
+
+## 变更摘要（v0.4.0 之后合入 main）
+
+- **U35**（#166/#171）：`semantix eval` / `eval-judge` 支持 `--json` 信封
+- **U32**（#156/#164）：复用可视化 — README 章节 + 首页终端 mockup
+- **U33**（#157/#168）：复用面板 — fork TUI 复用面板 + kernel `source_session`
+- **U36**（#167/#170）：serve/watch 触发条件评估 — 未触发，关闭 #167
+- 文档：README.zh-CN.md 中文介绍 + 双语切换（#173、#174）
+
+## 资产
+
+- semantix-agent-v0.4.1-darwin-arm64.tar.gz
+- semantix-agent-v0.4.1-darwin-amd64.tar.gz
+- semantix-agent-v0.4.1-linux-amd64.tar.gz
+- semantix-agent-v0.4.1-linux-arm64.tar.gz
+- SHA256SUMS.txt
+
+## 验证
+
+- `go build -ldflags "-X main.version=v0.4.1"` 后 `version --json` 与 `doctor --json` 信封一致（v0.4.1）
+- `scripts/release/build-full.sh --version v0.4.1` 产出 4 平台资产 + SHA256SUMS；抽查 tar 内含 reasonix + semantix + configs + install.sh


### PR DESCRIPTION
## 背景

Issue #179（U40 发版 v0.4.1）。发版记录入库走 PR 流程：main 已通过 #196 撤销原记录，本 PR 重新提交发版记录（内容同原 #195，新 commit）。

## 改动

- 新增 `docs/releases/v0.4.1.md`：v0.4.1 release notes（修复 #169 doctor 信封 version、#172 zoneIcon 同名冲突 + v0.4.0 后变更摘要 U35/U32/U33/U36 + 资产清单 + 验证记录）
- `docs/Agile路线图.md` §1 当前状态：补记 v0.4.0、v0.4.1 已发布（v0.4.1 指向 release notes 文档）

## 验证

- 纯文档改动（无 go:embed，不影响二进制）
- v0.4.1 资产已按验收标准构建并抽查通过（version/doctor --json 信封一致 v0.4.1；tar 含 reasonix+semantix+configs+install.sh）

关联 #179（发版完成后再关闭）