### PR TITLE
feat(gateway): Anthropic/Claude 适配——messages 双向转换 + cache_control 断点 + TTL 差异化 (Issue #185)

### DIFF
--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -275,6 +275,9 @@ POST /v1/chat/completions {model, messages, stream, ...}
 | GPT | `https://api.openai.com/v1` | 同上 | 同 OpenAI 兼容 |
 | Claude | `https://api.anthropic.com/v1` | `x-api-key` + `anthropic-version` | ① 需要把 messages 转 Anthropic 格式（或走官方 OpenAI 兼容端点）；② 注入块边界打 `cache_control:{type:"ephemeral"}`（≤2 断点：system 尾 + 最后消息尾） |
 
+> 转换规则与 cache_control 断点的具体设计见 §3.11（M2 上半，Issue #185）；§3.11 落地前
+> `vendor="anthropic"` 在配置层被显式拒绝，避免把 Anthropic 流量误发到 OpenAI 式端点。
+
 **模型映射**：`semantix-gateway.toml` 中定义 `upstreams[].model_alias`（New API 侧模型名 ↔ 上游模型名）；New API 渠道的模型名即网关的 model_alias，网关负责换成上游真实模型名。
 
 **超时与重试**：网关给上游设保守超时（connect 10s / 首字节 60s / 总时长继承 New API 配置）；重试逻辑**主要放 New API 渠道层**（New API 有重试/负载均衡），网关只做一次重试兜底（幂等 GET 类；chat 请求重试仅对网络错误）。
@@ -300,6 +303,7 @@ budget = 4096                             # L2 注入块字节预算
 
 [cache]
 ttl_seconds = 86400                       # 默认 TTL（vendor 差异化优先）
+vendor_ttl = { anthropic = 300 }          # 可选：按 vendor 覆盖 TTL（秒；内置默认 DeepSeek 24h / Anthropic 5m，§3.11.4）
 judge_api_key = "${SEMANTIX_JUDGE_API_KEY}"   # 可选：grey 区 LLM judge
 
 [ingest]
@@ -323,6 +327,82 @@ vendor = "deepseek"                       # deepseek | anthropic | openai | moon
 - 切片库 0600/0700 权限、原子写、防 symlink（沿用现有安全约定）；
 - 敏感内容：默认 `scope=project` 隔离；脱敏接入点预留（`sanitize` 已有，正式版按策略启用）；
 - 网关无公网暴露面：只允许 New API 所在网段访问（compose 内网即可，见 §5）。
+
+---
+
+## 3.11 M2 设计节：Claude / Anthropic 适配（Issue #185）
+
+> 本节是 §7 M2「多模型」的上半（Anthropic 一家），2026-08-17 起草，随 Issue #185 落地。
+> 覆盖：chat/completions ↔ Anthropic messages 双向转换、cache_control 断点注入、流式 SSE 事件映射、
+> TTL 按 vendor 差异化。Kimi / GPT（OpenAI 兼容系）与计费对账属 M2 下半，不在本节。
+
+**适配形态**：客户端（New API 侧）永远只看到 OpenAI 兼容协议；转换只发生在网关 → 上游这一跳。
+`vendor="anthropic"` 的上游走 `POST {base_url}/v1/messages`，鉴权头 `x-api-key` + `anthropic-version: 2023-06-01`
+（**不发** `Authorization`）。转换层独立文件 `gateway/anthropic.go`，不触碰 OpenAI 直通路径
+（非 anthropic vendor 的转发、透传、流式逻辑一律不变）。
+
+### 3.11.1 请求转换（chat/completions → /v1/messages）
+
+| OpenAI chat/completions | Anthropic /v1/messages | 规则 |
+|---|---|---|
+| `model`（客户端别名） | `model`（upstream_model） | 与 OpenAI 路径相同的三层模型映射（§4.2） |
+| `messages[].role=system` | 顶层 `system` | **system 提升**：全部 system 文本以 `\n\n` 合并到顶层；有注入块时升级为 block 数组 `[{type:"text",text,cache_control}]` |
+| `messages[].role=user` | `user`，content 为 block 数组 | 字符串 → `{type:"text"}`；part 数组：text → text block、image_url → image block（`data:` URI 转 base64 source，其余 url source） |
+| `messages[].role=assistant`（含 tool_calls） | `assistant`，content 含 text + `{type:"tool_use"}` | `tool_calls[].function.arguments`（JSON 字符串）→ `input`（object，解析失败置 `{}`） |
+| `messages[].role=tool` | 并入相邻 user 消息的 `{type:"tool_result",tool_use_id,content}` | Anthropic 无 tool role；连续 tool_result 合并进同一条 user 消息 |
+| 相邻同 role 消息 | 合并 | Anthropic 强制 user/assistant 交替，OpenAI 允许连续同角色 |
+| `max_tokens` / `max_completion_tokens` | `max_tokens`（**必填**） | OpenAI 未传时默认 4096 |
+| `temperature` / `top_p` / `stream` | 同名透传 | — |
+| `stop` | `stop_sequences` | string 或数组统一归一为数组 |
+| `tools[].function` | `tools[]{name,description,input_schema}` | `function.parameters` → `input_schema` |
+| `tool_choice` | `tool_choice` | auto→auto、none→none、required→any、`{function:{name}}`→`{type:"tool",name}` |
+
+**cache_control 断点注入（L2 注入块末尾，≤2 个）**：
+
+- 仅当本次请求真的注入了切片（`inject.Injection.Slices` 非空；空 marker block 不打断点，避免浪费 prompt-cache 预算）；
+- 断点 ① system 尾：注入块文本追加到合并后的 system 末尾，system 以 block 数组承载，最后一个 text block 带 `cache_control:{type:"ephemeral"}`；
+- 断点 ② 最后消息尾：最后一条消息的最后一个 text block 带 `cache_control:{type:"ephemeral"}`；
+- 与 §3.6「对 Claude 在注入块边界打 cache_control 断点（≤2 断点：system 尾 + 最后消息尾）」一致；断点让注入前缀按缓存价计费（§2.3 Claude 行：$3.00/M → $0.30/M）。
+
+### 3.11.2 响应转换（/v1/messages → chat.completion）
+
+| Anthropic | OpenAI | 规则 |
+|---|---|---|
+| `content[].type=text` | `choices[0].message.content` | 全部 text 块按序拼接 |
+| `content[].type=tool_use` | `choices[0].message.tool_calls[]` | `{id, type:"function", function:{name, arguments: JSON.stringify(input)}}` |
+| `stop_reason` | `finish_reason` | end_turn / stop_sequence → stop、max_tokens → length、tool_use → tool_calls |
+| `usage.input_tokens` | `usage.prompt_tokens` | — |
+| `usage.output_tokens` | `usage.completion_tokens` | — |
+| `usage.cache_read_input_tokens` | `usage.prompt_tokens_details.cached_tokens` | L3/计费口径：注入前缀按缓存价（§4.3 合成 usage 同源） |
+| `id` / `model` | `id` / `model`（客户端别名） | `created` 由网关生成 |
+
+### 3.11.3 流式 SSE 事件映射（Anthropic → OpenAI）
+
+| Anthropic 事件 | OpenAI 事件 | 规则 |
+|---|---|---|
+| `message_start` | `delta:{role:"assistant"}` 首块 | 客户端识别角色 |
+| `content_block_start`（tool_use） | `delta:{tool_calls:[{index,id,type:"function",function:{name,arguments:""}}]}` | tool index 独立编号 |
+| `content_block_delta`（text_delta） | `delta:{content}` | 文本增量原样透传 |
+| `content_block_delta`（input_json_delta） | `delta:{tool_calls:[{index,function:{arguments}}]}` | arguments 增量透传 |
+| `message_delta`（stop_reason） | `delta:{}, finish_reason` | 映射同非流式 |
+| `message_stop` | `data: [DONE]` | 终止 |
+| `event: ping` / 非 data 行 / thinking 块 | 丢弃 | 客户端只见 OpenAI 形状 |
+| 异常断流（无 message_stop） | 网关补 `finish_reason` + `[DONE]` | 客户端不挂死（同 §3.4 保证） |
+
+流式响应侧仍只写请求 turns 进旁路（assistant 内容解析属既有债务，与 OpenAI 流式路径一致）。
+
+### 3.11.4 TTL 按 vendor 差异化
+
+- 新增 `[cache] vendor_ttl`（`map[string]int64`，可选）；`Config.TTLFor(vendor)` 解析顺序：显式 `vendor_ttl` > 内置默认 > 通用 `ttl_seconds`；
+- 内置默认（§3.5）：DeepSeek 24h、**Anthropic 5m**；Kimi / GPT 用通用 `ttl_seconds`（上游文档确认后再配）；
+- L3 命中判定 `cacheFresh(slice, vendor)` 按上游 vendor 取 TTL（`l3Eligible` 传入 `up.Vendor`）。
+
+### 3.11.5 验收（e2e，假 Anthropic 上游）
+
+- 非流式全链路：客户端收到 OpenAI 格式响应（content / usage 映射正确），假上游收到 `x-api-key` + `anthropic-version`、`/v1/messages` 路径、system 提升后的 body，且**无** `Authorization` 头；
+- 流式全链路：客户端收到 OpenAI SSE（role 首块 → content 分块 → finish_reason → [DONE]），无 Anthropic 原始事件泄漏；
+- L2 注入断言：注入块出现在 system 尾且带 `cache_control:{type:"ephemeral"}`；
+- `go test ./gateway/... -race` 全绿。
 
 ---
 
@@ -427,7 +507,7 @@ docker-compose.yml
 |---|---|---|---|
 | **M0 网关 MVP** | `cmd/semantix-gateway`：OpenAI 兼容层（chat/completions + SSE 透传 + /healthz）+ 鉴权 + 上游 DeepSeek 适配 + 会话旁路入库 | 1–2 周 | 任意 OpenAI 兼容客户端 → New API → 网关 → DeepSeek 全链路跑通；会话入库后 `semantix search` 可检索到切片 |
 | **M1 缓存闭环** | L2 注入 + L3 缓存（指纹/RuleGate/promote/TTL）+ 流式命中回放 + usage 标记 | +1–2 周 | 重复任务第二次命中 `x-semantix-cache: hit` 且零上游调用；合成演示成本节省 ≥30%（复用 m0-cost-comparison 脚本） |
-| **M2 多模型 + 上线** | Claude（格式转换 + cache_control）/ Kimi / GPT 适配 + 模型映射表 + 计费对账 + 健康监控 | +1 周 | 四家模型渠道全通；命中率/节省率有周报数字；New API 侧对账一致 |
+| **M2 多模型 + 上线** | Claude（格式转换 + cache_control，**上半已落地，见 §3.11**）/ Kimi / GPT 适配 + 模型映射表 + 计费对账 + 健康监控 | +1 周 | 四家模型渠道全通；命中率/节省率有周报数字；New API 侧对账一致 |
 
 **M0 为决策门**：若网关形态下「请求级注入」收益显著低于预期（重复率低的场景），及时转向纯 L3 缓存策略或按会话聚合注入，控制投入在 2 周内。
 
@@ -467,5 +547,6 @@ docker-compose.yml
 
 Semantix Gateway 是 Semantix 从「agent kernel / CLI」走向「**API 网关形态**」的关键一步：
 把已验证的 79.8% 成本节省机制（L2 注入 + L3 复用 + L1 字节稳定）搬到 New API 后面，**零侵入任何客户端与 harness**，
-一条命令部署（`go build ./cmd/semantix-gateway`），天然服务 DeepSeek / Claude / Kimi / GPT 四家模型。
+一条命令部署（`go build ./cmd/semantix-gateway`），天然服务 DeepSeek / Claude / Kimi / GPT 四家模型
+（Claude 经 §3.11 的格式转换 + cache_control 断点接入，其余三家同为 OpenAI 兼容协议）。
 M0 决策门控制投入在 2 周内，收益不成立可随时退化为纯透传。

--- a/gateway/anthropic.go
+++ b/gateway/anthropic.go
@@ -1,0 +1,773 @@
+package gateway
+
+// Anthropic / Claude vendor adapter (Issue #185, gateway M2 upper half).
+//
+// The gateway's client-facing surface stays OpenAI-compatible (New API
+// speaks OpenAI); this file only translates on the upstream hop for
+// upstreams declared vendor="anthropic". It deliberately lives in its own
+// file and touches nothing on the OpenAI passthrough path.
+//
+// Translation rules (design: docs/specs/newapi-gateway-design.md §0.5):
+//   request   chat/completions  ->  POST {base_url}/v1/messages
+//             system            ->  top-level "system" (block array when a
+//                                   cache_control breakpoint is needed)
+//             assistant tool_calls -> content block {type:"tool_use"}
+//             role=tool         ->  user content block {type:"tool_result"}
+//             adjacent same-role messages merged (Anthropic alternation rule)
+//             max_tokens        ->  required upstream; defaulted when absent
+//   response  messages          ->  chat.completion (usage mapped, see
+//                                   anthropicToOpenAIResponse)
+//   stream    Anthropic SSE     ->  OpenAI SSE (see anthropicSSEConverter)
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"semantix/kernel/inject"
+	"semantix/kernel/usage"
+)
+
+// anthropicVersion is the API version pinned for the Anthropic messages
+// endpoint (design §3.8: x-api-key + anthropic-version headers).
+const anthropicVersion = "2023-06-01"
+
+// defaultAnthropicMaxTokens is the max_tokens sent when the OpenAI request
+// carries none: Anthropic requires the field, OpenAI clients often omit it.
+const defaultAnthropicMaxTokens = 4096
+
+// openAITool is the OpenAI tools[] entry the adapter maps to Anthropic.
+type openAITool struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Parameters  any    `json:"parameters"`
+	} `json:"function"`
+}
+
+// anthropicMessage is one messages[] entry of the Anthropic request.
+type anthropicMessage struct {
+	Role    string           `json:"role"`
+	Content []anthropicBlock `json:"content"`
+}
+
+// anthropicBlock is a content block: text / tool_use / tool_result / image.
+type anthropicBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+	// tool_use
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	// tool_use.input / tool_result.content both ride on Input.
+	Input any `json:"input,omitempty"`
+	// tool_result
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	// image source (url or base64)
+	Source *anthropicImageSource `json:"source,omitempty"`
+	// L1 breakpoint (design §3.6: only ever on the block that ends the L2
+	// injection block and the final message tail).
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+type anthropicImageSource struct {
+	Type      string `json:"type"` // "url" | "base64"
+	URL       string `json:"url,omitempty"`
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+}
+
+type anthropicCacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+type anthropicTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	InputSchema any    `json:"input_schema"`
+}
+
+// anthropicRequest mirrors the /v1/messages request body the adapter emits.
+type anthropicRequest struct {
+	Model         string             `json:"model"`
+	MaxTokens     int                `json:"max_tokens"`
+	Messages      []anthropicMessage `json:"messages"`
+	System        json.RawMessage    `json:"system,omitempty"` // string or block array
+	Stream        bool               `json:"stream,omitempty"`
+	Temperature   *float64           `json:"temperature,omitempty"`
+	TopP          *float64           `json:"top_p,omitempty"`
+	StopSequences []string           `json:"stop_sequences,omitempty"`
+	Tools         []anthropicTool    `json:"tools,omitempty"`
+	ToolChoice    any                `json:"tool_choice,omitempty"`
+}
+
+// openAIChatBody is the full OpenAI chat request body (a superset of
+// chatRequest: it also keeps the fields the Anthropic adapter maps).
+type openAIChatBody struct {
+	chatRequest
+	MaxTokens        int          `json:"max_tokens"`
+	MaxCompletionTok int          `json:"max_completion_tokens"`
+	TopP             *float64     `json:"top_p"`
+	Stop             any          `json:"stop"`
+	Tools            []openAITool `json:"tools"`
+	ToolChoice       any          `json:"tool_choice"`
+}
+
+// toAnthropicRequest converts an OpenAI chat/completions request body into
+// an Anthropic /v1/messages request body for the given upstream, applying
+// the L2 injection block with cache_control breakpoints when one was built.
+// Returns the marshaled Anthropic body (nil on conversion error).
+func toAnthropicRequest(body []byte, up UpstreamConfig, inj *inject.Injection) ([]byte, error) {
+	var openAI openAIChatBody
+	if err := json.Unmarshal(body, &openAI); err != nil {
+		return nil, fmt.Errorf("parse OpenAI body: %w", err)
+	}
+	if len(openAI.Messages) == 0 {
+		return nil, fmt.Errorf("messages must not be empty")
+	}
+
+	system, msgs := splitSystem(openAI.Messages)
+	// Only a real injection (retrieved slices, not the empty marker block)
+	// earns cache_control breakpoints — breakpoints cost prompt-cache budget
+	// and an empty marker is meaningless.
+	hasBlock := inj != nil && len(inj.Slices) > 0
+	if hasBlock {
+		if system != "" {
+			system += "\n\n" + inj.Text
+		} else {
+			system = inj.Text
+		}
+	}
+
+	out := anthropicRequest{
+		Model:     up.UpstreamModel,
+		MaxTokens: defaultAnthropicMaxTokens,
+		Messages:  msgs,
+		Stream:    openAI.Stream,
+	}
+	if openAI.MaxTokens > 0 {
+		out.MaxTokens = openAI.MaxTokens
+	} else if openAI.MaxCompletionTok > 0 {
+		out.MaxTokens = openAI.MaxCompletionTok
+	}
+	out.Temperature = openAI.Temperature
+	// Anthropic rejects requests that set both temperature and top_p; OpenAI
+	// clients routinely send both, so drop top_p whenever temperature is set.
+	if openAI.Temperature == nil {
+		out.TopP = openAI.TopP
+	}
+	if seqs, ok := toStopSequences(openAI.Stop); ok {
+		out.StopSequences = seqs
+	}
+	out.Tools = mapTools(openAI.Tools)
+	out.ToolChoice = mapToolChoice(openAI.ToolChoice, len(openAI.Tools))
+
+	if hasBlock {
+		// L1 breakpoints (design §3.6 / §0.5: ≤2 — system tail + final
+		// message tail), so the injection block and the last message are
+		// cached at the prompt-cache rate.
+		out.System = mustJSON([]anthropicBlock{{
+			Type: "text", Text: system, CacheControl: &anthropicCacheControl{Type: "ephemeral"},
+		}})
+		if len(out.Messages) > 0 {
+			markLastTextBlock(&out.Messages[len(out.Messages)-1])
+		}
+	} else if system != "" {
+		out.System = mustJSON(system)
+	}
+
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("marshal anthropic request: %w", err)
+	}
+	return raw, nil
+}
+
+// splitSystem lifts every system message out of the messages array into the
+// top-level system string (Anthropic has no system role) and converts the
+// remaining messages to Anthropic shape, merging adjacent same-role messages
+// (Anthropic requires user/assistant alternation).
+func splitSystem(messages []chatMessage) (system string, out []anthropicMessage) {
+	var sys []string
+	for _, m := range messages {
+		if m.Role == "system" {
+			if t := textParts(m.Content); t != "" {
+				sys = append(sys, t)
+			}
+			continue
+		}
+		var blocks []anthropicBlock
+		switch m.Role {
+		case "user":
+			blocks = userBlocks(m.Content)
+		case "assistant":
+			blocks = assistantBlocks(m.Content, m.ToolCalls)
+		case "tool":
+			tr := anthropicBlock{Type: "tool_result", ToolUseID: m.ToolCallID, Input: textParts(m.Content)}
+			// tool results must ride on a user message that follows the
+			// tool_use; merge consecutive results into one user message.
+			if len(out) > 0 && out[len(out)-1].Role == "user" {
+				out[len(out)-1].Content = append(out[len(out)-1].Content, tr)
+				continue
+			}
+			out = append(out, anthropicMessage{Role: "user", Content: []anthropicBlock{tr}})
+			continue
+		default:
+			// unknown role: keep as a text block rather than drop it
+			blocks = []anthropicBlock{{Type: "text", Text: textParts(m.Content)}}
+		}
+		if len(blocks) == 0 {
+			continue
+		}
+		if len(out) > 0 && out[len(out)-1].Role == m.Role {
+			out[len(out)-1].Content = append(out[len(out)-1].Content, blocks...)
+			continue
+		}
+		out = append(out, anthropicMessage{Role: m.Role, Content: blocks})
+	}
+	return strings.Join(sys, "\n\n"), out
+}
+
+// userBlocks converts a user message content (string or part array) into
+// Anthropic text/image blocks.
+func userBlocks(content any) []anthropicBlock {
+	switch v := content.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []anthropicBlock{{Type: "text", Text: v}}
+	case []any:
+		var blocks []anthropicBlock
+		for _, part := range v {
+			m, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch m["type"] {
+			case "text":
+				if s, _ := m["text"].(string); s != "" {
+					blocks = append(blocks, anthropicBlock{Type: "text", Text: s})
+				}
+			case "image_url":
+				if src := imageSource(m["image_url"]); src != nil {
+					blocks = append(blocks, anthropicBlock{Type: "image", Source: src})
+				}
+			}
+		}
+		return blocks
+	default:
+		return nil
+	}
+}
+
+// imageSource maps an OpenAI image_url part to an Anthropic image source:
+// data: URIs become base64 sources, everything else a URL source.
+func imageSource(v any) *anthropicImageSource {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	url, _ := m["url"].(string)
+	if url == "" {
+		return nil
+	}
+	if strings.HasPrefix(url, "data:") {
+		// data:[<mediatype>][;base64],<data>
+		rest := url[len("data:"):]
+		comma := strings.Index(rest, ",")
+		if comma < 0 {
+			return nil
+		}
+		meta, data := rest[:comma], rest[comma+1:]
+		mediaType, b64 := meta, false
+		if i := strings.Index(meta, ";base64"); i >= 0 {
+			mediaType, b64 = meta[:i], true
+		}
+		if !b64 {
+			return nil
+		}
+		return &anthropicImageSource{Type: "base64", MediaType: mediaType, Data: data}
+	}
+	return &anthropicImageSource{Type: "url", URL: url}
+}
+
+// assistantBlocks converts an assistant message into text + tool_use blocks.
+func assistantBlocks(content any, toolCalls any) []anthropicBlock {
+	blocks := userBlocks(content)
+	tcs, ok := toolCalls.([]any)
+	if !ok {
+		return blocks
+	}
+	for _, tc := range tcs {
+		m, ok := tc.(map[string]any)
+		if !ok || m["type"] != "function" {
+			continue
+		}
+		id, _ := m["id"].(string)
+		fn, _ := m["function"].(map[string]any)
+		name, _ := fn["name"].(string)
+		var input any = map[string]any{}
+		if args, _ := fn["arguments"].(string); args != "" {
+			if err := json.Unmarshal([]byte(args), &input); err != nil {
+				input = map[string]any{}
+			}
+		}
+		blocks = append(blocks, anthropicBlock{Type: "tool_use", ID: id, Name: name, Input: input})
+	}
+	return blocks
+}
+
+// mapTools converts OpenAI tools[] to Anthropic tools[] (input_schema).
+func mapTools(tools []openAITool) []anthropicTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]anthropicTool, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, anthropicTool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			InputSchema: t.Function.Parameters,
+		})
+	}
+	return out
+}
+
+// mapToolChoice converts the OpenAI tool_choice value to Anthropic's:
+// auto/auto, none/none, required/any, {function:{name}} -> {type:"tool"}.
+func mapToolChoice(tc any, nTools int) any {
+	if tc == nil {
+		if nTools == 0 {
+			return nil
+		}
+		return "auto"
+	}
+	switch v := tc.(type) {
+	case string:
+		switch v {
+		case "auto", "none":
+			return v
+		case "required":
+			return "any"
+		}
+	case map[string]any:
+		if fn, ok := v["function"].(map[string]any); ok {
+			if name, _ := fn["name"].(string); name != "" {
+				return map[string]any{"type": "tool", "name": name}
+			}
+		}
+	}
+	return nil
+}
+
+// toStopSequences normalizes the OpenAI stop field (string or array).
+func toStopSequences(v any) ([]string, bool) {
+	switch s := v.(type) {
+	case string:
+		if s == "" {
+			return nil, false
+		}
+		return []string{s}, true
+	case []any:
+		var out []string
+		for _, item := range s {
+			if str, ok := item.(string); ok && str != "" {
+				out = append(out, str)
+			}
+		}
+		return out, len(out) > 0
+	}
+	return nil, false
+}
+
+// markLastTextBlock attaches a cache_control breakpoint to the last text
+// block of a message (Anthropic only allows it on text/tool_use blocks).
+func markLastTextBlock(m *anthropicMessage) {
+	for i := len(m.Content) - 1; i >= 0; i-- {
+		if m.Content[i].Type == "text" {
+			m.Content[i].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
+			return
+		}
+	}
+}
+
+func mustJSON(v any) json.RawMessage {
+	raw, _ := json.Marshal(v)
+	return raw
+}
+
+// ---------------------------------------------------------------------------
+// non-streaming response translation
+
+// anthropicResponse is the subset of a /v1/messages response the gateway
+// maps back into OpenAI chat.completion shape.
+type anthropicResponse struct {
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Role       string `json:"role"`
+	Model      string `json:"model"`
+	StopReason string `json:"stop_reason"`
+	Content    []struct {
+		Type  string `json:"type"`
+		Text  string `json:"text"`
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Input any    `json:"input"`
+	} `json:"content"`
+	Usage struct {
+		InputTokens          int `json:"input_tokens"`
+		OutputTokens         int `json:"output_tokens"`
+		CacheReadInputTokens int `json:"cache_read_input_tokens"`
+	} `json:"usage"`
+}
+
+// anthropicToOpenAIResponse converts a non-streaming /v1/messages response
+// into OpenAI chat.completion JSON (usage: input_tokens -> prompt_tokens,
+// output_tokens -> completion_tokens, cache_read -> prompt_tokens_details.
+// cached_tokens; tool_use blocks -> tool_calls; stop_reason -> finish_reason).
+func anthropicToOpenAIResponse(body []byte, model string) ([]byte, error) {
+	var a anthropicResponse
+	if err := json.Unmarshal(body, &a); err != nil {
+		return nil, fmt.Errorf("parse anthropic response: %w", err)
+	}
+	var text strings.Builder
+	var toolCalls []map[string]any
+	for _, c := range a.Content {
+		switch c.Type {
+		case "text":
+			text.WriteString(c.Text)
+		case "tool_use":
+			args, _ := json.Marshal(c.Input)
+			toolCalls = append(toolCalls, map[string]any{
+				"id": c.ID, "type": "function",
+				"function": map[string]any{"name": c.Name, "arguments": string(args)},
+			})
+		}
+	}
+	msg := map[string]any{"role": "assistant", "content": text.String()}
+	if len(toolCalls) > 0 {
+		msg["tool_calls"] = toolCalls
+	}
+	usage := map[string]any{
+		"prompt_tokens":     a.Usage.InputTokens,
+		"completion_tokens": a.Usage.OutputTokens,
+		"total_tokens":      a.Usage.InputTokens + a.Usage.OutputTokens,
+	}
+	if a.Usage.CacheReadInputTokens > 0 {
+		usage["prompt_tokens_details"] = map[string]any{"cached_tokens": a.Usage.CacheReadInputTokens}
+	}
+	out := map[string]any{
+		"id":      a.ID,
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []any{map[string]any{
+			"index":         0,
+			"message":       msg,
+			"finish_reason": anthropicStopReason(a.StopReason),
+		}},
+		"usage": usage,
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("marshal openai response: %w", err)
+	}
+	return raw, nil
+}
+
+// anthropicStopReason maps Anthropic stop_reason to OpenAI finish_reason
+// (design §0.5 response table).
+func anthropicStopReason(s string) string {
+	switch s {
+	case "", "end_turn", "stop_sequence":
+		return "stop"
+	case "max_tokens":
+		return "length"
+	case "tool_use":
+		return "tool_calls"
+	default:
+		return "stop"
+	}
+}
+
+// anthropicError extracts the message from an Anthropic error body
+// {"error":{"type":...,"message":...}} for a readable envelope.
+func anthropicError(body []byte) string {
+	var e struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil || e.Error.Message == "" {
+		return strings.TrimSpace(string(body))
+	}
+	return e.Error.Message
+}
+
+// ---------------------------------------------------------------------------
+// streaming translation (Anthropic SSE -> OpenAI SSE)
+
+// anthropicSSEConverter is a stateful line filter that turns Anthropic
+// /v1/messages stream events into OpenAI chat.completion.chunk events.
+//
+//	message_start          -> delta {role:"assistant"} (first chunk); captures
+//	                          message.id/model for every subsequent chunk
+//	content_block_start    -> tool_use: delta {tool_calls:[{index,id,name,arguments:""}]}
+//	content_block_delta    -> text_delta -> delta {content}; input_json_delta
+//	                          -> delta {tool_calls:[{index,function.arguments}]}
+//	message_delta          -> delta {}, finish_reason (mapped)
+//	message_stop           -> data: [DONE]
+//	error                  -> OpenAI error envelope + [DONE] (upstream failure
+//	                          must never surface as a clean completion)
+//
+// Thinking blocks and non-data lines (event:, ping) are dropped: the client
+// only ever sees OpenAI-shaped chunks.
+type anthropicSSEConverter struct {
+	w          io.Writer
+	flusher    http.Flusher
+	toolIdx    int  // next tool_calls index
+	done       bool // stream has ended (message_stop / error / [DONE])
+	id         string
+	model      string
+	created    int64
+	finishSent bool // a real finish_reason already went out
+}
+
+func newAnthropicSSEConverter(w io.Writer, flusher http.Flusher) *anthropicSSEConverter {
+	return &anthropicSSEConverter{w: w, flusher: flusher, created: time.Now().Unix()}
+}
+
+// feed consumes one SSE line. It returns true once the stream has ended
+// (message_stop, error, or an explicit data: [DONE]).
+func (c *anthropicSSEConverter) feed(line []byte) bool {
+	trimmed := bytes.TrimSpace(line)
+	if !bytes.HasPrefix(trimmed, []byte("data:")) {
+		return false
+	}
+	payload := bytes.TrimSpace(bytes.TrimPrefix(trimmed, []byte("data:")))
+	if bytes.Equal(payload, []byte("[DONE]")) {
+		c.done = true
+		return true
+	}
+	var ev struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return false
+	}
+	switch ev.Type {
+	case "message_start":
+		c.messageStart(payload)
+		c.writeChunk(map[string]any{"role": "assistant"}, nil)
+	case "content_block_start":
+		c.blockStart(payload)
+	case "content_block_delta":
+		c.blockDelta(payload)
+	case "message_delta":
+		c.messageDelta(payload)
+	case "error":
+		c.writeError(payload)
+		c.done = true
+		return true
+	case "message_stop":
+		c.writeDone()
+		c.done = true
+		return true
+	}
+	return false
+}
+
+// finish terminates a stream that ended abnormally (no message_stop): emit
+// the final chunk + [DONE] so the client never hangs (same guarantee as the
+// OpenAI passthrough path, design §3.4). If a real finish_reason already
+// went out via message_delta, it is not overwritten.
+func (c *anthropicSSEConverter) finish() {
+	if c.done {
+		return
+	}
+	c.done = true
+	if !c.finishSent {
+		c.writeChunk(map[string]any{}, "stop")
+	}
+	c.writeDone()
+}
+
+// messageStart captures the message id/model so every OpenAI chunk carries
+// the stable identity the OpenAI SDKs validate on.
+func (c *anthropicSSEConverter) messageStart(payload []byte) {
+	var ev struct {
+		Message struct {
+			ID    string `json:"id"`
+			Model string `json:"model"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return
+	}
+	if ev.Message.ID != "" {
+		c.id = ev.Message.ID
+	}
+	if ev.Message.Model != "" {
+		c.model = ev.Message.Model
+	}
+}
+
+// writeError maps an Anthropic mid-stream error event to an OpenAI error
+// envelope + [DONE] so the client sees a failure, never a clean completion.
+func (c *anthropicSSEConverter) writeError(payload []byte) {
+	var ev struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		_, _ = fmt.Fprintf(c.w, "data: %s\n\n", `{"error":{"message":"upstream stream error"}}`)
+	} else {
+		msg := ev.Error.Message
+		if msg == "" {
+			msg = ev.Error.Type
+		}
+		if msg == "" {
+			msg = "upstream stream error"
+		}
+		raw, _ := json.Marshal(map[string]any{"error": map[string]any{"message": msg}})
+		_, _ = fmt.Fprintf(c.w, "data: %s\n\n", raw)
+	}
+	c.writeDone()
+	if c.flusher != nil {
+		c.flusher.Flush()
+	}
+}
+
+func (c *anthropicSSEConverter) blockStart(payload []byte) {
+	var ev struct {
+		Index        int `json:"index"`
+		ContentBlock struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"content_block"`
+	}
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return
+	}
+	if ev.ContentBlock.Type != "tool_use" {
+		return
+	}
+	c.writeChunk(map[string]any{"tool_calls": []any{map[string]any{
+		"index":    c.toolIdx,
+		"id":       ev.ContentBlock.ID,
+		"type":     "function",
+		"function": map[string]any{"name": ev.ContentBlock.Name, "arguments": ""},
+	}}}, nil)
+	c.toolIdx++
+}
+
+func (c *anthropicSSEConverter) blockDelta(payload []byte) {
+	var ev struct {
+		Index int `json:"index"`
+		Delta struct {
+			Type        string `json:"type"`
+			Text        string `json:"text"`
+			PartialJSON string `json:"partial_json"`
+		} `json:"delta"`
+	}
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return
+	}
+	switch ev.Delta.Type {
+	case "text_delta":
+		c.writeChunk(map[string]any{"content": ev.Delta.Text}, nil)
+	case "input_json_delta":
+		c.writeChunk(map[string]any{"tool_calls": []any{map[string]any{
+			"index":    c.toolIdx - 1,
+			"function": map[string]any{"arguments": ev.Delta.PartialJSON},
+		}}}, nil)
+	}
+}
+
+func (c *anthropicSSEConverter) messageDelta(payload []byte) {
+	var ev struct {
+		Delta struct {
+			StopReason string `json:"stop_reason"`
+		} `json:"delta"`
+	}
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return
+	}
+	if ev.Delta.StopReason == "" {
+		return
+	}
+	c.finishSent = true
+	c.writeChunk(map[string]any{}, anthropicStopReason(ev.Delta.StopReason))
+}
+
+func (c *anthropicSSEConverter) writeChunk(delta map[string]any, finish any) {
+	evt := map[string]any{
+		"id":      c.id,
+		"object":  "chat.completion.chunk",
+		"created": c.created,
+		"model":   c.model,
+		"choices": []any{map[string]any{
+			"index": 0, "delta": delta, "finish_reason": finish,
+		}},
+	}
+	raw, _ := json.Marshal(evt)
+	_, _ = fmt.Fprintf(c.w, "data: %s\n\n", raw)
+	if c.flusher != nil {
+		c.flusher.Flush()
+	}
+}
+
+func (c *anthropicSSEConverter) writeDone() {
+	_, _ = io.WriteString(c.w, "data: [DONE]\n\n")
+	if c.flusher != nil {
+		c.flusher.Flush()
+	}
+}
+
+// streamThroughAnthropic relays a streaming Anthropic upstream response as
+// OpenAI SSE (the events must be translated — Anthropic frames differ from
+// OpenAI's). Sidecar/usage accounting matches the OpenAI streaming path:
+// request turns only, assistant content extraction is deferred debt.
+func (g *Gateway) streamThroughAnthropic(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
+	if resp.StatusCode >= 400 {
+		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
+		writeAPIError(w, resp.StatusCode, "upstream_error",
+			fmt.Sprintf("upstream returned %d: %s", resp.StatusCode, anthropicError(out)))
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("x-semantix-cache", "miss")
+	w.WriteHeader(resp.StatusCode)
+	flusher, _ := w.(http.Flusher)
+
+	conv := newAnthropicSSEConverter(w, flusher)
+	br := bufio.NewReader(resp.Body)
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 && conv.feed(line) {
+			break
+		}
+		if err != nil {
+			break
+		}
+	}
+	conv.finish() // no-op when message_stop already seen
+	g.recordSession(sessionID, ctxHash, req.Model, turns(req, ""))
+	g.recordUsage(usage.Event{
+		SessionID:      sessionID,
+		TokensIn:       int64(len(query)/4) + injectedTokens,
+		InjectedTokens: injectedTokens,
+		SliceHits:      sliceHits,
+		At:             g.now().Unix(),
+	})
+}

--- a/gateway/anthropic_test.go
+++ b/gateway/anthropic_test.go
@@ -1,0 +1,446 @@
+package gateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"semantix/kernel/inject"
+	"semantix/kernel/slice"
+)
+
+// ---------------------------------------------------------------------------
+// request translation (OpenAI chat/completions -> Anthropic /v1/messages)
+
+func anthropicUp() UpstreamConfig {
+	return UpstreamConfig{
+		Name: "claude", BaseURL: "https://api.anthropic.com/v1",
+		APIKey: "up-key", ModelAlias: []string{"claude-sonnet"},
+		UpstreamModel: "claude-sonnet-4", Vendor: "anthropic",
+	}
+}
+
+func TestToAnthropicRequestSystemLift(t *testing.T) {
+	body := `{"model":"claude-sonnet","stream":false,
+		"messages":[
+			{"role":"system","content":"you are helpful"},
+			{"role":"user","content":"hello"},
+			{"role":"assistant","content":"hi there"},
+			{"role":"user","content":"tell me about widgets"}
+		]}`
+	raw, err := toAnthropicRequest([]byte(body), anthropicUp(), nil)
+	if err != nil {
+		t.Fatalf("toAnthropicRequest: %v", err)
+	}
+	var req anthropicRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Model != "claude-sonnet-4" {
+		t.Errorf("model = %q, want upstream model claude-sonnet-4", req.Model)
+	}
+	if req.MaxTokens != defaultAnthropicMaxTokens {
+		t.Errorf("max_tokens = %d, want default %d (Anthropic requires it)", req.MaxTokens, defaultAnthropicMaxTokens)
+	}
+	if string(req.System) != `"you are helpful"` {
+		t.Errorf("system = %s, want lifted system string", req.System)
+	}
+	if len(req.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3 (system lifted out)", len(req.Messages))
+	}
+	if req.Messages[0].Role != "user" || req.Messages[0].Content[0].Text != "hello" {
+		t.Errorf("messages[0] = %#v", req.Messages[0])
+	}
+	if req.Messages[1].Role != "assistant" || req.Messages[1].Content[0].Text != "hi there" {
+		t.Errorf("messages[1] = %#v", req.Messages[1])
+	}
+}
+
+func TestToAnthropicRequestToolCalls(t *testing.T) {
+	body := `{"model":"claude-sonnet","stream":false,
+		"tools":[{"type":"function","function":{"name":"read_file","description":"read","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}}],
+		"tool_choice":"auto",
+		"messages":[
+			{"role":"user","content":"read the file"},
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"/a\"}"}}]},
+			{"role":"tool","tool_call_id":"call_1","name":"read_file","content":"file contents"}
+		]}`
+	raw, err := toAnthropicRequest([]byte(body), anthropicUp(), nil)
+	if err != nil {
+		t.Fatalf("toAnthropicRequest: %v", err)
+	}
+	var req anthropicRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(req.Tools) != 1 || req.Tools[0].Name != "read_file" {
+		t.Fatalf("tools = %#v", req.Tools)
+	}
+	if req.ToolChoice != "auto" {
+		t.Errorf("tool_choice = %v, want auto", req.ToolChoice)
+	}
+	// user, assistant(tool_use), user(tool_result) — tool result rides on a
+	// user message, adjacent user messages merged
+	if len(req.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3, got %#v", len(req.Messages), req.Messages)
+	}
+	assistant := req.Messages[1]
+	if assistant.Role != "assistant" || len(assistant.Content) != 1 || assistant.Content[0].Type != "tool_use" {
+		t.Fatalf("assistant message = %#v, want one tool_use block", assistant)
+	}
+	tu := assistant.Content[0]
+	if tu.ID != "call_1" || tu.Name != "read_file" {
+		t.Errorf("tool_use = %#v", tu)
+	}
+	input, _ := json.Marshal(tu.Input)
+	if string(input) != `{"path":"/a"}` {
+		t.Errorf("tool_use.input = %s, want parsed arguments object", input)
+	}
+	toolResult := req.Messages[2]
+	if toolResult.Role != "user" || len(toolResult.Content) != 1 {
+		t.Fatalf("tool result message = %#v", toolResult)
+	}
+	tr := toolResult.Content[0]
+	if tr.Type != "tool_result" || tr.ToolUseID != "call_1" || tr.Input != "file contents" {
+		t.Errorf("tool_result = %#v", tr)
+	}
+}
+
+func TestToAnthropicRequestCacheControlBreakpoints(t *testing.T) {
+	body := `{"model":"claude-sonnet","stream":false,
+		"messages":[
+			{"role":"system","content":"base sys"},
+			{"role":"user","content":"query about widgets"}
+		]}`
+	inj := &inject.Injection{
+		Text:   "[semantix-reuse]\nprior knowledge\n[/semantix-reuse]",
+		Slices: []*slice.Slice{{ID: "s1", Type: slice.Prompt, Scope: slice.Project, Content: []byte("prior knowledge")}},
+	}
+	raw, err := toAnthropicRequest([]byte(body), anthropicUp(), inj)
+	if err != nil {
+		t.Fatalf("toAnthropicRequest: %v", err)
+	}
+	var req anthropicRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// system becomes a block array with the injection appended and a
+	// cache_control breakpoint on the last text block (design §3.6 / §0.5)
+	var sys []anthropicBlock
+	if err := json.Unmarshal(req.System, &sys); err != nil || len(sys) != 1 {
+		t.Fatalf("system = %s, want single block array (unmarshal err %v)", req.System, err)
+	}
+	if !strings.Contains(sys[0].Text, "[semantix-reuse]") {
+		t.Errorf("system block missing injection text: %q", sys[0].Text)
+	}
+	if sys[0].CacheControl == nil || sys[0].CacheControl.Type != "ephemeral" {
+		t.Errorf("system block missing cache_control breakpoint: %#v", sys[0])
+	}
+	// final message tail also gets a breakpoint (≤2 total)
+	if len(req.Messages) == 0 {
+		t.Fatal("no messages")
+	}
+	last := req.Messages[len(req.Messages)-1]
+	found := false
+	for _, b := range last.Content {
+		if b.Type == "text" && b.CacheControl != nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("final message tail missing cache_control breakpoint: %#v", last)
+	}
+}
+
+func TestToAnthropicRequestNoBlockNoBreakpoints(t *testing.T) {
+	body := `{"model":"claude-sonnet","messages":[{"role":"user","content":"hi"}]}`
+	raw, err := toAnthropicRequest([]byte(body), anthropicUp(), nil)
+	if err != nil {
+		t.Fatalf("toAnthropicRequest: %v", err)
+	}
+	if strings.Contains(string(raw), "cache_control") {
+		t.Errorf("no breakpoints expected without an injection block: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"system"`) || strings.Contains(string(raw), `[`) {
+		t.Logf("system without block is a plain string: %s", raw)
+	}
+}
+
+func TestToAnthropicRequestImageAndAdjacentMerge(t *testing.T) {
+	body := `{"model":"claude-sonnet",
+		"messages":[
+			{"role":"user","content":"first turn"},
+			{"role":"user","content":[{"type":"text","text":"second turn"},{"type":"image_url","image_url":{"url":"https://x/y.png"}}]}
+		]}`
+	raw, err := toAnthropicRequest([]byte(body), anthropicUp(), nil)
+	if err != nil {
+		t.Fatalf("toAnthropicRequest: %v", err)
+	}
+	var req anthropicRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// both user turns merge into one message (Anthropic alternation rule)
+	if len(req.Messages) != 1 {
+		t.Fatalf("messages = %d, want 1 (adjacent users merged): %#v", len(req.Messages), req.Messages)
+	}
+	blocks := req.Messages[0].Content
+	if len(blocks) != 3 {
+		t.Fatalf("blocks = %d, want 3 (two text + one image): %#v", len(blocks), blocks)
+	}
+	if blocks[0].Text != "first turn" || blocks[1].Text != "second turn" {
+		t.Errorf("text blocks = %q %q", blocks[0].Text, blocks[1].Text)
+	}
+	if blocks[2].Type != "image" || blocks[2].Source == nil || blocks[2].Source.Type != "url" {
+		t.Errorf("image block = %#v", blocks[2])
+	}
+}
+
+// TestToAnthropicRequestTemperatureTopPExclusive: Anthropic rejects requests
+// that set both temperature and top_p; the adapter must drop top_p when
+// temperature is present (OpenAI clients routinely send both).
+func TestToAnthropicRequestTemperatureTopPExclusive(t *testing.T) {
+	body := `{"model":"claude-sonnet","temperature":0.7,"top_p":0.9,
+		"messages":[{"role":"user","content":"hi"}]}`
+	raw, err := toAnthropicRequest([]byte(body), anthropicUp(), nil)
+	if err != nil {
+		t.Fatalf("toAnthropicRequest: %v", err)
+	}
+	var req anthropicRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Temperature == nil || *req.Temperature != 0.7 {
+		t.Errorf("temperature = %v, want 0.7", req.Temperature)
+	}
+	if req.TopP != nil {
+		t.Errorf("top_p = %v, want nil (must be dropped alongside temperature)", req.TopP)
+	}
+	// without temperature, top_p passes through
+	body = `{"model":"claude-sonnet","top_p":0.9,"messages":[{"role":"user","content":"hi"}]}`
+	raw, _ = toAnthropicRequest([]byte(body), anthropicUp(), nil)
+	req = anthropicRequest{}
+	_ = json.Unmarshal(raw, &req)
+	if req.TopP == nil || *req.TopP != 0.9 {
+		t.Errorf("top_p alone = %v, want 0.9", req.TopP)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// response translation (Anthropic /v1/messages -> OpenAI chat.completion)
+
+func TestAnthropicToOpenAIResponse(t *testing.T) {
+	body := `{"id":"msg_01","type":"message","role":"assistant","model":"claude-sonnet-4",
+		"content":[{"type":"text","text":"the answer"}],
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":100,"output_tokens":25,"cache_read_input_tokens":60}}`
+	raw, err := anthropicToOpenAIResponse([]byte(body), "claude-sonnet")
+	if err != nil {
+		t.Fatalf("anthropicToOpenAIResponse: %v", err)
+	}
+	var out struct {
+		Object  string `json:"object"`
+		Model   string `json:"model"`
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+			PromptDetails    struct {
+				CachedTokens int `json:"cached_tokens"`
+			} `json:"prompt_tokens_details"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Object != "chat.completion" || out.Model != "claude-sonnet" {
+		t.Errorf("object/model = %q/%q", out.Object, out.Model)
+	}
+	if out.Choices[0].Message.Content != "the answer" || out.Choices[0].FinishReason != "stop" {
+		t.Errorf("choice = %#v (end_turn must map to stop)", out.Choices[0])
+	}
+	if out.Usage.PromptTokens != 100 || out.Usage.CompletionTokens != 25 || out.Usage.TotalTokens != 125 {
+		t.Errorf("usage = %#v (input/output tokens must map)", out.Usage)
+	}
+	if out.Usage.PromptDetails.CachedTokens != 60 {
+		t.Errorf("cached_tokens = %d, want 60 (cache_read_input_tokens)", out.Usage.PromptDetails.CachedTokens)
+	}
+}
+
+func TestAnthropicToOpenAIResponseToolUse(t *testing.T) {
+	body := `{"id":"msg_02","type":"message","role":"assistant","model":"m",
+		"content":[{"type":"tool_use","id":"toolu_1","name":"read_file","input":{"path":"/a"}}],
+		"stop_reason":"tool_use",
+		"usage":{"input_tokens":10,"output_tokens":5}}`
+	raw, err := anthropicToOpenAIResponse([]byte(body), "m")
+	if err != nil {
+		t.Fatalf("anthropicToOpenAIResponse: %v", err)
+	}
+	var out struct {
+		Choices []struct {
+			Message struct {
+				Content   string `json:"content"`
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Type     string `json:"type"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", out.Choices[0].FinishReason)
+	}
+	tc := out.Choices[0].Message.ToolCalls
+	if len(tc) != 1 || tc[0].ID != "toolu_1" || tc[0].Function.Name != "read_file" {
+		t.Fatalf("tool_calls = %#v", tc)
+	}
+	if tc[0].Function.Arguments != `{"path":"/a"}` {
+		t.Errorf("arguments = %q, want marshaled input", tc[0].Function.Arguments)
+	}
+}
+
+func TestAnthropicStopReasonMapping(t *testing.T) {
+	cases := map[string]string{
+		"":              "stop",
+		"end_turn":      "stop",
+		"stop_sequence": "stop",
+		"max_tokens":    "length",
+		"tool_use":      "tool_calls",
+		"weird":         "stop",
+	}
+	for in, want := range cases {
+		if got := anthropicStopReason(in); got != want {
+			t.Errorf("anthropicStopReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// streaming translation (Anthropic SSE -> OpenAI SSE)
+
+func TestAnthropicSSEConverter(t *testing.T) {
+	var out strings.Builder
+	conv := newAnthropicSSEConverter(&out, nil)
+	events := []string{
+		`event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"m"}}`,
+		`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}`,
+		`event: content_block_stop
+data: {"type":"content_block_stop","index":0}`,
+		`event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"read_file","input":{}}}`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"/a\"}"}}`,
+		`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":5}}`,
+		`event: message_stop
+data: {"type":"message_stop"}`,
+	}
+	done := false
+	for _, e := range events {
+		lines := strings.Split(e, "\n")
+		for _, l := range lines {
+			if conv.feed([]byte(l)) {
+				done = true
+			}
+		}
+	}
+	if !done {
+		t.Error("converter did not finish on message_stop")
+	}
+	got := out.String()
+	for _, want := range []string{
+		`"id":"msg_1"`,                 // stable id captured from message_start
+		`"model":"m"`,                  // model echoed on every chunk
+		`"role":"assistant"`,           // first chunk carries the role
+		`"content":"Hel"`,              // text deltas mapped verbatim
+		`"content":"lo"`,               // text delta mapped verbatim (lowercase)
+		`"id":"toolu_1"`,               // tool_use start -> tool_calls chunk
+		`"arguments":"{\"path\":`,      // input_json deltas streamed
+		`"finish_reason":"tool_calls"`, // stop_reason mapped
+		"data: [DONE]",                 // message_stop terminator
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stream missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "message_start") || strings.Contains(got, "ping") {
+		t.Errorf("raw anthropic events leaked through:\n%s", got)
+	}
+}
+
+// TestAnthropicSSEConverterMidStreamError: an Anthropic error event must
+// surface as an OpenAI error envelope — never as a clean completion.
+func TestAnthropicSSEConverterMidStreamError(t *testing.T) {
+	var out strings.Builder
+	conv := newAnthropicSSEConverter(&out, nil)
+	conv.feed([]byte(`data: {"type":"message_start","message":{"id":"m1"}}`))
+	conv.feed([]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`))
+	done := conv.feed([]byte(`data: {"type":"error","error":{"type":"overloaded_error","message":"upstream blew up"}}`))
+	if !done {
+		t.Error("error event must terminate the stream")
+	}
+	conv.finish() // must be a no-op after error
+	got := out.String()
+	if !strings.Contains(got, `"error"`) || !strings.Contains(got, "upstream blew up") {
+		t.Errorf("error not surfaced as OpenAI envelope: %s", got)
+	}
+	if !strings.Contains(got, "data: [DONE]") {
+		t.Errorf("error path missing [DONE]: %s", got)
+	}
+	if strings.Contains(got, `"finish_reason":"`) {
+		t.Errorf("error path must not emit a real finish_reason (clean completion): %s", got)
+	}
+}
+
+// TestAnthropicSSEConverterFinishKeepsRealReason: when message_delta already
+// emitted the real finish_reason, an abnormal end must not clobber it.
+func TestAnthropicSSEConverterFinishKeepsRealReason(t *testing.T) {
+	var out strings.Builder
+	conv := newAnthropicSSEConverter(&out, nil)
+	conv.feed([]byte(`data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"}}`))
+	conv.finish()
+	got := out.String()
+	if n := strings.Count(got, "finish_reason"); n != 1 {
+		t.Errorf("finish_reason emitted %d times, want 1: %s", n, got)
+	}
+	if !strings.Contains(got, `"finish_reason":"length"`) {
+		t.Errorf("real finish_reason lost: %s", got)
+	}
+	if !strings.Contains(got, "data: [DONE]") {
+		t.Errorf("missing [DONE]: %s", got)
+	}
+}
+
+func TestAnthropicSSEConverterAbnormalEnd(t *testing.T) {
+	var out strings.Builder
+	conv := newAnthropicSSEConverter(&out, nil)
+	conv.feed([]byte(`data: {"type":"message_start","message":{}}`))
+	conv.feed([]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`))
+	conv.finish() // upstream disconnected without message_stop
+	got := out.String()
+	if !strings.Contains(got, "partial") || !strings.Contains(got, "data: [DONE]") {
+		t.Errorf("abnormal end must flush content + [DONE], got: %s", got)
+	}
+}

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -19,12 +19,12 @@ import (
 
 // Config mirrors semantix-gateway.toml (design doc §3.9).
 type Config struct {
-	Server    ServerConfig      `toml:"server"`
-	Store     StoreConfig       `toml:"store"`
-	Retrieval RetrievalConfig   `toml:"retrieval"`
-	Cache     CacheConfig       `toml:"cache"`
-	Ingest    IngestConfig      `toml:"ingest"`
-	Upstreams []UpstreamConfig  `toml:"upstreams"`
+	Server    ServerConfig     `toml:"server"`
+	Store     StoreConfig      `toml:"store"`
+	Retrieval RetrievalConfig  `toml:"retrieval"`
+	Cache     CacheConfig      `toml:"cache"`
+	Ingest    IngestConfig     `toml:"ingest"`
+	Upstreams []UpstreamConfig `toml:"upstreams"`
 }
 
 // ServerConfig is the listener and gateway-key settings.
@@ -36,8 +36,8 @@ type ServerConfig struct {
 // StoreConfig selects the slice store (which also holds L3 cache entries,
 // per decision D4: one JSONL store).
 type StoreConfig struct {
-	DB       string `toml:"db"`
-	Scope    string `toml:"scope"`
+	DB    string `toml:"db"`
+	Scope string `toml:"scope"`
 	// DepsRoot is the project root that L3 dep fingerprints are verified
 	// against (design §3.5: "deps root provided by config"). Missing files
 	// fail closed → the cached entry is treated as stale.
@@ -51,12 +51,15 @@ type RetrievalConfig struct {
 	Budget    int    `toml:"budget"`
 }
 
-// CacheConfig holds L3 policy. MVP: TTL is a gateway-side time window over
+// CacheConfig holds L3 policy. TTL is a gateway-side time window over
 // Slice.CreatedAt (CreatedAt==0 never expires); the kernel dep-fingerprint
-// chain remains the authority for staleness.
+// chain remains the authority for staleness. TTLSeconds is the generic
+// window; VendorTTL overrides it per vendor (design §3.5: DeepSeek 24h /
+// Anthropic 5m) and wins over the built-in vendor defaults in TTLFor.
 type CacheConfig struct {
-	TTLSeconds int64  `toml:"ttl_seconds"`
-	JudgeAPIKey string `toml:"judge_api_key"`
+	TTLSeconds  int64            `toml:"ttl_seconds"`
+	VendorTTL   map[string]int64 `toml:"vendor_ttl"`
+	JudgeAPIKey string           `toml:"judge_api_key"`
 }
 
 // IngestConfig controls the session-sidecar write path.
@@ -70,25 +73,46 @@ type IngestConfig struct {
 
 // UpstreamConfig is one model channel (New API channel = one upstream).
 type UpstreamConfig struct {
-	Name           string   `toml:"name"`
-	BaseURL        string   `toml:"base_url"`
-	APIKey         string   `toml:"api_key"`
-	ModelAlias     []string `toml:"model_alias"`
-	UpstreamModel  string   `toml:"upstream_model"`
-	Vendor         string   `toml:"vendor"`
+	Name          string   `toml:"name"`
+	BaseURL       string   `toml:"base_url"`
+	APIKey        string   `toml:"api_key"`
+	ModelAlias    []string `toml:"model_alias"`
+	UpstreamModel string   `toml:"upstream_model"`
+	Vendor        string   `toml:"vendor"`
 }
 
-// vendor names accepted by the v1 gateway. anthropic is deliberately
-// rejected: it needs message-format conversion + cache_control breakpoints
-// (design §3.8), which is a later milestone — configuring it here would
-// silently send Anthropic-format traffic to an OpenAI-style endpoint.
+// vendor names accepted by the v1 gateway. anthropic needs message-format
+// conversion + cache_control breakpoints (design §0.5), handled by
+// gateway/anthropic.go on the upstream hop; the other three speak OpenAI
+// protocol natively.
 var supportedVendors = map[string]bool{
-	"deepseek": true,
-	"openai":   true,
-	"moonshot": true,
+	"deepseek":  true,
+	"openai":    true,
+	"moonshot":  true,
+	"anthropic": true,
 }
 
-// Load parses semantix-gateway.toml, expands ${VAR} environment references
+// defaultVendorTTLSeconds are the vendor-aware L3 TTL windows from design
+// §3.5 (DeepSeek 24h / Anthropic 5m). An explicit [cache] vendor_ttl entry
+// overrides these; anything else falls back to [cache] ttl_seconds.
+var defaultVendorTTLSeconds = map[string]int64{
+	"deepseek":  24 * 60 * 60,
+	"anthropic": 5 * 60,
+}
+
+// TTLFor resolves the cache freshness window for an upstream vendor:
+// explicit vendor_ttl config wins, then the built-in vendor default, then
+// the generic ttl_seconds (<=0 disables the time window entirely).
+func (c *Config) TTLFor(vendor string) int64 {
+	if v, ok := c.Cache.VendorTTL[vendor]; ok {
+		return v
+	}
+	if v, ok := defaultVendorTTLSeconds[vendor]; ok {
+		return v
+	}
+	return c.Cache.TTLSeconds
+}
+
 // and ~ paths, then validates. Any unresolved ${...} fails startup so a
 // literal placeholder can never be used as a credential.
 func Load(path string) (*Config, error) {
@@ -242,7 +266,7 @@ func (c *Config) validate() error {
 			return fmt.Errorf("gateway config: upstreams[%d] (%s): model_alias must list at least one alias", i, u.Name)
 		}
 		if !supportedVendors[u.Vendor] {
-			return fmt.Errorf("gateway config: upstreams[%d] (%s): vendor %q is not supported by gateway v1 (supported: deepseek, openai, moonshot; anthropic needs format conversion, later milestone)", i, u.Name, u.Vendor)
+			return fmt.Errorf("gateway config: upstreams[%d] (%s): vendor %q is not supported by gateway v1 (supported: deepseek, openai, moonshot, anthropic)", i, u.Name, u.Vendor)
 		}
 		for _, alias := range u.ModelAlias {
 			if prev, dup := seenModel[alias]; dup {
@@ -265,11 +289,11 @@ func validScope(s string) bool {
 // DefaultConfig returns the built-in defaults (for tests and docs).
 func DefaultConfig() *Config {
 	return &Config{
-		Server: ServerConfig{Addr: ":8080", GatewayKey: "dev-key"},
-		Store:  StoreConfig{DB: ".semantix/gateway.jsonl", Scope: "project", DepsRoot: "."},
+		Server:    ServerConfig{Addr: ":8080", GatewayKey: "dev-key"},
+		Store:     StoreConfig{DB: ".semantix/gateway.jsonl", Scope: "project", DepsRoot: "."},
 		Retrieval: RetrievalConfig{Retriever: "bm25", TopK: 5, Budget: 4096},
-		Cache:  CacheConfig{TTLSeconds: 86400},
-		Ingest: IngestConfig{SessionsDir: ".semantix/sessions", UsageLog: ".semantix/gateway-usage.jsonl"},
+		Cache:     CacheConfig{TTLSeconds: 86400},
+		Ingest:    IngestConfig{SessionsDir: ".semantix/sessions", UsageLog: ".semantix/gateway-usage.jsonl"},
 	}
 }
 

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -78,16 +78,16 @@ func TestLoadFailsOnUnresolvedEnv(t *testing.T) {
 
 func TestLoadValidation(t *testing.T) {
 	cases := []struct {
-		name  string
-		mut   func(*Config)
-		msg   string
+		name string
+		mut  func(*Config)
+		msg  string
 	}{
 		{"missing addr", func(c *Config) { c.Server.Addr = "" }, "addr"},
 		{"missing key", func(c *Config) { c.Server.GatewayKey = "" }, "gateway_key"},
 		{"missing db", func(c *Config) { c.Store.DB = "" }, "db"},
 		{"no upstreams", func(c *Config) { c.Upstreams = nil }, "upstreams"},
 		{"bad scope", func(c *Config) { c.Store.Scope = "all" }, "scope"},
-		{"anthropic vendor", func(c *Config) { c.Upstreams[0].Vendor = "anthropic" }, "vendor"},
+		{"unsupported vendor", func(c *Config) { c.Upstreams[0].Vendor = "bogus" }, "vendor"},
 		{"dup alias", func(c *Config) {
 			c.Upstreams = append(c.Upstreams, c.Upstreams[0])
 			c.Upstreams[1].Name = "second"
@@ -147,5 +147,47 @@ func TestModelAliasEnvSubstitution(t *testing.T) {
 	aliases := cfg.Upstreams[0].ModelAlias
 	if len(aliases) != 2 || aliases[1] != "ds-chat" {
 		t.Fatalf("model_alias env substitution failed: %v", aliases)
+	}
+}
+
+// TestAnthropicVendorAccepted: vendor="anthropic" must pass validation
+// (Issue #185 — the conversion layer makes it a first-class vendor).
+func TestAnthropicVendorAccepted(t *testing.T) {
+	c := DefaultConfig()
+	c.Server.GatewayKey = "k"
+	c.Store.DB = "x.jsonl"
+	c.Upstreams = []UpstreamConfig{{
+		Name: "claude", BaseURL: "https://api.anthropic.com/v1", APIKey: "k",
+		ModelAlias: []string{"claude-sonnet"}, UpstreamModel: "claude-sonnet-4",
+		Vendor: "anthropic",
+	}}
+	if err := c.validate(); err != nil {
+		t.Fatalf("anthropic vendor must be accepted, got %v", err)
+	}
+}
+
+// TestTTLForVendorDifferentiation: L3 freshness TTL is vendor-aware
+// (design §3.5: DeepSeek 24h / Anthropic 5m), config vendor_ttl wins,
+// generic ttl_seconds is the fallback.
+func TestTTLForVendorDifferentiation(t *testing.T) {
+	c := DefaultConfig() // ttl_seconds = 86400, no vendor_ttl
+	if got := c.TTLFor("anthropic"); got != 5*60 {
+		t.Errorf("anthropic TTL = %d, want %d (5m)", got, 5*60)
+	}
+	if got := c.TTLFor("deepseek"); got != 24*60*60 {
+		t.Errorf("deepseek TTL = %d, want %d (24h)", got, 24*60*60)
+	}
+	if got := c.TTLFor("openai"); got != 86400 {
+		t.Errorf("openai TTL = %d, want config default 86400", got)
+	}
+	// explicit vendor_ttl overrides the built-in default
+	c.Cache.VendorTTL = map[string]int64{"anthropic": 60}
+	if got := c.TTLFor("anthropic"); got != 60 {
+		t.Errorf("anthropic TTL with vendor_ttl = %d, want 60", got)
+	}
+	// ttl_seconds <= 0 disables the window for vendors without a default
+	c.Cache.TTLSeconds = 0
+	if got := c.TTLFor("openai"); got != 0 {
+		t.Errorf("openai TTL with ttl_seconds=0 = %d, want 0 (disabled)", got)
 	}
 }

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -137,7 +137,9 @@ func respContent(t *testing.T, body []byte) string {
 	t.Helper()
 	var r struct {
 		Choices []struct {
-			Message struct{ Content string `json:"content"` } `json:"message"`
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
 		} `json:"choices"`
 	}
 	if err := json.Unmarshal(body, &r); err != nil {
@@ -536,5 +538,218 @@ func TestE2EL3SafeFalseRejected(t *testing.T) {
 	}
 	if n := up.callCount(); n != 1 {
 		t.Errorf("upstream calls = %d, want 1", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic vendor e2e (Issue #185): a fake /v1/messages upstream behind the
+// full pipeline. The client surface must stay OpenAI-compatible while the
+// upstream hop speaks Anthropic protocol (headers + body + response shape).
+
+// testAnthropicUpstream simulates POST {base}/v1/messages: it records the
+// request (headers + body) and answers with canned Anthropic responses.
+type testAnthropicUpstream struct {
+	mu         sync.Mutex
+	calls      int
+	lastPath   string
+	lastBody   map[string]any
+	lastHeader http.Header
+	stream     string // canned Anthropic SSE body when stream=true
+	plain      string // canned /v1/messages JSON otherwise
+}
+
+func (u *testAnthropicUpstream) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		u.mu.Lock()
+		u.calls++
+		u.lastPath = r.URL.Path
+		u.lastBody = parsed
+		u.lastHeader = r.Header.Clone()
+		u.mu.Unlock()
+		if stream, _ := parsed["stream"].(bool); stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, u.stream)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, u.plain)
+	}
+}
+
+func (u *testAnthropicUpstream) snapshot() (int, string, map[string]any, http.Header) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.calls, u.lastPath, u.lastBody, u.lastHeader
+}
+
+const anthropicPlainReply = `{"id":"msg_e2e","type":"message","role":"assistant","model":"claude-sonnet-4",
+	"content":[{"type":"text","text":"claude hello"}],
+	"stop_reason":"end_turn",
+	"usage":{"input_tokens":50,"output_tokens":10,"cache_read_input_tokens":20}}`
+
+// newAnthropicGateway wires a gateway whose only upstream is vendor=anthropic
+// (base_url points at the fake /v1/messages server).
+func newAnthropicGateway(t *testing.T, upURL string) *Gateway {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.Server.GatewayKey = "test-key"
+	cfg.Store.DB = filepath.Join(dir, "db.jsonl")
+	cfg.Store.DepsRoot = dir
+	cfg.Ingest.SessionsDir = filepath.Join(dir, "sessions")
+	cfg.Ingest.UsageLog = filepath.Join(dir, "usage.jsonl")
+	cfg.Upstreams = []UpstreamConfig{{
+		Name: "claude", BaseURL: upURL, APIKey: "claude-key",
+		ModelAlias: []string{"claude-sonnet"}, UpstreamModel: "claude-sonnet-4",
+		Vendor: "anthropic",
+	}}
+	g, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = g.Close() })
+	return g
+}
+
+func TestE2EAnthropicNonStreaming(t *testing.T) {
+	up := &testAnthropicUpstream{plain: anthropicPlainReply}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newAnthropicGateway(t, upSrv.URL+"/v1") // base_url carries /v1 like api.anthropic.com
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChat(t, srv, "test-key", `{"model":"claude-sonnet","stream":false,"messages":[
+		{"role":"system","content":"you are helpful"},
+		{"role":"user","content":"hello claude"}
+	]}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if got := respContent(t, out); got != "claude hello" {
+		t.Errorf("content = %q, want claude hello (translated response)", got)
+	}
+
+	calls, path, last, hdr := up.snapshot()
+	if calls != 1 {
+		t.Fatalf("upstream calls = %d, want 1", calls)
+	}
+	if path != "/v1/messages" {
+		t.Errorf("upstream path = %q, want /v1/messages", path)
+	}
+	if hdr.Get("x-api-key") != "claude-key" || hdr.Get("anthropic-version") == "" {
+		t.Errorf("anthropic auth headers wrong: x-api-key=%q version=%q", hdr.Get("x-api-key"), hdr.Get("anthropic-version"))
+	}
+	if hdr.Get("Authorization") != "" {
+		t.Errorf("anthropic upstream must not receive Authorization: %q", hdr.Get("Authorization"))
+	}
+	if model, _ := last["model"].(string); model != "claude-sonnet-4" {
+		t.Errorf("forwarded model = %q, want upstream model claude-sonnet-4", model)
+	}
+	// system lifted out of messages into the top-level field; user message
+	// carries the query
+	if sys, _ := last["system"].(string); sys != "you are helpful" {
+		t.Errorf("system = %#v, want lifted system string", last["system"])
+	}
+	msgs, _ := last["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %d, want 1 (system lifted): %v", len(msgs), msgs)
+	}
+}
+
+func TestE2EAnthropicStreaming(t *testing.T) {
+	up := &testAnthropicUpstream{stream: `event: message_start
+data: {"type":"message_start","message":{"id":"msg_s","type":"message","role":"assistant","model":"claude-sonnet-4"}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"stream "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"reply"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":10}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newAnthropicGateway(t, upSrv.URL+"/v1")
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChat(t, srv, "test-key", chatBody("claude-sonnet", "stream please", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	body := string(out)
+	for _, want := range []string{`"role":"assistant"`, `"content":"stream "`, `"content":"reply"`, `"finish_reason":"stop"`, "data: [DONE]"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("stream missing %q:\n%s", want, body)
+		}
+	}
+	// no raw anthropic events may leak through
+	if strings.Contains(body, "message_start") || strings.Contains(body, "content_block") {
+		t.Errorf("raw anthropic events leaked to client:\n%s", body)
+	}
+}
+
+func TestE2EAnthropicL2Breakpoint(t *testing.T) {
+	up := &testAnthropicUpstream{plain: anthropicPlainReply}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newAnthropicGateway(t, upSrv.URL+"/v1")
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	// L2 injection material: seed the reuse slices so Build(query) returns a
+	// non-empty injection block (same distractor trick as the OpenAI e2e).
+	for i, content := range []string{"alpha", "bravo", "charlie", "delta", "widgets knowhow"} {
+		seed(t, g, &slice.Slice{
+			ID: fmt.Sprintf("an-th-%d", i), Type: slice.Prompt, Scope: slice.Project,
+			Content: []byte(content),
+		})
+	}
+
+	resp, out := postChat(t, srv, "test-key", chatBody("claude-sonnet", "widgets", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if resp.Header.Get("x-semantix-cache") != "miss" {
+		t.Errorf("x-semantix-cache = %q, want miss", resp.Header.Get("x-semantix-cache"))
+	}
+
+	calls, _, last, _ := up.snapshot()
+	if calls != 1 {
+		t.Fatalf("upstream calls = %d, want 1", calls)
+	}
+	sys, ok := last["system"].([]any)
+	if !ok || len(sys) != 1 {
+		t.Fatalf("system = %#v, want block array with one text block", last["system"])
+	}
+	block, ok := sys[0].(map[string]any)
+	if !ok || block["type"] != "text" {
+		t.Fatalf("system block = %#v, want text block", sys[0])
+	}
+	text, _ := block["text"].(string)
+	if !strings.Contains(text, "[semantix-reuse]") {
+		t.Errorf("injection block not appended to system: %q", text)
+	}
+	cc, _ := block["cache_control"].(map[string]any)
+	if cc == nil || cc["type"] != "ephemeral" {
+		t.Errorf("system tail missing cache_control breakpoint: %#v", block)
 	}
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -40,7 +40,7 @@ type Gateway struct {
 	ingestWG   sync.WaitGroup
 	shutdownMu sync.Mutex // guards closing flag vs recordSession's Add
 	closing    bool
-	disabled   bool       // SEMANTIX_GATEWAY_DISABLE ablation switch
+	disabled   bool // SEMANTIX_GATEWAY_DISABLE ablation switch
 
 	now func() time.Time
 }
@@ -171,11 +171,12 @@ func (g *Gateway) resolveScope(r *http.Request) (slice.Scope, error) {
 	return parseScope(v)
 }
 
-// cacheFresh applies the configured TTL window over Slice.CreatedAt.
-// ttl_seconds<=0 or unknown age (CreatedAt==0) never expire (kernel gc
-// semantics); the kernel dep-fingerprint chain stays the staleness authority.
-func (g *Gateway) cacheFresh(s *slice.Slice) bool {
-	ttl := g.cfg.Cache.TTLSeconds
+// cacheFresh applies the vendor-aware TTL window over Slice.CreatedAt
+// (design §3.5: DeepSeek 24h / Anthropic 5m, resolved by Config.TTLFor).
+// ttl<=0 or unknown age (CreatedAt==0) never expire (kernel gc semantics);
+// the kernel dep-fingerprint chain stays the staleness authority.
+func (g *Gateway) cacheFresh(s *slice.Slice, vendor string) bool {
+	ttl := g.cfg.TTLFor(vendor)
 	if ttl <= 0 || s.CreatedAt == 0 {
 		return true
 	}
@@ -278,7 +279,7 @@ func (m metaStore) Put(s *slice.Slice) error {
 	return m.inner.Put(s)
 }
 
-func (m metaStore) Get(id string) (*slice.Slice, error)      { return m.inner.Get(id) }
+func (m metaStore) Get(id string) (*slice.Slice, error)            { return m.inner.Get(id) }
 func (m metaStore) List(scope slice.Scope) ([]*slice.Slice, error) { return m.inner.List(scope) }
 func (m metaStore) UpdateStats(id string, delta slice.SliceStats) error {
 	return m.inner.UpdateStats(id, delta)

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -48,9 +48,9 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 
 	// L3: verified reuse — zero upstream calls (design §3.3 step 3). The
 	// kernel gate enforces context/model isolation (fail closed) on top of
-	// the dep-fingerprint chain.
+	// the dep-fingerprint chain. TTL is vendor-aware (design §3.5).
 	if !g.disabled {
-		if res, lerr := g.decider.DecideL3(ctx, q); lerr == nil && res != nil && g.l3Eligible(res.SliceID) {
+		if res, lerr := g.decider.DecideL3(ctx, q); lerr == nil && res != nil && g.l3Eligible(res.SliceID, up.Vendor) {
 			g.recordUsage(usage.Event{
 				SessionID: sessionID, TokensIn: int64(len(query)/4) + int64(len(res.Response)/4),
 				TokensOut: 0, CacheHitToken: int64(len(res.Response) / 4),
@@ -72,7 +72,20 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 		injectedTokens = int64(inj.Bytes / 4)
 		sliceHits = len(inj.Slices)
 	}
-	body = g.rewriteOutgoing(body, req, up, inj)
+	if up.Vendor == "anthropic" {
+		// Anthropic hop (design §0.5): translate the OpenAI body to the
+		// /v1/messages shape, applying the L2 injection block with
+		// cache_control breakpoints. OpenAI passthrough is untouched.
+		abody, aerr := toAnthropicRequest(body, up, inj)
+		if aerr != nil {
+			writeAPIError(w, http.StatusBadRequest, "invalid_request_error",
+				"anthropic conversion: "+aerr.Error())
+			return
+		}
+		body = abody
+	} else {
+		body = g.rewriteOutgoing(body, req, up, inj)
+	}
 
 	resp, ferr := g.forward(ctx, up, body)
 	if ferr != nil {
@@ -83,21 +96,25 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	defer resp.Body.Close()
 
 	if req.Stream {
+		if up.Vendor == "anthropic" {
+			g.streamThroughAnthropic(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits)
+			return
+		}
 		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits)
 		return
 	}
-	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits)
+	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, up.Vendor)
 }
 
 // l3Eligible applies the gateway-side TTL window on top of the kernel
 // verification chain. A slice that disappeared from the store also fails
 // closed.
-func (g *Gateway) l3Eligible(id string) bool {
+func (g *Gateway) l3Eligible(id, vendor string) bool {
 	s, err := g.store.Get(id)
 	if err != nil {
 		return false
 	}
-	return g.cacheFresh(s)
+	return g.cacheFresh(s, vendor)
 }
 
 // rewriteOutgoing rewrites the outgoing body in place: the client model
@@ -141,20 +158,31 @@ func attachBlock(messages []chatMessage, block string) []chatMessage {
 	return append([]chatMessage{{Role: "system", Content: block}}, messages...)
 }
 
-// forward posts the (rewritten) body to the upstream OpenAI-compatible
-// endpoint with the upstream API key. Transport errors are retried once
-// (design §3.8: the gateway does a single best-effort retry; the body is
-// fully buffered so a resend is always safe); HTTP status errors are not
-// retried — they carry the upstream's own verdict.
+// forward posts the (rewritten) body to the upstream endpoint with the
+// upstream API key. vendor="anthropic" hits POST {base}/v1/messages with the
+// x-api-key + anthropic-version headers (design §0.5); every other vendor
+// hits /chat/completions with Authorization: Bearer. Transport errors are
+// retried once (design §3.8: the gateway does a single best-effort retry;
+// the body is fully buffered so a resend is always safe); HTTP status errors
+// are not retried — they carry the upstream's own verdict.
 func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (*http.Response, error) {
-	url := strings.TrimRight(up.BaseURL, "/") + "/chat/completions"
+	path := "/chat/completions"
+	if up.Vendor == "anthropic" {
+		path = "/messages"
+	}
+	url := strings.TrimRight(up.BaseURL, "/") + path
 	do := func() (*http.Response, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+up.APIKey)
+		if up.Vendor == "anthropic" {
+			req.Header.Set("x-api-key", up.APIKey)
+			req.Header.Set("anthropic-version", anthropicVersion)
+		} else {
+			req.Header.Set("Authorization", "Bearer "+up.APIKey)
+		}
 		return g.client.Do(req)
 	}
 	resp, err := do()
@@ -171,7 +199,9 @@ func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (
 // passthrough relays a non-streaming upstream response, records usage and
 // writes the session sidecar (request turns + assistant reply) — only for
 // successful exchanges, so failed requests never enter the reuse library.
-func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
+// Anthropic responses are translated to OpenAI chat.completion shape first
+// (the client surface is always OpenAI-compatible).
+func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, vendor string) {
 	out, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		writeAPIError(w, http.StatusBadGateway, "upstream_error",
@@ -180,15 +210,34 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 	}
 	if resp.StatusCode >= 400 {
 		// upstream error: relay the OpenAI error envelope, nothing reusable
+		msg := strings.TrimSpace(string(out))
+		if vendor == "anthropic" {
+			msg = anthropicError(out) // Anthropic errors use {error:{message}}
+		}
 		writeAPIError(w, resp.StatusCode, "upstream_error",
-			fmt.Sprintf("upstream returned %d: %s", resp.StatusCode, strings.TrimSpace(string(out))))
+			fmt.Sprintf("upstream returned %d: %s", resp.StatusCode, msg))
 		return
+	}
+	if vendor == "anthropic" {
+		out, err = anthropicToOpenAIResponse(out, req.Model)
+		if err != nil {
+			writeAPIError(w, http.StatusBadGateway, "upstream_error",
+				fmt.Sprintf("translate anthropic response: %v", err))
+			return
+		}
 	}
 	content := extractAssistantContent(out)
 	g.recordSession(sessionID, ctxHash, req.Model, turns(req, content))
 
 	for k, vs := range resp.Header {
 		if isHopByHopHeader(k) {
+			continue
+		}
+		if vendor == "anthropic" && http.CanonicalHeaderKey(k) == "Content-Length" {
+			// Only the translated hop may differ from the upstream body
+			// length; net/http recomputes Content-Length, so a copied value
+			// would truncate or stall the reply. The OpenAI passthrough path
+			// relays verbatim and keeps the upstream framing byte-identical.
 			continue
 		}
 		for _, v := range vs {
@@ -330,9 +379,9 @@ type chatCompletion struct {
 }
 
 type choicePayload struct {
-	Index        int           `json:"index"`
+	Index        int            `json:"index"`
 	Message      messagePayload `json:"message"`
-	FinishReason string        `json:"finish_reason"`
+	FinishReason string         `json:"finish_reason"`
 }
 
 type messagePayload struct {


### PR DESCRIPTION
关联 Issue #185（GW5: Anthropic/Claude 适配，网关 M2 上半）。按该 issue 的流程，先补 spec 设计节（§3.11）再实现，一并提交供 review。

## 改动

**spec（docs/specs/newapi-gateway-design.md）**
- 新增 §3.11 M2 设计节：chat/completions ↔ Anthropic messages 双向转换表（system 提升、tool_calls ↔ tool_use、usage 字段映射）、cache_control 断点注入规则（L2 注入块末尾 + 最后消息尾，≤2 个）、流式 SSE 事件映射表、TTL 按 vendor 差异化
- 同步更新 §3.8（Claude 行注记）、§3.9（vendor_ttl 配置示例）、§7（M2 行）、§10（结论）

**实现**
- `gateway/anthropic.go`（新增，独立文件，不污染 OpenAI 直通路径）
  - 请求转换 `toAnthropicRequest`：OpenAI chat/completions → `POST {base_url}/v1/messages`；system 提升为顶层字段；assistant tool_calls → `tool_use` block、tool → 相邻 user 消息的 `tool_result`；相邻同角色消息合并（Anthropic 交替规则）；`max_tokens` 缺失时默认 4096；tools/tool_choice/stop 映射；temperature 与 top_p 互斥（Anthropic 拒绝同时设置）
  - cache_control 断点：仅当真实注入切片（`Injection.Slices` 非空）时，在 system 尾 + 最后消息尾打 `{type:"ephemeral"}`（≤2，空 marker block 不打断点）
  - 响应转换 `anthropicToOpenAIResponse`：content/tool_use → message/tool_calls，stop_reason → finish_reason，input_tokens/output_tokens/cache_read_input_tokens → prompt/completion/cached_tokens
  - 流式转换 `anthropicSSEConverter`：message_start/block_start/block_delta/message_delta/message_stop → OpenAI SSE（chunk 携带 id/created/model）；`error` 事件转 OpenAI 错误信封而非伪完成；异常断流补 finish_reason + [DONE]
- `gateway/config.go`：`vendor="anthropic"` 放行；新增 `[cache] vendor_ttl` + `TTLFor(vendor)`（显式配置 > 内置默认 DeepSeek 24h / Anthropic 5m > 通用 ttl_seconds）
- `gateway/gateway.go`：`cacheFresh(slice, vendor)` 按 vendor 取 TTL
- `gateway/pipeline.go`：转发分支按 vendor 选端点与鉴权头（anthropic 走 `/v1/messages` + `x-api-key`/`anthropic-version`，不发 Authorization）；passthrough 转换 Anthropic 响应并跳过 Content-Length 复制（仅 anthropic 分支，OpenAI 直通路径字节不变）

**测试**
- `gateway/anthropic_test.go`（新增）：请求/响应/流式转换单测 + 断点、error 事件、异常断流、top_p 互斥用例
- `gateway/config_test.go`：anthropic 放行 + TTLFor 差异化
- `gateway/e2e_test.go`：假 Anthropic 上游全链路（非流式 + 流式 + L2 注入块含 cache_control 断点断言 + 鉴权头/路径验证）

## 验证
- `go test ./gateway/... -race -count=1` 全绿
- `go test ./...` 全仓 18 个包 ok
- `go vet ./gateway/...`、`go build ./...` 通过

## 说明
Issue #185 checklist 中的「spec 获批准（Song review）」项请 review 确认；本 PR 只提改动，合并/发版/关 issue 由上游决定。