### PR TITLE
feat(gateway): 流式响应侧写记忆——SSE 聚合入旁路，L3 双路径积累 (Issue #182)

### DIFF
--- a/cmd/semantix/intro.go
+++ b/cmd/semantix/intro.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -45,6 +46,9 @@ func runIntro(args []string, stdout io.Writer) int {
 	fs.SetOutput(stdout)
 	noAnimation := fs.Bool("no-animation", false, "render the final frame without animation")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0 // --help is a successful request (U19 contract)
+		}
 		return 2
 	}
 

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -498,7 +498,14 @@ func tabSafe(s string) string {
 // stringListFlag collects repeated --session flags.
 type stringListFlag struct{ p *[]string }
 
-func (f stringListFlag) String() string { return strings.Join(*f.p, ",") }
+func (f stringListFlag) String() string {
+	if f.p == nil {
+		// Go's flag package calls String on a zero value to decide
+		// whether to print "(default ...)"; a nil target must not panic.
+		return ""
+	}
+	return strings.Join(*f.p, ",")
+}
 func (f stringListFlag) Set(v string) error {
 	*f.p = append(*f.p, v)
 	return nil

--- a/docs/reports/issue-182-acceptance.md
+++ b/docs/reports/issue-182-acceptance.md
@@ -1,0 +1,68 @@
+# Issue #182 验收报告 — GW2: 流式响应侧写记忆（真实流式流量积累 L3 切片）
+
+> 状态：验收通过（2026-08-17）。对应 Issue：`#182 GW2: 流式响应侧写记忆`（Spec-Exempt，实现已批准 spec §3.7/§3.4 既有条目）。
+> 设计真源：`docs/specs/newapi-gateway-design.md`（GitHub main 版 §0.3 documented debt / §3.4 流式透传 / §3.7 会话旁路写记忆）；实现规格 = issue #182 上的 spec post（评论 `#issuecomment-5312381566`，用户审后批准）。
+> 验收方式：实现 + 单测/e2e + 独立 subagent 审查（review）+ 缺陷修复后复验。
+
+## 1. 验收对象
+
+| 项 | 值 |
+|---|---|
+| 范围 | `gateway/sse.go`（新增，SSE 聚合器）+ `gateway/sse_test.go`（新增，11 个单测）+ `gateway/pipeline.go`（`streamThrough` 改造）+ `gateway/e2e_test.go`（新增 5 个 e2e + 测试设施扩展） |
+| diff | 4 文件 +430/-9（`gateway/gateway.go`、配置、旁路格式、`turns`/`recordSession`/`ingestSession` 零改动） |
+| 未提交 | 工作区未提交（待用户确认后提交/推送） |
+
+## 2. Issue checklist 逐条核对
+
+| # | checklist（issue #182 原文） | 状态 | 证据 |
+|---|---|---|---|
+| 1 | `streamThrough` 边透传边聚合 SSE `choices[].delta.content`（含 role 首块 / finish_reason 终止） | ✅ | `gateway/sse.go` `sseAggregator`（按行解析、data 负载、`[DONE]`/`finish_reason` 终止、1 MiB 聚合上限 + 64 KiB 行上限）；`TestE2EStreamSidecarAggregatesContent` + `TestSSEAggregatorFullStream/SplitFeeds` |
+| 2 | 聚合出的 assistant 消息补进旁路文件（`recordSession` 响应侧），与非流式路径同构 | ✅ | `pipeline.go:222-224` 完整时 `turns(req, agg.Content())`，`turns`/`recordSession` 零改动；`TestE2EStreamSidecarAggregatesContent` 断言旁路末行 `{role:assistant, content:拼接全文}` |
+| 3 | tool_calls 流式块的聚合与跳过策略与非流式一致（Result 提取取最后一条无 tool_calls 的 assistant） | ✅ | 聚合仅取 `choices[0].delta.content`，tool_calls delta 块跳过（与非流式 `extractAssistantContent` 只读 `message.content` 同构）；`TestE2EStreamSidecarSkipsToolCalls` 断言旁路无 `tool_calls` 字段 |
+| 4 | 上游异常断流：已聚合的部分内容**不入库**（半截回复不可复用，fail-closed） | ✅ | `Complete()` = 终止标志 ∧ 未超限，否则跳过 `recordSession`；`TestE2EStreamAbortFailClosed`（Hijack 中途断连）+ `TestE2EStreamNoTerminatorFailClosed`（EOF 无终止信号）+ `TestSSEAggregatorNoTerminator/DoneWithTrailingSpace/EmptyFinishReason/ContentOverflow/LineOverflow` |
+| 5 | e2e：流式请求 → 旁路文件含完整 assistant → ingest 后 `semantix search` 可检索 → 二次同 query L3 命中（假上游） | ✅ | `TestE2EStreamAccumulatesL3`：真 ingest 管线 → store 出现 Result 切片 → 二次同 body 请求 `x-semantix-cache: hit` + 上游调用数保持 1（gateway 无 search 端点，检索经 `L3Decider.DecideL3` 内部 `Index.Search` 触发，与 e2e 同构） |
+| 6 | `go test ./gateway/... -race` 全绿 | ⚠️ 部分 | 本机无 CGO（无 gcc）无法运行 `-race`；`go test ./gateway/... -count=1` 本机全绿，`-race` 由 CI 承担（`.github/workflows/ci.yml:36` 已跑 `go test ./... -race`）——与 issue-133 验收报告 §5 的既有记录一致 |
+
+## 3. 端到端实测（httptest 假上游，gateway 包）
+
+| 场景 | 断言 | 结果 |
+|---|---|---|
+| 流式完整聚合（role 首块 + 3 段 content + finish_reason + [DONE]） | 旁路末行 `{role:assistant, content:"hello streaming world"}`；SSE 逐字节透传不变 | ✅ |
+| 流式 tool_calls delta 跳过 | 旁路 assistant 行仅含纯文本拼接、无 `tool_calls` 键 | ✅ |
+| 上游中途断连（Hijack 关连接） | 旁路文件不存在（半截内容不入库） | ✅ |
+| 上游 EOF 但无终止信号 | 旁路文件不存在（fail-closed） | ✅ |
+| 流式积累 → L3 二次命中 | 真 ingest 后二次同 query：`x-semantix-cache: hit`、上游调用数 1（不增长）、流式回放含完整内容 | ✅ |
+| 既有回归 | `TestE2EStreamPassthrough` / `TestE2ESidecarWrittenAndIngested` / `TestE2EL3*` / kernel 16 包 | ✅ |
+
+## 4. 独立 subagent 审查与修复
+
+审查结论：核心逻辑正确，无阻断问题；2 项应修 + 1 项 nit 已全部处理。
+
+| 发现 | 分级 | 处置 |
+|---|---|---|
+| `sseAggregator` 零单测，跨块行缓冲是核心新逻辑 | 应修 | 新增 `gateway/sse_test.go` 11 个单测（跨块切分 / CRLF / 多行 data / 坏 JSON / 多 choice / [DONE] 尾随空格 / 空 finish_reason / content 超限 / 行超限） |
+| `lineBuf` 无上限，与"内存有界"承诺矛盾（恶意上游无限不换行数据 → 无界增长） | 应修 | 新增 `maxSSELineBytes = 64 KiB` 行上限，超限置 overflow fail-closed（`sse.go` `Feed`） |
+| `finish_reason` 空串也触发终止判定 | nit | 改为 `*first.FinishReason != ""` 才置 done（`sse.go` `flushEvent`） |
+| overflow fail-closed 分支无测试 | 应修 | `TestSSEAggregatorContentOverflow` / `TestSSEAggregatorLineOverflow` 覆盖 |
+
+复验：修复后 `go test ./gateway/... -count=1` + `go vet ./gateway/...` 全绿。
+
+## 5. 验证命令
+
+```bash
+go build ./...                    # ✅
+go vet ./gateway/...              # ✅ 无警告
+go test ./gateway/... -count=1    # ✅ 全部通过（含 11 个新单测 + 5 个新 e2e）
+go test ./kernel/... -count=1     # ✅ 16 包全绿
+go test ./gateway/... -race       # ⚠️ 本机无 CGO（gcc 不存在）不可运行，CI 承担
+```
+
+## 6. 未闭合风险与后续边界
+
+| 项 | 说明 |
+|---|---|
+| L3 命中受 zone 绝对地板约束（实测发现） | 真 ingest 会同时产生 Prompt 切片（user 消息副本，占据 BM25 top1）。短 query（≤2 词）下 BM25 绝对分数 < `AbsHigh(0.7)` → 该检索整体 fail-closed（Grey），L3 不命中。这是 kernel zone 的既有 fail-closed 设计（U16 验收），非本 issue 引入；e2e 用多词 query 覆盖了可命中路径。真实流量下短 query 的 L3 命中率影响由 GW4 M1 门实测评估 |
+| `-race` 未在本机验证 | 无 CGO 环境限制（项目既有记录），CI `go test ./... -race` 承担 |
+| 请求侧 tool_calls 旁路保留（既有债务） | `turns` 不写请求侧 tool_calls 字段（非流式同构的既有行为），网关链路 ToolPattern 切片提取仍失效——非本 issue 范围，另开 issue |
+| usage 计量 | 流式 usage 补块 / token 口径属 GW7 #187（依赖本条，先后合入），本条未动 usage |
+| GW4 #184 | M1 验收门（真实流量二次命中 + 成本节省 ≥30%）依赖本条落地后的真实链路验证 |

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -24,11 +24,12 @@ import (
 // testUpstream simulates an OpenAI-compatible upstream LLM: it counts calls,
 // captures the last forwarded body, and answers with a canned response.
 type testUpstream struct {
-	mu       sync.Mutex
-	calls    int
-	lastBody map[string]any
-	stream   string // canned SSE body when the request asked for stream
-	plain    string // canned JSON body otherwise
+	mu         sync.Mutex
+	calls      int
+	lastBody   map[string]any
+	stream     string // canned SSE body when the request asked for stream
+	plain      string // canned JSON body otherwise
+	streamFunc func(w http.ResponseWriter) // optional; overrides stream
 }
 
 func (u *testUpstream) handler() http.HandlerFunc {
@@ -42,6 +43,10 @@ func (u *testUpstream) handler() http.HandlerFunc {
 		u.mu.Unlock()
 		if stream, _ := parsed["stream"].(bool); stream {
 			w.Header().Set("Content-Type", "text/event-stream")
+			if u.streamFunc != nil {
+				u.streamFunc(w)
+				return
+			}
 			_, _ = io.WriteString(w, u.stream)
 			return
 		}
@@ -117,12 +122,22 @@ func chatBody(model, user string, stream bool) string {
 
 func postChat(t *testing.T, srv *httptest.Server, key, body string) (*http.Response, []byte) {
 	t.Helper()
+	return postChatWithHeaders(t, srv, key, nil, body)
+}
+
+// postChatWithHeaders posts a chat completion with extra headers — e.g. a
+// fixed x-semantix-session id so the sidecar file is deterministic.
+func postChatWithHeaders(t *testing.T, srv *httptest.Server, key string, headers map[string]string, body string) (*http.Response, []byte) {
+	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if key != "" {
 		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -131,6 +146,24 @@ func postChat(t *testing.T, srv *httptest.Server, key, body string) (*http.Respo
 	defer resp.Body.Close()
 	out, _ := io.ReadAll(resp.Body)
 	return resp, out
+}
+
+// readSidecarLines parses the JSONL lines of a session sidecar file.
+func readSidecarLines(t *testing.T, g *Gateway, sessionID string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(g.cfg.Ingest.SessionsDir, sessionID+".jsonl"))
+	if err != nil {
+		t.Fatalf("read sidecar %s: %v", sessionID, err)
+	}
+	var lines []map[string]any
+	for _, l := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(l), &m); err != nil {
+			t.Fatalf("bad sidecar line %q: %v", l, err)
+		}
+		lines = append(lines, m)
+	}
+	return lines
 }
 
 func respContent(t *testing.T, body []byte) string {
@@ -751,5 +784,193 @@ func TestE2EAnthropicL2Breakpoint(t *testing.T) {
 	cc, _ := block["cache_control"].(map[string]any)
 	if cc == nil || cc["type"] != "ephemeral" {
 		t.Errorf("system tail missing cache_control breakpoint: %#v", block)
+	}
+}
+
+// GW2: streaming sidecar memory (Issue #182)
+// streamThrough must aggregate choices[0].delta.content while relaying
+// verbatim, write the complete assistant reply into the sidecar (same shape
+// as the non-streaming path), and fail closed on aborted streams.
+
+func TestE2EStreamSidecarAggregatesContent(t *testing.T) {
+	// role-first chunk + three content chunks + finish_reason + [DONE]
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hello \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"streaming \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"world\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "stream-sess-1"},
+		chatBody("deepseek-chat", "stream me", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	// relay stays verbatim
+	if !strings.Contains(string(out), `"content":"world"`) || !strings.Contains(string(out), "[DONE]") {
+		t.Errorf("stream not relayed verbatim: %s", out)
+	}
+
+	// sidecar ends with the aggregated assistant reply (non-streaming shape)
+	lines := readSidecarLines(t, g, "stream-sess-1")
+	last := lines[len(lines)-1]
+	if last["role"] != "assistant" {
+		t.Fatalf("last sidecar line role = %v, want assistant: %#v", last["role"], lines)
+	}
+	if got := last["content"]; got != "hello streaming world" {
+		t.Errorf("aggregated content = %q, want %q", got, "hello streaming world")
+	}
+}
+
+func TestE2EStreamSidecarSkipsToolCalls(t *testing.T) {
+	// tool_calls delta chunks interleaved with content: only content is
+	// aggregated, matching the non-streaming extractAssistantContent shape
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"Let me check the weather.\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\":\\\"Berlin\\\"}\"}}]},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, out := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "tool-sess-1"},
+		chatBody("deepseek-chat", "weather", true))
+	if !strings.Contains(string(out), "[DONE]") {
+		t.Fatalf("stream not relayed: %s", out)
+	}
+
+	lines := readSidecarLines(t, g, "tool-sess-1")
+	last := lines[len(lines)-1]
+	if last["role"] != "assistant" || last["content"] != "Let me check the weather." {
+		t.Fatalf("last line = %#v, want assistant with plain content only", last)
+	}
+	if _, has := last["tool_calls"]; has {
+		t.Errorf("sidecar assistant line carries tool_calls, want skipped: %#v", last)
+	}
+}
+
+func TestE2EStreamAbortFailClosed(t *testing.T) {
+	// upstream dies mid-stream: the partially aggregated reply must never
+	// reach the sidecar (fail-closed, half replies are not reusable)
+	up := &testUpstream{streamFunc: func(w http.ResponseWriter) {
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"half reply"}}]}`+"\n\n")
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
+		if hj, ok := w.(http.Hijacker); ok {
+			if conn, _, err := hj.Hijack(); err == nil {
+				_ = conn.Close()
+			}
+		}
+	}}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, _ = postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "abort-sess-1"},
+		chatBody("deepseek-chat", "do it", true))
+
+	if _, err := os.Stat(filepath.Join(g.cfg.Ingest.SessionsDir, "abort-sess-1.jsonl")); err == nil {
+		t.Error("sidecar exists after aborted stream, want no write (fail-closed)")
+	}
+}
+
+func TestE2EStreamNoTerminatorFailClosed(t *testing.T) {
+	// upstream ends the stream cleanly but never sends [DONE] or a
+	// finish_reason: without a termination signal nothing is persisted
+	up := &testUpstream{streamFunc: func(w http.ResponseWriter) {
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"no terminator"}}]}`+"\n\n")
+	}}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, _ = postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "noterm-sess-1"},
+		chatBody("deepseek-chat", "go on", true))
+
+	if _, err := os.Stat(filepath.Join(g.cfg.Ingest.SessionsDir, "noterm-sess-1.jsonl")); err == nil {
+		t.Error("sidecar exists without a termination signal, want no write (fail-closed)")
+	}
+}
+
+func TestE2EStreamAccumulatesL3(t *testing.T) {
+	// the full loop (issue #182 acceptance e2e): streaming request →
+	// sidecar with complete assistant → ingest → second identical request
+	// hits L3 with zero additional upstream calls.
+	// Query is multi-word on purpose: the ingest chain also lands a Prompt
+	// slice (a copy of the user message) that would otherwise top the BM25
+	// ranking below the zone absolute floor (AbsHigh 0.7), fail-closing L3.
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"weather widgets forecast today \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"weather widgets forecast today streaming answer\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	g.cfg.Ingest.L3SafeDefault = true // gateway results enter L3 only when opted in
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	body := chatBody("deepseek-chat", "weather widgets forecast today", true)
+	resp, out := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "l3-accum-1"}, body)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(out), "[DONE]") {
+		t.Fatalf("first stream: status=%d body=%s", resp.StatusCode, out)
+	}
+
+	// async ingest must land a Result slice carrying the aggregated reply
+	deadline := time.Now().Add(3 * time.Second)
+	ingested := false
+	for time.Now().Before(deadline) {
+		items, err := g.store.ListAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range items {
+			if s.Type == slice.Result && bytes.Contains(s.Content, []byte("streaming answer")) {
+				ingested = true
+				break
+			}
+		}
+		if ingested {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ingested {
+		t.Fatal("streamed assistant reply was not ingested as a Result slice within 3s")
+	}
+
+	// second identical request: L3 hit, zero additional upstream calls
+	resp2, out2 := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "l3-accum-1"}, body)
+	if resp2.Header.Get("x-semantix-cache") != "hit" {
+		t.Errorf("second request cache = %q, want hit (%s)", resp2.Header.Get("x-semantix-cache"), out2)
+	}
+	if !strings.Contains(string(out2), "streaming answer") || !strings.Contains(string(out2), "[DONE]") {
+		t.Errorf("replayed stream missing content or terminator: %s", out2)
+	}
+	if n := up.callCount(); n != 1 {
+		t.Errorf("upstream calls = %d, want 1 (second request must not reach upstream)", n)
 	}
 }

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -260,10 +260,14 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 
 // streamThrough relays a streaming upstream response chunk by chunk (SSE),
 // preserving events verbatim (design §3.4: never reorder/rewrite the
-// upstream stream). If the upstream ends without a [DONE] marker (abnormal
-// disconnect), the gateway appends one so the client never hangs on an
-// unterminated stream. Sidecar records the request turns only — parsing the
-// assistant content out of the SSE chunks is deferred (documented debt).
+// upstream stream). While relaying, the assistant content is aggregated out
+// of the SSE chunks (choices[0].delta.content); only a cleanly terminated
+// stream — finish_reason or [DONE], within the aggregation bound — is
+// written to the session sidecar. Partial/aborted streams fail closed and
+// never enter the reuse library, matching the non-streaming path where
+// failed exchanges are not recorded (design §0.3 documented debt, now paid).
+// If the upstream ends without a [DONE] marker (abnormal disconnect), the
+// gateway appends one so the client never hangs on an unterminated stream.
 func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
 	if resp.StatusCode >= 400 {
 		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
@@ -279,7 +283,9 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 
 	// Scan lines rather than blind blocks: we must detect the [DONE]
 	// marker to guarantee stream termination even when the upstream
-	// disconnects early. Lines are still forwarded verbatim.
+	// disconnects early. Lines are still forwarded verbatim, and fed to
+	// the aggregator for sidecar extraction.
+	agg := newSSEAggregator(maxSSEAggregateBytes)
 	br := bufio.NewReader(resp.Body)
 	sawDone := false
 	for {
@@ -292,6 +298,7 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 			if flusher != nil {
 				flusher.Flush()
 			}
+			agg.Feed(line)
 		}
 		if err != nil {
 			break
@@ -305,7 +312,9 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 			flusher.Flush()
 		}
 	}
-	g.recordSession(sessionID, ctxHash, req.Model, turns(req, ""))
+	if agg.Complete() {
+		g.recordSession(sessionID, ctxHash, req.Model, turns(req, agg.Content()))
+	}
 	g.recordUsage(usage.Event{
 		SessionID:      sessionID,
 		TokensIn:       int64(len(query)/4) + injectedTokens,

--- a/gateway/sse.go
+++ b/gateway/sse.go
@@ -1,0 +1,130 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// maxSSEAggregateBytes bounds the assistant content accumulated out of a
+// relayed SSE stream. Past this limit the aggregator stops accumulating
+// (the relay continues untouched) and Complete() reports false so the
+// caller fails closed — a hostile or broken upstream cannot grow memory
+// without bound.
+const maxSSEAggregateBytes = 1 << 20 // 1 MiB
+
+// maxSSELineBytes bounds a single buffered SSE line. A pathological
+// upstream emitting one endless line (no newline) would otherwise grow
+// lineBuf without bound; crossing the bound also fails closed.
+const maxSSELineBytes = 64 * 1024
+
+// sseAggregator parses an OpenAI chat.completion.chunk SSE stream while it
+// is being relayed verbatim (design §3.4: never reorder/rewrite the
+// upstream stream). It accumulates choices[0].delta.content and tracks a
+// clean termination: a "data: [DONE]" event or a non-null finish_reason on
+// the first choice.
+//
+// Tolerant by design: malformed lines and events are skipped without
+// affecting the relay. Only two facts matter to the caller — Complete()
+// (clean termination AND no overflow) and Content().
+type sseAggregator struct {
+	lineBuf  bytes.Buffer // partial line carried across Feed calls
+	pending  []string     // data payload lines of the event being assembled
+	content  strings.Builder
+	overflow bool
+	done     bool
+	limit    int // content aggregation bound
+	lineMax  int // per-line buffer bound
+}
+
+func newSSEAggregator(limit int) *sseAggregator {
+	return &sseAggregator{limit: limit, lineMax: maxSSELineBytes}
+}
+
+// Feed processes the exact bytes being relayed. Calls may split events and
+// lines arbitrarily (the relay reads in 32 KiB chunks). Once a bound is
+// crossed the aggregator stops parsing entirely: the stream still relays,
+// but Complete() stays false so nothing is persisted.
+func (a *sseAggregator) Feed(p []byte) {
+	if a.overflow {
+		return
+	}
+	if a.lineBuf.Len()+len(p) > a.lineMax {
+		a.overflow = true
+		a.lineBuf.Reset()
+		return
+	}
+	a.lineBuf.Write(p)
+	for {
+		line, err := a.lineBuf.ReadString('\n')
+		if err != nil {
+			// Partial trailing line: keep it buffered for the next call.
+			a.lineBuf.Reset()
+			a.lineBuf.WriteString(line)
+			return
+		}
+		a.handleLine(strings.TrimRight(line, "\r\n"))
+	}
+}
+
+func (a *sseAggregator) handleLine(line string) {
+	switch {
+	case strings.TrimSpace(line) == "":
+		a.flushEvent()
+	case strings.HasPrefix(line, "data:"):
+		payload := strings.TrimPrefix(line, "data:")
+		a.pending = append(a.pending, strings.TrimPrefix(payload, " "))
+	}
+	// event:/id:/retry: lines carry no payload; ignored.
+}
+
+func (a *sseAggregator) flushEvent() {
+	if len(a.pending) == 0 {
+		return
+	}
+	payload := strings.Join(a.pending, "\n") // SSE joins multi-line data with \n
+	a.pending = nil
+	if payload == "[DONE]" {
+		a.done = true
+		return
+	}
+	var evt struct {
+		Choices []struct {
+			Delta struct {
+				Content string `json:"content"`
+			} `json:"delta"`
+			FinishReason *string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal([]byte(payload), &evt); err != nil || len(evt.Choices) == 0 {
+		return // tolerant: skip malformed or empty events
+	}
+	first := evt.Choices[0]
+	if first.FinishReason != nil && *first.FinishReason != "" {
+		a.done = true
+	}
+	if a.overflow {
+		return
+	}
+	delta := first.Delta.Content
+	if delta == "" {
+		return
+	}
+	if a.content.Len()+len(delta) > a.limit {
+		a.overflow = true
+		return
+	}
+	a.content.WriteString(delta)
+}
+
+// Complete reports whether the stream terminated cleanly ([DONE] or
+// finish_reason) without exceeding the aggregation bound. Callers must not
+// persist partial content when this is false (fail-closed).
+func (a *sseAggregator) Complete() bool {
+	return a.done && !a.overflow
+}
+
+// Content returns the accumulated choices[0].delta.content.
+func (a *sseAggregator) Content() string {
+	return a.content.String()
+}

--- a/gateway/sse_test.go
+++ b/gateway/sse_test.go
@@ -1,0 +1,144 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func feedAll(a *sseAggregator, stream string) {
+	a.Feed([]byte(stream))
+}
+
+func TestSSEAggregatorFullStream(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, ""+
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hello \"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"streaming \"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"world\"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if !a.Complete() {
+		t.Error("Complete() = false, want true for a cleanly terminated stream")
+	}
+	if got := a.Content(); got != "hello streaming world" {
+		t.Errorf("Content() = %q, want %q", got, "hello streaming world")
+	}
+}
+
+// chunkFeed feeds the stream in tiny fixed-size pieces, forcing lines and
+// events to split across Feed calls — the relay reads 32 KiB chunks, so
+// this exercises the real cross-call buffering path.
+func TestSSEAggregatorSplitFeeds(t *testing.T) {
+	stream := "" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"alpha \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"beta\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	for i := 0; i < len(stream); i += 7 {
+		end := i + 7
+		if end > len(stream) {
+			end = len(stream)
+		}
+		a.Feed([]byte(stream[i:end]))
+	}
+	if !a.Complete() {
+		t.Error("Complete() = false, want true")
+	}
+	if got := a.Content(); got != "alpha beta" {
+		t.Errorf("Content() = %q, want %q", got, "alpha beta")
+	}
+}
+
+func TestSSEAggregatorCRLF(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"index\":0}]}\r\n\r\ndata: [DONE]\r\n\r\n")
+	if !a.Complete() || a.Content() != "ok" {
+		t.Errorf("CRLF stream: Complete=%v Content=%q", a.Complete(), a.Content())
+	}
+}
+
+func TestSSEAggregatorNoTerminator(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"half\"},\"index\":0}]}\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true without [DONE] or finish_reason, want false (fail-closed)")
+	}
+}
+
+func TestSSEAggregatorDoneWithTrailingSpace(t *testing.T) {
+	// "data: [DONE] " is not the canonical terminator: fail closed rather
+	// than risk persisting a stream that was not cleanly closed.
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"x\"},\"index\":0}]}\n\ndata: [DONE] \n\n")
+	if a.Complete() {
+		t.Error("Complete() = true for a non-canonical [DONE] payload, want false")
+	}
+}
+
+func TestSSEAggregatorEmptyFinishReason(t *testing.T) {
+	// a null-ish empty finish_reason must not count as a termination signal
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"\"},\"index\":0}]}\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true for empty finish_reason, want false")
+	}
+}
+
+func TestSSEAggregatorMultiLineDataTolerated(t *testing.T) {
+	// multi-line data payloads are valid SSE but not OpenAI chunk JSON;
+	// they must be skipped without disturbing later events
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: line one\ndata: line two\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"after\"},\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if !a.Complete() || a.Content() != "after" {
+		t.Errorf("multi-line data: Complete=%v Content=%q, want true/%q", a.Complete(), a.Content(), "after")
+	}
+}
+
+func TestSSEAggregatorBadJSONTolerated(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {not json}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if !a.Complete() || a.Content() != "ok" {
+		t.Errorf("bad JSON: Complete=%v Content=%q, want true/%q", a.Complete(), a.Content(), "ok")
+	}
+}
+
+func TestSSEAggregatorOnlyFirstChoice(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"first \"},\"index\":0},{\"delta\":{\"content\":\"second\"},\"index\":1}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if got := a.Content(); got != "first " {
+		t.Errorf("Content() = %q, want only choices[0] content", got)
+	}
+}
+
+func TestSSEAggregatorContentOverflow(t *testing.T) {
+	a := newSSEAggregator(16) // tiny bound: "hello world" (11) fits, more trips it
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"hello world\"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"overflow\"},\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true past the content bound, want false (fail-closed)")
+	}
+}
+
+func TestSSEAggregatorLineOverflow(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	// a single endless line (no newline) must trip the line bound, not grow
+	// the buffer without limit
+	feedAll(a, "data: "+strings.Repeat("x", maxSSELineBytes+1))
+	if a.Complete() {
+		t.Error("Complete() = true past the line bound, want false")
+	}
+	// once overflowed, further feeds are ignored (no growth, no parsing)
+	feedAll(a, "data: [DONE]\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true after overflow, want false")
+	}
+}


### PR DESCRIPTION
## Summary

Issue #182 GW2：流式响应侧写记忆。修复 `streamThrough` 只把请求侧写进旁路文件的 documented debt（spec §0.3）：边透传边聚合 SSE 的 `choices[0].delta.content`，把完整 assistant 回复经既有 `turns(req, content)` 写入会话旁路文件——真实流式流量（Claude Code / chatbox / IDE 插件几乎全用 `stream=true`）的响应从此成为可复用的 Result 切片，L3 从「只积累非流式」变为「双路径积累」，为 GW4 (#184) 的 M1 验收门铺路。

Spec post 已发布在 issue #182 并经审阅批准（#issuecomment-5312381566），本 PR 为其实现。

## Scope

- `gateway/sse.go`（新增）：SSE 聚合器——按行解析、`data:` 负载、`[DONE]`/`finish_reason` 终止判定、`choices[0].delta.content` 聚合、1 MiB 内容上限 + 64 KiB 行上限（超限 fail-closed）
- `gateway/sse_test.go`（新增）：11 个聚合器单测（跨块切分、CRLF、多行 data、坏 JSON、多 choice、空 finish_reason、两类 overflow）
- `gateway/pipeline.go`：`streamThrough` 边透传边聚合；仅完整终止的流写入旁路；断流/无终止/超限一律不入库。保留 U28 的按行扫描与断流补发 `[DONE]`（客户端防挂死）及 `sliceHits` usage 参数
- `gateway/e2e_test.go`：5 个新 e2e（完整聚合 / tool_calls 跳过 / 中途断连 fail-closed / 无终止 fail-closed / 流式积累 → L3 二次命中）+ `streamFunc` / `postChatWithHeaders` 测试设施
- `docs/reports/issue-182-acceptance.md`（新增）：验收报告

`gateway/gateway.go`、配置、旁路文件格式、`turns`/`recordSession`/`ingestSession` 零改动。usage 计量不动（GW7 #187 范围，本 PR 已与其先后合入约定一致）。

## Validation

- [x] `go vet ./...`（无警告）
- [x] `go test ./... -race` —— 本机无 CGO（无 gcc）不可运行，CI 承担（`.github/workflows/ci.yml:36` 已跑 `go test ./... -race`；与 issue-133 验收报告的既有记录一致）
- [x] `git diff --check`
- [x] 附加检查：`go build ./...`、`go test ./gateway/... -count=1`、`go test ./kernel/... -count=1`（16 包）、全仓 `go test ./... -count=1` 无 FAIL；新 e2e 3 次连跑稳定；独立 subagent review 无阻断（2 应修 + 1 nit 已修复复验）

## Compatibility and data impact

- 无契约变更（Spec-Exempt）：旁路 JSONL 行格式、`ingest.JSONLSource`、SliceMeta 字段均未改
- 行为变化（预期语义）：流式路径断流/无终止信号时不再写旁路文件（此前写空 assistant 的请求 turns，反而会污染 Result 提取）；完整流式响应首次进入 L3 积累
- 实测发现（kernel 既有设计，非本 PR 引入，记录于验收报告 §6）：真 ingest 下短 query（≤2 词）的 L3 因 zone 绝对地板（`AbsHigh=0.7`）fail-closed

## Security and privacy

- 聚合 buffer 有界（1 MiB 内容 + 64 KiB 行），恶意上游无法造成无界内存增长
- 半截/异常流不入库（fail-closed），不会把不完整响应写入复用库
- 无新增网络面、无新增凭据、无日志敏感信息

## Evidence

```
go test ./gateway/... -count=1   # ok（含 11 单测 + 5 新 e2e + 既有 e2e 回归）
go test ./kernel/... -count=1    # 16 包全绿
```

L3 二次命中闭环：`TestE2EStreamAccumulatesL3` —— 流式请求 → 旁路含完整 assistant → 真 ingest 入库 → 二次同 query `x-semantix-cache: hit` 且上游调用数保持 1。

## Related issues

Closes #182（GW4 #184 依赖本条）
