### PR TITLE
feat(gateway): GW7 计量口径收尾——流式 usage 补块 + 合成 usage estimator 标注 (Issue #187)

### DIFF
--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -88,11 +88,11 @@
 | §3.8 / §7 M2 | Claude / Anthropic 适配（messages 格式转换 + `cache_control` 断点） | **配置层显式拒绝**：`vendor="anthropic"` 在 `validate()` 直接报错，避免把 Anthropic 流量误发到 OpenAI 式端点。§3.6 对 Claude 打断点同理未做 |
 | §3.5 | `promote.CascadeInvalidate` 级联失效 | gateway 零引用 `kernel/promote`。上游内容版本变化时不会级联失效下游条目（deps 指纹仍能兜住文件类变更） |
 | §3.9 | `[retrieval] retriever = bm25 \| vector \| hybrid` | **死配置键**：字段被解析和校验，但 `New()` 固定构造 `bm25.New()`，填 `hybrid`/`vector` 不报错也不生效。与 `[cache] judge_api_key` 同属「保留但未接线」（验收报告 §4 已列为 nit、§6 记为「预留字段」） |
-| §3.4 | 未命中流式：上游不返回 usage 时，网关在 `[DONE]` 前补含注入统计的末块 | 未做。逐块原样透传，只在上游异常断流时补 `[DONE]` |
+| §3.4 | 未命中流式：上游不返回 usage 时，网关在 `[DONE]` 前补含注入统计的末块 | **GW7 已实现**（Issue #187）：`streamThrough` 扫描 SSE data 块，上游全程无 usage 时在 `[DONE]` 前合成 `{"choices":[],"usage":{...,"prompt_tokens_details":{"cached_tokens":<注入统计>},"estimator":"bytes/4"}}`；上游已带 usage 则原样透传不补。异常断流仍只补 `[DONE]` |
 | §3.7 | 流式路径的**响应侧**写记忆 | `streamThrough` 只把请求 turns 写进旁路文件，不解析 SSE 取 assistant 内容（代码内已标注为 documented debt，验收报告 §6 也记为债务）。后果：**流式请求的本次响应不会成为可复用的 Result 切片**——Result 提取取的是旁路文件里最后一条无 tool_calls 的 assistant 消息，流式路径下那只可能是请求里带的历史轮次。L3 的写入实际只来自非流式请求 |
 | §3.2 | `/healthz` 检查「切片库可打开 + **上游可达性**」 | 只回 `{"status":"ok"}`。切片库在 `New()` 阶段已打开（打不开进程起不来），上游探活未做 |
 | §5 | 部署产物：`docker-compose.yml`、网关镜像 Dockerfile、`semantix-gateway.toml` 示例 | 仓库中**均不存在**。§5 目前仍是纯文字方案，照它部署需要自己写 compose 与配置文件（验收报告 §6 建议另开运维 issue） |
-| §4.3 | 与 New API 计费对账的 token 口径 | 合成 usage 已实现，但 token 数是 `len(bytes)/4` 的**字节估算**，不是真 tokenizer 计数。对账时须知道这个口径差 |
+| §4.3 | 与 New API 计费对账的 token 口径 | 合成 usage（L3 命中非流式 + 流式补块）的 token 数是 `len(bytes)/4` 的**字节估算**，非真 tokenizer 计数；自 GW7（Issue #187）起合成 usage 均附 `"estimator":"bytes/4"` 字段，对账时按此字段识别口径差。未引入真 tokenizer（tiktoken 等）——依赖成本高（模型词表 + 外部库），口径文档化替代 |
 | §7 M0 | 门：真实客户端 → New API → 网关 → DeepSeek 全链路跑通 **且** 会话入库后 `semantix search` 可检索到切片 | **合取门只满足后半**：入库可检索有 e2e 证据（`TestE2ESidecarWrittenAndIngested`，验收报告 §3「写记忆」✅），这半句本就不依赖真上游；**真实全链路无记录**——`gateway/e2e_test.go` 与验收报告 §3 的上游都是 `httptest` 假上游 |
 | §7 M1 | 门：重复任务第二次命中 `x-semantix-cache: hit` 且零上游调用；成本节省 ≥30% 实测 | 前半在 e2e 中以假上游验证（`TestE2EL3HitZeroUpstreamCalls`：命中且上游 0 调用），**真实环境与成本节省实测无记录**；验收报告 §6 明确「M1/M2 里程碑项未在本 issue 范围」 |
 | §7 M2 | 四家模型全通 + 命中率周报 + New API 对账一致 | 未开始 |

--- a/gateway/gw7_test.go
+++ b/gateway/gw7_test.go
@@ -1,0 +1,115 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #187 / GW7: streaming usage block + token estimator
+
+// TestE2EStreamUsageBlockInjectedWhenUpstreamOmitsUsage: a streaming upstream
+// that never sends a usage event must get a synthetic usage block before
+// [DONE], carrying the injection stats (spec §3.4) and the bytes/4 estimator.
+func TestE2EStreamUsageBlockInjectedWhenUpstreamOmitsUsage(t *testing.T) {
+	up := &testUpstream{stream: "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\ndata: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	// Seed a Prompt slice so the L2 injector reports nonzero injection stats.
+	seed(t, g, &slice.Slice{
+		ID: "l2-gw7", Type: slice.Prompt, Scope: slice.Project,
+		Content: []byte("prior widgets knowledge to inject"),
+	})
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "widgets please", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	body := string(out)
+	if !strings.Contains(body, "[DONE]") {
+		t.Fatalf("stream missing [DONE]: %s", body)
+	}
+	// The synthetic usage block must appear before [DONE].
+	usageIdx := strings.Index(body, `"usage":`)
+	doneIdx := strings.Index(body, "data: [DONE]")
+	if usageIdx < 0 {
+		t.Fatalf("no usage block synthesized: %s", body)
+	}
+	if doneIdx < 0 || usageIdx > doneIdx {
+		t.Fatalf("usage block (%d) must precede [DONE] (%d): %s", usageIdx, doneIdx, body)
+	}
+	if !strings.Contains(body, `"estimator":"bytes/4"`) {
+		t.Errorf("usage block missing estimator: %s", body)
+	}
+	if !strings.Contains(body, `"cached_tokens"`) {
+		t.Errorf("usage block missing cached_tokens (injection stats): %s", body)
+	}
+}
+
+// TestE2EStreamUsageNotDuplicatedWhenUpstreamProvidesIt: when the upstream
+// already sends a usage event, the gateway must not add a second one.
+func TestE2EStreamUsageNotDuplicatedWhenUpstreamProvidesIt(t *testing.T) {
+	up := &testUpstream{stream: "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3,\"total_tokens\":10}}\n\ndata: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "stream me", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if got := strings.Count(string(out), `"usage"`); got != 1 {
+		t.Errorf(`usage occurrences = %d, want exactly 1 (no duplication): %s`, got, out)
+	}
+	if strings.Contains(string(out), `"estimator"`) {
+		t.Errorf("relayed upstream usage must not carry a gateway estimator: %s", out)
+	}
+}
+
+// TestE2EL3HitUsageCarriesEstimator: the synthetic non-streaming L3 usage
+// reports its byte-estimate origin so GW4 accounting knows the discrepancy.
+func TestE2EL3HitUsageCarriesEstimator(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"unused"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	chash, _ := contextHash([]chatMessage{msg("user", "hello world")})
+	seed(t, g, &slice.Slice{
+		ID: "l3-gw7", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("hello world hello world cached answer"),
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
+	})
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if resp.Header.Get("x-semantix-cache") != "hit" {
+		t.Fatalf("x-semantix-cache = %q, want hit", resp.Header.Get("x-semantix-cache"))
+	}
+	var body struct {
+		Usage struct {
+			Estimator string `json:"estimator"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(out, &body); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if body.Usage.Estimator != "bytes/4" {
+		t.Errorf(`usage.estimator = %q, want "bytes/4"`, body.Usage.Estimator)
+	}
+}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -231,13 +231,31 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 	// Scan lines rather than blind blocks: we must detect the [DONE]
 	// marker to guarantee stream termination even when the upstream
 	// disconnects early. Lines are still forwarded verbatim.
+	// Issue #187 / GW7 (spec §3.4): when the upstream finishes without a
+	// usage event, we synthesize one before [DONE] carrying the injection
+	// stats, so streaming clients see the same cached_tokens accounting as
+	// non-streaming paths.
 	br := bufio.NewReader(resp.Body)
 	sawDone := false
+	sawUsage := false
 	for {
 		line, err := br.ReadBytes('\n')
 		if len(line) > 0 {
-			if bytes.HasPrefix(bytes.TrimSpace(line), []byte("data: [DONE]")) {
+			trimmed := bytes.TrimSpace(line)
+			switch {
+			case bytes.HasPrefix(trimmed, []byte("data: [DONE]")):
 				sawDone = true
+			case bytes.HasPrefix(trimmed, []byte("data:")):
+				if sseDataHasUsage(trimmed) {
+					sawUsage = true
+				}
+			}
+			if sawDone && !sawUsage {
+				// Synthesize the usage block before the terminator.
+				_, _ = w.Write(g.streamUsageBlock(req.Model, int64(len(query)/4), injectedTokens))
+				if flusher != nil {
+					flusher.Flush()
+				}
 			}
 			_, _ = w.Write(line)
 			if flusher != nil {
@@ -250,7 +268,8 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 	}
 	if !sawDone {
 		// Abnormal termination: close the stream ourselves so the client
-		// does not hang (design §3.4: [DONE] always terminates).
+		// does not hang (design §3.4: [DONE] always terminates). No usage
+		// block: the stream never completed normally.
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 		if flusher != nil {
 			flusher.Flush()
@@ -264,6 +283,49 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 		SliceHits:      sliceHits,
 		At:             g.now().Unix(),
 	})
+}
+
+// sseDataHasUsage reports whether an SSE data line's JSON payload carries a
+// top-level "usage" object (OpenAI-compatible streaming usage block).
+func sseDataHasUsage(line []byte) bool {
+	payload := bytes.TrimSpace(bytes.TrimPrefix(bytes.TrimSpace(line), []byte("data:")))
+	var obj struct {
+		Usage json.RawMessage `json:"usage"`
+	}
+	if err := json.Unmarshal(payload, &obj); err != nil {
+		return false
+	}
+	return len(obj.Usage) > 0 && string(obj.Usage) != "null"
+}
+
+// streamUsageBlock builds the synthetic OpenAI-compatible streaming usage
+// block injected before [DONE] when the upstream omitted usage (Issue #187).
+// Token counts are byte estimates (len/4), stamped with estimator for
+// downstream accounting; cached_tokens carries the L2 injection stats.
+func (g *Gateway) streamUsageBlock(model string, promptTokens, cachedTokens int64) []byte {
+	chunk := struct {
+		ID      string          `json:"id"`
+		Object  string          `json:"object"`
+		Created int64           `json:"created"`
+		Model   string          `json:"model"`
+		Choices []choicePayload `json:"choices"`
+		Usage   usagePayload    `json:"usage"`
+	}{
+		ID:      "chatcmpl-stream",
+		Object:  "chat.completion.chunk",
+		Created: g.now().Unix(),
+		Model:   model,
+		Choices: []choicePayload{},
+		Usage: usagePayload{
+			PromptTokens:     int(promptTokens),
+			CompletionTokens: 0,
+			TotalTokens:      int(promptTokens),
+			PromptDetails:    struct{ CachedTokens int `json:"cached_tokens"` }{CachedTokens: int(cachedTokens)},
+			Estimator:        "bytes/4",
+		},
+	}
+	raw, _ := json.Marshal(chunk)
+	return append([]byte("data: "), append(raw, '\n', '\n')...)
 }
 
 // isHopByHopHeader reports connection-scoped headers that must never be
@@ -347,6 +409,10 @@ type usagePayload struct {
 	PromptDetails    struct {
 		CachedTokens int `json:"cached_tokens"`
 	} `json:"prompt_tokens_details"`
+	// Estimator marks gateway-synthesized token counts (Issue #187 / GW7):
+	// the numbers are byte estimates (len/4), not real tokenizer counts.
+	// Omitted when the usage block is relayed verbatim from upstream.
+	Estimator string `json:"estimator,omitempty"`
 }
 
 // replyFromCache serves a verified L3 hit: a plain JSON response, or a
@@ -374,6 +440,7 @@ func (g *Gateway) replyFromCache(w http.ResponseWriter, r *http.Request, req *ch
 			PromptTokens:     prompt + cached,
 			CompletionTokens: 0,
 			TotalTokens:      prompt + cached,
+			Estimator:        "bytes/4",
 		},
 	}
 	body.Usage.PromptDetails.CachedTokens = cached


### PR DESCRIPTION
## 概述

GW7（#187）计量口径收尾两项：① 未命中流式上游不回 usage 时，`[DONE]` 前补含注入统计的 usage 块（spec §3.4）；② 合成 usage 附 `"estimator":"bytes/4"` 标注字节估算口径（不引入真 tokenizer——依赖成本高，口径文档化）。

> 关联 #187（验收记录，不关闭）

## ① 流式 usage 补块（spec §3.4）

- `gateway/pipeline.go` `streamThrough`：逐行扫描 SSE data 块，跟踪上游是否发送过 usage 事件（`sseDataHasUsage`）
- 上游全程无 usage → 在 `[DONE]` **之前**合成 OpenAI 兼容 usage 块：`{"choices":[],"usage":{"prompt_tokens":…,"prompt_tokens_details":{"cached_tokens":<注入统计>},"estimator":"bytes/4"}}`
- 上游已带 usage → 原样透传，不补发、不污染 estimator
- 异常断流（无 `[DONE]`）保持只补 `[DONE]`，不补 usage

## ② token 口径标注（spec §4.3）

- `usagePayload` 新增 `"estimator"` 字段（`omitempty`，透传上游 usage 时不出现）
- 两处网关合成 usage 均标注 `"estimator":"bytes/4"`：L3 命中非流式（`replyFromCache`）+ 流式补块（`streamUsageBlock`）
- 未引入 tiktoken 等真 tokenizer：评估结论为依赖成本高（模型词表 + 外部库），口径以字段 + spec 注记文档化，GW4 对账按 `estimator` 识别

## spec 回写

§0.3 两行：`§3.4 流式补块` 从「未做」改「GW7 已实现」；`§4.3 token 口径` 补 estimator 字段与不引入 tokenizer 的决策注记。

## 测试

新增 `gateway/gw7_test.go` 3 个 e2e：
- `TestE2EStreamUsageBlockInjectedWhenUpstreamOmitsUsage`：无 usage 上游 → 补块在 `[DONE]` 前，含 `cached_tokens` + `estimator`（seed L2 切片产生注入统计）
- `TestE2EStreamUsageNotDuplicatedWhenUpstreamProvidesIt`：上游带 usage → 恰好 1 次、无 estimator 污染
- `TestE2EL3HitUsageCarriesEstimator`：非流式 L3 命中 → `usage.estimator == "bytes/4"`

**验证**：`go build ./...` ✅ + `go test -race ./...`（全仓 18 包）✅ + `go test -race ./gateway/...` ✅