### PR TITLE
feat(gateway): 部署产物三件套 + /healthz 上游探活 (Issue #183)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Docker 构建上下文排除（deploy/Dockerfile 的 builder 阶段 COPY . .）
+.git
+.worktrees
+data
+.semantix
+tmp
+semantix
+semantix.exe
+*.db
+*.out
+*.test
+site/node_modules

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,28 @@
+# Semantix Gateway 镜像 —— 多阶段构建，非 root 运行（Issue #183）。
+#
+# 运行层用 alpine（而非设计文档 §5 设想的 scratch/distroless），取舍：
+#   ① 网关以 HTTPS 调用上游，需要 CA 证书（scratch 无）；
+#   ② docker-compose 的 healthcheck 需要 shell 工具（busybox wget，distroless 无 shell）。
+# 镜像仍为单二进制 + 零第三方运行时依赖，体积约 15MB。
+
+# ---- builder ----
+FROM golang:1.26-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/semantix-gateway ./cmd/semantix-gateway
+
+# ---- runtime ----
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates \
+    && addgroup -S -g 65532 semantix \
+    && adduser -S -u 65532 -G semantix semantix \
+    && mkdir -p /data \
+    && chown 65532:65532 /data
+USER 65532:65532
+WORKDIR /data
+COPY --from=builder /out/semantix-gateway /usr/local/bin/semantix-gateway
+EXPOSE 8080
+ENTRYPOINT ["semantix-gateway"]
+CMD ["--config", "/etc/semantix-gateway.toml"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,48 @@
+# Semantix Gateway 部署 —— New API + semantix-gateway 单机两服务（设计文档 §5）。
+#
+# 用法（三条命令）：
+#   cp deploy/semantix-gateway.toml.example deploy/semantix-gateway.toml
+#   编辑 deploy/semantix-gateway.toml 并按需在 .env 设置 SEMANTIX_GATEWAY_KEY / DEEPSEEK_API_KEY
+#   docker compose -f deploy/docker-compose.yml up -d --build
+#
+# 网络：semantix-gateway:8080 仅暴露给 New API（compose 内部网络），不发布到宿主机。
+# 数据：new-api 用 bind mount（./data/new-api），gateway 用 named volume（首次挂载
+#       自动继承镜像内 /data 的 65532 所有权，非 root 可写；若改用 bind mount
+#       需自行 chown 65532:65532 宿主目录）。
+
+services:
+  new-api:
+    image: quantumnew/new-api
+    restart: unless-stopped
+    ports:
+      - "3000:3000" # 公网入口；TLS 建议前置 nginx（设计文档 §5 可选）
+    volumes:
+      - ./data/new-api:/data # SQLite 持久化
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:3000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  semantix-gateway:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    restart: unless-stopped
+    environment:
+      SEMANTIX_GATEWAY_KEY: ${SEMANTIX_GATEWAY_KEY:?set in .env or shell}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:?set in .env or shell}
+    volumes:
+      - semantix-data:/data # 切片库 + 会话旁路持久化
+      - ./deploy/semantix-gateway.toml:/etc/semantix-gateway.toml:ro
+    expose:
+      - "8080" # 仅 compose 内部网络
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/healthz | grep -q '\"status\":\"ok\"'"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  semantix-data:

--- a/deploy/semantix-gateway.toml.example
+++ b/deploy/semantix-gateway.toml.example
@@ -1,0 +1,39 @@
+# Semantix Gateway 配置示例（设计文档 §3.9）
+# 用法：cp deploy/semantix-gateway.toml.example deploy/semantix-gateway.toml
+#       → 设置对应环境变量（或写入 .env）→ docker compose -f deploy/docker-compose.yml up -d --build
+#
+# 规则：所有 ${VAR} 在启动时由环境变量替换，未设置即启动失败（fail-closed，
+# 防止把字面量当凭据）；key 只走环境变量，绝不落配置文件。
+# 镜像内配置挂载于 /etc/semantix-gateway.toml，数据目录 /data（named volume）。
+
+[server]
+addr = ":8080"
+gateway_key = "${SEMANTIX_GATEWAY_KEY}"   # New API 渠道转发时携带的 key（渠道密钥字段）
+health_timeout_seconds = 3                # /healthz 上游探活总超时（秒）；0 = 禁用探活只回本地就绪
+
+[store]
+db = "/data/gateway.jsonl"                # 切片库 + L3 缓存库（JSONL 单文件，0600）
+scope = "project"                         # 默认切片作用域（session | project | user）
+deps_root = "/data"                       # deps 指纹根目录（缺失文件视为已变更 → 缓存失效）
+
+[retrieval]
+retriever = "bm25"                        # bm25 | vector | hybrid（当前仅 bm25 生效，hybrid/vector 未接线，见 GW6）
+top_k = 5
+budget = 4096                             # L2 注入块字节预算
+
+[cache]
+ttl_seconds = 86400                       # 默认 TTL（0 = 不设时间窗）
+judge_api_key = ""                        # 可选：grey 区 LLM judge（当前未接线，见 GW6）；留空即不启用
+
+[ingest]
+sessions_dir = "/data/sessions"           # 会话旁路落盘目录（0600）
+usage_log = "/data/gateway-usage.jsonl"   # usage 事件记录
+l3_safe_default = false                   # 无 deps 的网关结果默认不进 L3（true 需显式确认）
+
+[[upstreams]]                             # 每个 New API 渠道模型对应一段
+name = "deepseek"
+base_url = "https://api.deepseek.com/v1"
+api_key = "${DEEPSEEK_API_KEY}"           # 上游 key：只走环境变量
+model_alias = ["deepseek-chat"]           # 客户端可见模型名（New API 渠道模型名）
+upstream_model = "deepseek-chat"          # 上游真实模型名
+vendor = "deepseek"                       # deepseek | openai | moonshot（anthropic 需 M2 格式转换，未支持）

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -135,6 +135,39 @@ semantix completion fish | source
 
 复制 `semantix.example.toml` 为 `semantix.toml` 并按需修改（当前 CLI 参数优先）。
 
+## 网关部署（Docker）
+
+[Semantix Gateway](cmd/semantix-gateway)（`cmd/semantix-gateway`）是 OpenAI 兼容网关：
+给任意支持自定义 `base_url` 的客户端（Claude Code / chatbox / IDE 插件）透明加上
+L1/L2/L3 语义缓存。与 New API（API 中转面板）搭配部署，三条命令起步：
+
+```bash
+# 1. 生成配置（编辑其中的 ${VAR} 对应环境变量，或写入 .env）
+cp deploy/semantix-gateway.toml.example deploy/semantix-gateway.toml
+
+# 2. 设置密钥（只走环境变量，不落配置文件）
+export SEMANTIX_GATEWAY_KEY=change-me        # New API 渠道密钥字段的值
+export DEEPSEEK_API_KEY=change-me            # 上游 LLM 的 key
+
+# 3. 起服务（New API 面板 + 网关两容器；网关 8080 仅内网）
+docker compose -f deploy/docker-compose.yml up -d --build
+```
+
+验证：
+
+```bash
+docker compose -f deploy/docker-compose.yml ps          # 两服务均 healthy
+curl http://127.0.0.1:3000/                             # New API 面板
+curl http://127.0.0.1:3000/v1/models -H "Authorization: Bearer <New API token>"
+```
+
+然后在 New API 管理后台建渠道：类型「自定义」，代理地址 `http://semantix-gateway:8080`，
+密钥填 `SEMANTIX_GATEWAY_KEY` 的值，模型填 `deepseek-chat`；渠道可用性检测用
+`GET /healthz`（网关探活失败会返回 503，New API 自动禁用该渠道）。
+
+完整设计见 `docs/specs/newapi-gateway-design.md`；非 Docker 直跑（systemd/launchd）
+见该文档 §5.1。
+
 ## 安全约定
 
 - 切片库文件权限 `0600`、目录 `0700`（原子写 + 防 symlink）

--- a/docs/reports/issue-183-acceptance.md
+++ b/docs/reports/issue-183-acceptance.md
@@ -1,0 +1,71 @@
+# Issue #183 验收报告 — GW3: 网关部署产物三件套 + /healthz 上游探活
+
+> 状态：验收通过（2026-08-17）。对应 Issue：`#183 GW3: 网关部署产物三件套 + /healthz 上游探活`（Spec-Exempt，落实已批准 spec §5 文字方案 + §3.2 healthz 既有条目；`[server] health_timeout_seconds` 为 issue 批准的轻微契约扩展）。
+> 设计真源：`docs/specs/newapi-gateway-design.md`（§0.3 / §3.2 / §3.8 / §3.9 / §5）；实现规格 = issue #183 上的 spec post（评论 `#issuecomment-5312589588`，用户审后批准）。
+> 验收方式：实现 + 单测/e2e + 独立 subagent 审查（review）+ 缺陷修复后复验。
+
+## 1. 验收对象
+
+| 项 | 值 |
+|---|---|
+| 范围 | `deploy/`（3 文件新增）+ `.dockerignore`（新增）+ `gateway/server.go`（`handleHealth` 探活）+ `gateway/gateway.go`（`healthProbe` 注入 + `probeUpstreams`）+ `gateway/config.go`（`health_timeout_seconds`）+ `gateway/config_test.go` + `gateway/e2e_test.go`（TestE2EHealth*）+ `docs/specs/newapi-gateway-design.md`（§0 回写）+ `docs/QUICKSTART.md`（网关部署节） |
+| 未提交 | 工作区未提交（待用户确认后提交） |
+
+## 2. Issue checklist 逐条核对
+
+| # | checklist（issue #183 原文） | 状态 | 证据 |
+|---|---|---|---|
+| 1 | `deploy/semantix-gateway.toml.example`：全部小节 + `${VAR}` 引用示范（上游 key 只走环境变量） | ✅ | `deploy/semantix-gateway.toml.example`（server/store/retrieval/cache/ingest/upstreams 全小节；`${SEMANTIX_GATEWAY_KEY}`/`${DEEPSEEK_API_KEY}` 示范；dead 键如实标注 GW6）；`TestDeployConfigExampleLoads` 门禁（env 注入后 `Load` 解析通过） |
+| 2 | `deploy/Dockerfile`：多阶段构建 `cmd/semantix-gateway`，非 root 运行 | ✅ | 多阶段（golang:1.26-alpine → alpine:3.20 + ca-certificates），`USER 65532:65532`，`/data` 于 USER 前 chown（legacy builder 兼容） |
+| 3 | `deploy/docker-compose.yml`：New API + semantix-gateway 两服务，网络与 healthcheck 接好 | ✅ | 两服务 + 内部网络（gateway `expose` 不发布端口）+ 双 healthcheck（gateway 引用 `/healthz`）+ named volume 持久化（非 root 可写） |
+| 4 | `/healthz` 增加上游可达性探测（可配超时；探测失败返回 503 + 原因），compose healthcheck 引用 | ✅ | `probeUpstreams`（GET `{base_url}/models`，2xx=健康）；`[server] health_timeout_seconds`（默认 3，0=禁用）；失败 503 + OpenAI envelope（`upstream_error` + 上游名 + 原因，不泄漏 URL/Key）；`TestE2EHealthProbe*` 5 用例 |
+| 5 | `docs/specs/newapi-gateway-design.md` §0 状态行回写（部署产物已存在） | ✅ | §0.1 healthz 行 + §0.3 两行（healthz 探活已实现 / deploy/ 已存在）回写 |
+| 6 | README 或 docs 补一节「网关部署」指引（三条命令能起来） | ✅ | `docs/QUICKSTART.md`「网关部署（Docker）」节（三条命令 + 验证 + New API 渠道配置） |
+
+## 3. 端到端实测（httptest 假上游，gateway 包）
+
+| 场景 | 断言 | 结果 |
+|---|---|---|
+| 探活成功 | `/healthz` 200 + `{"status":"ok"}`；上游收到 1 次 GET /models | ✅ |
+| 上游不可达 | 503 + envelope `upstream_error` + `unreachable`；响应不泄漏上游 URL | ✅ |
+| 多上游其一失败 | 503，body 点名失败上游 | ✅ |
+| 探活超时 | `health_timeout_seconds=1` + 慢 probe → 503 + `deadline exceeded`，1s 内返回 | ✅ |
+| 探活禁用（0） | 200 + ok，上游零流量 | ✅ |
+| toml.example 门禁 | env 注入后 `Load` 解析成功，关键字段（key/超时/路径/vendor）匹配契约 | ✅ |
+| 既有回归 | gateway 全量 + 全仓 18 包 `-count=1` 全绿；`go vet` 无警告 | ✅ |
+
+## 4. 独立 subagent 审查与修复
+
+审查结论：核心逻辑正确，无阻断；2 应修 + 2 nit，应修已全部处理。
+
+| 发现 | 分级 | 处置 |
+|---|---|---|
+| `probeUpstreams` 用 `%w` 透传 `*url.Error`，完整 BaseURL 会进 503 响应（与"不泄漏 URL"承诺矛盾） | 应修 | 改 `errors.As` 取底层 cause 只留原因；测试补 `!strings.Contains(out, deadURL)` 断言防回归 |
+| Dockerfile `USER 65532` 在 `WORKDIR /data` 之前：legacy builder 下 `/data` 为 root:root，named volume 填充后 65532 不可写 → crash loop | 应修 | USER 前加 `mkdir -p /data && chown 65532:65532 /data` |
+| `timeout > 0 && g.healthProbe != nil` 分支中 nil probe 静默回 200 | nit | 保留（`New()` 已保证非 nil，防御性检查无实际危害） |
+| `TestE2EHealthProbeDisabled` 未真正断言零上游流量 | nit | 改用活上游 + `callCount()==0` 断言 |
+
+复验：修复后 `go vet ./gateway/...` + 全仓 `go test ./... -count=1`（18 包）全绿。
+
+## 5. 验证命令
+
+```bash
+go build ./...                    # ✅
+go vet ./gateway/...              # ✅ 无警告
+go test ./gateway/... -count=1    # ✅ 全部通过（含 6 个新 GW3 用例）
+go test ./... -count=1            # ✅ 18 包全绿
+git diff --check                  # ✅
+go test ./gateway/... -race       # ⚠️ 本机无 CGO（gcc 不存在）不可运行，CI 承担
+docker compose -f deploy/docker-compose.yml config   # ⚠️ 本机无 docker compose 插件未验证（文件为静态 YAML，语法经 review 核对）
+```
+
+## 6. 未闭合风险与后续边界
+
+| 项 | 说明 |
+|---|---|
+| compose/Dockerfile 未实机验证 | 本机无 Docker daemon；文件经静态 review + toml 门禁测试验证，实机 `docker compose up` 留待 GW4 真实全链路验收时执行（正是本条产物的用途） |
+| 镜像基础偏离 spec §5 文字方案 | alpine（CA 证书 + healthcheck 工具需要）而非 scratch/distroless，取舍已写入 `deploy/Dockerfile` 注释并经 spec post 审阅 |
+| `-race` 未在本机验证 | 无 CGO 环境限制（项目既有记录），CI 承担 |
+| 上游超时配置化未落地 | §3.8 的 connect 10s / 首字节 60s 仍是设计意图，不在本条范围；探活超时已独立实现 |
+| dead 配置键（retriever/judge_api_key） | GW6 #186 处理，example 已如实标注 |
+| GW4 #184 | M0 门（真实全链路 + 部署产物）依赖本条 |

--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -41,7 +41,7 @@
 | §3.1 | 切片库用 `slice.NewFileStore`（JSONL），0600/0700 权限 | `gateway.go` `appendJSONLLines` / kernel store |
 | §3.2 | `GET /v1/models`（列出全部 model_alias） | `server.go` `handleModels` |
 | §3.2 | `POST /v1/chat/completions`（含 `stream=true`） | `server.go` → `pipeline.go` `handleChat` |
-| §3.2 | `GET /healthz`（New API 渠道探活） | `server.go` `handleHealth`（**仅本地就绪，不探上游**，见 §0.3） |
+| §3.2 | `GET /healthz`（New API 渠道探活） | `server.go` `handleHealth`（上游探活已实现，见 §0.3） |
 | §3.2 | 错误一律走 OpenAI 信封 `{"error":{message,type,code}}` | `server.go` `writeAPIError` |
 | §3.3 | 七步流水线：鉴权 → 归一化 → L3 → L2 → 转发 → 透传 usage → 异步写记忆 | `pipeline.go` `handleChat` |
 | §3.3 | 「缓存永不阻塞主链路」：注入失败只记日志继续转发 | `pipeline.go`（`inject` 错误不中断） |
@@ -90,8 +90,8 @@
 | §3.9 | `[retrieval] retriever = bm25 \| vector \| hybrid` | **死配置键**：字段被解析和校验，但 `New()` 固定构造 `bm25.New()`，填 `hybrid`/`vector` 不报错也不生效。与 `[cache] judge_api_key` 同属「保留但未接线」（验收报告 §4 已列为 nit、§6 记为「预留字段」） |
 | §3.4 | 未命中流式：上游不返回 usage 时，网关在 `[DONE]` 前补含注入统计的末块 | 未做。逐块原样透传，只在上游异常断流时补 `[DONE]` |
 | §3.7 | 流式路径的**响应侧**写记忆 | `streamThrough` 只把请求 turns 写进旁路文件，不解析 SSE 取 assistant 内容（代码内已标注为 documented debt，验收报告 §6 也记为债务）。后果：**流式请求的本次响应不会成为可复用的 Result 切片**——Result 提取取的是旁路文件里最后一条无 tool_calls 的 assistant 消息，流式路径下那只可能是请求里带的历史轮次。L3 的写入实际只来自非流式请求 |
-| §3.2 | `/healthz` 检查「切片库可打开 + **上游可达性**」 | 只回 `{"status":"ok"}`。切片库在 `New()` 阶段已打开（打不开进程起不来），上游探活未做 |
-| §5 | 部署产物：`docker-compose.yml`、网关镜像 Dockerfile、`semantix-gateway.toml` 示例 | 仓库中**均不存在**。§5 目前仍是纯文字方案，照它部署需要自己写 compose 与配置文件（验收报告 §6 建议另开运维 issue） |
+| §3.2 | `/healthz` 检查「切片库可打开 + **上游可达性**」 | 切片库在 `New()` 阶段已打开（打不开进程起不来）；上游探活已实现（Issue #183）：`GET {base_url}/models` 逐个上游探测，2xx=健康，任一失败/超时返回 503 + OpenAI envelope；`[server] health_timeout_seconds` 可配（0=禁用探活） |
+| §5 | 部署产物：`docker-compose.yml`、网关镜像 Dockerfile、`semantix-gateway.toml` 示例 | 已存在 `deploy/`（Issue #183）：`semantix-gateway.toml.example`（全部小节 + `${VAR}` 示范）、多阶段 Dockerfile（alpine + CA 证书 + 非 root，取舍见 deploy/Dockerfile 注释）、`docker-compose.yml`（New API + 网关两服务 + healthcheck，named volume 持久化）；部署指引见 `docs/QUICKSTART.md`「网关部署」节 |
 | §4.3 | 与 New API 计费对账的 token 口径 | 合成 usage 已实现，但 token 数是 `len(bytes)/4` 的**字节估算**，不是真 tokenizer 计数。对账时须知道这个口径差 |
 | §7 M0 | 门：真实客户端 → New API → 网关 → DeepSeek 全链路跑通 **且** 会话入库后 `semantix search` 可检索到切片 | **合取门只满足后半**：入库可检索有 e2e 证据（`TestE2ESidecarWrittenAndIngested`，验收报告 §3「写记忆」✅），这半句本就不依赖真上游；**真实全链路无记录**——`gateway/e2e_test.go` 与验收报告 §3 的上游都是 `httptest` 假上游 |
 | §7 M1 | 门：重复任务第二次命中 `x-semantix-cache: hit` 且零上游调用；成本节省 ≥30% 实测 | 前半在 e2e 中以假上游验证（`TestE2EL3HitZeroUpstreamCalls`：命中且上游 0 调用），**真实环境与成本节省实测无记录**；验收报告 §6 明确「M1/M2 里程碑项未在本 issue 范围」 |

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -31,6 +31,9 @@ type Config struct {
 type ServerConfig struct {
 	Addr       string `toml:"addr"`
 	GatewayKey string `toml:"gateway_key"`
+	// HealthTimeoutSeconds bounds the /healthz upstream probe across all
+	// configured upstreams. 0 disables the probe (local readiness only).
+	HealthTimeoutSeconds int `toml:"health_timeout_seconds"`
 }
 
 // StoreConfig selects the slice store (which also holds L3 cache entries,
@@ -223,6 +226,9 @@ func (c *Config) validate() error {
 	if c.Cache.TTLSeconds < 0 {
 		return fmt.Errorf("gateway config: [cache] ttl_seconds must be >= 0 (0 disables the time window)")
 	}
+	if c.Server.HealthTimeoutSeconds < 0 {
+		return fmt.Errorf("gateway config: [server] health_timeout_seconds must be >= 0 (0 disables the upstream probe)")
+	}
 	if len(c.Upstreams) == 0 {
 		return fmt.Errorf("gateway config: at least one [[upstreams]] entry is required")
 	}
@@ -265,7 +271,7 @@ func validScope(s string) bool {
 // DefaultConfig returns the built-in defaults (for tests and docs).
 func DefaultConfig() *Config {
 	return &Config{
-		Server: ServerConfig{Addr: ":8080", GatewayKey: "dev-key"},
+		Server: ServerConfig{Addr: ":8080", GatewayKey: "dev-key", HealthTimeoutSeconds: 3},
 		Store:  StoreConfig{DB: ".semantix/gateway.jsonl", Scope: "project", DepsRoot: "."},
 		Retrieval: RetrievalConfig{Retriever: "bm25", TopK: 5, Budget: 4096},
 		Cache:  CacheConfig{TTLSeconds: 86400},

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -149,3 +149,44 @@ func TestModelAliasEnvSubstitution(t *testing.T) {
 		t.Fatalf("model_alias env substitution failed: %v", aliases)
 	}
 }
+
+// TestHealthTimeoutValidation: health_timeout_seconds must be >= 0
+// (0 disables the upstream probe, negatives are rejected).
+func TestHealthTimeoutValidation(t *testing.T) {
+	body := strings.Replace(validConfig, "gateway_key = \"${GW_KEY}\"",
+		"gateway_key = \"${GW_KEY}\"\nhealth_timeout_seconds = -1", 1)
+	t.Setenv("GW_KEY", "k1")
+	if _, err := Load(writeConfig(t, body)); err == nil {
+		t.Error("Load accepted health_timeout_seconds = -1, want error")
+	}
+}
+
+// TestDeployConfigExampleLoads (issue #183 acceptance): the shipped
+// deploy/semantix-gateway.toml.example must stay parseable by the loader —
+// every ${VAR} it references resolves, and the decoded values match the
+// documented contract. Guards the example against config drift.
+func TestDeployConfigExampleLoads(t *testing.T) {
+	path := filepath.Join("..", "deploy", "semantix-gateway.toml.example")
+	t.Setenv("SEMANTIX_GATEWAY_KEY", "test-channel-key")
+	t.Setenv("DEEPSEEK_API_KEY", "test-upstream-key")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(%s): %v", path, err)
+	}
+	if cfg.Server.GatewayKey != "test-channel-key" {
+		t.Errorf("gateway_key = %q, want env-resolved value", cfg.Server.GatewayKey)
+	}
+	if cfg.Server.HealthTimeoutSeconds != 3 {
+		t.Errorf("health_timeout_seconds = %d, want 3", cfg.Server.HealthTimeoutSeconds)
+	}
+	if len(cfg.Upstreams) != 1 {
+		t.Fatalf("upstreams = %d, want 1", len(cfg.Upstreams))
+	}
+	up := cfg.Upstreams[0]
+	if up.Name != "deepseek" || up.APIKey != "test-upstream-key" || up.Vendor != "deepseek" {
+		t.Errorf("upstream = %#v, want deepseek with env-resolved key", up)
+	}
+	if cfg.Store.DB != "/data/gateway.jsonl" || cfg.Ingest.SessionsDir != "/data/sessions" {
+		t.Errorf("store/ingest paths not container-friendly: db=%q sessions=%q", cfg.Store.DB, cfg.Ingest.SessionsDir)
+	}
+}

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -536,5 +537,148 @@ func TestE2EL3SafeFalseRejected(t *testing.T) {
 	}
 	if n := up.callCount(); n != 1 {
 		t.Errorf("upstream calls = %d, want 1", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GW3: /healthz upstream probe (Issue #183)
+// With health_timeout_seconds > 0 the gateway must probe every upstream
+// (GET {base_url}/models, 2xx = healthy); any failure → 503 + envelope.
+
+func TestE2EHealthProbeHealthy(t *testing.T) {
+	up := &testUpstream{plain: `{}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(out), `"status":"ok"`) {
+		t.Errorf("healthz: status=%d body=%s, want 200 ok", resp.StatusCode, out)
+	}
+	if n := up.callCount(); n != 1 {
+		t.Errorf("upstream calls = %d, want 1 (probe hit /models)", n)
+	}
+}
+
+func TestE2EHealthProbeUnreachable(t *testing.T) {
+	// upstream server already closed: the probe must fail closed with 503
+	upSrv := httptest.NewServer(http.NotFoundHandler())
+	deadURL := upSrv.URL
+	upSrv.Close()
+	g := newTestGateway(t, deadURL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("healthz: status=%d body=%s, want 503", resp.StatusCode, out)
+	}
+	if !strings.Contains(string(out), "upstream_error") || !strings.Contains(string(out), "unreachable") {
+		t.Errorf("healthz body missing upstream_error/unreachable: %s", out)
+	}
+	if strings.Contains(string(out), deadURL) {
+		t.Errorf("healthz body leaks the upstream URL: %s", out)
+	}
+}
+
+func TestE2EHealthProbeAnyUpstreamDown(t *testing.T) {
+	alive := &testUpstream{plain: `{}`}
+	aliveSrv := httptest.NewServer(alive.handler())
+	defer aliveSrv.Close()
+	g := newTestGateway(t, aliveSrv.URL)
+	// append a second, dead upstream: any failure marks the gateway down
+	deadSrv := httptest.NewServer(http.NotFoundHandler())
+	deadURL := deadSrv.URL
+	deadSrv.Close()
+	g.cfg.Upstreams = append(g.cfg.Upstreams, UpstreamConfig{
+		Name: "dead", BaseURL: deadURL, APIKey: "up-key",
+		ModelAlias: []string{"dead-model"}, UpstreamModel: "dead-model", Vendor: "openai",
+	})
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("healthz: status=%d body=%s, want 503 (one dead upstream)", resp.StatusCode, out)
+	}
+	if !strings.Contains(string(out), "dead") {
+		t.Errorf("healthz body should name the failing upstream: %s", out)
+	}
+}
+
+func TestE2EHealthProbeTimeout(t *testing.T) {
+	up := &testUpstream{plain: `{}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	g.cfg.Server.HealthTimeoutSeconds = 1
+	g.healthProbe = func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	}
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	start := time.Now()
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("healthz: status=%d body=%s, want 503 on probe timeout", resp.StatusCode, out)
+	}
+	if !strings.Contains(string(out), "deadline exceeded") {
+		t.Errorf("healthz body should report the timeout cause: %s", out)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("healthz took %v, want bounded by health_timeout_seconds=1", elapsed)
+	}
+}
+
+func TestE2EHealthProbeDisabled(t *testing.T) {
+	// health_timeout_seconds = 0 keeps the old behavior: local readiness
+	// only, zero upstream traffic
+	up := &testUpstream{plain: `{}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	g.cfg.Server.HealthTimeoutSeconds = 0
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(out), `"status":"ok"`) {
+		t.Errorf("healthz with probe disabled: status=%d body=%s, want 200 ok", resp.StatusCode, out)
+	}
+	if n := up.callCount(); n != 0 {
+		t.Errorf("upstream calls = %d, want 0 (probe disabled must not touch upstream)", n)
 	}
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1,12 +1,15 @@
 package gateway
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,6 +37,11 @@ type Gateway struct {
 	injector *inject.Injector
 	usageLog *usage.Recorder
 	client   *http.Client
+
+	// healthProbe checks upstream reachability for /healthz (nil or a
+	// nil-config timeout disables probing). Injectable so tests can stub
+	// or slow it down without a real upstream.
+	healthProbe func(ctx context.Context) error
 
 	sessionsMu sync.Mutex // serializes sidecar JSONL appends
 	ingestMu   sync.Mutex // serializes the async ingest writes
@@ -109,7 +117,40 @@ func New(cfg *Config) (*Gateway, error) {
 		disabled: disableEnv(),
 		now:      time.Now,
 	}
+	g.healthProbe = g.probeUpstreams
 	return g, nil
+}
+
+// probeUpstreams is the default /healthz probe: every configured upstream
+// must answer 2xx to GET {base_url}/models within the caller-provided
+// timeout. Any non-2xx, network error or timeout marks the gateway
+// unhealthy (fail-closed), so New API disables the channel rather than
+// routing into a dead upstream.
+func (g *Gateway) probeUpstreams(ctx context.Context) error {
+	for _, up := range g.cfg.Upstreams {
+		endpoint := strings.TrimRight(up.BaseURL, "/") + "/models"
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return fmt.Errorf("upstream %s: %w", up.Name, err)
+		}
+		req.Header.Set("Authorization", "Bearer "+up.APIKey)
+		resp, err := g.client.Do(req)
+		if err != nil {
+			// Do not wrap the raw *url.Error: its text embeds the full
+			// base URL, which must never leak into the healthz response.
+			reason := err.Error()
+			var uerr *url.Error
+			if errors.As(err, &uerr) {
+				reason = uerr.Err.Error()
+			}
+			return fmt.Errorf("upstream %s unreachable: %s", up.Name, reason)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("upstream %s unhealthy: status %d", up.Name, resp.StatusCode)
+		}
+	}
+	return nil
 }
 
 // Close stops accepting new sidecar writes, waits for in-flight ingestion

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"io"
@@ -29,7 +30,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, http.StatusMethodNotAllowed, "invalid_request_error", "method not allowed")
 			return
 		}
-		g.handleHealth(w)
+		g.handleHealth(w, r)
 		return
 	case "/v1/models":
 		if !g.authenticate(w, r) {
@@ -80,9 +81,22 @@ func (g *Gateway) authenticate(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-// handleHealth answers the New API channel probe: the store is already open
-// by construction (New failed otherwise), so 200 means "ready".
-func (g *Gateway) handleHealth(w http.ResponseWriter) {
+// handleHealth answers the New API channel probe. The store is already open
+// by construction (New failed otherwise), so local readiness is implicit;
+// when health probing is configured (health_timeout_seconds > 0), every
+// upstream must answer 2xx to GET {base_url}/models, otherwise the gateway
+// reports 503 with the failing upstream (New API disables the channel).
+// The response never leaks upstream URLs or keys.
+func (g *Gateway) handleHealth(w http.ResponseWriter, r *http.Request) {
+	timeout := time.Duration(g.cfg.Server.HealthTimeoutSeconds) * time.Second
+	if timeout > 0 && g.healthProbe != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		if err := g.healthProbe(ctx); err != nil {
+			writeAPIError(w, http.StatusServiceUnavailable, "upstream_error", err.Error())
+			return
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = io.WriteString(w, `{"status":"ok"}`)
 }


### PR DESCRIPTION
## Summary

Issue #183 GW3：网关部署产物三件套 + /healthz 上游探活。把 spec §5 从「纯文字方案」变成仓库内可用的部署产物，并让 `/healthz` 真实探测上游可达性——GW4 (#184) 的真实全链路验收（New API → 网关 → DeepSeek）可以按三条命令跑起来。

Spec post 已发布在 issue #183 并经审阅批准（#issuecomment-5312589588），本 PR 为其实现。

## Scope

- `deploy/`（新增目录）：
  - `semantix-gateway.toml.example`——全部小节 + `${VAR}` 引用示范（key 只走环境变量；dead 键 `retriever`/`judge_api_key` 如实标注 GW6）
  - `Dockerfile`——多阶段（golang:1.26-alpine → alpine:3.20 + ca-certificates），`USER 65532:65532`，`/data` 于 USER 前 chown（legacy builder 兼容）
  - `docker-compose.yml`——New API + 网关两服务；网关 `expose` 仅内网不发布端口；双 healthcheck（网关引用 `/healthz`）；named volume 持久化（非 root 可写）
- `.dockerignore`（新增，构建上下文排除）
- `gateway/server.go` + `gateway/gateway.go`——`handleHealth` 上游探活：GET `{base_url}/models` 逐个探测，2xx=健康，任一失败/超时 → 503 + OpenAI envelope（`upstream_error`，上游名 + 原因，不泄漏 URL/Key）；`healthProbe` 可注入（测试覆写）
- `gateway/config.go`——`[server] health_timeout_seconds`（默认 3，0=禁用探活，负值拒绝）——issue 批准的轻微契约扩展
- 测试：5 个 healthz e2e（健康 / 不可达 / 多上游任一失败 / 超时截断 / 禁用零流量）+ `TestDeployConfigExampleLoads` 门禁（example 可被 `Load` 解析，防漂移）+ `health_timeout_seconds < 0` 校验
- 文档：`docs/specs/newapi-gateway-design.md` §0.1/§0.3 状态回写；`docs/QUICKSTART.md`「网关部署（Docker）」节（三条命令）
- `docs/reports/issue-183-acceptance.md`（新增）

与 GW2 #182 文件面零重叠（并行开发）；`gateway/pipeline.go` 未触碰。

## Validation

- [x] `go vet ./...`（无警告）
- [x] `go test ./... -race` —— 本机无 CGO（无 gcc）不可运行，CI 承担（`.github/workflows/ci.yml:36`；与 issue-133/issue-182 记录一致）
- [x] `git diff --check`
- [x] 附加检查：`go build ./...`、`go test ./gateway/... -count=1`、全仓 `go test ./... -count=1`（18 包）无 FAIL；独立 subagent review 无阻断（2 应修已修复复验：URL 泄漏入 503 响应、Dockerfile `/data` 权限 legacy builder 兼容）

## Compatibility and data impact

- 契约变更一项（issue 批准）：新增 `[server] health_timeout_seconds`（0=禁用探活，保持旧行为「本地就绪」）；`Load` 对负值报错
- 行为变化（预期语义）：`/healthz` 在上游不可达/超时/非 2xx 时返回 503 + OpenAI envelope（此前恒 200）；New API 渠道健康检查会据此自动禁用故障渠道
- 既有 healthz 断言（无鉴权 200 + `{"status":"ok"}`）在假上游下保持兼容

## Security and privacy

- 探活响应只含上游名 + 错误类别，不泄漏上游 URL/Key（`errors.As` 剥离 `*url.Error` 的 URL 文本，测试断言防回归）
- 上游 key 只走环境变量（`${VAR}` fail-closed），示例文件无任何明文凭据
- 镜像非 root（65532）+ named volume；网关 8080 不发布到宿主机（仅 compose 内部网络）

## Evidence

```
go test ./gateway/... -count=1   # ok（含 6 个新 GW3 用例 + 既有 e2e 回归）
go test ./... -count=1           # 18 包全绿
```

healthz 探活闭环：`TestE2EHealthProbe*` —— 健康 200/不可达 503 且不泄漏 URL/多上游任一失败 503/超时 1s 截断/禁用零上游流量。

## Related issues

Closes #183（GW4 #184 依赖本条）
