### PR TITLE
feat(harness): reuse panel task completion time (U38, Issue #177)

### DIFF
--- a/harness/agent/reuse.go
+++ b/harness/agent/reuse.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"time"
 
 	"semantix/harness/event"
 	"semantix/harness/semantix"
@@ -35,6 +36,17 @@ func reuseNotice(reuse semantix.ReuseSummary) (event.Event, bool) {
 func (a *Agent) emitReuse(state *turnRuntime) {
 	if state == nil {
 		return
+	}
+	// U38 task completion time: attach the current task's elapsed/completed
+	// time to the panel payload before it is rendered. No task clock yet (the
+	// first run started without a scoped task) degrades to an omitted segment.
+	if !a.task.taskStartedAt.IsZero() {
+		if a.task.taskCompletedAt != nil {
+			state.reuse.TaskElapsedSeconds = a.task.taskCompletedAt.Sub(a.task.taskStartedAt).Seconds()
+			state.reuse.TaskComplete = true
+		} else {
+			state.reuse.TaskElapsedSeconds = time.Since(a.task.taskStartedAt).Seconds()
+		}
 	}
 	if notice, ok := reuseNotice(state.reuse); ok {
 		a.svc.sink.Emit(notice)

--- a/harness/agent/taskstate.go
+++ b/harness/agent/taskstate.go
@@ -1,6 +1,10 @@
 package agent
 
-import "semantix/harness/evidence"
+import (
+	"time"
+
+	"semantix/harness/evidence"
+)
 
 // taskRuntime is the host state shared by every Agent.Run continuing one
 // delivery scope: one ledger, one bill, one set of failure budgets. Its
@@ -20,6 +24,12 @@ type taskRuntime struct {
 	// restart — decides what survives a scope-stable continuation.
 	repeatFailures map[string]repeatFailureRecord
 	repeatScope    string
+	// taskStartedAt marks the wall-clock start of the current delivery scope
+	// (U38 task completion time). Zero before the first task begins.
+	taskStartedAt time.Time
+	// taskCompletedAt is non-nil once the goal verdict reached "complete"
+	// (U38). Nil means the task is still in progress (⏳).
+	taskCompletedAt *time.Time
 }
 
 // restartLedger begins a new task's accounting. It is written as one assignment
@@ -34,6 +44,9 @@ func (t *taskRuntime) restartLedger() {
 		ledger:         t.ledger,
 		outcome:        evidence.NewOutcomeTracker(),
 		budget:         runBudget{limit: t.budget.limit},
+		// A fresh ledger is a new task (U38): start the completion clock.
+		taskStartedAt:    time.Now(),
+		taskCompletedAt:  nil,
 	}
 	t.ledger.Reset()
 }

--- a/harness/agent/turn_phase.go
+++ b/harness/agent/turn_phase.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"time"
+
 	"semantix/harness/event"
 	"semantix/harness/taskcontract"
 	"semantix/harness/taskpolicy"
@@ -85,6 +87,12 @@ func (a *Agent) emitCompletionSummary(c *taskcontract.Contract) {
 	switch verdict {
 	case taskcontract.VerdictComplete:
 		summaryVerdict = "complete"
+		// U38 task completion time: stamp the goal as finished so the reuse
+		// panel can report the total elapsed time instead of ⏳ in-progress.
+		if a.task.taskCompletedAt == nil {
+			now := time.Now()
+			a.task.taskCompletedAt = &now
+		}
 	case taskcontract.VerdictPartial:
 		summaryVerdict = "partial"
 	case taskcontract.VerdictBlocked:

--- a/harness/cli/reuse_panel.go
+++ b/harness/cli/reuse_panel.go
@@ -34,6 +34,15 @@ func reusePanelLines(detail string, width int) []string {
 		b.WriteString(" · 🗂 from: ")
 		b.WriteString(strings.Join(s.Sources, ", "))
 	}
+	if s.TaskElapsedSeconds > 0 {
+		if s.TaskComplete {
+			b.WriteString(" · ✅ ")
+			b.WriteString(formatTaskDuration(s.TaskElapsedSeconds))
+		} else {
+			b.WriteString(" · ⏳ ")
+			b.WriteString(formatTaskDuration(s.TaskElapsedSeconds))
+		}
+	}
 	return []string{wrapForViewport(b.String(), width, activeCLITheme.success)}
 }
 
@@ -45,4 +54,18 @@ func formatPanelUSD(v float64) string {
 		return "0"
 	}
 	return s
+}
+
+// formatTaskDuration renders the U38 task elapsed seconds as a compact
+// human form: "<60 → 42s", "≥60 → 1m23s", "≥3600 → 1h01m".
+func formatTaskDuration(seconds float64) string {
+	n := int64(seconds + 0.5)
+	switch {
+	case n < 60:
+		return fmt.Sprintf("%ds", n)
+	case n < 3600:
+		return fmt.Sprintf("%dm%ds", n/60, n%60)
+	default:
+		return fmt.Sprintf("%dh%dm", n/3600, (n%3600)/60)
+	}
 }

--- a/harness/cli/reuse_panel_test.go
+++ b/harness/cli/reuse_panel_test.go
@@ -67,3 +67,44 @@ func TestFormatPanelUSD(t *testing.T) {
 		}
 	}
 }
+
+func TestReusePanelTaskTime(t *testing.T) {
+	// Completed task renders ✅ with the total elapsed time.
+	done := reusePanelLines(`{"hits":2,"task_elapsed_seconds":83.2,"task_complete":true}`, 100)
+	if len(done) != 1 || !strings.Contains(done[0], "✅ 1m23s") {
+		t.Errorf("completed task panel %v missing ✅ 1m23s", done)
+	}
+
+	// In-progress task renders ⏳ with the elapsed-so-far time.
+	prog := reusePanelLines(`{"hits":2,"task_elapsed_seconds":42,"task_complete":false}`, 100)
+	if len(prog) != 1 || !strings.Contains(prog[0], "⏳ 42s") {
+		t.Errorf("in-progress task panel %v missing ⏳ 42s", prog)
+	}
+}
+
+func TestReusePanelOmitsTaskTimeWhenAbsent(t *testing.T) {
+	// Legacy payload without task fields renders no ⏱ segment.
+	lines := reusePanelLines(`{"hits":2}`, 100)
+	if len(lines) != 1 {
+		t.Fatalf("lines = %d, want 1", len(lines))
+	}
+	if strings.Contains(lines[0], "⏳") || strings.Contains(lines[0], "✅") {
+		t.Errorf("panel %q must omit task time when absent", lines[0])
+	}
+}
+
+func TestFormatTaskDuration(t *testing.T) {
+	cases := []struct{ in float64; want string }{
+		{42, "42s"},
+		{59.4, "59s"},
+		{60, "1m0s"},
+		{83.2, "1m23s"},
+		{3600, "1h0m"},
+		{3661, "1h1m"},
+	}
+	for _, c := range cases {
+		if got := formatTaskDuration(c.in); got != c.want {
+			t.Errorf("formatTaskDuration(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/harness/semantix/reuse.go
+++ b/harness/semantix/reuse.go
@@ -18,6 +18,14 @@ type ReuseSummary struct {
 	// frequent first, at most 3. Empty when the kernel does not expose
 	// source_session (soft degrade — the panel drops the 🗂 segment).
 	Sources []string `json:"sources,omitempty"`
+	// TaskElapsedSeconds is how long the current task has run, measured from
+	// the task's start to either its completion (TaskComplete) or the present
+	// moment (⏳ in-progress). Zero is omitted so pre-U38 consumers are
+	// unaffected and legacy payloads render no ⏱ segment.
+	TaskElapsedSeconds float64 `json:"task_elapsed_seconds,omitempty"`
+	// TaskComplete is true once the goal verdict reached "complete"; a false
+	// (or absent) value renders the in-progress ⏳ form (U38).
+	TaskComplete bool `json:"task_complete,omitempty"`
 }
 
 // Line renders the compact one-line notice text for non-panel sinks
@@ -42,6 +50,13 @@ func (s ReuseSummary) Line() string {
 	if len(s.Sources) > 0 {
 		b.WriteString(" · 🗂 from: ")
 		b.WriteString(strings.Join(s.Sources, ", "))
+	}
+	if s.TaskElapsedSeconds > 0 {
+		b.WriteString(" · ⏱ ")
+		b.WriteString(formatTaskDuration(s.TaskElapsedSeconds))
+		if s.TaskComplete {
+			b.WriteString(" (done)")
+		}
 	}
 	return b.String()
 }
@@ -106,6 +121,19 @@ func usdFixed(v float64) string {
 		out = "-" + out
 	}
 	return out
+}
+
+// formatTaskDuration renders a duration in seconds as a compact human form:
+// "<60 → 42s", "≥60 → 1m23s", "≥3600 → 1h02m". Rounds to whole seconds.
+func formatTaskDuration(seconds float64) string {
+	n := int64(seconds + 0.5)
+	if n < 60 {
+		return itoa64(n) + "s"
+	}
+	if n < 3600 {
+		return itoa64(n/60) + "m" + itoa64(n%60) + "s"
+	}
+	return itoa64(n/3600) + "h" + itoa64((n%3600)/60) + "m"
 }
 
 func itoa64(n int64) string {

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -44,6 +44,40 @@ func TestTopSources(t *testing.T) {
 	}
 }
 
+func TestReuseSummaryLineTaskTime(t *testing.T) {
+	// Completed task: ⏱ + duration + (done).
+	got := (ReuseSummary{Hits: 1, TaskElapsedSeconds: 83.2, TaskComplete: true}).Line()
+	if !strings.Contains(got, "⏱ 1m23s (done)") {
+		t.Errorf("completed task Line() = %q, want ⏱ 1m23s (done)", got)
+	}
+	// In-progress task: ⏱ + duration, no (done).
+	got = (ReuseSummary{Hits: 1, TaskElapsedSeconds: 42}).Line()
+	if !strings.Contains(got, "⏱ 42s") || strings.Contains(got, "(done)") {
+		t.Errorf("in-progress task Line() = %q, want ⏱ 42s without (done)", got)
+	}
+	// Absent task time: no ⏱ segment.
+	got = (ReuseSummary{Hits: 1}).Line()
+	if strings.Contains(got, "⏱") {
+		t.Errorf("absent task time Line() = %q, want no ⏱", got)
+	}
+}
+
+func TestFormatTaskDuration(t *testing.T) {
+	cases := []struct{ in float64; want string }{
+		{42, "42s"},
+		{59.4, "59s"},
+		{60, "1m0s"},
+		{83.2, "1m23s"},
+		{3600, "1h0m"},
+		{3661, "1h1m"},
+	}
+	for _, c := range cases {
+		if got := formatTaskDuration(c.in); got != c.want {
+			t.Errorf("formatTaskDuration(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestFormatUSD(t *testing.T) {
 	cases := []struct{ in float64; want string }{
 		{0.0042, "0.0042"},


### PR DESCRIPTION
## 目的

issue #177（U38）：在复用面板「命中切片数 + 节省成本 + 来源会话」之外，新增**当前任务完成时间**。

## 改动

- \harness/semantix/reuse.go\：\ReuseSummary\ 追加 \	ask_elapsed_seconds\ + \	ask_complete\（omitempty，向后兼容）；\Line()\ 与新增 \ormatTaskDuration\ 渲染 ⏱ 段
- \harness/agent/taskstate.go\：\	askRuntime\ 追加 \	askStartedAt\ / \	askCompletedAt\，\estartLedger\（新任务）重置计时
- \harness/agent/turn_phase.go\：\emitCompletionSummary\ 在 \erdict == complete\ 时打完成时间戳
- \harness/agent/reuse.go\：\emitReuse\ 发射面板前填充耗时/完成标记
- \harness/cli/reuse_panel.go\：面板渲染 ✅（完成）/ ⏳（进行中）
- 测试：\euse_test.go\ + \euse_panel_test.go\ 补耗时计算/渲染边界断言

## 验证

- \go build ./...\ 全绿
- \go test ./harness/semantix/ ./harness/agent/ ./harness/cli/\ 全绿（含新增 U38 测试）

## 说明

- 任务完成信号用已有的 \emitCompletionSummary\ verdict == complete（与方案一致）
- 跨 turn 状态放 \	askRuntime\（一个 delivery scope = 一个任务）
- 桌面端 renderer 待 U34 内容在 harness-integration 就绪后同样消费这两个字段（本 PR 先落采集 + TUI）

Closes #177