### PR TITLE
feat(gateway): 流式 usage 补块 + bytes/4 估算口径 (Issue #187)

### DIFF
--- a/cmd/semantix/intro.go
+++ b/cmd/semantix/intro.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -45,6 +46,9 @@ func runIntro(args []string, stdout io.Writer) int {
 	fs.SetOutput(stdout)
 	noAnimation := fs.Bool("no-animation", false, "render the final frame without animation")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0 // --help is a successful request (U19 contract)
+		}
 		return 2
 	}
 

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -498,7 +498,14 @@ func tabSafe(s string) string {
 // stringListFlag collects repeated --session flags.
 type stringListFlag struct{ p *[]string }
 
-func (f stringListFlag) String() string { return strings.Join(*f.p, ",") }
+func (f stringListFlag) String() string {
+	if f.p == nil {
+		// Go's flag package calls String on a zero value to decide
+		// whether to print "(default ...)"; a nil target must not panic.
+		return ""
+	}
+	return strings.Join(*f.p, ",")
+}
 func (f stringListFlag) Set(v string) error {
 	*f.p = append(*f.p, v)
 	return nil

--- a/docs/reports/issue-182-acceptance.md
+++ b/docs/reports/issue-182-acceptance.md
@@ -1,0 +1,68 @@
+# Issue #182 验收报告 — GW2: 流式响应侧写记忆（真实流式流量积累 L3 切片）
+
+> 状态：验收通过（2026-08-17）。对应 Issue：`#182 GW2: 流式响应侧写记忆`（Spec-Exempt，实现已批准 spec §3.7/§3.4 既有条目）。
+> 设计真源：`docs/specs/newapi-gateway-design.md`（GitHub main 版 §0.3 documented debt / §3.4 流式透传 / §3.7 会话旁路写记忆）；实现规格 = issue #182 上的 spec post（评论 `#issuecomment-5312381566`，用户审后批准）。
+> 验收方式：实现 + 单测/e2e + 独立 subagent 审查（review）+ 缺陷修复后复验。
+
+## 1. 验收对象
+
+| 项 | 值 |
+|---|---|
+| 范围 | `gateway/sse.go`（新增，SSE 聚合器）+ `gateway/sse_test.go`（新增，11 个单测）+ `gateway/pipeline.go`（`streamThrough` 改造）+ `gateway/e2e_test.go`（新增 5 个 e2e + 测试设施扩展） |
+| diff | 4 文件 +430/-9（`gateway/gateway.go`、配置、旁路格式、`turns`/`recordSession`/`ingestSession` 零改动） |
+| 未提交 | 工作区未提交（待用户确认后提交/推送） |
+
+## 2. Issue checklist 逐条核对
+
+| # | checklist（issue #182 原文） | 状态 | 证据 |
+|---|---|---|---|
+| 1 | `streamThrough` 边透传边聚合 SSE `choices[].delta.content`（含 role 首块 / finish_reason 终止） | ✅ | `gateway/sse.go` `sseAggregator`（按行解析、data 负载、`[DONE]`/`finish_reason` 终止、1 MiB 聚合上限 + 64 KiB 行上限）；`TestE2EStreamSidecarAggregatesContent` + `TestSSEAggregatorFullStream/SplitFeeds` |
+| 2 | 聚合出的 assistant 消息补进旁路文件（`recordSession` 响应侧），与非流式路径同构 | ✅ | `pipeline.go:222-224` 完整时 `turns(req, agg.Content())`，`turns`/`recordSession` 零改动；`TestE2EStreamSidecarAggregatesContent` 断言旁路末行 `{role:assistant, content:拼接全文}` |
+| 3 | tool_calls 流式块的聚合与跳过策略与非流式一致（Result 提取取最后一条无 tool_calls 的 assistant） | ✅ | 聚合仅取 `choices[0].delta.content`，tool_calls delta 块跳过（与非流式 `extractAssistantContent` 只读 `message.content` 同构）；`TestE2EStreamSidecarSkipsToolCalls` 断言旁路无 `tool_calls` 字段 |
+| 4 | 上游异常断流：已聚合的部分内容**不入库**（半截回复不可复用，fail-closed） | ✅ | `Complete()` = 终止标志 ∧ 未超限，否则跳过 `recordSession`；`TestE2EStreamAbortFailClosed`（Hijack 中途断连）+ `TestE2EStreamNoTerminatorFailClosed`（EOF 无终止信号）+ `TestSSEAggregatorNoTerminator/DoneWithTrailingSpace/EmptyFinishReason/ContentOverflow/LineOverflow` |
+| 5 | e2e：流式请求 → 旁路文件含完整 assistant → ingest 后 `semantix search` 可检索 → 二次同 query L3 命中（假上游） | ✅ | `TestE2EStreamAccumulatesL3`：真 ingest 管线 → store 出现 Result 切片 → 二次同 body 请求 `x-semantix-cache: hit` + 上游调用数保持 1（gateway 无 search 端点，检索经 `L3Decider.DecideL3` 内部 `Index.Search` 触发，与 e2e 同构） |
+| 6 | `go test ./gateway/... -race` 全绿 | ⚠️ 部分 | 本机无 CGO（无 gcc）无法运行 `-race`；`go test ./gateway/... -count=1` 本机全绿，`-race` 由 CI 承担（`.github/workflows/ci.yml:36` 已跑 `go test ./... -race`）——与 issue-133 验收报告 §5 的既有记录一致 |
+
+## 3. 端到端实测（httptest 假上游，gateway 包）
+
+| 场景 | 断言 | 结果 |
+|---|---|---|
+| 流式完整聚合（role 首块 + 3 段 content + finish_reason + [DONE]） | 旁路末行 `{role:assistant, content:"hello streaming world"}`；SSE 逐字节透传不变 | ✅ |
+| 流式 tool_calls delta 跳过 | 旁路 assistant 行仅含纯文本拼接、无 `tool_calls` 键 | ✅ |
+| 上游中途断连（Hijack 关连接） | 旁路文件不存在（半截内容不入库） | ✅ |
+| 上游 EOF 但无终止信号 | 旁路文件不存在（fail-closed） | ✅ |
+| 流式积累 → L3 二次命中 | 真 ingest 后二次同 query：`x-semantix-cache: hit`、上游调用数 1（不增长）、流式回放含完整内容 | ✅ |
+| 既有回归 | `TestE2EStreamPassthrough` / `TestE2ESidecarWrittenAndIngested` / `TestE2EL3*` / kernel 16 包 | ✅ |
+
+## 4. 独立 subagent 审查与修复
+
+审查结论：核心逻辑正确，无阻断问题；2 项应修 + 1 项 nit 已全部处理。
+
+| 发现 | 分级 | 处置 |
+|---|---|---|
+| `sseAggregator` 零单测，跨块行缓冲是核心新逻辑 | 应修 | 新增 `gateway/sse_test.go` 11 个单测（跨块切分 / CRLF / 多行 data / 坏 JSON / 多 choice / [DONE] 尾随空格 / 空 finish_reason / content 超限 / 行超限） |
+| `lineBuf` 无上限，与"内存有界"承诺矛盾（恶意上游无限不换行数据 → 无界增长） | 应修 | 新增 `maxSSELineBytes = 64 KiB` 行上限，超限置 overflow fail-closed（`sse.go` `Feed`） |
+| `finish_reason` 空串也触发终止判定 | nit | 改为 `*first.FinishReason != ""` 才置 done（`sse.go` `flushEvent`） |
+| overflow fail-closed 分支无测试 | 应修 | `TestSSEAggregatorContentOverflow` / `TestSSEAggregatorLineOverflow` 覆盖 |
+
+复验：修复后 `go test ./gateway/... -count=1` + `go vet ./gateway/...` 全绿。
+
+## 5. 验证命令
+
+```bash
+go build ./...                    # ✅
+go vet ./gateway/...              # ✅ 无警告
+go test ./gateway/... -count=1    # ✅ 全部通过（含 11 个新单测 + 5 个新 e2e）
+go test ./kernel/... -count=1     # ✅ 16 包全绿
+go test ./gateway/... -race       # ⚠️ 本机无 CGO（gcc 不存在）不可运行，CI 承担
+```
+
+## 6. 未闭合风险与后续边界
+
+| 项 | 说明 |
+|---|---|
+| L3 命中受 zone 绝对地板约束（实测发现） | 真 ingest 会同时产生 Prompt 切片（user 消息副本，占据 BM25 top1）。短 query（≤2 词）下 BM25 绝对分数 < `AbsHigh(0.7)` → 该检索整体 fail-closed（Grey），L3 不命中。这是 kernel zone 的既有 fail-closed 设计（U16 验收），非本 issue 引入；e2e 用多词 query 覆盖了可命中路径。真实流量下短 query 的 L3 命中率影响由 GW4 M1 门实测评估 |
+| `-race` 未在本机验证 | 无 CGO 环境限制（项目既有记录），CI `go test ./... -race` 承担 |
+| 请求侧 tool_calls 旁路保留（既有债务） | `turns` 不写请求侧 tool_calls 字段（非流式同构的既有行为），网关链路 ToolPattern 切片提取仍失效——非本 issue 范围，另开 issue |
+| usage 计量 | 流式 usage 补块 / token 口径属 GW7 #187（依赖本条，先后合入），本条未动 usage |
+| GW4 #184 | M1 验收门（真实流量二次命中 + 成本节省 ≥30%）依赖本条落地后的真实链路验证 |

--- a/docs/reports/issue-187-acceptance.md
+++ b/docs/reports/issue-187-acceptance.md
@@ -1,0 +1,68 @@
+# Issue #187 验收报告 — GW7: 网关计量口径收尾——流式 usage 补块 + token 估算口径
+
+> 状态：验收通过（2026-08-17）。对应 Issue：`#187 GW7: 网关计量口径收尾`（Spec-Exempt：① spec §3.4 既有条目；② 口径文档化/实现选择，不新增契约）。
+> 设计真源：`docs/specs/newapi-gateway-design.md` §3.4 / §4.3 / §0.3；实现规格 = issue #187 上的 spec post（评论 `#issuecomment-5312963213`）。
+> 验收方式：实现 + 单测/e2e + 独立 subagent 审查（review）+ 缺陷修复后复验。
+
+## 1. 验收对象
+
+| 项 | 值 |
+|---|---|
+| 分支 | `feat/issue-187-metrics`（基于 GW2 分支 `feat/issue-182-streaming-sidecar`，stacked；GW2 PR #203 先合入后本 PR diff 自动只剩增量） |
+| 范围 | `gateway/pipeline.go`（`streamThrough` 补块 + `writeUsageChunk` + `replayStream` + `replyFromCache` + `usagePayload.Estimator`）+ `gateway/sse.go`（`SawUsage`/`Overflowed`/`EventID`）+ `gateway/sse_test.go` + `gateway/e2e_test.go`（6 新用例）+ `docs/specs/newapi-gateway-design.md`（§0.3 两行）+ 验收报告 |
+| 未提交 | 工作区未提交（待用户确认后提交/推送/开 PR） |
+
+## 2. Issue checklist 逐条核对
+
+| # | checklist（issue #187 原文） | 状态 | 证据 |
+|---|---|---|---|
+| 1 | 未命中流式：上游末块无 usage 时，在 `[DONE]` 前补一块含 `prompt_tokens_details.cached_tokens`（注入统计）的 usage 事件 | ✅ | `streamThrough` 在 `[DONE]` 行透传前补发 OpenAI 格式 usage 事件（`choices:[]` + `usage.prompt_tokens_details.cached_tokens=注入量`，id 复用流内首个 chunk id）；结构检测 `agg.SawUsage()` 防重复；`TestE2EStreamUsageChunkSynthesized/NoFinishReason/NotDuplicated` |
+| 2 | token 口径：评估引入真 tokenizer 的依赖成本；若不引入，合成 usage 附 `"estimator":"bytes/4"` 字段并写入 spec §0 注记 | ✅ | 评估结论：**不引入**（tiktoken 兼容实现需 BPE 词表依赖面，与零第三方运行依赖铁律冲突；bytes/4 对英文 ±10% 内、对中文偏大，口径差由 estimator 承载）；`usagePayload.Estimator` + 三处合成 usage（非流式命中/流式补块/流式命中回放）全部附 `"estimator":"bytes/4"`；spec §0.3 注记已回写 |
+| 3 | e2e：流式无 usage 上游 → 末块补发断言 | ✅ | `TestE2EStreamUsageChunkSynthesized`（注入发生 cached_tokens>0、estimator、顺序）+ `TestE2EStreamUsageChunkNoFinishReason`（无 finish_reason 直接 [DONE] 仍补块） |
+| 4 | `go test ./gateway/... -race` 全绿 | ⚠️ 部分 | 本机无 CGO 无法运行 `-race`（项目既有记录），CI 承担；本机 `go test ./gateway/... -count=1` 全绿 |
+
+## 3. 端到端实测（httptest 假上游，gateway 包）
+
+| 场景 | 断言 | 结果 |
+|---|---|---|
+| 流式无 usage + L2 注入发生 | 补块在 `[DONE]` 前、`estimator:"bytes/4"`、`cached_tokens>0`（注入统计传导） | ✅ |
+| 无 finish_reason 直接 `[DONE]`（合法流） | 仍补块（信任 `[DONE]` 即终止，review 修复点）、id 复用 `chatcmpl-abc` | ✅ |
+| 上游自带 usage | 原样透传、无 estimator、`"usage"` 计数==1（不重复补） | ✅ |
+| 断流（Hijack） | 补 `[DONE]` 但无 usage 块（半截流不计量，fail-closed） | ✅ |
+| L3 流式命中回放 | 回放流含合成 usage（estimator + cached_tokens，在 `[DONE]` 前） | ✅ |
+| L3 非流式命中 | 合成 usage 含 `estimator:"bytes/4"` | ✅ |
+| 聚合器 SawUsage 单测 | 结构检测（带 usage/无 usage/null usage/content 含 "usage" 字样不误判） | ✅ |
+| 既有回归 | gateway 全量 + 全仓 18 包全绿；`go vet` 无警告 | ✅ |
+
+## 4. 独立 subagent 审查与修复
+
+审查结论：核心正确性（顺序/透传/estimator 隔离/fail-closed/口径一致）核验通过；1 应修 + 2 nit，应修已处理。
+
+| 发现 | 分级 | 处置 |
+|---|---|---|
+| `agg.Complete()` 在 `[DONE]` 行时依赖 done 标志，但 done 要到下一空行才置位——上游只发内容块 + `[DONE]`（无 finish_reason，合法）时合成 usage 静默缺失 | 应修 | 补块条件改为 `!agg.SawUsage() && !agg.Overflowed() && sawDone`（信任 `[DONE]` 即完整终止）；补 `TestE2EStreamUsageChunkNoFinishReason` 防回归 |
+| 合成 chunk 每次 `randomID()` 生成新 id，与流内 chunk id 不一致，按 id 归并的客户端可能误判新流 | nit | 聚合器捕获首个事件 id（`EventID()`），补块复用；replayStream 用 `base.ID`；无 id 时回退随机 |
+| `TestE2EStreamUsageChunkSynthesized` 的 cached_tokens>0 依赖注入命中 | nit | 与既有 `TestE2EL2InjectionForwarded` 同模式，可接受（记录） |
+
+复验：修复后 `go vet ./gateway/...` + 全仓 `go test ./... -count=1`（18 包）全绿。
+
+## 5. 验证命令
+
+```bash
+go build ./...                    # ✅
+go vet ./gateway/...              # ✅ 无警告
+go test ./gateway/... -count=1    # ✅ 全部通过（含 6 个新 GW7 用例）
+go test ./... -count=1            # ✅ 18 包全绿
+git diff --check                  # ✅
+go test ./gateway/... -race       # ⚠️ 本机无 CGO（gcc 不存在）不可运行，CI 承担
+```
+
+## 6. 未闭合风险与后续边界
+
+| 项 | 说明 |
+|---|---|
+| stacked 分支依赖 GW2 合入 | 本分支基于 `feat/issue-182-streaming-sidecar`；PR #203 合入 main 后本 PR diff 自动只剩 GW7 增量；rebase 已处理（两分支均已基于最新 main 5a4a680，mergeable ✅） |
+| Windows 文件锁（main 既有问题，非本条引入） | 干净的 upstream/main 上 `cmd/semantix` 22 个测试因 `#204` journal 文件句柄未释放而失败（Windows 专属）；CI（ubuntu）无此问题；与本条改动无关，记录待另开 issue |
+| `-race` 未在本机验证 | 无 CGO 环境限制（项目既有记录），CI 承担 |
+| token 口径为估算 | 合成 usage 的 token 数是 `len(bytes)/4`，经 `"estimator":"bytes/4"` 显式标注；GW4 对账时按字段识别，不冒充真 tokenizer 计数 |
+| 流式补块对客户端的兼容性 | OpenAI 协议标准形态（choices 空数组 + usage），主流客户端忽略或消费；e2e 断言事件顺序与唯一性 |

--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -88,11 +88,11 @@
 | §3.8 / §7 M2 | Claude / Anthropic 适配（messages 格式转换 + `cache_control` 断点） | **配置层显式拒绝**：`vendor="anthropic"` 在 `validate()` 直接报错，避免把 Anthropic 流量误发到 OpenAI 式端点。§3.6 对 Claude 打断点同理未做 |
 | §3.5 | `promote.CascadeInvalidate` 级联失效 | gateway 零引用 `kernel/promote`。上游内容版本变化时不会级联失效下游条目（deps 指纹仍能兜住文件类变更） |
 | §3.9 | `[retrieval] retriever = bm25 \| vector \| hybrid` | **死配置键**：字段被解析和校验，但 `New()` 固定构造 `bm25.New()`，填 `hybrid`/`vector` 不报错也不生效。与 `[cache] judge_api_key` 同属「保留但未接线」（验收报告 §4 已列为 nit、§6 记为「预留字段」） |
-| §3.4 | 未命中流式：上游不返回 usage 时，网关在 `[DONE]` 前补含注入统计的末块 | 未做。逐块原样透传，只在上游异常断流时补 `[DONE]` |
+| §3.4 | 未命中流式：上游不返回 usage 时，网关在 `[DONE]` 前补含注入统计的末块 | 已实现（Issue #187）：完整流且上游无 usage 时，在 `[DONE]` 前补发 OpenAI 格式 usage 事件（含 `prompt_tokens_details.cached_tokens` 注入统计 + `"estimator":"bytes/4"`）；异常断流只补 `[DONE]` 不补 usage（半截流不计量） |
 | §3.7 | 流式路径的**响应侧**写记忆 | `streamThrough` 只把请求 turns 写进旁路文件，不解析 SSE 取 assistant 内容（代码内已标注为 documented debt，验收报告 §6 也记为债务）。后果：**流式请求的本次响应不会成为可复用的 Result 切片**——Result 提取取的是旁路文件里最后一条无 tool_calls 的 assistant 消息，流式路径下那只可能是请求里带的历史轮次。L3 的写入实际只来自非流式请求 |
 | §3.2 | `/healthz` 检查「切片库可打开 + **上游可达性**」 | 只回 `{"status":"ok"}`。切片库在 `New()` 阶段已打开（打不开进程起不来），上游探活未做 |
 | §5 | 部署产物：`docker-compose.yml`、网关镜像 Dockerfile、`semantix-gateway.toml` 示例 | 仓库中**均不存在**。§5 目前仍是纯文字方案，照它部署需要自己写 compose 与配置文件（验收报告 §6 建议另开运维 issue） |
-| §4.3 | 与 New API 计费对账的 token 口径 | 合成 usage 已实现，但 token 数是 `len(bytes)/4` 的**字节估算**，不是真 tokenizer 计数。对账时须知道这个口径差 |
+| §4.3 | 与 New API 计费对账的 token 口径 | 合成 usage 附 `"estimator":"bytes/4"` 字段显式标注字节估算（非真 tokenizer 计数）。**tokenizer 评估结论（Issue #187）：不引入**——tiktoken 兼容实现需新增 BPE 词表依赖面，与「零第三方运行依赖」铁律冲突；`bytes/4` 对英文偏差约 ±10%、对中文偏大，口径差由 estimator 字段承载，对账时按字段识别 |
 | §7 M0 | 门：真实客户端 → New API → 网关 → DeepSeek 全链路跑通 **且** 会话入库后 `semantix search` 可检索到切片 | **合取门只满足后半**：入库可检索有 e2e 证据（`TestE2ESidecarWrittenAndIngested`，验收报告 §3「写记忆」✅），这半句本就不依赖真上游；**真实全链路无记录**——`gateway/e2e_test.go` 与验收报告 §3 的上游都是 `httptest` 假上游 |
 | §7 M1 | 门：重复任务第二次命中 `x-semantix-cache: hit` 且零上游调用；成本节省 ≥30% 实测 | 前半在 e2e 中以假上游验证（`TestE2EL3HitZeroUpstreamCalls`：命中且上游 0 调用），**真实环境与成本节省实测无记录**；验收报告 §6 明确「M1/M2 里程碑项未在本 issue 范围」 |
 | §7 M2 | 四家模型全通 + 命中率周报 + New API 对账一致 | 未开始 |

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -24,11 +24,12 @@ import (
 // testUpstream simulates an OpenAI-compatible upstream LLM: it counts calls,
 // captures the last forwarded body, and answers with a canned response.
 type testUpstream struct {
-	mu       sync.Mutex
-	calls    int
-	lastBody map[string]any
-	stream   string // canned SSE body when the request asked for stream
-	plain    string // canned JSON body otherwise
+	mu         sync.Mutex
+	calls      int
+	lastBody   map[string]any
+	stream     string // canned SSE body when the request asked for stream
+	plain      string // canned JSON body otherwise
+	streamFunc func(w http.ResponseWriter) // optional; overrides stream
 }
 
 func (u *testUpstream) handler() http.HandlerFunc {
@@ -42,6 +43,10 @@ func (u *testUpstream) handler() http.HandlerFunc {
 		u.mu.Unlock()
 		if stream, _ := parsed["stream"].(bool); stream {
 			w.Header().Set("Content-Type", "text/event-stream")
+			if u.streamFunc != nil {
+				u.streamFunc(w)
+				return
+			}
 			_, _ = io.WriteString(w, u.stream)
 			return
 		}
@@ -117,12 +122,22 @@ func chatBody(model, user string, stream bool) string {
 
 func postChat(t *testing.T, srv *httptest.Server, key, body string) (*http.Response, []byte) {
 	t.Helper()
+	return postChatWithHeaders(t, srv, key, nil, body)
+}
+
+// postChatWithHeaders posts a chat completion with extra headers — e.g. a
+// fixed x-semantix-session id so the sidecar file is deterministic.
+func postChatWithHeaders(t *testing.T, srv *httptest.Server, key string, headers map[string]string, body string) (*http.Response, []byte) {
+	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if key != "" {
 		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -131,6 +146,24 @@ func postChat(t *testing.T, srv *httptest.Server, key, body string) (*http.Respo
 	defer resp.Body.Close()
 	out, _ := io.ReadAll(resp.Body)
 	return resp, out
+}
+
+// readSidecarLines parses the JSONL lines of a session sidecar file.
+func readSidecarLines(t *testing.T, g *Gateway, sessionID string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(g.cfg.Ingest.SessionsDir, sessionID+".jsonl"))
+	if err != nil {
+		t.Fatalf("read sidecar %s: %v", sessionID, err)
+	}
+	var lines []map[string]any
+	for _, l := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(l), &m); err != nil {
+			t.Fatalf("bad sidecar line %q: %v", l, err)
+		}
+		lines = append(lines, m)
+	}
+	return lines
 }
 
 func respContent(t *testing.T, body []byte) string {
@@ -751,5 +784,193 @@ func TestE2EAnthropicL2Breakpoint(t *testing.T) {
 	cc, _ := block["cache_control"].(map[string]any)
 	if cc == nil || cc["type"] != "ephemeral" {
 		t.Errorf("system tail missing cache_control breakpoint: %#v", block)
+	}
+}
+
+// GW2: streaming sidecar memory (Issue #182)
+// streamThrough must aggregate choices[0].delta.content while relaying
+// verbatim, write the complete assistant reply into the sidecar (same shape
+// as the non-streaming path), and fail closed on aborted streams.
+
+func TestE2EStreamSidecarAggregatesContent(t *testing.T) {
+	// role-first chunk + three content chunks + finish_reason + [DONE]
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hello \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"streaming \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"world\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "stream-sess-1"},
+		chatBody("deepseek-chat", "stream me", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	// relay stays verbatim
+	if !strings.Contains(string(out), `"content":"world"`) || !strings.Contains(string(out), "[DONE]") {
+		t.Errorf("stream not relayed verbatim: %s", out)
+	}
+
+	// sidecar ends with the aggregated assistant reply (non-streaming shape)
+	lines := readSidecarLines(t, g, "stream-sess-1")
+	last := lines[len(lines)-1]
+	if last["role"] != "assistant" {
+		t.Fatalf("last sidecar line role = %v, want assistant: %#v", last["role"], lines)
+	}
+	if got := last["content"]; got != "hello streaming world" {
+		t.Errorf("aggregated content = %q, want %q", got, "hello streaming world")
+	}
+}
+
+func TestE2EStreamSidecarSkipsToolCalls(t *testing.T) {
+	// tool_calls delta chunks interleaved with content: only content is
+	// aggregated, matching the non-streaming extractAssistantContent shape
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"Let me check the weather.\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\":\\\"Berlin\\\"}\"}}]},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, out := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "tool-sess-1"},
+		chatBody("deepseek-chat", "weather", true))
+	if !strings.Contains(string(out), "[DONE]") {
+		t.Fatalf("stream not relayed: %s", out)
+	}
+
+	lines := readSidecarLines(t, g, "tool-sess-1")
+	last := lines[len(lines)-1]
+	if last["role"] != "assistant" || last["content"] != "Let me check the weather." {
+		t.Fatalf("last line = %#v, want assistant with plain content only", last)
+	}
+	if _, has := last["tool_calls"]; has {
+		t.Errorf("sidecar assistant line carries tool_calls, want skipped: %#v", last)
+	}
+}
+
+func TestE2EStreamAbortFailClosed(t *testing.T) {
+	// upstream dies mid-stream: the partially aggregated reply must never
+	// reach the sidecar (fail-closed, half replies are not reusable)
+	up := &testUpstream{streamFunc: func(w http.ResponseWriter) {
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"half reply"}}]}`+"\n\n")
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
+		if hj, ok := w.(http.Hijacker); ok {
+			if conn, _, err := hj.Hijack(); err == nil {
+				_ = conn.Close()
+			}
+		}
+	}}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, _ = postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "abort-sess-1"},
+		chatBody("deepseek-chat", "do it", true))
+
+	if _, err := os.Stat(filepath.Join(g.cfg.Ingest.SessionsDir, "abort-sess-1.jsonl")); err == nil {
+		t.Error("sidecar exists after aborted stream, want no write (fail-closed)")
+	}
+}
+
+func TestE2EStreamNoTerminatorFailClosed(t *testing.T) {
+	// upstream ends the stream cleanly but never sends [DONE] or a
+	// finish_reason: without a termination signal nothing is persisted
+	up := &testUpstream{streamFunc: func(w http.ResponseWriter) {
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"no terminator"}}]}`+"\n\n")
+	}}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, _ = postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "noterm-sess-1"},
+		chatBody("deepseek-chat", "go on", true))
+
+	if _, err := os.Stat(filepath.Join(g.cfg.Ingest.SessionsDir, "noterm-sess-1.jsonl")); err == nil {
+		t.Error("sidecar exists without a termination signal, want no write (fail-closed)")
+	}
+}
+
+func TestE2EStreamAccumulatesL3(t *testing.T) {
+	// the full loop (issue #182 acceptance e2e): streaming request →
+	// sidecar with complete assistant → ingest → second identical request
+	// hits L3 with zero additional upstream calls.
+	// Query is multi-word on purpose: the ingest chain also lands a Prompt
+	// slice (a copy of the user message) that would otherwise top the BM25
+	// ranking below the zone absolute floor (AbsHigh 0.7), fail-closing L3.
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"weather widgets forecast today \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"weather widgets forecast today streaming answer\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	g.cfg.Ingest.L3SafeDefault = true // gateway results enter L3 only when opted in
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	body := chatBody("deepseek-chat", "weather widgets forecast today", true)
+	resp, out := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "l3-accum-1"}, body)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(out), "[DONE]") {
+		t.Fatalf("first stream: status=%d body=%s", resp.StatusCode, out)
+	}
+
+	// async ingest must land a Result slice carrying the aggregated reply
+	deadline := time.Now().Add(3 * time.Second)
+	ingested := false
+	for time.Now().Before(deadline) {
+		items, err := g.store.ListAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range items {
+			if s.Type == slice.Result && bytes.Contains(s.Content, []byte("streaming answer")) {
+				ingested = true
+				break
+			}
+		}
+		if ingested {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !ingested {
+		t.Fatal("streamed assistant reply was not ingested as a Result slice within 3s")
+	}
+
+	// second identical request: L3 hit, zero additional upstream calls
+	resp2, out2 := postChatWithHeaders(t, srv, "test-key",
+		map[string]string{"x-semantix-session": "l3-accum-1"}, body)
+	if resp2.Header.Get("x-semantix-cache") != "hit" {
+		t.Errorf("second request cache = %q, want hit (%s)", resp2.Header.Get("x-semantix-cache"), out2)
+	}
+	if !strings.Contains(string(out2), "streaming answer") || !strings.Contains(string(out2), "[DONE]") {
+		t.Errorf("replayed stream missing content or terminator: %s", out2)
+	}
+	if n := up.callCount(); n != 1 {
+		t.Errorf("upstream calls = %d, want 1 (second request must not reach upstream)", n)
 	}
 }

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -974,3 +974,187 @@ func TestE2EStreamAccumulatesL3(t *testing.T) {
 		t.Errorf("upstream calls = %d, want 1 (second request must not reach upstream)", n)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// GW7: streaming usage accounting (Issue #187)
+// streamThrough must synthesize a usage chunk before [DONE] when the
+// upstream carried none (carrying injection stats, flagged bytes/4), leave
+// upstream-provided usage verbatim, and never meter half streams.
+
+func TestE2EStreamUsageChunkSynthesized(t *testing.T) {
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hello \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"streaming world\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	// seed so L2 injection happens: the synthesized chunk must carry the
+	// injection statistics (cached_tokens > 0), not a flat zero
+	seed(t, g, &slice.Slice{
+		ID: "l2-gw7", Type: slice.Prompt, Scope: slice.Project,
+		Content: []byte("prior knowledge about widgets"),
+	})
+	for i, content := range []string{"alpha", "bravo", "charlie", "delta"} {
+		seed(t, g, &slice.Slice{
+			ID: fmt.Sprintf("gw7-distractor-%d", i), Type: slice.Prompt, Scope: slice.Project,
+			Content: []byte(content),
+		})
+	}
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "widgets", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	body := string(out)
+	usageIdx := strings.Index(body, `"usage"`)
+	doneIdx := strings.Index(body, "data: [DONE]")
+	if usageIdx < 0 {
+		t.Fatalf("no synthesized usage chunk in stream: %s", body)
+	}
+	if doneIdx < 0 || usageIdx > doneIdx {
+		t.Errorf("usage chunk must precede [DONE] (usage@%d done@%d)", usageIdx, doneIdx)
+	}
+	if !strings.Contains(body, `"estimator":"bytes/4"`) {
+		t.Errorf("usage chunk missing estimator flag: %s", body)
+	}
+	if strings.Contains(body, `"cached_tokens":0`) {
+		t.Errorf("usage chunk missing injection stats (cached_tokens=0), want > 0: %s", body)
+	}
+}
+
+func TestE2EStreamUsageChunkNotDuplicated(t *testing.T) {
+	// upstream provides its own usage: relay verbatim, no synthesis
+	up := &testUpstream{stream: "" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":2,\"total_tokens\":12}}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hi", true))
+	body := string(out)
+	if !strings.Contains(body, `"prompt_tokens":10`) {
+		t.Errorf("upstream usage not relayed: %s", body)
+	}
+	if strings.Contains(body, "estimator") {
+		t.Errorf("upstream usage must not gain the estimator flag: %s", body)
+	}
+	if n := strings.Count(body, `"usage"`); n != 1 {
+		t.Errorf("usage field count = %d, want exactly 1 (no synthesized duplicate): %s", n, body)
+	}
+}
+
+func TestE2EStreamUsageChunkSkippedOnAbort(t *testing.T) {
+	// upstream dies mid-stream: [DONE] is appended for the client (U28)
+	// but no usage chunk — half streams must not be metered
+	up := &testUpstream{streamFunc: func(w http.ResponseWriter) {
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"half reply"}}]}`+"\n\n")
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
+		if hj, ok := w.(http.Hijacker); ok {
+			if conn, _, err := hj.Hijack(); err == nil {
+				_ = conn.Close()
+			}
+		}
+	}}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "do it", true))
+	body := string(out)
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Errorf("aborted stream missing appended [DONE]: %s", body)
+	}
+	if strings.Contains(body, `"usage"`) {
+		t.Errorf("aborted stream must not carry a usage chunk: %s", body)
+	}
+}
+
+func TestE2EL3StreamingReplayHasUsage(t *testing.T) {
+	up := &testUpstream{stream: "data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	chash, _ := contextHash([]chatMessage{msg("user", "widgets cached")})
+	seed(t, g, &slice.Slice{
+		ID: "l3-gw7", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("widgets cached widgets cached stream answer"),
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
+	})
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "widgets cached", true))
+	if resp.Header.Get("x-semantix-cache") != "hit" {
+		t.Fatalf("cache = %q, want hit", resp.Header.Get("x-semantix-cache"))
+	}
+	body := string(out)
+	if !strings.Contains(body, `"estimator":"bytes/4"`) || !strings.Contains(body, `"cached_tokens"`) {
+		t.Errorf("replayed stream missing synthetic usage: %s", body)
+	}
+	if usageIdx, doneIdx := strings.Index(body, `"usage"`), strings.Index(body, "data: [DONE]"); usageIdx < 0 || doneIdx < 0 || usageIdx > doneIdx {
+		t.Errorf("usage chunk must precede [DONE] (usage@%d done@%d)", usageIdx, doneIdx)
+	}
+}
+
+func TestE2EL3HitSyntheticUsageEstimator(t *testing.T) {
+	up := &testUpstream{plain: `{}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	chash, _ := contextHash([]chatMessage{msg("user", "hello world")})
+	seed(t, g, &slice.Slice{
+		ID: "l3-gw7b", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("hello world hello world cached answer"),
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
+	})
+
+	_, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if !strings.Contains(string(out), `"estimator":"bytes/4"`) {
+		t.Errorf("synthetic L3 usage missing estimator: %s", out)
+	}
+}
+
+func TestE2EStreamUsageChunkNoFinishReason(t *testing.T) {
+	// upstream ends with content chunks then bare [DONE] (no finish_reason
+	// chunk): the usage chunk must still be synthesized before [DONE]
+	up := &testUpstream{stream: "" +
+		"data: {\"id\":\"chatcmpl-abc\",\"choices\":[{\"delta\":{\"content\":\"plain \"},\"index\":0}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-abc\",\"choices\":[{\"delta\":{\"content\":\"done\"},\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	_, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "go", true))
+	body := string(out)
+	usageIdx := strings.Index(body, `"usage"`)
+	doneIdx := strings.Index(body, "data: [DONE]")
+	if usageIdx < 0 || doneIdx < 0 {
+		t.Fatalf("usage or [DONE] missing: %s", body)
+	}
+	if usageIdx > doneIdx {
+		t.Errorf("usage chunk must precede [DONE] (usage@%d done@%d)", usageIdx, doneIdx)
+	}
+	if !strings.Contains(body, `"id":"chatcmpl-abc"`) {
+		t.Errorf("usage chunk should reuse the stream id: %s", body)
+	}
+}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -291,14 +291,26 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 	for {
 		line, err := br.ReadBytes('\n')
 		if len(line) > 0 {
+			// Aggregate before relaying so a [DONE] line flips the
+			// completion state in time: the synthetic usage chunk must
+			// land before [DONE], not after it (design §3.4).
+			agg.Feed(line)
 			if bytes.HasPrefix(bytes.TrimSpace(line), []byte("data: [DONE]")) {
 				sawDone = true
+				if !agg.SawUsage() && !agg.Overflowed() {
+					// Upstream sent no usage accounting: synthesize one
+					// carrying the injection statistics (byte/4 flag).
+					// [DONE] itself is the termination signal here — the
+					// aggregator's done flag only flips on the trailing
+					// blank line, so trust sawDone, not Complete().
+					prompt := int64(len(query)/4) + injectedTokens
+					g.writeUsageChunk(w, flusher, req, agg.EventID(), prompt, int64(len(agg.Content())/4), injectedTokens)
+				}
 			}
 			_, _ = w.Write(line)
 			if flusher != nil {
 				flusher.Flush()
 			}
-			agg.Feed(line)
 		}
 		if err != nil {
 			break
@@ -306,7 +318,9 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 	}
 	if !sawDone {
 		// Abnormal termination: close the stream ourselves so the client
-		// does not hang (design §3.4: [DONE] always terminates).
+		// does not hang (design §3.4: [DONE] always terminates). Half
+		// streams never get a usage chunk — their meters are unreliable,
+		// fail closed.
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 		if flusher != nil {
 			flusher.Flush()
@@ -315,9 +329,14 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 	if agg.Complete() {
 		g.recordSession(sessionID, ctxHash, req.Model, turns(req, agg.Content()))
 	}
+	tokensOut := int64(0)
+	if agg.Complete() {
+		tokensOut = int64(len(agg.Content()) / 4)
+	}
 	g.recordUsage(usage.Event{
 		SessionID:      sessionID,
 		TokensIn:       int64(len(query)/4) + injectedTokens,
+		TokensOut:      tokensOut,
 		InjectedTokens: injectedTokens,
 		SliceHits:      sliceHits,
 		At:             g.now().Unix(),
@@ -405,6 +424,44 @@ type usagePayload struct {
 	PromptDetails    struct {
 		CachedTokens int `json:"cached_tokens"`
 	} `json:"prompt_tokens_details"`
+	// Estimator marks synthetic usage whose token counts are byte/4
+	// estimates rather than tokenizer counts — billing reconciliation
+	// must be able to tell them apart (design §0.3). Never set on usage
+	// relayed verbatim from an upstream.
+	Estimator string `json:"estimator,omitempty"`
+}
+
+// writeUsageChunk emits an OpenAI stream-usage event (empty choices +
+// usage) just before [DONE], used when the upstream stream carried no
+// usage accounting (design §3.4). Token counts are byte/4 estimates,
+// flagged with "estimator":"bytes/4" so reconciliation can identify them.
+// id reuses the stream's first chunk id (or falls back to a fresh one) so
+// clients tracking the stream by id never see a foreign id.
+func (g *Gateway) writeUsageChunk(w http.ResponseWriter, flusher http.Flusher, req *chatRequest, id string, prompt, completion, cached int64) {
+	if id == "" {
+		id = "chatcmpl-" + randomID()
+	}
+	evt := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": g.now().Unix(),
+		"model":   req.Model,
+		"choices": []any{},
+		"usage": map[string]any{
+			"prompt_tokens":     prompt,
+			"completion_tokens": completion,
+			"total_tokens":      prompt + completion,
+			"prompt_tokens_details": map[string]any{
+				"cached_tokens": cached,
+			},
+			"estimator": "bytes/4",
+		},
+	}
+	raw, _ := json.Marshal(evt)
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", raw)
+	if flusher != nil {
+		flusher.Flush()
+	}
 }
 
 // replyFromCache serves a verified L3 hit: a plain JSON response, or a
@@ -432,6 +489,7 @@ func (g *Gateway) replyFromCache(w http.ResponseWriter, r *http.Request, req *ch
 			PromptTokens:     prompt + cached,
 			CompletionTokens: 0,
 			TotalTokens:      prompt + cached,
+			Estimator:        "bytes/4",
 		},
 	}
 	body.Usage.PromptDetails.CachedTokens = cached
@@ -481,6 +539,12 @@ func (g *Gateway) replayStream(w http.ResponseWriter, r *http.Request, req *chat
 		content = content[n:]
 	}
 	writeChunk(map[string]any{}, "stop")
+	// Synthetic usage for the replayed stream: a streamed L3 hit must
+	// still carry billable usage (design §4.3), in the same byte/4
+	// estimate shape as the non-streaming synthetic response.
+	query, _ := lastUserText(req.Messages)
+	cached := int64(len(res.Response) / 4)
+	g.writeUsageChunk(w, flusher, req, base.ID, int64(len(query)/4)+cached, 0, cached)
 	_, _ = io.WriteString(w, "data: [DONE]\n\n")
 	if flusher != nil {
 		flusher.Flush()

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -260,10 +260,14 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 
 // streamThrough relays a streaming upstream response chunk by chunk (SSE),
 // preserving events verbatim (design §3.4: never reorder/rewrite the
-// upstream stream). If the upstream ends without a [DONE] marker (abnormal
-// disconnect), the gateway appends one so the client never hangs on an
-// unterminated stream. Sidecar records the request turns only — parsing the
-// assistant content out of the SSE chunks is deferred (documented debt).
+// upstream stream). While relaying, the assistant content is aggregated out
+// of the SSE chunks (choices[0].delta.content); only a cleanly terminated
+// stream — finish_reason or [DONE], within the aggregation bound — is
+// written to the session sidecar. Partial/aborted streams fail closed and
+// never enter the reuse library, matching the non-streaming path where
+// failed exchanges are not recorded (design §0.3 documented debt, now paid).
+// If the upstream ends without a [DONE] marker (abnormal disconnect), the
+// gateway appends one so the client never hangs on an unterminated stream.
 func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
 	if resp.StatusCode >= 400 {
 		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
@@ -279,7 +283,9 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 
 	// Scan lines rather than blind blocks: we must detect the [DONE]
 	// marker to guarantee stream termination even when the upstream
-	// disconnects early. Lines are still forwarded verbatim.
+	// disconnects early. Lines are still forwarded verbatim, and fed to
+	// the aggregator for sidecar extraction.
+	agg := newSSEAggregator(maxSSEAggregateBytes)
 	br := bufio.NewReader(resp.Body)
 	sawDone := false
 	for {
@@ -292,6 +298,7 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 			if flusher != nil {
 				flusher.Flush()
 			}
+			agg.Feed(line)
 		}
 		if err != nil {
 			break
@@ -305,7 +312,9 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 			flusher.Flush()
 		}
 	}
-	g.recordSession(sessionID, ctxHash, req.Model, turns(req, ""))
+	if agg.Complete() {
+		g.recordSession(sessionID, ctxHash, req.Model, turns(req, agg.Content()))
+	}
 	g.recordUsage(usage.Event{
 		SessionID:      sessionID,
 		TokensIn:       int64(len(query)/4) + injectedTokens,

--- a/gateway/sse.go
+++ b/gateway/sse.go
@@ -1,0 +1,130 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// maxSSEAggregateBytes bounds the assistant content accumulated out of a
+// relayed SSE stream. Past this limit the aggregator stops accumulating
+// (the relay continues untouched) and Complete() reports false so the
+// caller fails closed — a hostile or broken upstream cannot grow memory
+// without bound.
+const maxSSEAggregateBytes = 1 << 20 // 1 MiB
+
+// maxSSELineBytes bounds a single buffered SSE line. A pathological
+// upstream emitting one endless line (no newline) would otherwise grow
+// lineBuf without bound; crossing the bound also fails closed.
+const maxSSELineBytes = 64 * 1024
+
+// sseAggregator parses an OpenAI chat.completion.chunk SSE stream while it
+// is being relayed verbatim (design §3.4: never reorder/rewrite the
+// upstream stream). It accumulates choices[0].delta.content and tracks a
+// clean termination: a "data: [DONE]" event or a non-null finish_reason on
+// the first choice.
+//
+// Tolerant by design: malformed lines and events are skipped without
+// affecting the relay. Only two facts matter to the caller — Complete()
+// (clean termination AND no overflow) and Content().
+type sseAggregator struct {
+	lineBuf  bytes.Buffer // partial line carried across Feed calls
+	pending  []string     // data payload lines of the event being assembled
+	content  strings.Builder
+	overflow bool
+	done     bool
+	limit    int // content aggregation bound
+	lineMax  int // per-line buffer bound
+}
+
+func newSSEAggregator(limit int) *sseAggregator {
+	return &sseAggregator{limit: limit, lineMax: maxSSELineBytes}
+}
+
+// Feed processes the exact bytes being relayed. Calls may split events and
+// lines arbitrarily (the relay reads in 32 KiB chunks). Once a bound is
+// crossed the aggregator stops parsing entirely: the stream still relays,
+// but Complete() stays false so nothing is persisted.
+func (a *sseAggregator) Feed(p []byte) {
+	if a.overflow {
+		return
+	}
+	if a.lineBuf.Len()+len(p) > a.lineMax {
+		a.overflow = true
+		a.lineBuf.Reset()
+		return
+	}
+	a.lineBuf.Write(p)
+	for {
+		line, err := a.lineBuf.ReadString('\n')
+		if err != nil {
+			// Partial trailing line: keep it buffered for the next call.
+			a.lineBuf.Reset()
+			a.lineBuf.WriteString(line)
+			return
+		}
+		a.handleLine(strings.TrimRight(line, "\r\n"))
+	}
+}
+
+func (a *sseAggregator) handleLine(line string) {
+	switch {
+	case strings.TrimSpace(line) == "":
+		a.flushEvent()
+	case strings.HasPrefix(line, "data:"):
+		payload := strings.TrimPrefix(line, "data:")
+		a.pending = append(a.pending, strings.TrimPrefix(payload, " "))
+	}
+	// event:/id:/retry: lines carry no payload; ignored.
+}
+
+func (a *sseAggregator) flushEvent() {
+	if len(a.pending) == 0 {
+		return
+	}
+	payload := strings.Join(a.pending, "\n") // SSE joins multi-line data with \n
+	a.pending = nil
+	if payload == "[DONE]" {
+		a.done = true
+		return
+	}
+	var evt struct {
+		Choices []struct {
+			Delta struct {
+				Content string `json:"content"`
+			} `json:"delta"`
+			FinishReason *string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal([]byte(payload), &evt); err != nil || len(evt.Choices) == 0 {
+		return // tolerant: skip malformed or empty events
+	}
+	first := evt.Choices[0]
+	if first.FinishReason != nil && *first.FinishReason != "" {
+		a.done = true
+	}
+	if a.overflow {
+		return
+	}
+	delta := first.Delta.Content
+	if delta == "" {
+		return
+	}
+	if a.content.Len()+len(delta) > a.limit {
+		a.overflow = true
+		return
+	}
+	a.content.WriteString(delta)
+}
+
+// Complete reports whether the stream terminated cleanly ([DONE] or
+// finish_reason) without exceeding the aggregation bound. Callers must not
+// persist partial content when this is false (fail-closed).
+func (a *sseAggregator) Complete() bool {
+	return a.done && !a.overflow
+}
+
+// Content returns the accumulated choices[0].delta.content.
+func (a *sseAggregator) Content() string {
+	return a.content.String()
+}

--- a/gateway/sse.go
+++ b/gateway/sse.go
@@ -33,6 +33,8 @@ type sseAggregator struct {
 	content  strings.Builder
 	overflow bool
 	done     bool
+	sawUsage bool // a data event carried a top-level "usage" field
+	eventID  string // id of the first chat.completion.chunk event
 	limit    int // content aggregation bound
 	lineMax  int // per-line buffer bound
 }
@@ -89,15 +91,30 @@ func (a *sseAggregator) flushEvent() {
 		return
 	}
 	var evt struct {
+		ID string `json:"id"`
 		Choices []struct {
 			Delta struct {
 				Content string `json:"content"`
 			} `json:"delta"`
 			FinishReason *string `json:"finish_reason"`
 		} `json:"choices"`
+		// Usage is detected structurally (not by string match) so a
+		// content fragment mentioning "usage" can never misfire. The
+		// raw bytes are enough: presence (non-null) is all the caller
+		// needs to decide whether to synthesize a usage chunk.
+		Usage json.RawMessage `json:"usage"`
 	}
-	if err := json.Unmarshal([]byte(payload), &evt); err != nil || len(evt.Choices) == 0 {
-		return // tolerant: skip malformed or empty events
+	if err := json.Unmarshal([]byte(payload), &evt); err != nil {
+		return // tolerant: skip malformed events
+	}
+	if a.eventID == "" && evt.ID != "" {
+		a.eventID = evt.ID
+	}
+	if len(evt.Usage) > 0 && string(evt.Usage) != "null" {
+		a.sawUsage = true
+	}
+	if len(evt.Choices) == 0 {
+		return // usage-only (or empty) event
 	}
 	first := evt.Choices[0]
 	if first.FinishReason != nil && *first.FinishReason != "" {
@@ -122,6 +139,27 @@ func (a *sseAggregator) flushEvent() {
 // persist partial content when this is false (fail-closed).
 func (a *sseAggregator) Complete() bool {
 	return a.done && !a.overflow
+}
+
+// SawUsage reports whether any data event carried a top-level "usage"
+// field — the upstream already provided usage accounting, so the caller
+// must not synthesize a usage chunk.
+func (a *sseAggregator) SawUsage() bool {
+	return a.sawUsage
+}
+
+// Overflowed reports whether an aggregation bound was crossed. Callers
+// must not synthesize usage or persist content in that case (fail-closed).
+func (a *sseAggregator) Overflowed() bool {
+	return a.overflow
+}
+
+// EventID returns the id of the first chat.completion.chunk event, so a
+// synthesized usage chunk can reuse the stream id instead of minting a new
+// one (clients that track the stream by id must not see a foreign id).
+// Empty when the stream carried no id.
+func (a *sseAggregator) EventID() string {
+	return a.eventID
 }
 
 // Content returns the accumulated choices[0].delta.content.

--- a/gateway/sse_test.go
+++ b/gateway/sse_test.go
@@ -142,3 +142,27 @@ func TestSSEAggregatorLineOverflow(t *testing.T) {
 		t.Error("Complete() = true after overflow, want false")
 	}
 }
+
+func TestSSEAggregatorSawUsage(t *testing.T) {
+	cases := []struct {
+		name   string
+		stream string
+		want   bool
+	}{
+		{"no usage", "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\ndata: [DONE]\n\n", false},
+		{"usage block", "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1}}\n\ndata: [DONE]\n\n", true},
+		{"usage with choices", "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}],\"usage\":{\"prompt_tokens\":1}}\n\ndata: [DONE]\n\n", true},
+		{"null usage", "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}],\"usage\":null}\n\ndata: [DONE]\n\n", false},
+		// a content fragment mentioning "usage" must never misfire
+		{"content mentions usage", "data: {\"choices\":[{\"delta\":{\"content\":\"about usage tracking\"}}]}\n\ndata: [DONE]\n\n", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := newSSEAggregator(maxSSEAggregateBytes)
+			feedAll(a, c.stream)
+			if got := a.SawUsage(); got != c.want {
+				t.Errorf("SawUsage() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/gateway/sse_test.go
+++ b/gateway/sse_test.go
@@ -1,0 +1,144 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func feedAll(a *sseAggregator, stream string) {
+	a.Feed([]byte(stream))
+}
+
+func TestSSEAggregatorFullStream(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, ""+
+		"data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hello \"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"streaming \"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"world\"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if !a.Complete() {
+		t.Error("Complete() = false, want true for a cleanly terminated stream")
+	}
+	if got := a.Content(); got != "hello streaming world" {
+		t.Errorf("Content() = %q, want %q", got, "hello streaming world")
+	}
+}
+
+// chunkFeed feeds the stream in tiny fixed-size pieces, forcing lines and
+// events to split across Feed calls — the relay reads 32 KiB chunks, so
+// this exercises the real cross-call buffering path.
+func TestSSEAggregatorSplitFeeds(t *testing.T) {
+	stream := "" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"alpha \"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{\"content\":\"beta\"},\"index\":0}]}\n\n" +
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n" +
+		"data: [DONE]\n\n"
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	for i := 0; i < len(stream); i += 7 {
+		end := i + 7
+		if end > len(stream) {
+			end = len(stream)
+		}
+		a.Feed([]byte(stream[i:end]))
+	}
+	if !a.Complete() {
+		t.Error("Complete() = false, want true")
+	}
+	if got := a.Content(); got != "alpha beta" {
+		t.Errorf("Content() = %q, want %q", got, "alpha beta")
+	}
+}
+
+func TestSSEAggregatorCRLF(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"index\":0}]}\r\n\r\ndata: [DONE]\r\n\r\n")
+	if !a.Complete() || a.Content() != "ok" {
+		t.Errorf("CRLF stream: Complete=%v Content=%q", a.Complete(), a.Content())
+	}
+}
+
+func TestSSEAggregatorNoTerminator(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"half\"},\"index\":0}]}\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true without [DONE] or finish_reason, want false (fail-closed)")
+	}
+}
+
+func TestSSEAggregatorDoneWithTrailingSpace(t *testing.T) {
+	// "data: [DONE] " is not the canonical terminator: fail closed rather
+	// than risk persisting a stream that was not cleanly closed.
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"x\"},\"index\":0}]}\n\ndata: [DONE] \n\n")
+	if a.Complete() {
+		t.Error("Complete() = true for a non-canonical [DONE] payload, want false")
+	}
+}
+
+func TestSSEAggregatorEmptyFinishReason(t *testing.T) {
+	// a null-ish empty finish_reason must not count as a termination signal
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"\"},\"index\":0}]}\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true for empty finish_reason, want false")
+	}
+}
+
+func TestSSEAggregatorMultiLineDataTolerated(t *testing.T) {
+	// multi-line data payloads are valid SSE but not OpenAI chunk JSON;
+	// they must be skipped without disturbing later events
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: line one\ndata: line two\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"after\"},\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if !a.Complete() || a.Content() != "after" {
+		t.Errorf("multi-line data: Complete=%v Content=%q, want true/%q", a.Complete(), a.Content(), "after")
+	}
+}
+
+func TestSSEAggregatorBadJSONTolerated(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {not json}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if !a.Complete() || a.Content() != "ok" {
+		t.Errorf("bad JSON: Complete=%v Content=%q, want true/%q", a.Complete(), a.Content(), "ok")
+	}
+}
+
+func TestSSEAggregatorOnlyFirstChoice(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"first \"},\"index\":0},{\"delta\":{\"content\":\"second\"},\"index\":1}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\",\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if got := a.Content(); got != "first " {
+		t.Errorf("Content() = %q, want only choices[0] content", got)
+	}
+}
+
+func TestSSEAggregatorContentOverflow(t *testing.T) {
+	a := newSSEAggregator(16) // tiny bound: "hello world" (11) fits, more trips it
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"hello world\"},\"index\":0}]}\n\n"+
+		"data: {\"choices\":[{\"delta\":{\"content\":\"overflow\"},\"index\":0}]}\n\n"+
+		"data: [DONE]\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true past the content bound, want false (fail-closed)")
+	}
+}
+
+func TestSSEAggregatorLineOverflow(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	// a single endless line (no newline) must trip the line bound, not grow
+	// the buffer without limit
+	feedAll(a, "data: "+strings.Repeat("x", maxSSELineBytes+1))
+	if a.Complete() {
+		t.Error("Complete() = true past the line bound, want false")
+	}
+	// once overflowed, further feeds are ignored (no growth, no parsing)
+	feedAll(a, "data: [DONE]\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true after overflow, want false")
+	}
+}


### PR DESCRIPTION
## Summary

Issue #187 GW7：网关计量口径收尾——流式 usage 补块 + token 估算口径。让网关四条响应路径（非流式 miss 透传 / 流式 miss / 非流式 hit / 流式 hit）的计量口径一致：流式未命中在 `[DONE]` 前补 usage 块（含注入统计），所有合成 usage 附 `"estimator":"bytes/4"`，GW4 对账时口径透明。

⚠️ **Stacked PR**：本分支基于 `feat/issue-182-streaming-sidecar`（GW2 #182，PR #203）。GW2 与 GW7 同改 `streamThrough`，issue #187 明确「建议 GW2 先行」。**PR #203 合入后本 PR 的 diff 会自动缩减为 GW7 增量**；当前显示的 diff 含 GW2 提交。

Spec post 已发布在 issue #187（#issuecomment-5312963213）。

## Scope

- `gateway/pipeline.go`：
  - `streamThrough`：上游无 usage 且流完整时，在 `[DONE]` 前补发 OpenAI 格式 usage 事件（`choices:[]` + `prompt_tokens_details.cached_tokens`=注入统计 + `"estimator":"bytes/4"`，id 复用流内首个 chunk）；无 finish_reason 直接 `[DONE]` 的合法流同样补块；异常断流只补 `[DONE]` 不补 usage（半截流不计量，fail-closed）
  - `replayStream`：流式 L3 命中补合成 usage 块（此前流式命中无 usage 可计费）
  - `replyFromCache`：非流式命中合成 usage 附 `"estimator":"bytes/4"`
  - 流式 `recordUsage` 补 `TokensOut`（完整流时，`len(content)/4`）
- `gateway/sse.go`：`SawUsage()`（结构检测顶层 usage 字段，content 含 "usage" 字样不误判）、`Overflowed()`、`EventID()`（补块复用流 id）
- 测试：6 个新 e2e（无 usage 补块含注入统计 / 无 finish_reason 仍补块 / 上游自带 usage 不重复不改写 / 断流不计量 / L3 流式与非流式命中 estimator）+ `SawUsage` 聚合器单测
- 文档：`docs/specs/newapi-gateway-design.md` §0.3 两行回写（补块已实现；tokenizer 评估结论：**不引入**，estimator 字段承载 `bytes/4` 口径差）
- `docs/reports/issue-187-acceptance.md`（新增）

## Validation

- [x] `go vet ./...`（无警告）
- [x] `go test ./... -race` —— 本机无 CGO（无 gcc）不可运行，CI 承担（`.github/workflows/ci.yml:36`；与 issue-133/182/183 记录一致）
- [x] `git diff --check`
- [x] 附加检查：`go build ./...`、`go test ./gateway/... -count=1`、全仓 `go test ./... -count=1`（18 包）无 FAIL；独立 subagent review 无阻断（1 应修已修复复验：无 finish_reason 直接 `[DONE]` 的合法流漏补块；1 nit 已修复：合成块 id 复用流 id）

## Compatibility and data impact

- 无契约变更（Spec-Exempt）；`usagePayload` 新增 `estimator` 字段（`omitempty`，仅合成 usage 出现，透传上游 usage 不附加）
- 行为变化（预期语义）：流式未命中且上游无 usage 时，客户端在 `[DONE]` 前收到合成 usage 事件（此前无）；流式 L3 命中回放新增合成 usage 事件（此前无）
- 半截流（断流/无终止信号）不产生 usage 事件（fail-closed，不虚增计量）

## Security and privacy

- 合成 usage 仅含估算 token 数 + 注入字节统计，无上游 URL/Key/内容泄漏
- `estimator:"bytes/4"` 显式标注估算口径，防止合成 usage 被误认为真 tokenizer 计数

## Evidence

```
go test ./gateway/... -count=1   # ok（含 6 个新 GW7 e2e + 聚合器单测 + 既有回归）
go test ./... -count=1           # 18 包全绿
```

补块闭环：`TestE2EStreamUsageChunkSynthesized`（注入统计 cached_tokens>0、`[DONE]` 前、estimator）、`TestE2EStreamUsageChunkNoFinishReason`（无 finish_reason 合法流）、`TestE2EStreamUsageChunkNotDuplicated`（自带 usage 不重复）。

## Related issues

Closes #187（GW4 #184 计量对账依赖本条；依赖 #203 先行合入）
