### PR TITLE
fix(cli): intro --help 按 U19 help 契约退出 0——flag.ErrHelp 处理（PR #180 回归）

### DIFF
--- a/cmd/semantix/intro.go
+++ b/cmd/semantix/intro.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -45,6 +46,11 @@ func runIntro(args []string, stdout io.Writer) int {
 	fs.SetOutput(stdout)
 	noAnimation := fs.Bool("no-animation", false, "render the final frame without animation")
 	if err := fs.Parse(args); err != nil {
+		// --help is a clean exit (U19 help contract): flag prints the usage
+		// to stdout (fs.SetOutput(stdout)) and returns ErrHelp.
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 2
 	}
 


### PR DESCRIPTION
## 概述

修复 `intro --help` 返回 exit code 2 的回归——PR #180（codex/terminal-intro）引入的 `intro` 命令是**唯一**未按 U19 help 契约处理 `flag.ErrHelp` 的子命令，导致 CI（Go checks）在 `TestEveryCommandHelpExitsZero` / `TestCompletionFlagsMatchCommandHelp` 失败，并连带让 GW6（PR #202）等 PR 的 CI 变红。

## 根因

`cmd/semantix/intro.go` `runIntro` 用 `flag.NewFlagSet` 且未定义 `-h/--help` 标志：flag 包遇到未定义的 `--help` 会打印 usage 并返回 `flag.ErrHelp`，`runIntro` 直接 `return 2`。仓库内其余 9 个 flag 子命令（completion/config/dashboard/doctor/eval/eval_judge/export/gc/import/init）都有 `errors.Is(err, flag.ErrHelp) → return 0` 处理，唯独 `intro` 遗漏。

## 修复

`runIntro` 的 `fs.Parse` 错误分支补 ErrHelp 处理（usage 已由 `fs.SetOutput(stdout)` 打印，help 请求视为干净退出）：

```go
if err := fs.Parse(args); err != nil {
    if errors.Is(err, flag.ErrHelp) {
        return 0 // U19 help contract
    }
    return 2
}
```

## 验证

- `go test -race -count=1 -run "TestEveryCommandHelpExitsZero|TestCompletionFlagsMatchCommandHelp" ./cmd/semantix/` ✅
- `go build ./...` ✅ + `go test -race ./...`（全仓 18 包）✅——之前纯 main 上复现失败的 2 个用例随之全绿