### PR TITLE
feat(harness): BudgetController laddered budget degradation (U41 C3, Issue #192)

### DIFF
--- a/harness/agent/agent.go
+++ b/harness/agent/agent.go
@@ -317,6 +317,9 @@ type Agent struct {
 	sched sched.Decider
 	// resources owns the full catalog snapshot emitted to the kernel bus.
 	resources *resourceCatalogState
+	// budgetCtrl accumulates window financial spend and maps it to the
+	// laddered budget action (U41 C3). Nil when no limit is configured.
+	budgetCtrl *BudgetController
 	// prefetchedInject caches a warmed [semantix-reuse] block assembled
 	// during LLM wait time (N12); used as a fallback when the turn's
 	// synchronous injection produced nothing.
@@ -1154,6 +1157,9 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		strictAlternatingRoles: opts.StrictAlternatingRoles,
 	}
 	a.resources = newResourceCatalogState(opts.KernelEvents, tools, opts.ResourceModels, opts.ResourceBudget)
+	if opts.ResourceBudget.LimitUSD > 0 {
+		a.budgetCtrl = NewBudgetController(opts.ResourceBudget.LimitUSD, opts.ResourceBudget.Window)
+	}
 	a.sess.output.outputBudget = outputBudgetOf(prov)
 	if a.sess.path != "" {
 		a.LoadProjectionSidecar(a.sess.path)
@@ -2914,6 +2920,11 @@ func finishReasonMessage(u *provider.Usage) (string, bool) {
 // injection in beginRunTurn produced nothing (kernel timeout, cold cache).
 // The background goroutine never blocks the main loop.
 func (a *Agent) startInjectWarm(ctx context.Context) {
+	// U41 C3 halt_prefetch: once the window budget crosses 70% (or higher),
+	// stop the speculative warm-up — the first thing to cut (spec §5.1).
+	if a.budgetCtrl != nil && a.budgetCtrl.Action() != "" {
+		return
+	}
 	input := a.turn.input
 	if input == "" {
 		return

--- a/harness/agent/budget_controller.go
+++ b/harness/agent/budget_controller.go
@@ -1,0 +1,138 @@
+package agent
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	kernelevent "semantix/kernel/event"
+	"semantix/kernel/sched"
+)
+
+// BudgetController accumulates window spend and maps the spent/limit ratio to
+// a degrade action (U41 C3): halt_prefetch ≥ 70%, degrade_tier ≥ 90%,
+// hard_stop ≥ 100%. The escalation is sticky within a window — it never
+// relaxes — and resets only when the window rolls over (day boundary).
+//
+// It is distinct from runBudget (task-level token/cost/wall cap): this is a
+// window-level financial quota with laddered degradation, not a per-task stop.
+type BudgetController struct {
+	mu        sync.Mutex
+	limitUSD  float64
+	window    string
+	spentUSD  float64
+	lastAction string
+	dayKey    int // UTC day ordinal; changes trigger a day-window reset
+}
+
+// NewBudgetController builds a controller with the given quota. limitUSD <= 0
+// disables budgeting (no action ever fires). window is "session" or "day";
+// anything else is treated as "session".
+func NewBudgetController(limitUSD float64, window string) *BudgetController {
+	if window != "day" {
+		window = "session"
+	}
+	return &BudgetController{limitUSD: limitUSD, window: window, dayKey: currentUTCDayKey()}
+}
+
+// currentUTCDayKey returns the UTC day ordinal (whole-day boundary).
+func currentUTCDayKey() int {
+	return int(time.Now().UTC().Unix() / 86400)
+}
+
+// Observe folds one billed cost into the window spend, rolling the window
+// across a day boundary first. A non-positive cost is ignored (free reads
+// must never look like a crossing).
+func (b *BudgetController) Observe(costUSD float64) {
+	if b == nil || costUSD <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.window == "day" {
+		if dk := currentUTCDayKey(); dk != b.dayKey {
+			b.dayKey = dk
+			b.spentUSD = 0
+			b.lastAction = ""
+		}
+	}
+	b.spentUSD += costUSD
+}
+
+// Action returns the current degrade action, sticky within the window.
+func (b *BudgetController) Action() string {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limitUSD <= 0 {
+		return ""
+	}
+	a := b.classify()
+	if rankOf(a) > rankOf(b.lastAction) {
+		b.lastAction = a
+	}
+	return b.lastAction
+}
+
+// Snapshot returns the catalog budget state for the kernel scheduler.
+func (b *BudgetController) Snapshot() kernelevent.ResourceBudget {
+	if b == nil {
+		return kernelevent.ResourceBudget{}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return kernelevent.ResourceBudget{LimitUSD: b.limitUSD, SpentUSD: b.spentUSD, Window: b.window}
+}
+
+// SpentUSD returns the accumulated spend (test/display seam).
+func (b *BudgetController) SpentUSD() float64 {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.spentUSD
+}
+
+// classify maps the current ratio to an action without touching lastAction.
+func (b *BudgetController) classify() string {
+	r := b.spentUSD / b.limitUSD
+	switch {
+	case r >= 1.0:
+		return sched.BudgetActionHardStop
+	case r >= 0.9:
+		return sched.BudgetActionDegradeTier
+	case r >= 0.7:
+		return sched.BudgetActionHaltPrefetch
+	default:
+		return ""
+	}
+}
+
+// budgetHardStopError returns the user-visible hard_stop message (U41 C3).
+// It is an explicit, non-silent error: the harness refuses the next tool round
+// and tells the user exactly how much was spent against the cap.
+func (a *Agent) budgetHardStopError() error {
+	if a == nil || a.budgetCtrl == nil {
+		return fmt.Errorf("budget exhausted")
+	}
+	snap := a.budgetCtrl.Snapshot()
+	return fmt.Errorf("budget exhausted: spent $%.4f of the $%.4f %s limit; no further tool calls will be issued",
+		snap.SpentUSD, snap.LimitUSD, snap.Window)
+}
+
+// rankOf orders actions by escalation severity (higher = more severe).
+func rankOf(action string) int {
+	switch action {
+	case sched.BudgetActionHardStop:
+		return 3
+	case sched.BudgetActionDegradeTier:
+		return 2
+	case sched.BudgetActionHaltPrefetch:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/harness/agent/budget_controller_test.go
+++ b/harness/agent/budget_controller_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"semantix/kernel/sched"
+)
+
+func TestBudgetControllerClassifiesThresholds(t *testing.T) {
+	b := NewBudgetController(100, "session")
+	cases := []struct {
+		spend float64
+		want  string
+	}{
+		{0, ""},
+		{69.99, ""},
+		{70, sched.BudgetActionHaltPrefetch},   // ≥70% includes boundary
+		{89.99, sched.BudgetActionHaltPrefetch},
+		{90, sched.BudgetActionDegradeTier},    // ≥90% includes boundary
+		{99.99, sched.BudgetActionDegradeTier},
+		{100, sched.BudgetActionHardStop},      // ≥100% includes boundary
+		{110, sched.BudgetActionHardStop},
+	}
+	for _, c := range cases {
+		b = NewBudgetController(100, "session")
+		b.Observe(c.spend)
+		if got := b.Action(); got != c.want {
+			t.Errorf("spend=%v → action %q, want %q", c.spend, got, c.want)
+		}
+	}
+}
+
+func TestBudgetControllerStickyEscalation(t *testing.T) {
+	b := NewBudgetController(100, "session")
+	b.Observe(100) // hard_stop
+	if got := b.Action(); got != sched.BudgetActionHardStop {
+		t.Fatalf("action = %q, want hard_stop", got)
+	}
+	// Even if a later read were lower, the action never relaxes within the window.
+	if got := b.Action(); got != sched.BudgetActionHardStop {
+		t.Errorf("action regressed to %q", got)
+	}
+}
+
+func TestBudgetControllerUnlimited(t *testing.T) {
+	b := NewBudgetController(0, "session") // 0 = unlimited
+	b.Observe(999999)
+	if got := b.Action(); got != "" {
+		t.Errorf("unlimited action = %q, want empty", got)
+	}
+	neg := NewBudgetController(-5, "session")
+	neg.Observe(999999)
+	if got := neg.Action(); got != "" {
+		t.Errorf("negative-limit action = %q, want empty", got)
+	}
+}
+
+func TestBudgetControllerIgnoresNonPositive(t *testing.T) {
+	b := NewBudgetController(100, "session")
+	b.Observe(0)
+	b.Observe(-10)
+	if got := b.SpentUSD(); got != 0 {
+		t.Errorf("spentUSD = %v, want 0", got)
+	}
+}
+
+func TestBudgetControllerSnapshot(t *testing.T) {
+	b := NewBudgetController(100, "day")
+	b.Observe(30)
+	snap := b.Snapshot()
+	if snap.LimitUSD != 100 || snap.SpentUSD != 30 || snap.Window != "day" {
+		t.Errorf("snapshot = %+v", snap)
+	}
+}
+
+func TestBudgetControllerWindowDefaultsToSession(t *testing.T) {
+	b := NewBudgetController(100, "")
+	if b.window != "session" {
+		t.Errorf("window = %q, want session", b.window)
+	}
+	b2 := NewBudgetController(100, "bogus")
+	if b2.window != "session" {
+		t.Errorf("window = %q, want session", b2.window)
+	}
+}
+
+func TestBudgetHardStopError(t *testing.T) {
+	a := &Agent{budgetCtrl: NewBudgetController(100, "session")}
+	a.budgetCtrl.Observe(120)
+	err := a.budgetHardStopError()
+	if err == nil {
+		t.Fatal("expected a hard-stop error")
+	}
+	if !containsAny(err.Error(), "budget exhausted", "120", "100") {
+		t.Errorf("error %q should name the spend and limit", err.Error())
+	}
+}
+
+func TestBudgetHardStopErrorNoController(t *testing.T) {
+	if err := (&Agent{}).budgetHardStopError(); err == nil {
+		t.Fatal("expected a fallback error without a controller")
+	}
+	if err := (&Agent{}).budgetHardStopError(); err.Error() != "budget exhausted" {
+		t.Errorf("fallback error = %q", err.Error())
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/harness/agent/run_budget.go
+++ b/harness/agent/run_budget.go
@@ -149,6 +149,16 @@ func (a *Agent) observeRunBudget(state *turnRuntime, usage *provider.Usage) {
 		Task:     a.task.budget.totals(),
 		Currency: currency,
 	})
+	// U41 C3: fold this round's billed cost into the window budget and refresh
+	// the catalog snapshot so the kernel scheduler sees the latest spend. The
+	// cost uses the same rate-card float path as runBudget (CostQuote amounts
+	// are numerically equivalent; the quote layer adds audit fields only).
+	if a.budgetCtrl != nil && usage != nil && a.svc.pricing != nil {
+		if cost := a.svc.pricing.Cost(usage); cost > 0 {
+			a.budgetCtrl.Observe(cost)
+			a.SetResourceBudget(a.budgetCtrl.Snapshot())
+		}
+	}
 }
 
 type taskBudgetContextKey struct{}

--- a/harness/agent/run_loop.go
+++ b/harness/agent/run_loop.go
@@ -16,6 +16,7 @@ import (
 	"semantix/harness/taskintent"
 	"semantix/harness/taskpolicy"
 	"semantix/harness/tool"
+	"semantix/kernel/sched"
 )
 
 // streamedTurn is one provider completion collected by stream. Keeping the
@@ -637,6 +638,14 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 
 	if boundaryErr, stop := a.stopUnexecutedBoundaryCalls(state, calls, usage); stop {
 		return false, boundaryErr
+	}
+
+	// U41 C3 hard_stop: the window budget is exhausted — refuse the new tool
+	// round and surface a user-visible error (never swallowed silently). The
+	// local controller is the fallback; the kernel scheduler may have already
+	// issued the same action via DecideRound (whoever fires first wins).
+	if a.budgetCtrl != nil && a.budgetCtrl.Action() == sched.BudgetActionHardStop {
+		return false, a.budgetHardStopError()
 	}
 
 	receiptMark := 0

--- a/harness/boot/boot.go
+++ b/harness/boot/boot.go
@@ -1736,6 +1736,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		TierResolver:                 tierResolver,
 		KernelEvents:                 semantixBridge.Events(),
 		ResourceModels:               resourceModels,
+		ResourceBudget:               kernelevent.ResourceBudget{LimitUSD: cfg.Semantix.LimitUSD, Window: cfg.Semantix.Window},
 	}, sink)
 
 	var runner agent.Runner = executor

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -970,6 +970,10 @@ type SemantixConfig struct {
 	// [cost] keys here when they are customized.
 	CostInputPriceUSD float64 `toml:"cost_input_price_usd"`
 	CostCachePriceUSD  float64 `toml:"cost_cache_price_usd"`
+	// LimitUSD caps the window's total financial spend (U41 C3). 0 = unlimited.
+	LimitUSD float64 `toml:"limit_usd"`
+	// Window is the reset window for LimitUSD: "session" | "day". Empty = "session".
+	Window string `toml:"window"`
 }
 
 // NetworkConfig controls ordinary outbound HTTP traffic such as model providers,


### PR DESCRIPTION
## 目的

issue #192（U41 C3）：实现 \BudgetController\ 预算阶梯降级（70/90/100 三阈值）。

## 改动

- \harness/agent/budget_controller.go\（新）：累计 \spentUSD\（\Observe\）、三阈值判级（≥70% halt_prefetch / ≥90% degrade_tier / ≥100% hard_stop，含边界）、窗口内粘滞升不降、\Snapshot()\ 目录快照、\udgetHardStopError()\ 用户可见文案
- \harness/agent/budget_controller_test.go\（新）：8 个边界测试
- \harness/config/config.go\：\SemantixConfig\ 追加 \LimitUSD\（limit_usd）+ \Window\（window）
- \harness/boot/boot.go\：config → \Options.ResourceBudget\ 接线
- \harness/agent/agent.go\：\udgetCtrl\ 字段 + \startInjectWarm\ 处 halt_prefetch 关闭预取
- \harness/agent/run_budget.go\：\observeRunBudget\ 处累计 spend 并 \SetResourceBudget\ 刷新目录
- \harness/agent/run_loop.go\：hard_stop 拦截下一工具轮 + 用户可见报错

## 与 U40 的关系

U40（issue #191，已合并）落地了 \RoundPlan.BudgetAction\ + \ResourceCatalog\ + \SetResourceBudget\ seam（注释明示「U41's BudgetController uses this seam」）。本 PR 直接对接该 seam：本地累计判级产 \BudgetAction\ 同值字符串，写目录供 kernel \RuleDecider\ 提前下发（kernel 优先、本地兜底）。\degrade_tier\ 执行点已由 U40 的 \pplyScheduledTier\ 接好，本 PR 补齐 \halt_prefetch\ 与 \hard_stop\ 两个执行点。

## 验证

- \go build ./...\ 全绿
- \go test ./harness/agent/ ./harness/boot/\ 全绿（含 8 个新增 U41 测试）

Closes #192