### PR TITLE
fix(gateway): l3Eligible fails closed on a slice missing from the store

### DIFF
--- a/gateway/l3eligible_test.go
+++ b/gateway/l3eligible_test.go
@@ -1,0 +1,39 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"semantix/kernel/slice"
+)
+
+// lazyStore simulates a store where every Get misses (returns (nil, nil)),
+// exactly the contract fileStore.Get uses for a slice that left the store.
+type lazyStore struct{}
+
+func (lazyStore) Get(_ string) (*slice.Slice, error)         { return nil, nil }
+func (lazyStore) Put(*slice.Slice) error                     { return nil }
+func (lazyStore) List(slice.Scope) ([]*slice.Slice, error)   { return nil, nil }
+func (lazyStore) ListAll() ([]*slice.Slice, error)           { return nil, nil }
+func (lazyStore) UpdateStats(string, slice.SliceStats) error { return nil }
+func (lazyStore) UpdateStatsBatch(map[string]slice.SliceStats) error { return nil }
+func (lazyStore) Delete(string) error                        { return nil }
+
+// TestL3EligibleFailClosedOnMissingSlice guards the nil-dereference in
+// l3Eligible: a candidate slice that disappeared from the store (Get returns
+// nil, nil) must make l3Eligible fail closed (return false). Use the deepseek
+// vendor so TTLFor yields a non-zero window and cacheFresh has to touch
+// s.CreatedAt — exactly the path that panicked on a nil slice before the
+// s == nil guard.
+func TestL3EligibleFailClosedOnMissingSlice(t *testing.T) {
+	g := &Gateway{
+		store: lazyStore{},
+		cfg:   &Config{},
+		now:   time.Now,
+	}
+	// deepseek resolves to the 24h default TTL; a missing slice must fail
+	// closed without panicking in cacheFresh.
+	if g.l3Eligible("gone", "deepseek") {
+		t.Fatal("l3Eligible must fail closed when the slice is missing from the store")
+	}
+}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -111,7 +111,11 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 // closed.
 func (g *Gateway) l3Eligible(id, vendor string) bool {
 	s, err := g.store.Get(id)
-	if err != nil {
+	if err != nil || s == nil {
+		// s == nil: the candidate slice left the store (concurrent
+		// eviction/compact, or an index entry whose persistence was rolled
+		// back) after DecideL3 retrieved it. Fail closed rather than
+		// dereference nil in cacheFresh.
 		return false
 	}
 	return g.cacheFresh(s, vendor)


### PR DESCRIPTION
## Bug

\gateway/pipeline.go\ 的 \l3Eligible\ 在 \DecideL3\ 从索引检索出候选 slice 之后，用其 ID 重新走 \Store.Get\。\ileStore.Get\ 在 slice 不存在时返回 \(nil, nil)\，但 \l3Eligible\ 只检查了 \err\、未检查 \s == nil\，把 nil 传给了 \cacheFresh\。

\cacheFresh\ 对任意非零 TTL 的 vendor（deepseek 24h / anthropic 5m 内置默认，或显式 \endor_ttl\/\	tl_seconds>0\）会解引用 \s.CreatedAt\ → **nil 指针 panic**。这正好违背函数注释声明的意图：

> \A slice that disappeared from the store also fails closed.\

触发前提：slice 在索引检索与 store 重查之间被并发删除（eviction/compact/回滚持久化）。

## 修复

\l3Eligible\ 加 \s == nil\ guard —— slice 从 store 消失时 fail closed（返回 false），与注释意图一致，不再 crash。

## 验证

- \go -C <worktree> test ./gateway/ -run TestL3EligibleFailClosedOnMissingSlice -v\：新回归测试通过
- 已复核：在未修复代码上该测试于 \cacheFresh\（\gateway.go:253\，\s.CreatedAt\）**真实 panic**（nil dereference），修复后 fail closed 不 panic
- \go build ./...\ 全仓编译通过；\go test ./gateway/\ 全量通过；\go vet ./gateway/\ 零警告