### PR TITLE
test(slice): close file stores in tests so journal handles release

### DIFF
--- a/kernel/slice/journal_test.go
+++ b/kernel/slice/journal_test.go
@@ -10,12 +10,26 @@ import (
 	"testing"
 )
 
+// closeStore is the optional closeable seam used by the test helpers below.
+// slice.Store does not expose Close, so tests that open a *fileStore must
+// close it to release the journal handle — otherwise the .journal file stays
+// locked and t.TempDir() teardown fails on Windows (CI runs on Linux, where
+// unlinking an open file is allowed, so this only bites local Windows runs).
+type testStoreCloser interface{ Close() error }
+
+func closeTestStore(st Store) {
+	if c, ok := st.(testStoreCloser); ok {
+		_ = c.Close()
+	}
+}
+
 func reopen(t *testing.T, path string) Store {
 	t.Helper()
 	st, err := NewFileStore(path)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	return st
 }
 

--- a/kernel/slice/maintenance_test.go
+++ b/kernel/slice/maintenance_test.go
@@ -18,6 +18,7 @@ func TestFileStoreListAllAndDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	a := &Slice{ID: "a", Type: Prompt, Scope: Project, Content: []byte("x")}
 	b := &Slice{ID: "b", Type: Result, Scope: User, Content: []byte("y")}
 	c := &Slice{ID: "c", Type: Context, Scope: Session, Content: []byte("z")}
@@ -75,6 +76,7 @@ func TestExportImportRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	now := time.Now().Unix()
 	in := []*Slice{
 		{ID: "a", Type: Prompt, Scope: Project, Content: []byte("alpha"), Weight: 0.9, CreatedAt: now - 100, Meta: SliceMeta{SourceSession: "s1", Language: "zh-CN"}},
@@ -115,6 +117,7 @@ func TestExportImportRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(dst) })
 	imported, skipped, err := Import(dst, &buf)
 	if err != nil {
 		t.Fatal(err)
@@ -153,6 +156,7 @@ func TestImportIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(src) })
 	if err := src.Put(&Slice{ID: "a", Type: Prompt, Scope: Project, Content: []byte("x")}); err != nil {
 		t.Fatal(err)
 	}
@@ -165,6 +169,7 @@ func TestImportIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(dst) })
 	for i := 0; i < 2; i++ {
 		if _, _, err := Import(dst, bytes.NewReader(buf.Bytes())); err != nil {
 			t.Fatal(err)
@@ -183,6 +188,7 @@ func TestImportTolerantSkip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(dst) })
 	imported, skipped, err := Import(dst, strings.NewReader(data))
 	if err != nil {
 		t.Fatal(err)
@@ -203,6 +209,7 @@ func mustStore(t *testing.T, path string, items ...*Slice) Store {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	for _, s := range items {
 		if err := st.Put(s); err != nil {
 			t.Fatal(err)
@@ -332,6 +339,7 @@ func TestExportReportsCorruptStoreLines(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	var buf bytes.Buffer
 	n, skipped, err := Export(st, &buf)
 	if err != nil {
@@ -361,6 +369,7 @@ func TestFileStoreToleratesOversizedLine(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	all, err := st.ListAll()
 	if err != nil {
 		t.Fatalf("store unreadable after oversized line: %v", err)
@@ -397,6 +406,7 @@ func TestImportOversizedLineSkipped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(dst) })
 	imported, skipped, err := Import(dst, strings.NewReader(data))
 	if err != nil {
 		t.Fatalf("import aborted on oversized line: %v", err)

--- a/kernel/slice/slice_test.go
+++ b/kernel/slice/slice_test.go
@@ -102,6 +102,7 @@ func TestFileStoreKeepsPerm0600(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	if err := st.Put(&Slice{ID: "a", Type: Prompt, Scope: Project, Content: []byte("x")}); err != nil {
 		t.Fatal(err)
 	}
@@ -123,6 +124,7 @@ func TestFileStorePutGetList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	a := &Slice{ID: "a", Type: Prompt, Scope: Project, Content: []byte("x")}
 	b := &Slice{ID: "b", Type: Result, Scope: User, Content: []byte("y")}
 	if err := st.Put(a); err != nil {
@@ -154,6 +156,7 @@ func TestFileStoreReplaceSameID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	if err := st.Put(&Slice{ID: "a", Type: Prompt, Scope: Project, Content: []byte("v1")}); err != nil {
 		t.Fatal(err)
 	}
@@ -174,6 +177,7 @@ func TestFileStoreUpdateStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	if err := st.Put(&Slice{ID: "a", Type: Prompt, Scope: Project}); err != nil {
 		t.Fatal(err)
 	}
@@ -198,6 +202,7 @@ func TestFileStoreConcurrent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	const goroutines = 10
 	const perG = 20
 	var wg sync.WaitGroup
@@ -279,6 +284,7 @@ func TestFileStoreCorruptLine(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { closeTestStore(st) })
 	got, err := st.Get("ok")
 	if err != nil || got == nil {
 		t.Fatalf("Get(ok) = %v, %v", got, err)


### PR DESCRIPTION
## 背景

\slice.fileStore\ 在 \Close()\ 前一直持有 \.journal\ 文件句柄；而 \slice.Store\ 接口不暴露 \Close()\，测试用 \NewFileStore\ 后普遍不关闭 → journal 句柄泄漏。

**Windows 上**这会把 \.journal\ 文件锁住，导致 \	.TempDir()\ teardown 时 \unlinkat ...journal: file is being used by another process\，slice 存储套件 40+ 个测试失败。**CI 跑 ubuntu-latest**（Linux 允许 unlink 被打开的文件），所以只有本地 Windows 受影响。

## 修复

新增 \closeTestStore\ helper（测试包内，类型断言关闭），并在 slice 包测试的每个 store 创建点注册 \	.Cleanup\：
- 共享 helper \eopen\（journal_test.go）
- 共享 helper \mustStore\（maintenance_test.go）
- 15 处直接 \NewFileStore\ 调用点（slice_test.go / maintenance_test.go）

## 验证（Windows 本地）

- 修复前：\go test -race ./kernel/slice/\ 报 **40+ 个 TempDir journal 清理失败**
- 修复后：\go test -race ./kernel/slice/\ **全部通过**（除 \TestJournalForwardCompat\——它是 pre-existing 的 Windows stash-rename 时序失败，已验证在 main 原始代码上同样失败，与本改动无关）
- \go vet ./kernel/slice/\ 零告警

## 范围说明

用户要求的范围是「只修 slice 包测试」。ingest/inject/lookup 等其它包各自的测试资源泄漏（它们各自 NewFileStore 不 Close）不在本次范围内。