### PR TITLE
fix(cmd): export/import/gc --db 默认值读取 config store.db (Issue #221)

### DIFF
--- a/cmd/semantix/db_config_default_test.go
+++ b/cmd/semantix/db_config_default_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/config"
+	"semantix/kernel/slice"
+)
+
+// Issue #221: export/import/gc's --db default must read config store.db (like
+// lookup/verify), not the hardcoded "" that always falls back to
+// .semantix/project.db. Each test configures store.db to a custom path, runs
+// the command WITHOUT --db, and asserts the command operated on the configured
+// store. t.Chdir isolates the default project.db to an empty temp dir so a
+// regression (default "") fails instead of silently hitting a stray project.db.
+
+func configDBDeps(customDB string) dependencies {
+	return dependencies{
+		newExtractor: slice.NewExtractor,
+		openStore:    slice.NewFileStore,
+		newIndex:     func() slice.Index { return bm25.New() },
+		resolved: &config.Resolved{Fields: []config.Field{
+			{Key: "store.db", Value: customDB, Source: config.SourceFile},
+		}},
+	}
+}
+
+func seedStore(t *testing.T, path string, contents ...string) {
+	t.Helper()
+	store, err := slice.NewFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(store)
+	for i, c := range contents {
+		sl := &slice.Slice{ID: fmt.Sprintf("s%d", i), Type: slice.Prompt, Scope: slice.Project, Content: []byte(c)}
+		if err := store.Put(sl); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestExportReadsConfiguredDB(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	customDB := filepath.Join(dir, "custom.db")
+	seedStore(t, customDB, "修复 go 测试", "加 CI 配置", "补单元测试")
+
+	var out, errOut bytes.Buffer
+	if err := runExport([]string{"--output", "-"}, &out, &errOut, configDBDeps(customDB)); err != nil {
+		t.Fatalf("export: %v (stderr: %s)", err, errOut.String())
+	}
+	lines := 0
+	for _, ln := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if strings.TrimSpace(ln) != "" {
+			lines++
+		}
+	}
+	if lines != 3 {
+		t.Fatalf("exported %d JSONL lines, want 3 — export did not read the configured store.db", lines)
+	}
+}
+
+func TestImportReadsConfiguredDB(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Build a 2-slice backup from a source store.
+	srcDB := filepath.Join(dir, "src.db")
+	seedStore(t, srcDB, "会话 A 切片", "会话 B 切片")
+	backup := filepath.Join(dir, "backup.jsonl")
+	src, err := slice.NewFileStore(srcDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bf, err := os.Create(backup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := slice.Export(src, bf); err != nil {
+		t.Fatal(err)
+	}
+	bf.Close()
+	closeStore(src)
+
+	customDB := filepath.Join(dir, "custom.db")
+	var out, errOut bytes.Buffer
+	if err := runImport([]string{"--input", backup}, &out, &errOut, configDBDeps(customDB)); err != nil {
+		t.Fatalf("import: %v (stderr: %s)", err, errOut.String())
+	}
+
+	// The configured store.db must now hold the imported slices; the default
+	// project.db (in this temp cwd) must not have been touched.
+	restored, err := slice.NewFileStore(customDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeStore(restored)
+	all, err := restored.ListAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(all); got != 2 {
+		t.Fatalf("configured store has %d slices after import, want 2 — import did not read the configured store.db", got)
+	}
+}
+
+func TestGCReadsConfiguredDB(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	customDB := filepath.Join(dir, "custom.db")
+	seedStore(t, customDB, "切片一", "切片二", "切片三")
+
+	var out, errOut bytes.Buffer
+	// --dry-run with an unreachable min-weight checks every slice, deletes none.
+	if err := runGC([]string{"--dry-run", "--min-weight", "1000000", "--json"}, &out, &errOut, configDBDeps(customDB)); err != nil {
+		t.Fatalf("gc: %v (stderr: %s)", err, errOut.String())
+	}
+	var env envelope
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, out.String())
+	}
+	data, ok := env.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("envelope data is not an object: %#v", env.Data)
+	}
+	if checked, _ := data["checked"].(float64); checked != 3 {
+		t.Fatalf("gc checked=%v slices, want 3 — gc did not read the configured store.db", data["checked"])
+	}
+}

--- a/cmd/semantix/export.go
+++ b/cmd/semantix/export.go
@@ -17,7 +17,7 @@ func runExport(args []string, stdout, stderr io.Writer, deps dependencies) error
 	flags := flag.NewFlagSet("export", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	output := flags.String("output", "-", "backup file path, or - for stdout")
-	dbOverride := flags.String("db", "", "database path override")
+	dbOverride := flags.String("db", cfgString(deps.resolved, "store.db", ""), "database path override")
 	jsonOutput := flags.Bool("json", false, "write JSON envelope output")
 	if err := flags.Parse(args); err != nil {
 		// Parse failures (unknown flag, bad value) are usage errors: exit 2

--- a/cmd/semantix/gc.go
+++ b/cmd/semantix/gc.go
@@ -24,7 +24,7 @@ func runGC(args []string, stdout, stderr io.Writer, deps dependencies) error {
 	retentionDays := flags.Int("retention-days", 0, "remove slices older than N days (0 disables)")
 	minWeight := flags.Float64("min-weight", 0, "remove slices with weight below W (0 disables)")
 	dryRun := flags.Bool("dry-run", false, "report candidates without deleting")
-	dbOverride := flags.String("db", "", "database path override")
+	dbOverride := flags.String("db", cfgString(deps.resolved, "store.db", ""), "database path override")
 	jsonOutput := flags.Bool("json", false, "write JSON envelope output")
 	if err := flags.Parse(args); err != nil {
 		// Parse failures (unknown flag, bad value) are usage errors: exit 2

--- a/cmd/semantix/import.go
+++ b/cmd/semantix/import.go
@@ -17,7 +17,7 @@ func runImport(args []string, stdout, stderr io.Writer, deps dependencies) error
 	flags := flag.NewFlagSet("import", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	input := flags.String("input", "-", "backup file path, or - for stdin")
-	dbOverride := flags.String("db", "", "database path override")
+	dbOverride := flags.String("db", cfgString(deps.resolved, "store.db", ""), "database path override")
 	jsonOutput := flags.Bool("json", false, "write JSON envelope output")
 	if err := flags.Parse(args); err != nil {
 		// Parse failures (unknown flag, bad value) are usage errors: exit 2


### PR DESCRIPTION
## 现象

`export`、`import`、`gc` 的 `--db` flag 默认值硬编码 `""`，不走 `cfgString(deps.resolved, "store.db", "")`——semantix.toml 里配的 `store.db` 对这几条命令无效，恒落到 `.semantix/project.db`。

> 注：issue 认为 gc 已由某 PR 顺带修复，但该修复**不在 upstream/main 上**（main 的 `gc.go` 仍是硬编码 `""`），故本 PR 一并修 gc。

## 改动

三处对齐 `lookup.go:22` / `verify.go:215` 的既有模式：

```go
flags.String("db", cfgString(deps.resolved, "store.db", ""), "database path override")
```

三条命令的 `--db` 都是唯一库路径（无 `--project-db`），config 默认是正确来源；显式 `--db` 仍覆盖，空 config 仍回退默认 project store。

`extract`/`search` **不碰**——它们的 `--db` 是独立显式覆盖，另有读 config 的 `--project-db`（合理默认 `""`）。

## 测试

`db_config_default_test.go`：为三条命令各加一个 config 生效 CLI 测试（仿 `config_wiring_test.go`）——配 `store.db=<customDB>`、不带 `--db` 跑命令、断言操作落到配置的 store（`t.Chdir` 隔离默认 project.db）。按 TDD 先红后绿。

## 校验

- 三个新测试 RED→GREEN；`go vet ./cmd/semantix/` 干净；gofmt 干净。
- 注：本地 Windows 上 `verify`/`maintenance` 若干文件类测试因 journaled FileStore 的 `.journal` 在 `t.TempDir` 清理时被占用而失败——pre-existing、Windows-only（base 代码同样失败），Linux CI 正常。

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)