### PR TITLE
feat(harness): U39 H4 换皮落地——品牌名+品牌色一次换完（refs #190）

### DIFF
--- a/harness/brand/brand.go
+++ b/harness/brand/brand.go
@@ -1,0 +1,23 @@
+// Package brand centralizes the user-facing product identity of this
+// Semantix-branded fork. Only display strings route through here:
+// filesystem names, config paths, env vars, keyring services, binary
+// names, and wire identifiers deliberately stay "reasonix" so existing
+// installs, patches, and upstream merges keep working (see the semantix
+// repo, docs/specs/h4-branding.md §3.1).
+package brand
+
+const (
+	// Name is the product name shown to users (window title, transcript
+	// header, CLI banners, generated document metadata).
+	Name = "Semantix"
+
+	// Vendor is the publisher shown in application metadata.
+	Vendor = "Semantix"
+
+	// Copyright is the user-visible copyright line.
+	Copyright = "Copyright © 2026 Semantix Contributors"
+
+	// Tagline is the one-line product description used on splash and
+	// about surfaces.
+	Tagline = "A self-evolving agent that learns how you work."
+)

--- a/harness/brand/brand_test.go
+++ b/harness/brand/brand_test.go
@@ -1,0 +1,32 @@
+package brand
+
+import (
+	"strings"
+	"testing"
+)
+
+// The product display name feeds window titles, transcript headers, and
+// document metadata; keep it a single clean word so those surfaces never
+// need to trim or escape it.
+func TestNameIsCleanDisplayToken(t *testing.T) {
+	if Name != "Semantix" {
+		t.Fatalf("Name = %q, want %q", Name, "Semantix")
+	}
+	if strings.ContainsAny(Name, " \t\r\n") {
+		t.Fatalf("Name %q must not contain whitespace", Name)
+	}
+}
+
+// Rebranding must stay display-only: the Windows AppUserModelID and every
+// on-disk name remain "Reasonix"/"reasonix" (h4-branding spec §3.1). This
+// guard fails if someone points brand identity at the appidentity constant.
+func TestBrandDoesNotLeakIntoStateNames(t *testing.T) {
+	for _, s := range []string{Vendor, Copyright, Tagline} {
+		if strings.TrimSpace(s) == "" {
+			t.Fatal("brand constants must be non-empty")
+		}
+		if strings.Contains(s, "Reasonix") {
+			t.Fatalf("brand constant %q still carries the harness name", s)
+		}
+	}
+}

--- a/harness/cli/bot.go
+++ b/harness/cli/bot.go
@@ -504,7 +504,7 @@ func botWeixinLogin(args []string) int {
 		return 1
 	}
 	fmt.Printf("\n微信登录成功: account_id=%s user_id=%s base_url=%s\n", result.AccountID, result.UserID, result.BaseURL)
-	fmt.Println("凭据已保存到 Reasonix 用户配置目录；也可以把 [bot.weixin] account_id 设置为该 account_id。")
+	fmt.Println("凭据已保存到 Semantix 用户配置目录；也可以把 [bot.weixin] account_id 设置为该 account_id。")
 
 	return 0
 }

--- a/harness/cli/catalogs.go
+++ b/harness/cli/catalogs.go
@@ -65,7 +65,7 @@ func doctorCatalogsCommand(args []string) int {
 		}
 		return 0
 	}
-	fmt.Println("Reasonix disposable catalogs")
+	fmt.Println("Semantix disposable catalogs")
 	for _, item := range items {
 		state := "missing"
 		if item.Info.Exists && item.Info.Error == "" {

--- a/harness/cli/chat_render_test.go
+++ b/harness/cli/chat_render_test.go
@@ -103,7 +103,7 @@ func TestIngestSeparatesReasoningFromAnswer(t *testing.T) {
 	if len(m.transcript) != 3 || !strings.Contains(m.transcript[2], "Hello") {
 		t.Fatalf("answer should commit as a separate entry, transcript=%v", m.transcript)
 	}
-	if plain := ansi.Strip(m.transcript[2]); !strings.HasPrefix(plain, "  ◆ Reasonix\n\n  Hello answer") {
+	if plain := ansi.Strip(m.transcript[2]); !strings.HasPrefix(plain, "  ◆ Semantix\n\n  Hello answer") {
 		t.Fatalf("answer should have an explicit assistant identity and indented body, got %q", plain)
 	}
 }
@@ -116,7 +116,7 @@ func TestAssistantAnswerWithoutReasoningHasNoLeadingSpacer(t *testing.T) {
 	if len(m.transcript) != 1 {
 		t.Fatalf("direct answer should remain one compact block, got %d: %v", len(m.transcript), m.transcript)
 	}
-	if plain := ansi.Strip(m.transcript[0]); !strings.HasPrefix(plain, "  ◆ Reasonix\n\n  Direct answer") {
+	if plain := ansi.Strip(m.transcript[0]); !strings.HasPrefix(plain, "  ◆ Semantix\n\n  Direct answer") {
 		t.Fatalf("direct answer block = %q", plain)
 	}
 }

--- a/harness/cli/chat_tui_test.go
+++ b/harness/cli/chat_tui_test.go
@@ -1461,22 +1461,22 @@ func TestUnsendDiscardsBufferedEvents(t *testing.T) {
 
 func TestRecoveryPauseTurnDoneIsInformational(t *testing.T) {
 	t.Cleanup(func() { i18n.DetectLanguage("en") })
-	const backendFallback = "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send \"continue\" to start a fresh attempt, or add instructions to change direction."
+	const backendFallback = "Automatic retries paused. Semantix stopped repeated attempts and kept completed work. Send \"continue\" to start a fresh attempt, or add instructions to change direction."
 	tests := []struct {
 		lang string
 		want string
 	}{
 		{
 			lang: "en",
-			want: "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
+			want: "Automatic retries paused. Semantix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
 		},
 		{
 			lang: "zh",
-			want: "已暂停自动重试。Reasonix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
+			want: "已暂停自动重试。Semantix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
 		},
 		{
 			lang: "zh-TW",
-			want: "已暫停自動重試。Reasonix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
+			want: "已暫停自動重試。Semantix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
 		},
 	}
 	for _, tt := range tests {
@@ -3803,7 +3803,7 @@ func TestSlashMigrateShowsProgress(t *testing.T) {
 
 func TestSlashMigrateFromImportsExplicitSessions(t *testing.T) {
 	home := isolateCLIConfigHome(t)
-	legacySessions := filepath.Join(home, "Old Reasonix", "sessions")
+	legacySessions := filepath.Join(home, "Old Semantix", "sessions")
 	if err := os.MkdirAll(legacySessions, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/harness/cli/cli.go
+++ b/harness/cli/cli.go
@@ -498,7 +498,7 @@ func runAgent(args []string, version string) int {
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	cont := registerContinueFlag(fs)
 	resume := fs.String("resume", "", "resume by session file path, session ID, or machine session ID (takes precedence over --continue)")
-	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
+	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the session and continue in the copy (escape hatch when the original is held by another Semantix process)")
 	effort := fs.String("effort", "", "session reasoning effort override")
 	permissionMode := fs.String("permission-mode", "ask", "permission mode: manual | ask | auto | acceptEdits | dontAsk | plan | bypassPermissions")
 	autoApprove := fs.BoolP("auto", "y", false, "explicitly auto-approve ordinary writer fallbacks (alias for --permission-mode auto)")
@@ -991,7 +991,7 @@ func chatREPL(args []string, version string) int {
 	cont := registerContinueFlag(fs)
 	resume := fs.StringP("resume", "r", "", "resume by session ID/query, or open the picker when no value is given")
 	fs.Lookup("resume").NoOptDefVal = resumePickerSentinel
-	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the selected session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
+	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the selected session and continue in the copy (escape hatch when the original is held by another Semantix process)")
 	yolo := fs.Bool("dangerously-skip-permissions", false, "YOLO: auto-approve approval-gated tool calls this session; same runtime mode as Ctrl+Y")
 	fs.BoolVar(yolo, "yolo", false, "alias for --dangerously-skip-permissions")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")

--- a/harness/cli/doctor.go
+++ b/harness/cli/doctor.go
@@ -95,7 +95,7 @@ func doctorSessionsCommand(args []string) int {
 		return code
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix doctor sessions [--json]")
+		fmt.Fprintln(os.Stderr, "usage: semantix-agent doctor sessions [--json]")
 		return 2
 	}
 	status, err := sessioncatalog.Inspect(context.Background(), sessioncatalog.DefaultPath())
@@ -112,7 +112,7 @@ func doctorSessionsCommand(args []string) int {
 		}
 		return 0
 	}
-	fmt.Println("Reasonix session catalog")
+	fmt.Println("Semantix session catalog")
 	fmt.Printf("  state: %s\n", status.State)
 	fmt.Printf("  mode: %s\n", status.Mode)
 	fmt.Printf("  revision: %d\n", status.Revision)
@@ -138,7 +138,7 @@ func doctorRepairCommand(args []string) int {
 		return code
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix doctor repair [--root PATH] [--apply] [--project] [--json]")
+		fmt.Fprintln(os.Stderr, "usage: semantix-agent doctor repair [--root PATH] [--apply] [--project] [--json]")
 		return 2
 	}
 	report, err := repair.InspectAndRepairConfig(repair.ConfigOptions{
@@ -158,7 +158,7 @@ func doctorRepairCommand(args []string) int {
 			return 1
 		}
 	} else {
-		fmt.Println("Reasonix repair report")
+		fmt.Println("Semantix repair report")
 		for _, check := range report.Checks {
 			status := "ok"
 			if !check.Exists {
@@ -189,21 +189,21 @@ func doctorQualityCommand(args []string, version string) int {
 	for _, arg := range args {
 		switch arg {
 		case "-h", "--help":
-			fmt.Fprintln(os.Stdout, "usage: reasonix doctor quality <branch-id-or-path> [--json]")
+			fmt.Fprintln(os.Stdout, "usage: semantix-agent doctor quality <branch-id-or-path> [--json]")
 			fmt.Fprintln(os.Stdout, "Prints a public-safe, content-free coding-quality summary for one session.")
 			return 0
 		case "--json":
 			jsonOut = true
 		default:
 			if strings.HasPrefix(arg, "-") || ref != "" {
-				fmt.Fprintln(os.Stderr, "usage: reasonix doctor quality <branch-id-or-path> [--json]")
+				fmt.Fprintln(os.Stderr, "usage: semantix-agent doctor quality <branch-id-or-path> [--json]")
 				return 2
 			}
 			ref = arg
 		}
 	}
 	if ref == "" {
-		fmt.Fprintln(os.Stderr, "usage: reasonix doctor quality <branch-id-or-path> [--json]")
+		fmt.Fprintln(os.Stderr, "usage: semantix-agent doctor quality <branch-id-or-path> [--json]")
 		return 2
 	}
 	report, err := doctor.CollectQuality(doctor.QualityOptions{Version: version, SessionRef: ref})
@@ -252,7 +252,7 @@ func doctorRedactSessionsCommand(args []string) int {
 		return code
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix doctor redact-sessions [--dry-run] [--json] [--dir PATH]")
+		fmt.Fprintln(os.Stderr, "usage: semantix-agent doctor redact-sessions [--dry-run] [--json] [--dir PATH]")
 		return 2
 	}
 	res := doctor.RedactSessions(doctor.RedactSessionsOptions{
@@ -293,10 +293,10 @@ func doctorSessionCommand(args []string, version string) int {
 		arg := args[i]
 		switch arg {
 		case "-h", "--help":
-			fmt.Fprintln(os.Stdout, "usage: reasonix doctor session <branch-id-or-path> [--zip] [--out PATH]")
+			fmt.Fprintln(os.Stdout, "usage: semantix-agent doctor session <branch-id-or-path> [--zip] [--out PATH]")
 			fmt.Fprintln(os.Stdout, "")
 			fmt.Fprintln(os.Stdout, "Bundles the session transcript, persistence sidecars, conflict diagnostics,")
-			fmt.Fprintln(os.Stdout, "and the recovery parent chain into a zip for support. Unlike `reasonix doctor`,")
+			fmt.Fprintln(os.Stdout, "and the recovery parent chain into a zip for support. Unlike `semantix-agent doctor`,")
 			fmt.Fprintln(os.Stdout, "bundled transcripts are NOT redacted; share only with a trusted support channel.")
 			return 0
 		case "--zip":
@@ -324,14 +324,14 @@ func doctorSessionCommand(args []string, version string) int {
 				return 2
 			}
 			if ref != "" {
-				fmt.Fprintln(os.Stderr, "usage: reasonix doctor session <branch-id-or-path> [--zip] [--out PATH]")
+				fmt.Fprintln(os.Stderr, "usage: semantix-agent doctor session <branch-id-or-path> [--zip] [--out PATH]")
 				return 2
 			}
 			ref = arg
 		}
 	}
 	if ref == "" {
-		fmt.Fprintln(os.Stderr, "usage: reasonix doctor session <branch-id-or-path> [--zip] [--out PATH]")
+		fmt.Fprintln(os.Stderr, "usage: semantix-agent doctor session <branch-id-or-path> [--zip] [--out PATH]")
 		return 2
 	}
 	result, err := doctor.WriteSessionBundle(doctor.SessionBundleOptions{

--- a/harness/cli/doctor_test.go
+++ b/harness/cli/doctor_test.go
@@ -34,7 +34,7 @@ func TestRunDispatchesDoctor(t *testing.T) {
 			t.Fatalf("Run doctor rc = %d, want 0", rc)
 		}
 	})
-	if !strings.Contains(out, "reasonix dispatch-version doctor") {
+	if !strings.Contains(out, "semantix-agent dispatch-version doctor") {
 		t.Fatalf("doctor output missing header:\n%s", out)
 	}
 }

--- a/harness/cli/hooks_view.go
+++ b/harness/cli/hooks_view.go
@@ -24,6 +24,6 @@ func renderHooks(width int, hooks []hook.ResolvedHook) string {
 			h.Event, viewMeta(fmt.Sprintf("%-8s", h.Scope)), viewMeta(fmt.Sprintf("%-8s", match)), viewCompactText(h.Command, viewBudget(width, used)))
 	}
 	b.WriteByte('\n')
-	b.WriteString(viewHint(viewCompactText("config: project .reasonix/settings.json + global <Reasonix home>/settings.json", viewBudget(width, 2))))
+	b.WriteString(viewHint(viewCompactText("config: project .reasonix/settings.json + global <Semantix home>/settings.json", viewBudget(width, 2))))
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/harness/cli/mcp_manager_view.go
+++ b/harness/cli/mcp_manager_view.go
@@ -215,7 +215,7 @@ func (p *mcpManager) renderConfirmRemove(width int) string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "Remove MCP server %q?\n", v.Name)
-	b.WriteString(viewMeta("This removes it from Reasonix config. It cannot be undone from this panel.") + "\n\n")
+	b.WriteString(viewMeta("This removes it from Semantix config. It cannot be undone from this panel.") + "\n\n")
 	b.WriteString(rowLine(p.confirm == 0, 1, "", "Confirm remove", false) + "\n")
 	b.WriteString(rowLine(p.confirm == 1, 2, "", "Cancel", false) + "\n")
 	return strings.TrimRight(b.String(), "\n")

--- a/harness/cli/session_lease.go
+++ b/harness/cli/session_lease.go
@@ -15,7 +15,7 @@ import (
 // duplicated session via --copy).
 func sessionLeaseResumeRefusal(err error) string {
 	return control.SessionInUseMessage(err) +
-		"; close the other Reasonix window or process, or rerun with --copy to continue in a duplicated session"
+		"; close the other Semantix window or process, or rerun with --copy to continue in a duplicated session"
 }
 
 // sessionLeaseHeldNotice is the in-TUI refusal for /resume and /switch, where

--- a/harness/cli/session_machine.go
+++ b/harness/cli/session_machine.go
@@ -324,7 +324,7 @@ func machineTime(value time.Time) string {
 func loadMachineIdentityKey() ([]byte, error) {
 	root := strings.TrimSpace(config.MemoryUserDir())
 	if root == "" {
-		return nil, fmt.Errorf("machine identity: Reasonix state directory is unavailable")
+		return nil, fmt.Errorf("machine identity: Semantix state directory is unavailable")
 	}
 	path := filepath.Join(root, machineIdentityKeyFile)
 	key, err := readMachineIdentityKey(path)

--- a/harness/cli/shell_completion.go
+++ b/harness/cli/shell_completion.go
@@ -443,9 +443,9 @@ func completionCommand(args []string) int {
 
 func completionUsage(w *os.File) {
 	fmt.Fprintln(w, `Usage:
-  reasonix completion bash
-  reasonix completion zsh
-  reasonix completion fish
+  semantix-agent completion bash
+  semantix-agent completion zsh
+  semantix-agent completion fish
 
 The command prints a completion script to stdout. Source it directly or save it
 in your shell's completion directory.`)
@@ -652,35 +652,35 @@ func stableUniqueCompletionValues(values []string) []string {
 	return out
 }
 
-const bashCompletionScript = `# bash completion for reasonix
-_reasonix_completion() {
+const bashCompletionScript = `# bash completion for semantix-agent
+_semantix_agent_completion() {
   local line
   COMPREPLY=()
   while IFS= read -r line; do
     COMPREPLY+=("$line")
-  done < <(command reasonix completion __complete "$COMP_CWORD" "${COMP_WORDS[@]}" 2>/dev/null)
+  done < <(command semantix-agent completion __complete "$COMP_CWORD" "${COMP_WORDS[@]}" 2>/dev/null)
 }
-complete -o default -F _reasonix_completion reasonix
+complete -o default -F _semantix_agent_completion semantix-agent
 `
 
-const zshCompletionScript = `#compdef reasonix
-_reasonix_completion() {
+const zshCompletionScript = `#compdef semantix-agent
+_semantix_agent_completion() {
   local -a candidates
-  candidates=("${(@f)$(command reasonix completion __complete "$((CURRENT - 1))" "${words[@]}" 2>/dev/null)}")
+  candidates=("${(@f)$(command semantix-agent completion __complete "$((CURRENT - 1))" "${words[@]}" 2>/dev/null)}")
   if (( ${#candidates[@]} )); then
     compadd -- "${candidates[@]}"
   else
     _default
   fi
 }
-compdef _reasonix_completion reasonix
+compdef _semantix_agent_completion semantix-agent
 `
 
-const fishCompletionScript = `function __reasonix_completion
+const fishCompletionScript = `function __semantix_agent_completion
     set -l tokens (commandline -opc)
     set -a tokens (commandline -ct)
     set -l current_index (math (count $tokens) - 1)
-    command reasonix completion __complete $current_index $tokens 2>/dev/null
+    command semantix-agent completion __complete $current_index $tokens 2>/dev/null
 end
-complete -c reasonix -a '(__reasonix_completion)'
+complete -c semantix-agent -a '(__semantix_agent_completion)'
 `

--- a/harness/cli/shell_completion_test.go
+++ b/harness/cli/shell_completion_test.go
@@ -149,7 +149,7 @@ func TestCompletionCommandPrintsShellScripts(t *testing.T) {
 					t.Fatalf("completion %s exit code = %d", shell, code)
 				}
 			})
-			if !strings.Contains(out, "reasonix completion __complete") {
+			if !strings.Contains(out, "semantix-agent completion __complete") {
 				t.Fatalf("completion %s script does not route to the shared registry:\n%s", shell, out)
 			}
 			if shell == "fish" && strings.Contains(out, "complete -c reasonix -f ") {

--- a/harness/cli/theme.go
+++ b/harness/cli/theme.go
@@ -51,7 +51,7 @@ type cliThemeStyle struct {
 	mode        string
 	accent      cliColor
 	// success, when non-nil, overrides the palette success color. Only the
-	// Semantix Design style sets it (semantic green #2F967F, blueprint §4);
+	// Semantix Design style sets it (brand green #009c6d, h4-branding.md);
 	// other styles keep their palette default.
 	success     *cliColor
 	description string
@@ -101,6 +101,12 @@ var (
 		toolProc:     cliColor{"#8a6bb8", 97},
 	}
 	cliThemeStyles = []cliThemeStyle{
+		// semantix leads the list: cliThemeStyles[0] is the dark default and
+		// the startup theme. Brand green #009c6d = the semantix site --primary
+		// (oklch(0.608 0.14 165)); see the semantix repo, docs/specs/h4-branding.md.
+		{name: "semantix", mode: "dark", accent: cliColor{"#009c6d", 35},
+			success: &cliColor{"#009c6d", 35}, description: "Semantix brand green (default)"},
+		{name: "semantix-light", mode: "light", accent: cliColor{"#008159", 29}, description: "Semantix brand green light (default)"},
 		{name: "graphite", mode: "dark", accent: cliColor{"#d97757", 173}, description: "warm clay accent"},
 		{name: "ember", mode: "dark", accent: cliColor{"#f06d38", 209}, description: "hot orange accent"},
 		{name: "aurora", mode: "dark", accent: cliColor{"#34c3a6", 79}, description: "cool teal accent"},
@@ -109,11 +115,6 @@ var (
 		{name: "porcelain", mode: "light", accent: cliColor{"#7d63c8", 104}, description: "soft violet light accent"},
 		{name: "linen", mode: "light", accent: cliColor{"#bd5d4d", 167}, description: "muted coral light accent"},
 		{name: "glacier", mode: "light", accent: cliColor{"#357fa8", 74}, description: "cool blue light accent"},
-		// Semantix Design (U39, blueprint §4): dark base + semantic green
-		// #2F967F accent, brand-consistent with the landing page. Select via
-		// REASONIX_THEME=semantix or the /theme slash command.
-		{name: "semantix", mode: "dark", accent: cliColor{"#2F967F", 79},
-			success: &cliColor{"#2F967F", 79}, description: "Semantix Design semantic green"},
 	}
 	activeCLITheme = applyCLIThemeStyle(cliDarkTheme, cliThemeStyles[0])
 	// activeBackgroundProbe stays inert unless a caller that owns stdin opts in
@@ -222,7 +223,7 @@ func cliThemeStyleByName(name string) (cliThemeStyle, bool) {
 func defaultCLIThemeStyle(mode string) cliThemeStyle {
 	if mode == "light" {
 		for _, st := range cliThemeStyles {
-			if st.name == "sandstone" {
+			if st.name == "semantix-light" {
 				return st
 			}
 		}

--- a/harness/cli/theme_test.go
+++ b/harness/cli/theme_test.go
@@ -3,7 +3,7 @@ package cli
 import "testing"
 
 // TestSemantixThemeStyle: the Semantix Design style (U39, blueprint §4)
-// ships a dark base with the semantic green #2F967F accent and success
+// ships a dark base with the brand green #009c6d accent and success
 // color, and leaves every other style's palette untouched.
 func TestSemantixThemeStyle(t *testing.T) {
 	st, ok := cliThemeStyleByName("semantix")
@@ -13,11 +13,11 @@ func TestSemantixThemeStyle(t *testing.T) {
 	if st.mode != "dark" {
 		t.Errorf("semantix mode = %q, want dark", st.mode)
 	}
-	if st.accent.hex != "#2F967F" {
-		t.Errorf("semantix accent = %q, want #2F967F", st.accent.hex)
+	if st.accent.hex != "#009c6d" {
+		t.Errorf("semantix accent = %q, want #009c6d", st.accent.hex)
 	}
-	if st.success == nil || st.success.hex != "#2F967F" {
-		t.Errorf("semantix success = %+v, want #2F967F override", st.success)
+	if st.success == nil || st.success.hex != "#009c6d" {
+		t.Errorf("semantix success = %+v, want #009c6d override", st.success)
 	}
 }
 
@@ -27,8 +27,8 @@ func TestSemantixThemeStyle(t *testing.T) {
 func TestApplySemantixThemeStyle(t *testing.T) {
 	st, _ := cliThemeStyleByName("semantix")
 	p := applyCLIThemeStyle(cliDarkTheme, st)
-	if p.accent.hex != "#2F967F" || p.selection.hex != "#2F967F" || p.success.hex != "#2F967F" {
-		t.Errorf("applied palette accent/selection/success = %s/%s/%s, want #2F967F",
+	if p.accent.hex != "#009c6d" || p.selection.hex != "#009c6d" || p.success.hex != "#009c6d" {
+		t.Errorf("applied palette accent/selection/success = %s/%s/%s, want #009c6d",
 			p.accent.hex, p.selection.hex, p.success.hex)
 	}
 }

--- a/harness/cli/transcript.go
+++ b/harness/cli/transcript.go
@@ -13,6 +13,7 @@ import (
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 
+	"semantix/harness/brand"
 	"semantix/harness/provider"
 )
 
@@ -165,7 +166,7 @@ func renderAssistantMarkdown(raw string, contentWidth int) string {
 		rendered = raw
 	}
 	body := strings.TrimRight(rendered, "\n")
-	header := indent + accent("◆") + " " + bold("Reasonix")
+	header := indent + accent("◆") + " " + bold(brand.Name)
 	if body == "" {
 		return header
 	}
@@ -187,7 +188,7 @@ func renderAssistantMarkdownCopy(raw string, contentWidth int, prefix string) st
 		rendered = raw
 	}
 	body := strings.TrimRight(rendered, "\n")
-	header := indent + accent("◆") + " " + bold("Reasonix")
+	header := indent + accent("◆") + " " + bold(brand.Name)
 	if body == "" {
 		return header
 	}

--- a/harness/cli/transcript_test.go
+++ b/harness/cli/transcript_test.go
@@ -22,8 +22,8 @@ func TestAssistantMarkdownHasIdentityAndIndentedBody(t *testing.T) {
 	if len(lines) < 4 {
 		t.Fatalf("assistant block should contain a header, gap, and wrapped body:\n%s", rendered)
 	}
-	if lines[0] != "  ◆ Reasonix" {
-		t.Fatalf("assistant header = %q, want %q", lines[0], "  ◆ Reasonix")
+	if lines[0] != "  ◆ Semantix" {
+		t.Fatalf("assistant header = %q, want %q", lines[0], "  ◆ Semantix")
 	}
 	if lines[1] != "" {
 		t.Fatalf("assistant header/body separator = %q, want blank row", lines[1])
@@ -50,7 +50,7 @@ func TestReplaySectionsKeepAssistantIdentity(t *testing.T) {
 	if len(sections) != 2 {
 		t.Fatalf("replay sections = %d, want user and assistant", len(sections))
 	}
-	if plain := ansi.Strip(sections[1]); !strings.HasPrefix(plain, "  ◆ Reasonix\n\n  Version 1.2.3") {
+	if plain := ansi.Strip(sections[1]); !strings.HasPrefix(plain, "  ◆ Semantix\n\n  Version 1.2.3") {
 		t.Fatalf("replayed assistant answer lost its identity: %q", plain)
 	}
 }

--- a/harness/cli/upgrade.go
+++ b/harness/cli/upgrade.go
@@ -76,7 +76,7 @@ func parseCLIReleaseChannel(value string) (cliReleaseChannel, error) {
 	case "", string(cliReleaseStable), "preview", "canary", "beta", "next":
 		return cliReleaseStable, nil
 	default:
-		return "", fmt.Errorf("release channel %q is unsupported; Reasonix now uses the official release", value)
+		return "", fmt.Errorf("release channel %q is unsupported; Semantix now uses the official release", value)
 	}
 }
 

--- a/harness/cli/web_runtime.go
+++ b/harness/cli/web_runtime.go
@@ -133,7 +133,7 @@ type webInstanceRegistration struct {
 
 func registerWebInstance(reasonixHome, addr string) (*webInstanceRegistration, error) {
 	if strings.TrimSpace(reasonixHome) == "" {
-		return nil, errors.New("cannot register Web instance: Reasonix home is empty")
+		return nil, errors.New("cannot register Web instance: Semantix home is empty")
 	}
 	registry := &webInstanceRegistry{
 		dir:               filepath.Join(reasonixHome, "server", webInstanceDirectoryName),
@@ -146,7 +146,7 @@ func registerWebInstance(reasonixHome, addr string) (*webInstanceRegistration, e
 
 func (r *webInstanceRegistry) register(addr string, pid int) (*webInstanceRegistration, error) {
 	if strings.TrimSpace(r.dir) == "" {
-		return nil, errors.New("cannot register Web instance: Reasonix home is empty")
+		return nil, errors.New("cannot register Web instance: Semantix home is empty")
 	}
 	host, rawPort, err := net.SplitHostPort(addr)
 	if err != nil {

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -258,7 +258,7 @@ const (
 // DesktopConfig so desktop preferences cannot alter terminal output or prompts.
 type UIConfig struct {
 	Theme          string `toml:"theme"`           // auto|dark|light; empty resolves to auto
-	ThemeStyle     string `toml:"theme_style"`     // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
+	ThemeStyle     string `toml:"theme_style"`     // semantix|semantix-light|graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 	ShortcutLayout string `toml:"shortcut_layout"` // classic|desktop; accepted for compatibility
 	CloseBehavior  string `toml:"close_behavior"`  // legacy desktop close behavior; prefer desktop.close_behavior
 	ShowReasoning  bool   `toml:"show_reasoning"`  // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
@@ -373,7 +373,7 @@ func (c *Config) UICursorShape() string {
 
 func normalizeThemeStyle(style string) string {
 	switch strings.ToLower(strings.TrimSpace(style)) {
-	case "graphite", "aurora", "slate", "carbon", "nocturne", "amber", "ember", "midnight", "sandstone", "porcelain", "linen", "glacier":
+	case "semantix", "semantix-light", "graphite", "aurora", "slate", "carbon", "nocturne", "amber", "ember", "midnight", "sandstone", "porcelain", "linen", "glacier":
 		return strings.ToLower(strings.TrimSpace(style))
 	default:
 		return ""

--- a/harness/config/credentials.go
+++ b/harness/config/credentials.go
@@ -264,7 +264,7 @@ func loadCredentialStoreForRoot(root string) {
 		return
 	}
 	if p := UserCredentialsPath(); p != "" {
-		loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials (.env)"})
+		loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Semantix credentials (.env)"})
 	}
 }
 
@@ -490,7 +490,7 @@ func parseCredentialLines(lines []string) map[string]string {
 func pinCredentialAssignments(assignments map[string]string) {
 	for key, value := range assignments {
 		_ = os.Setenv(key, value)
-		recordCredentialSource(key, value, CredentialSource{Kind: CredentialSourceCredentials, Path: UserCredentialsPath(), Label: "Reasonix credentials (.env)"})
+		recordCredentialSource(key, value, CredentialSource{Kind: CredentialSourceCredentials, Path: UserCredentialsPath(), Label: "Semantix credentials (.env)"})
 	}
 }
 
@@ -543,7 +543,7 @@ func credentialSourceLabel(source CredentialSource) string {
 	case CredentialSourceProjectEnv:
 		return "project .env"
 	case CredentialSourceCredentials:
-		return "Reasonix credentials"
+		return "Semantix credentials"
 	case CredentialSourceHomeEnv:
 		return "home .env"
 	case CredentialSourceLegacy:
@@ -608,7 +608,7 @@ func resolveCredentialForRootGlobalFirst(root, key string) CredentialResolution 
 func storedCredentialValue(key string) (string, CredentialSource, bool) {
 	if p := UserCredentialsPath(); p != "" {
 		if value, ok := envFileValue(p, key); ok && value != "" {
-			return value, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials (.env)"}, true
+			return value, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Semantix credentials (.env)"}, true
 		}
 	}
 	return "", CredentialSource{}, false

--- a/harness/control/controller_test.go
+++ b/harness/control/controller_test.go
@@ -4317,7 +4317,7 @@ func TestPlanModeReadOnlyTrustApprovalUsesChineseCatalog(t *testing.T) {
 	if !strings.Contains(approval.Subject, "在计划模式中信任") || !strings.Contains(approval.Subject, "gh issue view 5867") {
 		t.Fatalf("approval subject = %q, want Chinese plan-mode trust subject", approval.Subject)
 	}
-	if !strings.Contains(approval.Reason, "不在 Reasonix 内置只读集合中") {
+	if !strings.Contains(approval.Reason, "不在 Semantix 内置只读集合中") {
 		t.Fatalf("approval reason = %q, want Chinese plan-mode trust reason", approval.Reason)
 	}
 

--- a/harness/doctor/billing.go
+++ b/harness/doctor/billing.go
@@ -126,7 +126,7 @@ func officialKindForBilling(p *config.ProviderEntry) string {
 // RenderBillingText formats a human-readable billing doctor report.
 func RenderBillingText(r BillingReport) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "reasonix doctor billing\n")
+	fmt.Fprintf(&b, "semantix-agent doctor billing\n")
 	fmt.Fprintf(&b, "  display preference: %s\n", r.DisplayCurrencyPref)
 	fmt.Fprintf(&b, "  display resolved:   %s\n", r.DisplayCurrency)
 	fmt.Fprintf(&b, "  fx source:          %s\n", r.FX.Source)

--- a/harness/doctor/report.go
+++ b/harness/doctor/report.go
@@ -231,7 +231,7 @@ func Collect(opts Options) Report {
 
 func RenderText(r Report) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "reasonix %s doctor\n", r.Version)
+	fmt.Fprintf(&b, "semantix-agent %s doctor\n", r.Version)
 	fmt.Fprintf(&b, "  system       %s/%s\n", r.OS, r.Arch)
 	if r.CWD != "" {
 		fmt.Fprintf(&b, "  cwd          %s\n", r.CWD)

--- a/harness/doctor/report_test.go
+++ b/harness/doctor/report_test.go
@@ -97,7 +97,7 @@ func TestCollectReportDoesNotRequireAPIKey(t *testing.T) {
 	if report.Providers[0].KeyPresent {
 		t.Fatal("provider key should be reported missing when env is empty")
 	}
-	if !strings.Contains(text, "reasonix 1.2.3 doctor") {
+	if !strings.Contains(text, "semantix-agent 1.2.3 doctor") {
 		t.Fatalf("text report missing header:\n%s", text)
 	}
 	if !strings.Contains(text, "missing") {

--- a/harness/i18n/messages_en.go
+++ b/harness/i18n/messages_en.go
@@ -11,7 +11,7 @@ var English = Messages{
 	ChatTip:             "Context is kept across turns. Type 'exit' or Ctrl-D to quit.",
 	TurnCancelled:       "cancelled — back to prompt",
 	InterruptedRecovery: "This turn was interrupted. Partial output is kept for reference; only completed tool pairs and a bounded recovery summary enter the next model turn. Inspect the workspace before continuing or reverting changes.",
-	RecoveryPaused:      "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
+	RecoveryPaused:      "Automatic retries paused. Semantix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
 	ReceiptVerified:     "nothing left unverified",
 	ReceiptGapsHeader:   "not verified:",
 	ReceiptRisksHeader:  "declared risks:",
@@ -125,17 +125,17 @@ var English = Messages{
 	MemoryApprovalBodyLabel:                "body",
 	MemoryApprovalArchiveFmt:               "Archive memory %q",
 	PlanModeBashTrustSubjectFmt:            "Trust %q as a read-only command prefix while planning\nCommand: %s",
-	PlanModeBashTrustReason:                "This bash command is not in Reasonix's built-in read-only set. Confirm only if this exact prefix is read-only for planning and research. Auto/YOLO approval cannot answer this trust prompt.",
+	PlanModeBashTrustReason:                "This bash command is not in Semantix's built-in read-only set. Confirm only if this exact prefix is read-only for planning and research. Auto/YOLO approval cannot answer this trust prompt.",
 	PlanModeBashTrustDeclined:              "the user declined to trust this bash command as read-only for plan mode - do not retry it; continue with other trusted read-only tools or ask how to proceed.",
 	SandboxEscapeSubjectFallback:           "run shell command unconfined once",
 	SandboxEscapeSubjectPrefix:             "run unconfined once: ",
 	SandboxEscapeWrapReason:                "Windows does not provide an OS-level Bash sandbox for this command. Run it unconfined one time? This bypasses OS isolation for this command only.",
 	SandboxEscapeRuntimeReason:             "The OS sandbox could not start this command. Run it unconfined one time? This bypasses OS isolation for this command only.",
 	SandboxEscapeDeclined:                  "the user declined to run this command without the OS sandbox - do not retry it unconfined; ask how they would like to proceed.",
-	ApprovalToolLabelConfigWrite:           "Reasonix config write",
-	ConfigWriteSubjectPrefix:               "write Reasonix config: ",
-	ConfigWriteReason:                      "This write targets a Reasonix-managed configuration file outside the workspace. It can change providers, sandbox rules, permissions, and MCP servers for future sessions, so it needs your explicit approval.",
-	ConfigWriteDeclined:                    "the user declined this Reasonix config write - do not retry it; ask how they would like to proceed.",
+	ApprovalToolLabelConfigWrite:           "Semantix config write",
+	ConfigWriteSubjectPrefix:               "write Semantix config: ",
+	ConfigWriteReason:                      "This write targets a Semantix-managed configuration file outside the workspace. It can change providers, sandbox rules, permissions, and MCP servers for future sessions, so it needs your explicit approval.",
+	ConfigWriteDeclined:                    "the user declined this Semantix config write - do not retry it; ask how they would like to proceed.",
 	ConfigWriteApprovalChoices:             "1. Allow once\n2. Allow for this session\n3. Deny\nChoose [1/2/3] (y/a/n also work)",
 	PermissionSavedFmt:                     "permission saved to %s: %s",
 	PermissionAlreadyAllowedFmt:            "permission already covered in %s: %s",
@@ -319,7 +319,7 @@ var English = Messages{
 	ListSkillsHeaderFmt: "skills (%d)",
 	ListSkillsNone:      "skills: none defined — invoke a built-in like /init, or author one with install_skill",
 	ListHooksHeaderFmt:  "hooks (%d active)",
-	ListHooksNone:       "hooks: none active — configure in .semantix-agent/settings.json (project) or <Reasonix home>/settings.json (global)",
+	ListHooksNone:       "hooks: none active — configure in .reasonix/settings.json (project) or <Semantix home>/settings.json (global)",
 	ListMcpHeader:       "mcp servers",
 	ListMcpNone:         "mcp: no servers connected — add one in reasonix.toml ([[plugins]]) or a project .mcp.json",
 
@@ -547,7 +547,7 @@ var English = Messages{
   semantix-agent report send [ID]       send a reviewed report and delete it after success
   semantix-agent report delete [ID]     delete a local report without sending`,
 
-	CLITelemetryConsentNotice:           "Reasonix can send anonymous, content-free CLI usage statistics to crash.reasonix.io: a random install ID, version, OS, and fixed quality buckets. It never sends prompts, answers, code, paths, model or tool content, or environment variables. You can disable this later with `semantix-agent config telemetry off`.",
+	CLITelemetryConsentNotice:           "Semantix can send anonymous, content-free CLI usage statistics to crash.reasonix.io: a random install ID, version, OS, and fixed quality buckets. It never sends prompts, answers, code, paths, model or tool content, or environment variables. You can disable this later with `semantix-agent config telemetry off`.",
 	CLITelemetryConsentPrompt:           "Allow anonymous CLI usage statistics?",
 	CLITelemetryConsentInvalid:          "Please answer y or n.",
 	CLITelemetryConsentSaveFailedFmt:    "CLI telemetry remains disabled because the preference could not be saved: %v",
@@ -599,7 +599,7 @@ Examples:
   echo "explain this code" | semantix-agent run
 
 Configuration:
-  Resolution: flag > ./reasonix.toml > <Reasonix home>/config.toml > built-in defaults
+  Resolution: flag > ./reasonix.toml > <Semantix home>/config.toml > built-in defaults
   Secrets come from the environment via api_key_env (e.g. DEEPSEEK_API_KEY).
   Run 'semantix-agent setup' to scaffold a config; see docs/SPEC.md.
 `,

--- a/harness/i18n/messages_zh.go
+++ b/harness/i18n/messages_zh.go
@@ -12,7 +12,7 @@ var Chinese = Messages{
 	ChatTip:             "对话上下文将跨轮保留。输入 'exit' 或按 Ctrl-D 退出。",
 	TurnCancelled:       "已取消 — 回到提示符",
 	InterruptedRecovery: "本轮已中断。部分输出会永久保留供查看；只有完整工具调用及结果和有界恢复摘要会进入模型下一轮。继续或回滚前请先检查当前工作区。",
-	RecoveryPaused:      "已暂停自动重试。Reasonix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
+	RecoveryPaused:      "已暂停自动重试。Semantix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
 	ReceiptVerified:     "没有未经验证的部分",
 	ReceiptGapsHeader:   "未验证:",
 	ReceiptRisksHeader:  "已申报的风险:",
@@ -126,17 +126,17 @@ var Chinese = Messages{
 	MemoryApprovalBodyLabel:                "正文",
 	MemoryApprovalArchiveFmt:               "归档记忆 %q",
 	PlanModeBashTrustSubjectFmt:            "在计划模式中信任 %q 为只读命令前缀\n命令：%s",
-	PlanModeBashTrustReason:                "这条 bash 命令不在 Reasonix 内置只读集合中。只有在确认这个精确前缀用于计划和研究时是只读的，才应批准。自动/YOLO 审批不能回答这个信任提示。",
+	PlanModeBashTrustReason:                "这条 bash 命令不在 Semantix 内置只读集合中。只有在确认这个精确前缀用于计划和研究时是只读的，才应批准。自动/YOLO 审批不能回答这个信任提示。",
 	PlanModeBashTrustDeclined:              "用户拒绝将这条 bash 命令信任为计划模式只读命令；不要重试它，请继续使用其它已信任的只读工具，或询问用户希望如何继续。",
 	SandboxEscapeSubjectFallback:           "仅本次不进沙箱运行 shell 命令",
 	SandboxEscapeSubjectPrefix:             "仅本次不进沙箱运行：",
 	SandboxEscapeWrapReason:                "Windows 不提供这条命令所需的 OS 级 Bash 沙箱。是否仅本次不受限运行？这只会对此命令绕过 OS 隔离。",
 	SandboxEscapeRuntimeReason:             "OS 沙箱无法启动这条命令。是否仅本次不受限运行？这只会对此命令绕过 OS 隔离。",
 	SandboxEscapeDeclined:                  "用户拒绝在没有 OS 沙箱的情况下运行这条命令；不要不进沙箱重试，请询问用户希望如何继续。",
-	ApprovalToolLabelConfigWrite:           "Reasonix 配置写入审批",
-	ConfigWriteSubjectPrefix:               "写入 Reasonix 配置：",
-	ConfigWriteReason:                      "这次写入的目标是工作区之外的 Reasonix 托管配置文件。它可以改变后续会话的模型服务商、沙箱规则、权限和 MCP 服务器，因此需要你的明确批准。",
-	ConfigWriteDeclined:                    "用户拒绝了这次 Reasonix 配置写入；不要重试，请询问用户希望如何继续。",
+	ApprovalToolLabelConfigWrite:           "Semantix 配置写入审批",
+	ConfigWriteSubjectPrefix:               "写入 Semantix 配置：",
+	ConfigWriteReason:                      "这次写入的目标是工作区之外的 Semantix 托管配置文件。它可以改变后续会话的模型服务商、沙箱规则、权限和 MCP 服务器，因此需要你的明确批准。",
+	ConfigWriteDeclined:                    "用户拒绝了这次 Semantix 配置写入；不要重试，请询问用户希望如何继续。",
 	ConfigWriteApprovalChoices:             "1. 允许一次\n2. 本会话允许\n3. 拒绝\n选择 [1/2/3]（兼容 y/a/n）",
 	PermissionSavedFmt:                     "授权已保存到 %s：%s",
 	PermissionAlreadyAllowedFmt:            "授权已由 %s 中的规则覆盖：%s",
@@ -320,7 +320,7 @@ var Chinese = Messages{
 	ListSkillsHeaderFmt: "skills（%d 个）",
 	ListSkillsNone:      "暂无 skill — 调用内置的（如 /init），或用 install_skill 创建一个",
 	ListHooksHeaderFmt:  "hooks（生效 %d 个）",
-	ListHooksNone:       "无生效 hooks — 在 .semantix-agent/settings.json（项目）或 <Reasonix home>/settings.json（全局）配置",
+	ListHooksNone:       "无生效 hooks — 在 .reasonix/settings.json（项目）或 <Semantix home>/settings.json（全局）配置",
 	ListMcpHeader:       "MCP 服务器",
 	ListMcpNone:         "未连接 MCP 服务器 — 在 reasonix.toml（[[plugins]]）或项目 .mcp.json 中添加",
 
@@ -548,7 +548,7 @@ var Chinese = Messages{
   semantix-agent report send [ID]       发送已审阅报告，成功后删除本地副本
   semantix-agent report delete [ID]     不发送，直接删除本地报告`,
 
-	CLITelemetryConsentNotice:           "Reasonix 可以向 crash.reasonix.io 发送匿名、完全不含内容的 CLI 使用统计：随机安装 ID、版本、操作系统和固定质量分桶。绝不会发送 prompt、回答、代码、路径、模型或工具内容、环境变量。之后可运行 `semantix-agent config telemetry off` 关闭。",
+	CLITelemetryConsentNotice:           "Semantix 可以向 crash.reasonix.io 发送匿名、完全不含内容的 CLI 使用统计：随机安装 ID、版本、操作系统和固定质量分桶。绝不会发送 prompt、回答、代码、路径、模型或工具内容、环境变量。之后可运行 `semantix-agent config telemetry off` 关闭。",
 	CLITelemetryConsentPrompt:           "允许发送匿名 CLI 使用统计吗？",
 	CLITelemetryConsentInvalid:          "请输入 y 或 n。",
 	CLITelemetryConsentSaveFailedFmt:    "由于无法保存偏好设置，CLI 使用统计仍保持关闭：%v",
@@ -600,7 +600,7 @@ var Chinese = Messages{
   echo "解释这段代码" | semantix-agent run
 
 配置：
-  优先级：flag > ./reasonix.toml > <Reasonix home>/config.toml > 内置默认值
+  优先级：flag > ./reasonix.toml > <Semantix home>/config.toml > 内置默认值
   密钥通过 api_key_env 从环境变量注入（如 DEEPSEEK_API_KEY）。
   运行 'semantix-agent setup' 生成配置；详见 docs/SPEC.md。
 `,

--- a/harness/i18n/messages_zh_tw.go
+++ b/harness/i18n/messages_zh_tw.go
@@ -12,7 +12,7 @@ var ChineseTraditional = Messages{
 	ChatTip:             "對話上下文將跨輪保留。輸入 'exit' 或按 Ctrl-D 退出。",
 	TurnCancelled:       "已取消 — 回到提示符",
 	InterruptedRecovery: "本輪已中斷。部分輸出會永久保留供查看；只有完整工具呼叫及結果和有界恢復摘要會進入模型下一輪。繼續或回復前請先檢查目前工作區。",
-	RecoveryPaused:      "已暫停自動重試。Reasonix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
+	RecoveryPaused:      "已暫停自動重試。Semantix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
 	ReceiptVerified:     "沒有未經驗證的部分",
 	ReceiptGapsHeader:   "未驗證:",
 	ReceiptRisksHeader:  "已申報的風險:",
@@ -122,17 +122,17 @@ var ChineseTraditional = Messages{
 	MemoryApprovalBodyLabel:                "正文",
 	MemoryApprovalArchiveFmt:               "封存記憶 %q",
 	PlanModeBashTrustSubjectFmt:            "在計劃模式中信任 %q 為唯讀命令前綴\n命令：%s",
-	PlanModeBashTrustReason:                "這條 bash 命令不在 Reasonix 內建唯讀集合中。只有在確認這個精確前綴用於計劃和研究時是唯讀的，才應核准。自動/YOLO 核准不能回答這個信任提示。",
+	PlanModeBashTrustReason:                "這條 bash 命令不在 Semantix 內建唯讀集合中。只有在確認這個精確前綴用於計劃和研究時是唯讀的，才應核准。自動/YOLO 核准不能回答這個信任提示。",
 	PlanModeBashTrustDeclined:              "使用者拒絕將這條 bash 命令信任為計劃模式唯讀命令；不要重試它，請繼續使用其他已信任的唯讀工具，或詢問使用者希望如何繼續。",
 	SandboxEscapeSubjectFallback:           "僅本次不進沙箱執行 shell 命令",
 	SandboxEscapeSubjectPrefix:             "僅本次不進沙箱執行：",
 	SandboxEscapeWrapReason:                "Windows 不提供這條命令所需的 OS 級 Bash 沙箱。是否僅本次不受限執行？這只會對此命令繞過 OS 隔離。",
 	SandboxEscapeRuntimeReason:             "OS 沙箱無法啟動這條命令。是否僅本次不受限執行？這只會對此命令繞過 OS 隔離。",
 	SandboxEscapeDeclined:                  "使用者拒絕在沒有 OS 沙箱的情況下執行這條命令；不要不進沙箱重試，請詢問使用者希望如何繼續。",
-	ApprovalToolLabelConfigWrite:           "Reasonix 設定寫入核准",
-	ConfigWriteSubjectPrefix:               "寫入 Reasonix 設定：",
-	ConfigWriteReason:                      "這次寫入的目標是工作區之外的 Reasonix 託管設定檔。它可以改變後續工作階段的模型供應商、沙箱規則、權限和 MCP 伺服器，因此需要你的明確核准。",
-	ConfigWriteDeclined:                    "使用者拒絕了這次 Reasonix 設定寫入；不要重試，請詢問使用者希望如何繼續。",
+	ApprovalToolLabelConfigWrite:           "Semantix 設定寫入核准",
+	ConfigWriteSubjectPrefix:               "寫入 Semantix 設定：",
+	ConfigWriteReason:                      "這次寫入的目標是工作區之外的 Semantix 託管設定檔。它可以改變後續工作階段的模型供應商、沙箱規則、權限和 MCP 伺服器，因此需要你的明確核准。",
+	ConfigWriteDeclined:                    "使用者拒絕了這次 Semantix 設定寫入；不要重試，請詢問使用者希望如何繼續。",
 	ConfigWriteApprovalChoices:             "1. 允許一次\n2. 本工作階段允許\n3. 拒絕\n選擇 [1/2/3]（相容 y/a/n）",
 	PermissionSavedFmt:                     "授權已儲存到 %s：%s",
 	PermissionAlreadyAllowedFmt:            "授權已由 %s 中的規則覆蓋：%s",
@@ -304,7 +304,7 @@ var ChineseTraditional = Messages{
 	ListSkillsHeaderFmt: "skills（%d 個）",
 	ListSkillsNone:      "暫無 skill — 呼叫內建的（如 /init），或用 install_skill 建立一個",
 	ListHooksHeaderFmt:  "hooks（生效 %d 個）",
-	ListHooksNone:       "無生效 hooks — 在 .semantix-agent/settings.json（專案）或 <Reasonix home>/settings.json（全域）設定",
+	ListHooksNone:       "無生效 hooks — 在 .reasonix/settings.json（專案）或 <Semantix home>/settings.json（全域）設定",
 	ListMcpHeader:       "MCP 伺服器",
 	ListMcpNone:         "未連線 MCP 伺服器 — 在 reasonix.toml（[[plugins]]）或專案 .mcp.json 中新增",
 
@@ -488,7 +488,7 @@ var ChineseTraditional = Messages{
   semantix-agent report send [ID]       傳送已審閱報告，成功後刪除本機副本
   semantix-agent report delete [ID]     不傳送，直接刪除本機報告`,
 
-	CLITelemetryConsentNotice:           "Reasonix 可以向 crash.reasonix.io 傳送匿名、完全不含內容的 CLI 使用統計：隨機安裝 ID、版本、作業系統和固定品質分桶。絕不會傳送 prompt、回答、程式碼、路徑、模型或工具內容、環境變數。之後可執行 `semantix-agent config telemetry off` 關閉。",
+	CLITelemetryConsentNotice:           "Semantix 可以向 crash.reasonix.io 傳送匿名、完全不含內容的 CLI 使用統計：隨機安裝 ID、版本、作業系統和固定品質分桶。絕不會傳送 prompt、回答、程式碼、路徑、模型或工具內容、環境變數。之後可執行 `semantix-agent config telemetry off` 關閉。",
 	CLITelemetryConsentPrompt:           "允許傳送匿名 CLI 使用統計嗎？",
 	CLITelemetryConsentInvalid:          "請輸入 y 或 n。",
 	CLITelemetryConsentSaveFailedFmt:    "由於無法儲存偏好設定，CLI 使用統計仍維持關閉：%v",
@@ -540,7 +540,7 @@ var ChineseTraditional = Messages{
   echo "解釋這段程式碼" | semantix-agent run
 
 設定：
-  優先順序：flag > ./reasonix.toml > <Reasonix home>/config.toml > 內建預設值
+  優先順序：flag > ./reasonix.toml > <Semantix home>/config.toml > 內建預設值
   金鑰透過 api_key_env 從環境變數注入（如 DEEPSEEK_API_KEY）。
   執行 'semantix-agent setup' 生成設定；詳見 docs/SPEC.md。
 `,

--- a/harness/productdocs/docs.go
+++ b/harness/productdocs/docs.go
@@ -1,4 +1,4 @@
-// Package productdocs provides offline retrieval over the official Reasonix
+// Package productdocs provides offline retrieval over the official Semantix
 // documentation embedded in the application binary.
 package productdocs
 
@@ -124,7 +124,7 @@ var (
 )
 
 // NewTool returns a read-only tool backed by the documentation embedded in the
-// current Reasonix build. Loading stays lazy so merely registering the stable
+// current Semantix build. Loading stays lazy so merely registering the stable
 // schema does not add Markdown parsing work to application startup.
 func NewTool() tool.Tool {
 	return &docsTool{}
@@ -169,11 +169,11 @@ func CommandOverviewFor(language, commandName string) (string, error) {
 	stats := fmt.Sprintf("documents=%d sections=%d releases=%d", m.Documents, m.Sections, m.ReleaseNotes)
 	switch strings.ToLower(strings.TrimSpace(language)) {
 	case "zh", "zh-cn":
-		return fmt.Sprintf("内置 Reasonix 文档\n%s\n%s\n\n用法：%s <问题>\n示例：%s 1.19.5 更新日志\n\n搜索在本地完成，命中的版本匹配资料会交给当前配置的 AI 组织答案。", identity, stats, commandName, commandName), nil
+		return fmt.Sprintf("内置 Semantix 文档\n%s\n%s\n\n用法：%s <问题>\n示例：%s 1.19.5 更新日志\n\n搜索在本地完成，命中的版本匹配资料会交给当前配置的 AI 组织答案。", identity, stats, commandName, commandName), nil
 	case "zh-tw":
-		return fmt.Sprintf("內建 Reasonix 文件\n%s\n%s\n\n用法：%s <問題>\n範例：%s 1.19.5 更新日誌\n\n搜尋在本機完成，命中的版本匹配資料會交給目前設定的 AI 組織答案。", identity, stats, commandName, commandName), nil
+		return fmt.Sprintf("內建 Semantix 文件\n%s\n%s\n\n用法：%s <問題>\n範例：%s 1.19.5 更新日誌\n\n搜尋在本機完成，命中的版本匹配資料會交給目前設定的 AI 組織答案。", identity, stats, commandName, commandName), nil
 	default:
-		return fmt.Sprintf("Embedded Reasonix documentation\n%s\n%s\n\nUsage: %s <question>\nExample: %s 1.19.5 changelog\n\nSearch runs locally, then the version-matched evidence is passed to the configured AI to compose the answer.", identity, stats, commandName, commandName), nil
+		return fmt.Sprintf("Embedded Semantix documentation\n%s\n%s\n\nUsage: %s <question>\nExample: %s 1.19.5 changelog\n\nSearch runs locally, then the version-matched evidence is passed to the configured AI to compose the answer.", identity, stats, commandName, commandName), nil
 	}
 }
 
@@ -249,8 +249,8 @@ func (c *catalog) identityLine() string {
 func (*docsTool) Name() string { return "docs" }
 
 func (*docsTool) Description() string {
-	return "Search and read the official documentation embedded in this exact Reasonix build. " +
-		"Use it before web search or assumptions for Reasonix setup, CLI, Desktop, configuration, permissions, MCP, memory, recovery, provider behavior, and maintainer workflows. " +
+	return "Search and read the official documentation embedded in this exact Semantix build. " +
+		"Use it before web search or assumptions for Semantix setup, CLI, Desktop, configuration, permissions, MCP, memory, recovery, provider behavior, and maintainer workflows. " +
 		"Search first, then read the returned section_id when the full section is needed."
 }
 
@@ -405,7 +405,7 @@ func (t *docsTool) read(sectionID, documentPath string) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("unknown section_id %q; use operation=search or read with an exact path to list section ids", sectionID)
 		}
-		return fmt.Sprintf("Embedded Reasonix documentation (%s)\nsource: %s\npath: %s\nsection_id: %s\nlocale: %s\naudience: %s\nheading: %s\n\n%s",
+		return fmt.Sprintf("Embedded Semantix documentation (%s)\nsource: %s\npath: %s\nsection_id: %s\nlocale: %s\naudience: %s\nheading: %s\n\n%s",
 			t.catalog.identityLine(), section.document.sourceRange(section.startLine, section.endLine), section.document.displayPath(), section.id,
 			section.document.locale, section.document.audience, section.heading, strings.TrimSpace(section.content)), nil
 	}
@@ -430,7 +430,7 @@ func (t *docsTool) read(sectionID, documentPath string) (string, error) {
 
 func (t *docsTool) list(language, audience string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Embedded Reasonix documentation catalog (%s):\n", t.catalog.identityLine())
+	fmt.Fprintf(&b, "Embedded Semantix documentation catalog (%s):\n", t.catalog.identityLine())
 	count := 0
 	for _, doc := range t.catalog.docs {
 		if language != "auto" && language != "all" && doc.locale != language {
@@ -779,10 +779,10 @@ func documentAudience(name string) string {
 
 func formatSearchResults(query, identity string, hits []searchHit) string {
 	if len(hits) == 0 {
-		return fmt.Sprintf("No embedded Reasonix documentation matched %q (%s). Try fewer terms, an exact command/configuration key, language=all, or audience=all.", query, identity)
+		return fmt.Sprintf("No embedded Semantix documentation matched %q (%s). Try fewer terms, an exact command/configuration key, language=all, or audience=all.", query, identity)
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "Embedded Reasonix documentation results for %q (%s):\n", query, identity)
+	fmt.Fprintf(&b, "Embedded Semantix documentation results for %q (%s):\n", query, identity)
 	for i, hit := range hits {
 		section := hit.section
 		fmt.Fprintf(&b, "\n%d. score=%.3f source=%s path=%s section_id=%s locale=%s audience=%s\n   heading: %s\n   snippet: %s\n",

--- a/harness/productdocs/docs_test.go
+++ b/harness/productdocs/docs_test.go
@@ -66,7 +66,7 @@ func TestDocsCommandOverviewAndSearchUseEmbeddedCorpus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"内置 Reasonix 文档", "version=", "revision=", "digest=sha256:", "/docs 1.19.5 更新日志"} {
+	for _, want := range []string{"内置 Semantix 文档", "version=", "revision=", "digest=sha256:", "/docs 1.19.5 更新日志"} {
 		if !strings.Contains(overview, want) {
 			t.Fatalf("command overview missing %q:\n%s", want, overview)
 		}
@@ -439,7 +439,9 @@ func TestDocsToolContractIsStableAndReadOnly(t *testing.T) {
 	}
 	contract := tl.Name() + "\n" + tl.Description() + "\n" + string(canonical)
 	got := fmt.Sprintf("%x", sha256.Sum256([]byte(contract)))
-	const want = "0113a592b6bcba5dd2be78c552f95ca27337534b6bb55b7b5e6fd89414f95be5"
+	// Pin refreshed for the Semantix rebrand of the tool description
+	// (h4-branding): provider-visible wording changed intentionally.
+	const want = "fa54f67e27b70fc15376b80809e6ebc7fd329565c5fc69e0001e6a51ef19e429"
 	if got != want {
 		t.Fatalf("provider-visible docs contract changed: got %s, want %s", got, want)
 	}

--- a/harness/productdocs/release_notes.go
+++ b/harness/productdocs/release_notes.go
@@ -113,7 +113,7 @@ func renderReleaseMarkdown(release releaseRecord, locale string) string {
 		return en
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "# Reasonix v%s — %s\n\n", release.Version, localize(release.Title))
+	fmt.Fprintf(&b, "# Semantix v%s — %s\n\n", release.Version, localize(release.Title))
 	if zh {
 		fmt.Fprintf(&b, "发布日期：%s\n\n发布渠道：%s\n\n状态：%s\n", release.Date, release.Channel, release.Status)
 	} else {


### PR DESCRIPTION
## 目的（U39 收尾：H4 换皮全量落地，refs #190）

把 fork 工作树里的 H4 换皮成果（`docs/specs/h4-branding.md` as-built）落到扁平 harness 树，并补齐 patch 未覆盖的品牌残留——品牌名与品牌色一次换完。

## 来源与套用方式

- H4 patch 从 fork `feat/h4-branding` 工作树导出（69 文件；43 个 desktop 部分不适用留给 #158，完整副本已存 `~/.reasonix/global-workspace/h4-branding-reskin-full.patch`）
- 25 个 internal 文件路径改写后套用：20 个干净命中；5 个手工移植（`transcript.go` brand 引用、i18n ×3 词条逐对替换、`theme_test.go` 色值断言）
- `harness/brand/` 包从 fork 工作树补入（untracked 状态，`git diff` 不含——patch 缺它的根因）

## 关键合并决策

- **theme.go 双 semantix 条目合一**：扁平线此前用蓝图作废旧色 `#2F967F` 实现过主题条目，H4 patch 又插入定案色条目——合并为单条目：定案色 `#009c6d`（xterm 35）+ 保留扁平线的 success override 设计（复用面板绿走 success），表首即启动默认；`semantix-light`（`#008159`/29）为 light 默认
- **i18n 词条合成**：品牌词按 H4（Semantix 开头），命令名按扁平线现状（`semantix-agent config telemetry off`）；`ListHooksNone` 修正扁平线文案与实现脱节（实现项目目录是 `.reasonix`，文案写 `.semantix-agent` 会误导用户）
- **patch 未覆盖的品牌残留一并清理**（#190 清单）：completion 脚本硬编码 `command reasonix`（装上即坏的真 bug，函数名改 `_semantix_agent_completion`）、doctor 报告头与 usage 行、billing 头

## 不改清单（Tier B，遵守 h4-branding.md §3.1）

`.reasonix` 配置目录、`reasonix.toml`、`crash.reasonix.io`、`REASONIX_THEME` 等 env、wire 标识、worktree 分支名模板、ACP vendor method 名——全部保持。

## 验证

- 全量 `go test ./... -race`：**134 包 ok**；唯一失败 `TestSemantixLookupSubprocess` 为已知并发 3s 超时 flake（单跑复验绿，PR #227 已记录同类）
- 打包冒烟：v0.4.1-alpha.2 darwin-arm64 解包冒烟通过（真实 DeepSeek 单发 ALPHA2-OK）；tmux TUI 走查：横幅 `◆ semantix-agent`、品牌绿 38;5;35 命中 4 处、consent 文案合成词条正确；doctor/completion/version 三面品牌名验证通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
