### PR TITLE
fix(cli): usage --evolve-db 空转修复——重放喂 cache_hit + params.json 接上消费者

### DIFF
--- a/cmd/semantix/flags.go
+++ b/cmd/semantix/flags.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"semantix/kernel/evolve"
 	"semantix/kernel/slice"
 	"semantix/kernel/zone"
 )
@@ -37,6 +38,43 @@ func (zf *zoneFlagSet) zones() zone.Zones {
 		AbsHigh: *zf.absHigh,
 		AbsLow:  *zf.absLow,
 	}
+}
+
+// applyEvolveParams lets the evolved TauL2 drive the grey-zone floor
+// (Issue #220: params.json gains its first consumer). An explicit
+// --tau-low always wins over the evolved value; the evolved value is
+// clamped to the engine's own tuning band so a hand-edited or stale file
+// cannot push the classifier outside what evolve itself could produce.
+// Call between flag.Parse and validate.
+func (zf *zoneFlagSet) applyEvolveParams(fs *flag.FlagSet, dir string) error {
+	if dir == "" {
+		return nil
+	}
+	explicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "tau-low" {
+			explicit = true
+		}
+	})
+	if explicit {
+		return nil
+	}
+	st, err := loadEvolveState(dir)
+	if err != nil || st == nil {
+		return err
+	}
+	tau := st.Params.TauL2
+	if math.IsNaN(tau) || math.IsInf(tau, 0) {
+		return nil
+	}
+	if tau < evolve.DefaultMinTau {
+		tau = evolve.DefaultMinTau
+	}
+	if tau > evolve.DefaultMaxTau {
+		tau = evolve.DefaultMaxTau
+	}
+	*zf.tauLow = tau
+	return nil
 }
 
 // validate checks the parsed thresholds: NaN/Inf/out-of-range values would

--- a/cmd/semantix/flags_evolve_test.go
+++ b/cmd/semantix/flags_evolve_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"semantix/kernel/evolve"
+)
+
+// writeParams persists an evolveState with the given TauL2 for consumer tests.
+func writeParams(t *testing.T, dir string, tau float64) {
+	t.Helper()
+	b, err := json.Marshal(evolveState{Params: evolve.Params{TauL2: tau}, Epoch: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "params.json"), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newZoneFlagSet(t *testing.T, args ...string) (*flag.FlagSet, *zoneFlagSet) {
+	t.Helper()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	zf := addZoneFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	return fs, zf
+}
+
+// The evolved TauL2 becomes the grey-zone floor when --tau-low is not given
+// (Issue #220: params.json gains a consumer).
+func TestApplyEvolveParamsOverridesDefaultTauLow(t *testing.T) {
+	dir := t.TempDir()
+	writeParams(t, dir, 0.75)
+	fs, zf := newZoneFlagSet(t)
+	if err := zf.applyEvolveParams(fs, dir); err != nil {
+		t.Fatal(err)
+	}
+	if got := zf.zones().TauLow; got != 0.75 {
+		t.Fatalf("TauLow = %v, want evolved 0.75", got)
+	}
+	if err := zf.validate(); err != nil {
+		t.Fatalf("evolved value must pass validation: %v", err)
+	}
+}
+
+// An explicit --tau-low always beats the evolved value.
+func TestApplyEvolveParamsExplicitFlagWins(t *testing.T) {
+	dir := t.TempDir()
+	writeParams(t, dir, 0.75)
+	fs, zf := newZoneFlagSet(t, "--tau-low", "0.40")
+	if err := zf.applyEvolveParams(fs, dir); err != nil {
+		t.Fatal(err)
+	}
+	if got := zf.zones().TauLow; got != 0.40 {
+		t.Fatalf("TauLow = %v, explicit flag must win", got)
+	}
+}
+
+// Values outside the engine's tuning band are clamped so a hand-edited file
+// cannot push the classifier into extremes evolve itself could not reach.
+func TestApplyEvolveParamsClampsToTuningBand(t *testing.T) {
+	dir := t.TempDir()
+	writeParams(t, dir, 0.99)
+	fs, zf := newZoneFlagSet(t)
+	if err := zf.applyEvolveParams(fs, dir); err != nil {
+		t.Fatal(err)
+	}
+	if got := zf.zones().TauLow; got != evolve.DefaultMaxTau {
+		t.Fatalf("TauLow = %v, want clamped to %v", got, evolve.DefaultMaxTau)
+	}
+}
+
+// Empty dir flag and missing state file both leave the defaults untouched.
+func TestApplyEvolveParamsFailOpen(t *testing.T) {
+	fs, zf := newZoneFlagSet(t)
+	if err := zf.applyEvolveParams(fs, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyEvolveParams(fs, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if got := zf.zones().TauLow; got != 0.55 {
+		t.Fatalf("TauLow = %v, want untouched default 0.55", got)
+	}
+}

--- a/cmd/semantix/lookup.go
+++ b/cmd/semantix/lookup.go
@@ -24,9 +24,13 @@ func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error
 	// `semantix lookup --json`): the envelope is the machine-readable form.
 	// Without --json the legacy bare-array output is kept for compat.
 	jsonOut := flags.Bool("json", false, "output as JSON envelope (H1 protocol)")
+	evolveDB := flags.String("evolve-db", "", "optional evolve state dir; its tuned tau_l2 sets the grey-zone floor unless --tau-low is given (Issue #220)")
 	zf := addZoneFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return usageWrap(err)
+	}
+	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
+		return usagef("%v", err)
 	}
 	if err := zf.validate(); err != nil {
 		return usagef("%v", err)
@@ -105,9 +109,13 @@ func runInject(args []string, stdout, stderr io.Writer, deps dependencies) error
 	k := flags.Int("k", cfgInt(deps.resolved, "retrieval.limit", 5), "top-k slices to consider")
 	budget := flags.Int("budget", cfgInt(deps.resolved, "inject.budget", inject.DefaultBudget), "max injection block bytes")
 	dbOverride := flags.String("db", cfgString(deps.resolved, "store.db", ""), "database path override")
+	evolveDB := flags.String("evolve-db", "", "optional evolve state dir; its tuned tau_l2 sets the grey-zone floor unless --tau-low is given (Issue #220)")
 	zf := addZoneFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return usageWrap(err)
+	}
+	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
+		return usagef("%v", err)
 	}
 	if err := zf.validate(); err != nil {
 		return usagef("%v", err)

--- a/cmd/semantix/usage.go
+++ b/cmd/semantix/usage.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -30,14 +31,14 @@ type usageJSON struct {
 }
 
 // runUsage summarizes the usage log and reports cost savings (Issue #60 /
-// U17). With --evolve-db it also feeds cost/latency signals into the
-// evolution engine and prints the adjusted params.
+// U17). With --evolve-db it also replays the log as cache_hit signals into
+// the evolution engine and prints the adjusted params (Issue #220).
 func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 	fs := flag.NewFlagSet("usage", flag.ContinueOnError)
 	db := fs.String("db", filepath.Join(".semantix", "usage.jsonl"), "usage log path (default .semantix/usage.jsonl)")
 	costMiss := fs.Float64("cost-miss", cfgFloat(deps.resolved, "cost.input_price_usd", usage.DefaultCostMissPerMTok), "USD per 1M tokens at cache miss")
 	costHit := fs.Float64("cost-hit", cfgFloat(deps.resolved, "cost.cache_price_usd", usage.DefaultCostHitPerMTok), "USD per 1M tokens at cache hit")
-	evolveDB := fs.String("evolve-db", "", "optional evolve engine state dir (feeds cost signals and prints adjusted params)")
+	evolveDB := fs.String("evolve-db", "", "optional evolve state dir (replays the log as cache_hit signals; params consumed by lookup/inject --evolve-db)")
 	jsonOut := fs.Bool("json", false, "output as JSON envelope")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -56,7 +57,7 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 		data := usageJSON{
 			Events: s.Events, TokensIn: s.TokensIn, TokensOut: s.TokensOut,
 			CacheHitTokens: s.CacheHitTokens, L3Reuses: s.L3Reuses, InjectedTokens: s.InjectedTokens,
-			SliceHits: s.SliceHits,
+			SliceHits:   s.SliceHits,
 			CostPaidUSD: s.CostPaidUSD, CostNoCacheUSD: s.CostNoCacheUSD,
 			SavingsUSD: s.SavingsUSD, SavingsRate: s.SavingsRate,
 		}
@@ -89,7 +90,7 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 	fmt.Fprintf(stdout, "savings_rate\t%.4f\n", s.SavingsRate)
 
 	if *evolveDB != "" {
-		if err := feedEvolve(*evolveDB, s, stdout); err != nil {
+		if err := feedEvolve(*evolveDB, *db, stdout); err != nil {
 			fmt.Fprintln(os.Stderr, "usage: evolve:", err)
 			return 1 // runtime error
 		}
@@ -97,41 +98,56 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 	return 0
 }
 
-// feedEvolve loads (or creates) an evolution engine and records cost/latency
-// signals derived from the summary, then prints the current params. The
-// persisted state carries the epoch so repeated runs advance it.
-func feedEvolve(dir string, s *usage.Summary, stdout io.Writer) error {
+// feedEvolve deterministically replays the usage log through a fresh
+// evolution engine — one "cache_hit" signal per recorded turn (L3 reuse
+// counts as a full hit), epoch = turn ordinal — then persists the resulting
+// parameter snapshot for consumers (lookup/inject --evolve-db). Because the
+// log is append-only, replaying from scratch on every run reproduces the
+// same cumulative EWMA state, so params.json is a pure output: no engine
+// internals need to survive between runs, and reruns are idempotent.
+func feedEvolve(dir, logPath string, stdout io.Writer) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	statePath := filepath.Join(dir, "params.json")
+	f, err := os.Open(logPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
 	e := evolve.New(evolve.Config{})
-	epoch := uint64(1)
-	if b, err := os.ReadFile(statePath); err == nil && len(b) > 0 {
-		var st evolveState
-		if err := json.Unmarshal(b, &st); err == nil {
-			_ = e.Apply(st.Params) // ignore freeze errors on load; defaults remain
-			if st.Epoch > 0 {
-				epoch = st.Epoch + 1
-			}
+	epoch := uint64(0)
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		var ev usage.Event
+		// Malformed lines are skipped, matching usage.Summarize tolerance.
+		if err := json.Unmarshal(sc.Bytes(), &ev); err != nil {
+			continue
 		}
+		var v float64
+		switch {
+		case ev.L3Reuse:
+			v = 1 // turn fully served from the library: strongest hit signal
+		case ev.TokensIn > 0:
+			v = float64(ev.CacheHitToken) / float64(ev.TokensIn)
+		default:
+			continue // no usable signal in this turn
+		}
+		epoch++
+		_ = e.RecordSignal(evolve.Signal{Name: "cache_hit", Value: v, Epoch: epoch})
 	}
-	// cost signal: 1 - savings rate (higher savings → lower cost signal)
-	costVal := 1 - s.SavingsRate
-	if costVal < 0 {
-		costVal = 0
+	if err := sc.Err(); err != nil {
+		return err
 	}
-	if costVal > 1 {
-		costVal = 1
-	}
-	_ = e.RecordSignal(evolve.Signal{Name: "cost", Value: costVal, Epoch: epoch})
-	_ = e.RecordSignal(evolve.Signal{Name: "latency", Value: costVal, Epoch: epoch})
 
 	p := e.Params()
-	if b, err := json.Marshal(evolveState{Params: p, Epoch: epoch}); err == nil {
-		if err := os.WriteFile(statePath, b, 0o600); err != nil {
-			return err
-		}
+	b, err := json.Marshal(evolveState{Params: p, Epoch: epoch})
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "params.json"), b, 0o600); err != nil {
+		return err
 	}
 	fmt.Fprintf(stdout, "evolve_epoch\t%d\n", epoch)
 	fmt.Fprintf(stdout, "evolve_tau_l2\t%.3f\n", p.TauL2)
@@ -139,10 +155,30 @@ func feedEvolve(dir string, s *usage.Summary, stdout io.Writer) error {
 	return nil
 }
 
-// evolveState is the persisted evolution state (params + last epoch).
+// evolveState is the persisted parameter snapshot (params + turns consumed).
+// It is written by `usage --evolve-db` and read by `lookup`/`inject`
+// --evolve-db; the file is derived state, never an input to the engine.
 type evolveState struct {
 	Params evolve.Params `json:"params"`
 	Epoch  uint64        `json:"epoch"`
+}
+
+// loadEvolveState reads the persisted snapshot; a missing file is a silent
+// no-op (fail-open, matching the kernel's degradation philosophy) while a
+// corrupt file is a real error the operator should see.
+func loadEvolveState(dir string) (*evolveState, error) {
+	b, err := os.ReadFile(filepath.Join(dir, "params.json"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var st evolveState
+	if err := json.Unmarshal(b, &st); err != nil {
+		return nil, fmt.Errorf("evolve state %s: %w", filepath.Join(dir, "params.json"), err)
+	}
+	return &st, nil
 }
 
 // barChart renders an ASCII bar (█ filled, ░ empty) for a ratio in [0,1].

--- a/cmd/semantix/usage_test.go
+++ b/cmd/semantix/usage_test.go
@@ -118,12 +118,86 @@ func TestRunUsageWithEvolve(t *testing.T) {
 			t.Fatalf("evolve state perms = %o, want 600", st.Mode().Perm())
 		}
 	}
-	// Second run loads state (epoch advances).
+	// Replay semantics (Issue #220): the same log yields the same state —
+	// rerunning must NOT advance the epoch, only new events do.
 	var out2 bytes.Buffer
 	if code := runUsage([]string{"--db", logPath, "--evolve-db", evolveDir}, &out2, productionDependencies()); code != 0 {
 		t.Fatalf("second usage --evolve exit code = %d", code)
 	}
-	if !strings.Contains(out2.String(), "evolve_epoch\t2") {
-		t.Fatalf("second run must advance epoch:\n%s", out2.String())
+	if !strings.Contains(out2.String(), "evolve_epoch\t1") {
+		t.Fatalf("replay over the same log must be idempotent:\n%s", out2.String())
+	}
+	if err := r.Append(usage.Event{Turn: 2, TokensIn: 1000, TokensOut: 100, CacheHitToken: 500}); err != nil {
+		t.Fatal(err)
+	}
+	var out3 bytes.Buffer
+	if code := runUsage([]string{"--db", logPath, "--evolve-db", evolveDir}, &out3, productionDependencies()); code != 0 {
+		t.Fatalf("third usage --evolve exit code = %d", code)
+	}
+	if !strings.Contains(out3.String(), "evolve_epoch\t2") {
+		t.Fatalf("a new event must advance the epoch:\n%s", out3.String())
+	}
+}
+
+// TestFeedEvolveAdjustsTauAfterHistory proves the loop is no longer inert
+// (Issue #220): with enough high-hit turns the engine leaves the cold-start
+// window (FreezeEpochs) and actually moves TauL2 off its default.
+func TestFeedEvolveAdjustsTauAfterHistory(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "usage.jsonl")
+	r, err := usage.NewRecorder(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 65; i++ {
+		if err := r.Append(usage.Event{Turn: uint64(i), TokensIn: 1000, TokensOut: 100, CacheHitToken: 900}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	evolveDir := filepath.Join(dir, "evolve")
+	var out bytes.Buffer
+	if err := feedEvolve(evolveDir, logPath, &out); err != nil {
+		t.Fatal(err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "evolve_epoch\t65") {
+		t.Fatalf("epoch must count consumed turns:\n%s", s)
+	}
+	// 65 signals at 0.9 hit ratio: hit EWMA ≥ HitTarget with zero pollution
+	// after the 60-epoch cold start → exactly one +TauStep adjustment
+	// (0.55 → 0.60), then the freeze window blocks further movement.
+	if !strings.Contains(s, "evolve_tau_l2\t0.600") {
+		t.Fatalf("tau must move off the default after sustained hits:\n%s", s)
+	}
+	// The persisted snapshot carries the adjusted value for consumers.
+	st, err := loadEvolveState(evolveDir)
+	if err != nil || st == nil {
+		t.Fatalf("loadEvolveState: st=%v err=%v", st, err)
+	}
+	if diff := st.Params.TauL2 - 0.60; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("persisted TauL2 = %v, want 0.60", st.Params.TauL2)
+	}
+	// Deterministic replay: a second pass reproduces the identical output.
+	var again bytes.Buffer
+	if err := feedEvolve(evolveDir, logPath, &again); err != nil {
+		t.Fatal(err)
+	}
+	if again.String() != s {
+		t.Fatalf("replay must be deterministic:\nfirst:\n%s\nsecond:\n%s", s, again.String())
+	}
+}
+
+// TestLoadEvolveState covers the consumer-side contract: missing file is a
+// silent no-op, corrupt file is a visible error.
+func TestLoadEvolveState(t *testing.T) {
+	dir := t.TempDir()
+	if st, err := loadEvolveState(dir); st != nil || err != nil {
+		t.Fatalf("missing file: st=%v err=%v, want nil/nil", st, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "params.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadEvolveState(dir); err == nil {
+		t.Fatal("corrupt file must surface an error")
 	}
 }

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -75,8 +75,8 @@ semantix verify --session <会话目录> --project demo > eval.tsv
 | `eval` | 检索策略比较（单阈值 vs 三段） | `--set` `--train-frac` `--tau-*` |
 | `eval-judge` | LLM judge 真实性评估（门禁） | `--stub` `--audit` `--min-consistency` |
 | `usage` | 成本节省统计 | `--db` `--evolve-db` |
-| `lookup` | semantix_lookup 工具（JSON） | `--query` `--limit` `--scope` |
-| `inject` | L2 注入块（规范序/预算截断） | `--query` `--budget` `--k` |
+| `lookup` | semantix_lookup 工具（JSON） | `--query` `--limit` `--scope` `--evolve-db` |
+| `inject` | L2 注入块（规范序/预算截断） | `--query` `--budget` `--k` `--evolve-db` |
 
 **产品与管理**：`doctor` 健康检查（db / config / embedder / judge，任一 FAIL 退出码 3）、
 `install` 一键安装、`completion` 生成 shell 补全脚本（bash / zsh / fish，加载方式见下文）、

--- a/kernel/evolve/evolve.go
+++ b/kernel/evolve/evolve.go
@@ -11,33 +11,33 @@ import (
 // prefix for ~24h (DeepSeek policy) — we never change params inside the
 // window (Reasonix lesson, cache_policy.go:21-45).
 const (
-	DefaultAlpha       = 0.1   // EWMA smoothing (10% weight on newest sample)
-	DefaultTauL2       = 0.55  // relative-confidence threshold for L2 hit
-	DefaultInjectCap   = 0.3   // max injected budget as fraction of context
-	DefaultFreezeEpoch = 60    // epochs a param change stays frozen
-	DefaultMinTau      = 0.30  // floor for tau tuning (never below)
-	DefaultMaxTau      = 0.80  // ceiling for tau tuning (never above)
-	TauStep            = 0.05  // per adjustment step
-	PollutionRiseAt    = 0.30  // pollution EWMA above this → tighten tau
-	HitTarget          = 0.70  // hit EWMA above this (and pollution low) → relax tau
-	PollutionLow       = 0.10  // pollution below this to allow relaxation
-	MinSamples         = 20    // signals required before the first adjustment
+	DefaultAlpha       = 0.1  // EWMA smoothing (10% weight on newest sample)
+	DefaultTauL2       = 0.55 // relative-confidence threshold for L2 hit
+	DefaultInjectCap   = 0.3  // max injected budget as fraction of context
+	DefaultFreezeEpoch = 60   // epochs a param change stays frozen
+	DefaultMinTau      = 0.30 // floor for tau tuning (never below)
+	DefaultMaxTau      = 0.80 // ceiling for tau tuning (never above)
+	TauStep            = 0.05 // per adjustment step
+	PollutionRiseAt    = 0.30 // pollution EWMA above this → tighten tau
+	HitTarget          = 0.70 // hit EWMA above this (and pollution low) → relax tau
+	PollutionLow       = 0.10 // pollution below this to allow relaxation
+	MinSamples         = 20   // signals required before the first adjustment
 )
 
 // Config carries operator-provided tuning constants (zero values → defaults).
 type Config struct {
-	Alpha          float64
-	TauL2          float64
-	InjectCap      float64
-	FreezeEpochs   uint64
-	MinTau         float64
-	MaxTau         float64
-	MinSamples     uint64
+	Alpha        float64
+	TauL2        float64
+	InjectCap    float64
+	FreezeEpochs uint64
+	MinTau       float64
+	MaxTau       float64
+	MinSamples   uint64
 }
 
 // Signal is one feedback sample consumed by the evolution engine.
 type Signal struct {
-	Name  string // "cache_hit" | "inject_pollution" | "prefetch_waste" | "latency" | "cost" | "success"
+	Name  string // "cache_hit" | "success" (hit EWMA) | "inject_pollution" | "prefetch_waste" (pollution EWMA); unknown names are ignored
 	Value float64
 	Epoch uint64
 }
@@ -63,20 +63,20 @@ type Engine interface {
 // estimates of hit rate and pollution rate, and adjusts TauL2 in small
 // steps inside a freeze window (epoch-based).
 type ewmaEngine struct {
-	mu          sync.Mutex
-	alpha       float64
-	minTau      float64
-	maxTau      float64
-	minSamples  uint64
-	epoch       uint64
-	freezeUntil uint64 // freeze opened by Apply or an auto-adjustment
+	mu            sync.Mutex
+	alpha         float64
+	minTau        float64
+	maxTau        float64
+	minSamples    uint64
+	epoch         uint64
+	freezeUntil   uint64 // freeze opened by Apply or an auto-adjustment
 	firstAdjustAt uint64 // cold-start observation window (no auto-adjust before this epoch)
-	params      Params
+	params        Params
 
-	hitEWMA      float64
-	polEWMA      float64
-	sampleCount  uint64
-	adjustments  uint64
+	hitEWMA     float64
+	polEWMA     float64
+	sampleCount uint64
+	adjustments uint64
 }
 
 // New returns a ready MVP engine with default tuning constants.


### PR DESCRIPTION
## Summary

修复 #220：`usage --evolve-db` 此前是「epoch 计数器 + 常量参数回显器」——信号名不被引擎识别、EWMA 状态不跨运行、params.json 零消费者。本 PR 让 evolve 环真正转起来。

## Spec

- Spec-Exempt (rule E1), because: 单命令行为修复 + 既有状态文件接一个消费者；`--json` 信封与 wire 契约零变化；params.json 键名不变（与 PR #228 对 `evolve.Params` 加 json tag 的改动正交，合并侧无键名冲突）。判级已在 issue #220 评论区预告。

## Scope

`cmd/semantix`（usage/lookup/flags + 测试）· `kernel/evolve`（仅 Signal.Name 注释对齐实现）· `docs/QUICKSTART.md`（flag 表同步）

## 设计要点

1. **确定性全量重放**：feedEvolve 每次从零重放 usage 日志，逐 turn 喂 `cache_hit`（值 = CacheHitToken/TokensIn，L3 复用记 1.0；epoch = turn 序号）。日志 append-only ⇒ 重放幂等 ⇒ params.json 是纯输出，无需持久化引擎内部态。epoch 语义从「运行次数」变为「消耗 turn 数」（该文件为派生状态，非对外契约）。
2. **首个消费者**：`lookup`/`inject` 新增可选 `--evolve-db`——进化出的 tau_l2 作为灰区下界 zone.TauLow（两者默认值同为 0.55，本就是同一语义的两处落点）。显式 `--tau-low` 永远优先；值钳制在 [MinTau, MaxTau]；文件缺失 fail-open、损坏报错。
3. 引擎的 60-epoch 冷启动窗（FreezeEpochs）保持原样：≥60 turn 的真实日志才会开始调参，符合「前缀缓存窗口内不动参数」的既有设计。

## Validation

- [x] `go vet ./...`
- [x] `go test ./... -race`（135 包全绿，含 harness/）
- [x] `git diff --check`
- [x] 新增测试：65 轮高命中重放实际调参 0.55→0.60 + 重放幂等；消费者覆盖 / 显式 flag 优先 / 钳制 / fail-open 四例；损坏文件报错

## Compatibility and data impact

CLI `--json` 信封无变化；新 flag 均为可选且默认关闭；params.json 键名不变、epoch 数值语义变更（内部派生文件）。

## Security and privacy

params.json 读取路径固定为 `<dir>/params.json`，写入保持 0600；损坏文件显式报错不静默。

## 顺带观察（不在本 PR 处理）

`maybeAdjustLocked` 的调整方向疑似与注释相反：pollution 高 → TauL2 **减**（更宽松），hit 好 → TauL2 **增**（更严格），而注释语义是 tighten/relax。未动，建议单独确认。

## Related issues

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)