### PR TITLE
test(gateway): 流式 L3 e2e 轮询索引可见性，消除 Put/Insert 缝隙竞态

### DIFF
--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -939,16 +939,20 @@ func TestE2EStreamAccumulatesL3(t *testing.T) {
 		t.Fatalf("first stream: status=%d body=%s", resp.StatusCode, out)
 	}
 
-	// async ingest must land a Result slice carrying the aggregated reply
+	// async ingest must land a Result slice carrying the aggregated reply.
+	// Poll the INDEX, not the store: ingest.Pipeline persists (Store.Put)
+	// before indexing (Index.Insert), and the second request's L3 lookup
+	// only sees indexed slices — polling the store can pass inside that
+	// gap and race the lookup (flaked on CI, see PR #234 run 32330979045).
 	deadline := time.Now().Add(3 * time.Second)
 	ingested := false
 	for time.Now().Before(deadline) {
-		items, err := g.store.ListAll()
+		hits, err := g.index.Search("weather widgets forecast today", 5, g.injector.Scope)
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, s := range items {
-			if s.Type == slice.Result && bytes.Contains(s.Content, []byte("streaming answer")) {
+		for _, h := range hits {
+			if h.Slice.Type == slice.Result && bytes.Contains(h.Slice.Content, []byte("streaming answer")) {
 				ingested = true
 				break
 			}
@@ -959,7 +963,7 @@ func TestE2EStreamAccumulatesL3(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	if !ingested {
-		t.Fatal("streamed assistant reply was not ingested as a Result slice within 3s")
+		t.Fatal("streamed assistant reply was not indexed as a Result slice within 3s")
 	}
 
 	// second identical request: L3 hit, zero additional upstream calls


### PR DESCRIPTION
## Summary

修复 main 上的存量 flaky：`TestE2EStreamAccumulatesL3` 在 CI 慢机上偶发 `second request cache = miss` + `upstream calls = 2`（PR #234 的 [run 32330979045](https://github.com/Gnosil/semantix/actions/runs/32330979045) 实录；该 PR 未触碰 gateway，属被误伤）。

## Spec

- Spec-Exempt (rule E3), because: 纯测试修复，不改任何产品代码。

## 根因

`ingest.Pipeline.Run` 的顺序是 `Store.Put` → `Index.Insert`（先持久化后索引，产品侧正确）。测试等待侧写完成时轮询的是 **store** 层，可在「已入库、未入索引」的缝隙里放行第二请求；而第二请求的 L3 lookup 走 **index**。快机器上 Put→Insert 间隙极小难以命中，CI 负载下 goroutine 恰好被抢占在两调用之间即复现。

## 修法

等待条件从 `g.store.ListAll()` 改为轮询 `g.index.Search(...)` 直到命中含目标内容的 Result 切片——与第二请求真正依赖的可见性层一致。同文件另一处 ListAll 轮询（TestE2E 非流式侧写）只断言入库、无后续索引依赖，不需要动。

## Validation

- [x] `go vet ./gateway/`
- [x] `go test ./gateway/ -race` 全绿；目标测试 `-race -count=20` 稳定
- [x] `git diff --check`

## Compatibility and data impact

None（测试文件单处改动）。

## Security and privacy

None.

## Related issues

关联 #234（其 CI 失败由本 flaky 引起，已触发 rerun）；GW2 测试出自 #182。

🤖 Generated with [Claude Code](https://claude.com/claude-code)