### PR TITLE
fix(evolve): 调参方向反转修正——收紧应抬高 TauL2，放宽应降低

### DIFF
--- a/cmd/semantix/usage_test.go
+++ b/cmd/semantix/usage_test.go
@@ -164,18 +164,18 @@ func TestFeedEvolveAdjustsTauAfterHistory(t *testing.T) {
 		t.Fatalf("epoch must count consumed turns:\n%s", s)
 	}
 	// 65 signals at 0.9 hit ratio: hit EWMA ≥ HitTarget with zero pollution
-	// after the 60-epoch cold start → exactly one +TauStep adjustment
-	// (0.55 → 0.60), then the freeze window blocks further movement.
-	if !strings.Contains(s, "evolve_tau_l2\t0.600") {
-		t.Fatalf("tau must move off the default after sustained hits:\n%s", s)
+	// after the 60-epoch cold start → exactly one -TauStep relaxation
+	// (0.55 → 0.50), then the freeze window blocks further movement.
+	if !strings.Contains(s, "evolve_tau_l2\t0.500") {
+		t.Fatalf("tau must relax after sustained hits:\n%s", s)
 	}
 	// The persisted snapshot carries the adjusted value for consumers.
 	st, err := loadEvolveState(evolveDir)
 	if err != nil || st == nil {
 		t.Fatalf("loadEvolveState: st=%v err=%v", st, err)
 	}
-	if diff := st.Params.TauL2 - 0.60; diff < -1e-9 || diff > 1e-9 {
-		t.Fatalf("persisted TauL2 = %v, want 0.60", st.Params.TauL2)
+	if diff := st.Params.TauL2 - 0.50; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("persisted TauL2 = %v, want 0.50", st.Params.TauL2)
 	}
 	// Deterministic replay: a second pass reproduces the identical output.
 	var again bytes.Buffer

--- a/kernel/evolve/evolve.go
+++ b/kernel/evolve/evolve.go
@@ -213,11 +213,13 @@ func (e *ewmaEngine) maybeAdjustLocked() {
 		return
 	}
 	old := e.params.TauL2
+	// TauL2 is a relative-confidence floor (zone.TauLow semantics): raising
+	// it admits fewer slices (tighten), lowering it admits more (relax).
 	switch {
 	case e.polEWMA >= PollutionRiseAt:
-		e.params.TauL2 = e.params.TauL2 - TauStep
+		e.params.TauL2 = e.params.TauL2 + TauStep // tighten: raise the floor
 	case e.hitEWMA >= HitTarget && e.polEWMA <= PollutionLow:
-		e.params.TauL2 = e.params.TauL2 + TauStep
+		e.params.TauL2 = e.params.TauL2 - TauStep // relax: admit more reuse
 	default:
 		return
 	}

--- a/kernel/evolve/evolve_test.go
+++ b/kernel/evolve/evolve_test.go
@@ -87,8 +87,8 @@ func TestPollutionTightensTau(t *testing.T) {
 	if e.Adjustments() == 0 {
 		t.Fatal("pollution must trigger a tightening adjustment")
 	}
-	if got := e.Params().TauL2; got >= DefaultTauL2 {
-		t.Fatalf("TauL2 = %v, want < %v after pollution", got, DefaultTauL2)
+	if got := e.Params().TauL2; got <= DefaultTauL2 {
+		t.Fatalf("TauL2 = %v, want > %v after pollution (tighten = raise the floor)", got, DefaultTauL2)
 	}
 }
 
@@ -103,21 +103,31 @@ func TestHitsRelaxTau(t *testing.T) {
 	if e.Adjustments() == 0 {
 		t.Fatal("high hit rate must trigger a relaxation adjustment")
 	}
-	if got := e.Params().TauL2; got <= DefaultTauL2 {
-		t.Fatalf("TauL2 = %v, want > %v after hits", got, DefaultTauL2)
+	if got := e.Params().TauL2; got >= DefaultTauL2 {
+		t.Fatalf("TauL2 = %v, want < %v after hits (relax = admit more reuse)", got, DefaultTauL2)
 	}
 }
 
 func TestTauClampedToBounds(t *testing.T) {
 	cfg := Config{Alpha: 0.5, MinSamples: 1, FreezeEpochs: 0, MinTau: 0.30, MaxTau: 0.80}
 	e := New(cfg)
-	// Hammer pollution: tau must never go below MinTau.
+	// Hammer pollution (tighten drives tau up): must never exceed MaxTau.
 	for i := uint64(1); i <= 30; i++ {
 		if err := e.RecordSignal(Signal{Name: "inject_pollution", Value: 1, Epoch: i}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if got := e.Params().TauL2; got < cfg.MinTau {
+	if got := e.Params().TauL2; got > cfg.MaxTau {
+		t.Fatalf("TauL2 = %v above max %v", got, cfg.MaxTau)
+	}
+	// Hammer hits (relax drives tau down): must never go below MinTau.
+	e2 := New(cfg)
+	for i := uint64(1); i <= 30; i++ {
+		if err := e2.RecordSignal(Signal{Name: "cache_hit", Value: 1, Epoch: i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := e2.Params().TauL2; got < cfg.MinTau {
 		t.Fatalf("TauL2 = %v below min %v", got, cfg.MinTau)
 	}
 }


### PR DESCRIPTION
## Summary

核实 #234 里指出的疑点，定性为**实现 bug**：`maybeAdjustLocked` 的调整方向与注释、测试命名、以及 TauL2 的消费语义（zone.TauLow 相对置信度下界，值高=严格）全部相反——pollution 高时反而放宽（放大污染），hits 好时反而收紧（惩罚成功）。该 bug 在 #234 之前是潜伏的（TauL2 无消费者），#234 接线后才有实际后果，故必须在其上修正。

## Spec

- Spec-Exempt (rule E1), because: 单包（kernel/evolve）行为修复 + 联动测试；无接口/契约变化。

## 三重证据

1. **注释**：`pollution high → tighten`、`hits high → relax (be more generous)`——tighten=少注入=抬门槛，generous=多复用=降门槛；
2. **zone.Classify 数学**：`score/top1 >= TauLow` 才可注入，TauLow 越高越严格；
3. **测试命名自证**：`TestPollutionTightensTau` 却断言 `TauL2 < Default`、`TestHitsRelaxTau` 却断言 `>`——名字与断言互相矛盾，说明断言是跟着反向实现写的。

## 改动

kernel/evolve：方向对调 + 语义锚注释；两个方向测试断言翻转；clamp 测试改双向锤（pollution→MaxTau 上界、hits→MinTau 下界）。cmd/semantix：#234 的重放测试联动（高命中 0.55→**0.50**）。

## Validation

- [x] `go vet ./kernel/evolve/ ./cmd/semantix/`
- [x] `go test ./kernel/evolve/ ./cmd/semantix/ -race` 全绿
- [x] `git diff --check`

## Compatibility and data impact

行为变化：自动调参方向反转（此前该路径实际不可达——#220 空转——故无既有用户依赖反向行为）。params.json 格式不变。

## Security and privacy

None。方向修正后污染信号收紧注入门槛，安全性变好。

## Related issues

跟进 #234 的「顺带观察」；**Stacked on #234**，其合入后本 PR 改 base 到 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)