### PR TITLE
docs(readme): link GLM cache experiment evidence (#233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,6 +1113,10 @@ Detailed architecture documents are available in [`docs/`](./docs).
 
 [`site/`](./site) — marketing site and product docs (Next.js), including the blog on semantic caching and cross-session reuse.
 
+### Provider Cache Experiments
+
+[`docs/reports/glm-spike-week.md`](./docs/reports/glm-spike-week.md) — controlled GLM cache observations, including an AtomClub→GLM-5.2 gateway pilot. The pilot observed 96–98% cached input at 0–120 seconds and 28% at about five minutes, Anthropic Messages usage-field mapping, and strict-prefix invalidation. These measurements are gateway-specific and do not claim direct Z.AI behavior.
+
 ### Architecture
 
 [`docs/Agent-Infra-架构设计.md`](./docs/Agent-Infra-架构设计.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -244,6 +244,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | [docs/Agile路线图.md](./docs/Agile路线图.md) | Agile 1–3 路线图与 DoD |
 | [docs/GEO.md](./docs/GEO.md) / [GEO-guide.md](./docs/GEO-guide.md) | 面向 AI 引擎的项目语义档案与深度解读 |
 | [docs/Security-安全设计.md](./docs/Security-安全设计.md) | 威胁模型与安全机制 |
+| [docs/reports/glm-spike-week.md](./docs/reports/glm-spike-week.md) | GLM 缓存事实核验与 AtomClub→GLM-5.2 网关预实验（不外推为 Z.AI 直连结论） |
 
 官网：[semantix.ensureok.ai](https://semantix.ensureok.ai)
 


### PR DESCRIPTION
## Summary

Adds a discoverable README entry for the GLM cache evidence produced for issue #233.

- English README: adds a concise `Provider Cache Experiments` entry.
- Chinese README: adds the same report to the documentation index.
- Keeps the evidence boundary explicit: AtomClub→GLM-5.2 observations are gateway-specific and are not presented as direct Z.AI results.

## Dependency

Depends on #238, which adds `docs/reports/glm-spike-week.md`. This PR stays draft until #238 lands so the README link is not merged before its target exists on `main`.

## Commit structure

- `docs(readme): link GLM cache experiment evidence (#233)`
- `docs(readme): add Chinese GLM experiment index (#233)`

Each README change is an independent minimal commit.

## Verification

- Compared against current `main`: only `README.md` and `README.zh-CN.md` change.
- No product code, generated files, or API credentials are included.

## Non-goals

- Does not duplicate the experiment report from #238.
- Does not claim Z.AI direct-endpoint behavior.
- Does not change gateway or cache implementation.