### PR TITLE
fix(evolve): 把 #236 的 tau 方向反转修正补到 main（#236 合进了已被合并的分支，修复从未到达 main）

### DIFF
--- a/cmd/semantix/usage_test.go
+++ b/cmd/semantix/usage_test.go
@@ -164,18 +164,18 @@ func TestFeedEvolveAdjustsTauAfterHistory(t *testing.T) {
 		t.Fatalf("epoch must count consumed turns:\n%s", s)
 	}
 	// 65 signals at 0.9 hit ratio: hit EWMA ≥ HitTarget with zero pollution
-	// after the 60-epoch cold start → exactly one +TauStep adjustment
-	// (0.55 → 0.60), then the freeze window blocks further movement.
-	if !strings.Contains(s, "evolve_tau_l2\t0.600") {
-		t.Fatalf("tau must move off the default after sustained hits:\n%s", s)
+	// after the 60-epoch cold start → exactly one -TauStep relaxation
+	// (0.55 → 0.50), then the freeze window blocks further movement.
+	if !strings.Contains(s, "evolve_tau_l2\t0.500") {
+		t.Fatalf("tau must relax after sustained hits:\n%s", s)
 	}
 	// The persisted snapshot carries the adjusted value for consumers.
 	st, err := loadEvolveState(evolveDir)
 	if err != nil || st == nil {
 		t.Fatalf("loadEvolveState: st=%v err=%v", st, err)
 	}
-	if diff := st.Params.TauL2 - 0.60; diff < -1e-9 || diff > 1e-9 {
-		t.Fatalf("persisted TauL2 = %v, want 0.60", st.Params.TauL2)
+	if diff := st.Params.TauL2 - 0.50; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("persisted TauL2 = %v, want 0.50", st.Params.TauL2)
 	}
 	// Deterministic replay: a second pass reproduces the identical output.
 	var again bytes.Buffer

--- a/kernel/evolve/evolve.go
+++ b/kernel/evolve/evolve.go
@@ -213,11 +213,13 @@ func (e *ewmaEngine) maybeAdjustLocked() {
 		return
 	}
 	old := e.params.TauL2
+	// TauL2 is a relative-confidence floor (zone.TauLow semantics): raising
+	// it admits fewer slices (tighten), lowering it admits more (relax).
 	switch {
 	case e.polEWMA >= PollutionRiseAt:
-		e.params.TauL2 = e.params.TauL2 - TauStep
+		e.params.TauL2 = e.params.TauL2 + TauStep // tighten: raise the floor
 	case e.hitEWMA >= HitTarget && e.polEWMA <= PollutionLow:
-		e.params.TauL2 = e.params.TauL2 + TauStep
+		e.params.TauL2 = e.params.TauL2 - TauStep // relax: admit more reuse
 	default:
 		return
 	}

--- a/kernel/evolve/evolve_test.go
+++ b/kernel/evolve/evolve_test.go
@@ -87,8 +87,8 @@ func TestPollutionTightensTau(t *testing.T) {
 	if e.Adjustments() == 0 {
 		t.Fatal("pollution must trigger a tightening adjustment")
 	}
-	if got := e.Params().TauL2; got >= DefaultTauL2 {
-		t.Fatalf("TauL2 = %v, want < %v after pollution", got, DefaultTauL2)
+	if got := e.Params().TauL2; got <= DefaultTauL2 {
+		t.Fatalf("TauL2 = %v, want > %v after pollution (tighten = raise the floor)", got, DefaultTauL2)
 	}
 }
 
@@ -103,21 +103,31 @@ func TestHitsRelaxTau(t *testing.T) {
 	if e.Adjustments() == 0 {
 		t.Fatal("high hit rate must trigger a relaxation adjustment")
 	}
-	if got := e.Params().TauL2; got <= DefaultTauL2 {
-		t.Fatalf("TauL2 = %v, want > %v after hits", got, DefaultTauL2)
+	if got := e.Params().TauL2; got >= DefaultTauL2 {
+		t.Fatalf("TauL2 = %v, want < %v after hits (relax = admit more reuse)", got, DefaultTauL2)
 	}
 }
 
 func TestTauClampedToBounds(t *testing.T) {
 	cfg := Config{Alpha: 0.5, MinSamples: 1, FreezeEpochs: 0, MinTau: 0.30, MaxTau: 0.80}
 	e := New(cfg)
-	// Hammer pollution: tau must never go below MinTau.
+	// Hammer pollution (tighten drives tau up): must never exceed MaxTau.
 	for i := uint64(1); i <= 30; i++ {
 		if err := e.RecordSignal(Signal{Name: "inject_pollution", Value: 1, Epoch: i}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if got := e.Params().TauL2; got < cfg.MinTau {
+	if got := e.Params().TauL2; got > cfg.MaxTau {
+		t.Fatalf("TauL2 = %v above max %v", got, cfg.MaxTau)
+	}
+	// Hammer hits (relax drives tau down): must never go below MinTau.
+	e2 := New(cfg)
+	for i := uint64(1); i <= 30; i++ {
+		if err := e2.RecordSignal(Signal{Name: "cache_hit", Value: 1, Epoch: i}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := e2.Params().TauL2; got < cfg.MinTau {
 		t.Fatalf("TauL2 = %v below min %v", got, cfg.MinTau)
 	}
 }


### PR DESCRIPTION
## 问题：#220 的修复只有一半到了 main，而缺的那半是更危险的那半

PR #236「调参方向反转修正」的 base 是 **`fix/issue-220-evolve-wiring`**（特性分支），不是 `main`：

| PR | base | 合入时间 | 到 main 了吗 |
|---|---|---|---|
| #234 信号重放 + params.json 消费者 | `main` | 04:50:12Z | ✅ |
| #236 tau 方向反转修正 | `fix/issue-220-evolve-wiring` | 05:22:05Z | ❌ |

#236 合进了一个**在 32 分钟前就已经被合并掉的分支**。#236 自己的提交信息其实写明了意图：

> Stacked on #234（fix/issue-220-evolve-wiring）——#234 合入后本分支改 base 到 main。

改 base 这一步没做，于是修复停在孤儿分支 `94862b0e` 上。`git merge-base --is-ancestor 94862b0e upstream/main` → 不是祖先。

## 后果：现在 main 上的状态比修之前更糟

`#234` 让信号真的进了 EWMA（重放 + `cache_hit` 对齐 + params.json 消费者），所以 **TauL2 现在会真的动**。但 `upstream/main:kernel/evolve/evolve.go:217-220` 仍是反的：

```go
case e.polEWMA >= PollutionRiseAt:
    e.params.TauL2 = e.params.TauL2 - TauStep   // 污染高 → 降低阈值 → 注入更多
case e.hitEWMA >= HitTarget && e.polEWMA <= PollutionLow:
    e.params.TauL2 = e.params.TauL2 + TauStep   // 一切正常 → 抬高阈值 → 注入更少
```

TauL2 是相对置信度**下限**（`kernel/zone/zone.go:63` 的 `score/top1 >= TauHigh` 是 `>=` 比较，降低下限必然放进更多候选）。所以现在的行为是：**注入内容正在造成污染时，系统的反应是注入得更多**。

修之前循环是死的，符号错了也无害；#234 把它接活之后，这个符号就活了。这正是 #220 要解决的问题的反面。

## 本 PR

把孤儿提交 `31285d7` cherry-pick 到 main（无冲突，作者与 Co-Author 署名保留）：

```go
case e.polEWMA >= PollutionRiseAt:
    e.params.TauL2 = e.params.TauL2 + TauStep // tighten: raise the floor
case e.hitEWMA >= HitTarget && e.polEWMA <= PollutionLow:
    e.params.TauL2 = e.params.TauL2 - TauStep // relax: admit more reuse
```

连带 `evolve_test.go` / `usage_test.go` 里锁死错误方向的断言一并带过来（原提交已处理）。

## 独立佐证

我在动手前用一个评审面板独立复核过这个方向问题：**3 个反驳者用 3 个不同视角（阈值代数 / 测试意图 / 下游消费者）各自尝试推翻「方向是反的」这个判断，全部失败**。三条独立证据：

1. `docs/Agent-Infra-架构设计.md:292` §6.3：「冷启动：无习惯数据时用保守默认（**τ 高**、不预取）」——保守 = τ 高，所以「收紧」= **抬高**。
2. 仓内每一个 tau 都是 `>=` 比较的下限（`kernel/zone/zone.go:63-65`、`kernel/cache/cache.go:41`、架构 §4.1「相似 ≥ τ」）。降低下限只会放进更多。
3. **同一个 `maybeAdjustLocked` 函数里的另一个阈值用的是相反约定**：PR #228 对 `PrefetchConf` 的调法是「waste 多 → **抬高** MinConf」。坏结果抬高阈值才是这个函数的既定约定，TauL2 是唯一的例外。

结论与 #236 作者的判断一字不差，本 PR 只是把它送到该去的分支。

## Validation

- [x] `go build ./...`
- [x] `go test ./kernel/evolve/...` → ok
- [x] `go test ./cmd/semantix/ -run "Evolve|Usage"` → ok
- [ ] `go test -race ./...` — 本机 Windows `CGO_ENABLED=0` 无 C 编译器，由 CI 执行

## 建议

#220 目前是 CLOSED/COMPLETED，但按 main 的实际状态它并未完成。建议本 PR 合入后再确认关闭；另建议删掉或保护 `fix/issue-220-evolve-wiring` 分支，避免再有改动落到那上面。

Refs #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
