### PR TITLE
docs(readme): add bilingual repository module guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ This map follows the current repository layout. It describes observable responsi
 
 | Module | Path | Responsibility | Focused verification |
 |---|---|---|---|
-
+| CLI | [`cmd/semantix`](./cmd/semantix) | Command registry, stable JSON envelope, exit-code contract, maintenance and evaluation commands. | `go test ./cmd/semantix -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -698,6 +698,7 @@ This map follows the current repository layout. It describes observable responsi
 | Gateway | [`gateway`](./gateway), [`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI-compatible proxy, Anthropic conversion, SSE relay, retrieval/injection and fail-open upstream routing. | `go test ./gateway ./cmd/semantix-gateway -race` |
 | Configuration | [`kernel/config`](./kernel/config) | Resolves built-ins, TOML, environment variables and CLI overrides with source tracking and typed errors. | `go test ./kernel/config -race` |
 | Event ingestion | [`kernel/ingest`](./kernel/ingest) | Reads harness JSONL event streams and feeds normalized sessions into extraction without requiring a live harness. | `go test ./kernel/ingest -race` |
+| Semantic slices | [`kernel/slice`](./kernel/slice) | Slice types, scopes, metadata, extraction, file-backed storage, append journal, compaction and maintenance. | `go test ./kernel/slice -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ This map follows the current repository layout. It describes observable responsi
 | Evolution | [`kernel/evolve`](./kernel/evolve) | EWMA-driven tuning for retrieval thresholds and injection budget with bounded, inspectable parameters. | `go test ./kernel/evolve -race` |
 | Event contract | [`kernel/event`](./kernel/event) | Typed kernel event kinds, payloads, wire format and synchronous in-process bus. | `go test ./kernel/event -race` |
 | Usage accounting | [`kernel/usage`](./kernel/usage) | Records per-turn token/cache events and summarizes baseline cost, paid cost and estimated savings. | `go test ./kernel/usage -race` |
+| Reasonix harness | [`harness`](./harness) | Bundled agent runtime: providers, tools, permissions, extensions, sessions, recovery, remote execution and UI-facing contracts. | `go test ./harness/... -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ This map follows the current repository layout. It describes observable responsi
 | Reuse judge | [`kernel/judge`](./kernel/judge) | Rule gate plus optional LLM judge, prompt sanitization and verdict statistics for risky L3 candidates. | `go test ./kernel/judge -race` |
 | Result promotion | [`kernel/promote`](./kernel/promote) | Stores judge-approved reusable results with content versions and cascade invalidation by source slice. | `go test ./kernel/promote -race` |
 | Scheduler | [`kernel/sched`](./kernel/sched) | Produces per-round parallel groups, budget actions, model-tier hints, injection IDs and prefetch hints. | `go test ./kernel/sched -race` |
+| Prefetch | [`kernel/prefetch`](./kernel/prefetch) | Offline planner, transition-matrix learner, waste-aware online predictor and read-only execution runner. | `go test ./kernel/prefetch -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ This map follows the current repository layout. It describes observable responsi
 | Harness bridge | [`harness/semantix`](./harness/semantix) | Mirrors harness events into session JSONL and surfaces reuse summaries while keeping Semantix fail-open. | `go test ./harness/semantix -race` |
 | Agent Skill | [`agent-skill`](./agent-skill) | Self-serve install, tool schema, session-bypass hook and self-test for external harness integration. | `bash agent-skill/scripts/selftest.sh` |
 | Deployment | [`deploy`](./deploy) | Gateway Docker image, Compose topology and environment-expandable example configuration. | `docker compose -f deploy/docker-compose.yml config` |
+| Automation scripts | [`scripts`](./scripts) | Cross-session demo, release builders and Go bootstrap helper used by local and release workflows. | Run the relevant demo or release script in a clean workspace. |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@ This map follows the current repository layout. It describes observable responsi
 | Usage accounting | [`kernel/usage`](./kernel/usage) | Records per-turn token/cache events and summarizes baseline cost, paid cost and estimated savings. | `go test ./kernel/usage -race` |
 | Reasonix harness | [`harness`](./harness) | Bundled agent runtime: providers, tools, permissions, extensions, sessions, recovery, remote execution and UI-facing contracts. | `go test ./harness/... -race` |
 | Harness bridge | [`harness/semantix`](./harness/semantix) | Mirrors harness events into session JSONL and surfaces reuse summaries while keeping Semantix fail-open. | `go test ./harness/semantix -race` |
+| Agent Skill | [`agent-skill`](./agent-skill) | Self-serve install, tool schema, session-bypass hook and self-test for external harness integration. | `bash agent-skill/scripts/selftest.sh` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ This map follows the current repository layout. It describes observable responsi
 | Event ingestion | [`kernel/ingest`](./kernel/ingest) | Reads harness JSONL event streams and feeds normalized sessions into extraction without requiring a live harness. | `go test ./kernel/ingest -race` |
 | Semantic slices | [`kernel/slice`](./kernel/slice) | Slice types, scopes, metadata, extraction, file-backed storage, append journal, compaction and maintenance. | `go test ./kernel/slice -race` |
 | BM25 retrieval | [`kernel/bm25`](./kernel/bm25) | Lexical index and CJK-aware tokenizer used by local search and hybrid retrieval. | `go test ./kernel/bm25 -race` |
+| Embeddings | [`kernel/embed`](./kernel/embed) | Embedder contract, deterministic hash embedder, model-backed embedding and in-memory cosine vector index. | `go test ./kernel/embed -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -722,6 +722,7 @@ This map follows the current repository layout. It describes observable responsi
 | Integration patches | [`patches`](./patches) | Versioned delivery patches for external Reasonix forks, with drift notes and explicit preflight instructions. | `git apply --check patches/semantix-sched-prefetch.patch` |
 | Blog sources | [`blog`](./blog) | Versioned Markdown sources for technical articles; site content tests validate metadata, links and encoding. | `cd site && npm run test:content` |
 | Website | [`site`](./site) | Next.js product site, documentation, blog renderer, structured data, generated `llms-full.txt` and content-quality tests. | `cd site && npm run check` |
+| CI and workflows | [`.github/workflows`](./.github/workflows) | Runs Go vet/race tests, full website checks and the site deployment workflow with concurrency control. | Required GitHub checks: `Go checks` and `Website checks`. |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ This map follows the current repository layout. It describes observable responsi
 | Semantic slices | [`kernel/slice`](./kernel/slice) | Slice types, scopes, metadata, extraction, file-backed storage, append journal, compaction and maintenance. | `go test ./kernel/slice -race` |
 | BM25 retrieval | [`kernel/bm25`](./kernel/bm25) | Lexical index and CJK-aware tokenizer used by local search and hybrid retrieval. | `go test ./kernel/bm25 -race` |
 | Embeddings | [`kernel/embed`](./kernel/embed) | Embedder contract, deterministic hash embedder, model-backed embedding and in-memory cosine vector index. | `go test ./kernel/embed -race` |
+| Lookup tool | [`kernel/lookup`](./kernel/lookup) | Read-only `semantix_lookup` schema and executor that exposes ranked slice hits to agent harnesses. | `go test ./kernel/lookup` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ This map follows the current repository layout. It describes observable responsi
 | Prefetch | [`kernel/prefetch`](./kernel/prefetch) | Offline planner, transition-matrix learner, waste-aware online predictor and read-only execution runner. | `go test ./kernel/prefetch -race` |
 | Evolution | [`kernel/evolve`](./kernel/evolve) | EWMA-driven tuning for retrieval thresholds and injection budget with bounded, inspectable parameters. | `go test ./kernel/evolve -race` |
 | Event contract | [`kernel/event`](./kernel/event) | Typed kernel event kinds, payloads, wire format and synchronous in-process bus. | `go test ./kernel/event -race` |
+| Usage accounting | [`kernel/usage`](./kernel/usage) | Records per-turn token/cache events and summarizes baseline cost, paid cost and estimated savings. | `go test ./kernel/usage -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ This map follows the current repository layout. It describes observable responsi
 | L3 cache | [`kernel/cache`](./kernel/cache) | Conservative result-reuse decision interface and L3 decider; uncertain candidates fall back to normal execution. | `go test ./kernel/cache -race` |
 | Dependency fingerprints | [`kernel/fingerprint`](./kernel/fingerprint) | Captures and verifies file dependencies so stale project state invalidates otherwise reusable results. | `go test ./kernel/fingerprint -race` |
 | Reuse judge | [`kernel/judge`](./kernel/judge) | Rule gate plus optional LLM judge, prompt sanitization and verdict statistics for risky L3 candidates. | `go test ./kernel/judge -race` |
+| Result promotion | [`kernel/promote`](./kernel/promote) | Stores judge-approved reusable results with content versions and cascade invalidation by source slice. | `go test ./kernel/promote -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ This map follows the current repository layout. It describes observable responsi
 | BM25 retrieval | [`kernel/bm25`](./kernel/bm25) | Lexical index and CJK-aware tokenizer used by local search and hybrid retrieval. | `go test ./kernel/bm25 -race` |
 | Embeddings | [`kernel/embed`](./kernel/embed) | Embedder contract, deterministic hash embedder, model-backed embedding and in-memory cosine vector index. | `go test ./kernel/embed -race` |
 | Lookup tool | [`kernel/lookup`](./kernel/lookup) | Read-only `semantix_lookup` schema and executor that exposes ranked slice hits to agent harnesses. | `go test ./kernel/lookup` |
+| L2 injection | [`kernel/inject`](./kernel/inject) | Selects whole slices under a budget and emits a deterministic, marker-escaped reuse block. | `go test ./kernel/inject -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -695,6 +695,7 @@ This map follows the current repository layout. It describes observable responsi
 |---|---|---|---|
 | CLI | [`cmd/semantix`](./cmd/semantix) | Command registry, stable JSON envelope, exit-code contract, maintenance and evaluation commands. | `go test ./cmd/semantix -race` |
 | Agent executable | [`cmd/semantix-agent`](./cmd/semantix-agent) | Packaged Reasonix-derived agent entry point with crash capture and build-version wiring. | `go test ./cmd/semantix-agent` |
+| Gateway | [`gateway`](./gateway), [`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI-compatible proxy, Anthropic conversion, SSE relay, retrieval/injection and fail-open upstream routing. | `go test ./gateway ./cmd/semantix-gateway -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ This map follows the current repository layout. It describes observable responsi
 | Event contract | [`kernel/event`](./kernel/event) | Typed kernel event kinds, payloads, wire format and synchronous in-process bus. | `go test ./kernel/event -race` |
 | Usage accounting | [`kernel/usage`](./kernel/usage) | Records per-turn token/cache events and summarizes baseline cost, paid cost and estimated savings. | `go test ./kernel/usage -race` |
 | Reasonix harness | [`harness`](./harness) | Bundled agent runtime: providers, tools, permissions, extensions, sessions, recovery, remote execution and UI-facing contracts. | `go test ./harness/... -race` |
+| Harness bridge | [`harness/semantix`](./harness/semantix) | Mirrors harness events into session JSONL and surfaces reuse summaries while keeping Semantix fail-open. | `go test ./harness/semantix -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ This map follows the current repository layout. It describes observable responsi
 | CLI | [`cmd/semantix`](./cmd/semantix) | Command registry, stable JSON envelope, exit-code contract, maintenance and evaluation commands. | `go test ./cmd/semantix -race` |
 | Agent executable | [`cmd/semantix-agent`](./cmd/semantix-agent) | Packaged Reasonix-derived agent entry point with crash capture and build-version wiring. | `go test ./cmd/semantix-agent` |
 | Gateway | [`gateway`](./gateway), [`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI-compatible proxy, Anthropic conversion, SSE relay, retrieval/injection and fail-open upstream routing. | `go test ./gateway ./cmd/semantix-gateway -race` |
+| Configuration | [`kernel/config`](./kernel/config) | Resolves built-ins, TOML, environment variables and CLI overrides with source tracking and typed errors. | `go test ./kernel/config -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ This map follows the current repository layout. It describes observable responsi
 | Module | Path | Responsibility | Focused verification |
 |---|---|---|---|
 | CLI | [`cmd/semantix`](./cmd/semantix) | Command registry, stable JSON envelope, exit-code contract, maintenance and evaluation commands. | `go test ./cmd/semantix -race` |
+| Agent executable | [`cmd/semantix-agent`](./cmd/semantix-agent) | Packaged Reasonix-derived agent entry point with crash capture and build-version wiring. | `go test ./cmd/semantix-agent` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ This map follows the current repository layout. It describes observable responsi
 | Configuration | [`kernel/config`](./kernel/config) | Resolves built-ins, TOML, environment variables and CLI overrides with source tracking and typed errors. | `go test ./kernel/config -race` |
 | Event ingestion | [`kernel/ingest`](./kernel/ingest) | Reads harness JSONL event streams and feeds normalized sessions into extraction without requiring a live harness. | `go test ./kernel/ingest -race` |
 | Semantic slices | [`kernel/slice`](./kernel/slice) | Slice types, scopes, metadata, extraction, file-backed storage, append journal, compaction and maintenance. | `go test ./kernel/slice -race` |
+| BM25 retrieval | [`kernel/bm25`](./kernel/bm25) | Lexical index and CJK-aware tokenizer used by local search and hybrid retrieval. | `go test ./kernel/bm25 -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -720,6 +720,7 @@ This map follows the current repository layout. It describes observable responsi
 | Automation scripts | [`scripts`](./scripts) | Cross-session demo, release builders and Go bootstrap helper used by local and release workflows. | Run the relevant demo or release script in a clean workspace. |
 | Specs and evidence | [`docs`](./docs) | Architecture, security, roadmap, specifications and acceptance reports that separate design targets from measured results. | Review the linked acceptance report for each shipped unit. |
 | Integration patches | [`patches`](./patches) | Versioned delivery patches for external Reasonix forks, with drift notes and explicit preflight instructions. | `git apply --check patches/semantix-sched-prefetch.patch` |
+| Blog sources | [`blog`](./blog) | Versioned Markdown sources for technical articles; site content tests validate metadata, links and encoding. | `cd site && npm run test:content` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ This map follows the current repository layout. It describes observable responsi
 | Result promotion | [`kernel/promote`](./kernel/promote) | Stores judge-approved reusable results with content versions and cascade invalidation by source slice. | `go test ./kernel/promote -race` |
 | Scheduler | [`kernel/sched`](./kernel/sched) | Produces per-round parallel groups, budget actions, model-tier hints, injection IDs and prefetch hints. | `go test ./kernel/sched -race` |
 | Prefetch | [`kernel/prefetch`](./kernel/prefetch) | Offline planner, transition-matrix learner, waste-aware online predictor and read-only execution runner. | `go test ./kernel/prefetch -race` |
+| Evolution | [`kernel/evolve`](./kernel/evolve) | EWMA-driven tuning for retrieval thresholds and injection budget with bounded, inspectable parameters. | `go test ./kernel/evolve -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ This map follows the current repository layout. It describes observable responsi
 | Dependency fingerprints | [`kernel/fingerprint`](./kernel/fingerprint) | Captures and verifies file dependencies so stale project state invalidates otherwise reusable results. | `go test ./kernel/fingerprint -race` |
 | Reuse judge | [`kernel/judge`](./kernel/judge) | Rule gate plus optional LLM judge, prompt sanitization and verdict statistics for risky L3 candidates. | `go test ./kernel/judge -race` |
 | Result promotion | [`kernel/promote`](./kernel/promote) | Stores judge-approved reusable results with content versions and cascade invalidation by source slice. | `go test ./kernel/promote -race` |
+| Scheduler | [`kernel/sched`](./kernel/sched) | Produces per-round parallel groups, budget actions, model-tier hints, injection IDs and prefetch hints. | `go test ./kernel/sched -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ This map follows the current repository layout. It describes observable responsi
 | Scheduler | [`kernel/sched`](./kernel/sched) | Produces per-round parallel groups, budget actions, model-tier hints, injection IDs and prefetch hints. | `go test ./kernel/sched -race` |
 | Prefetch | [`kernel/prefetch`](./kernel/prefetch) | Offline planner, transition-matrix learner, waste-aware online predictor and read-only execution runner. | `go test ./kernel/prefetch -race` |
 | Evolution | [`kernel/evolve`](./kernel/evolve) | EWMA-driven tuning for retrieval thresholds and injection budget with bounded, inspectable parameters. | `go test ./kernel/evolve -race` |
+| Event contract | [`kernel/event`](./kernel/event) | Typed kernel event kinds, payloads, wire format and synchronous in-process bus. | `go test ./kernel/event -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ This map follows the current repository layout. It describes observable responsi
 | Retrieval zones | [`kernel/zone`](./kernel/zone) | Three-region hit, grey and miss classifier shared by retrieval, verification and evolution. | `go test ./kernel/zone -race` |
 | L3 cache | [`kernel/cache`](./kernel/cache) | Conservative result-reuse decision interface and L3 decider; uncertain candidates fall back to normal execution. | `go test ./kernel/cache -race` |
 | Dependency fingerprints | [`kernel/fingerprint`](./kernel/fingerprint) | Captures and verifies file dependencies so stale project state invalidates otherwise reusable results. | `go test ./kernel/fingerprint -race` |
+| Reuse judge | [`kernel/judge`](./kernel/judge) | Rule gate plus optional LLM judge, prompt sanitization and verdict statistics for risky L3 candidates. | `go test ./kernel/judge -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ This map follows the current repository layout. It describes observable responsi
 | L2 injection | [`kernel/inject`](./kernel/inject) | Selects whole slices under a budget and emits a deterministic, marker-escaped reuse block. | `go test ./kernel/inject -race` |
 | Retrieval zones | [`kernel/zone`](./kernel/zone) | Three-region hit, grey and miss classifier shared by retrieval, verification and evolution. | `go test ./kernel/zone -race` |
 | L3 cache | [`kernel/cache`](./kernel/cache) | Conservative result-reuse decision interface and L3 decider; uncertain candidates fall back to normal execution. | `go test ./kernel/cache -race` |
+| Dependency fingerprints | [`kernel/fingerprint`](./kernel/fingerprint) | Captures and verifies file dependencies so stale project state invalidates otherwise reusable results. | `go test ./kernel/fingerprint -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -719,6 +719,7 @@ This map follows the current repository layout. It describes observable responsi
 | Deployment | [`deploy`](./deploy) | Gateway Docker image, Compose topology and environment-expandable example configuration. | `docker compose -f deploy/docker-compose.yml config` |
 | Automation scripts | [`scripts`](./scripts) | Cross-session demo, release builders and Go bootstrap helper used by local and release workflows. | Run the relevant demo or release script in a clean workspace. |
 | Specs and evidence | [`docs`](./docs) | Architecture, security, roadmap, specifications and acceptance reports that separate design targets from measured results. | Review the linked acceptance report for each shipped unit. |
+| Integration patches | [`patches`](./patches) | Versioned delivery patches for external Reasonix forks, with drift notes and explicit preflight instructions. | `git apply --check patches/semantix-sched-prefetch.patch` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ This map follows the current repository layout. It describes observable responsi
 | Lookup tool | [`kernel/lookup`](./kernel/lookup) | Read-only `semantix_lookup` schema and executor that exposes ranked slice hits to agent harnesses. | `go test ./kernel/lookup` |
 | L2 injection | [`kernel/inject`](./kernel/inject) | Selects whole slices under a budget and emits a deterministic, marker-escaped reuse block. | `go test ./kernel/inject -race` |
 | Retrieval zones | [`kernel/zone`](./kernel/zone) | Three-region hit, grey and miss classifier shared by retrieval, verification and evolution. | `go test ./kernel/zone -race` |
+| L3 cache | [`kernel/cache`](./kernel/cache) | Conservative result-reuse decision interface and L3 decider; uncertain candidates fall back to normal execution. | `go test ./kernel/cache -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ This map follows the current repository layout. It describes observable responsi
 | Embeddings | [`kernel/embed`](./kernel/embed) | Embedder contract, deterministic hash embedder, model-backed embedding and in-memory cosine vector index. | `go test ./kernel/embed -race` |
 | Lookup tool | [`kernel/lookup`](./kernel/lookup) | Read-only `semantix_lookup` schema and executor that exposes ranked slice hits to agent harnesses. | `go test ./kernel/lookup` |
 | L2 injection | [`kernel/inject`](./kernel/inject) | Selects whole slices under a budget and emits a deterministic, marker-escaped reuse block. | `go test ./kernel/inject -race` |
+| Retrieval zones | [`kernel/zone`](./kernel/zone) | Three-region hit, grey and miss classifier shared by retrieval, verification and evolution. | `go test ./kernel/zone -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ This map follows the current repository layout. It describes observable responsi
 | Reasonix harness | [`harness`](./harness) | Bundled agent runtime: providers, tools, permissions, extensions, sessions, recovery, remote execution and UI-facing contracts. | `go test ./harness/... -race` |
 | Harness bridge | [`harness/semantix`](./harness/semantix) | Mirrors harness events into session JSONL and surfaces reuse summaries while keeping Semantix fail-open. | `go test ./harness/semantix -race` |
 | Agent Skill | [`agent-skill`](./agent-skill) | Self-serve install, tool schema, session-bypass hook and self-test for external harness integration. | `bash agent-skill/scripts/selftest.sh` |
+| Deployment | [`deploy`](./deploy) | Gateway Docker image, Compose topology and environment-expandable example configuration. | `docker compose -f deploy/docker-compose.yml config` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ This map follows the current repository layout. It describes observable responsi
 | Agent Skill | [`agent-skill`](./agent-skill) | Self-serve install, tool schema, session-bypass hook and self-test for external harness integration. | `bash agent-skill/scripts/selftest.sh` |
 | Deployment | [`deploy`](./deploy) | Gateway Docker image, Compose topology and environment-expandable example configuration. | `docker compose -f deploy/docker-compose.yml config` |
 | Automation scripts | [`scripts`](./scripts) | Cross-session demo, release builders and Go bootstrap helper used by local and release workflows. | Run the relevant demo or release script in a clean workspace. |
+| Specs and evidence | [`docs`](./docs) | Architecture, security, roadmap, specifications and acceptance reports that separate design targets from measured results. | Review the linked acceptance report for each shipped unit. |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ This map follows the current repository layout. It describes observable responsi
 | Specs and evidence | [`docs`](./docs) | Architecture, security, roadmap, specifications and acceptance reports that separate design targets from measured results. | Review the linked acceptance report for each shipped unit. |
 | Integration patches | [`patches`](./patches) | Versioned delivery patches for external Reasonix forks, with drift notes and explicit preflight instructions. | `git apply --check patches/semantix-sched-prefetch.patch` |
 | Blog sources | [`blog`](./blog) | Versioned Markdown sources for technical articles; site content tests validate metadata, links and encoding. | `cd site && npm run test:content` |
+| Website | [`site`](./site) | Next.js product site, documentation, blog renderer, structured data, generated `llms-full.txt` and content-quality tests. | `cd site && npm run check` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ This map follows the current repository layout. It describes observable responsi
 | Agent executable | [`cmd/semantix-agent`](./cmd/semantix-agent) | Packaged Reasonix-derived agent entry point with crash capture and build-version wiring. | `go test ./cmd/semantix-agent` |
 | Gateway | [`gateway`](./gateway), [`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI-compatible proxy, Anthropic conversion, SSE relay, retrieval/injection and fail-open upstream routing. | `go test ./gateway ./cmd/semantix-gateway -race` |
 | Configuration | [`kernel/config`](./kernel/config) | Resolves built-ins, TOML, environment variables and CLI overrides with source tracking and typed errors. | `go test ./kernel/config -race` |
+| Event ingestion | [`kernel/ingest`](./kernel/ingest) | Reads harness JSONL event streams and feeds normalized sessions into extraction without requiring a live harness. | `go test ./kernel/ingest -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -686,6 +686,16 @@ It can then return optimization decisions without owning the agent's primary rea
 
 This allows Semantix to remain portable across different agent runtimes.
 
+<!-- repository-module-guide:start -->
+# Repository Module Guide
+
+This map follows the current repository layout. It describes observable responsibilities and focused checks; it does not turn design targets into production-performance claims.
+
+| Module | Path | Responsibility | Focused verification |
+|---|---|---|---|
+
+<!-- repository-module-guide:end -->
+
 ---
 
 # How a Request Flows

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -235,6 +235,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | Agent Skill | [`agent-skill`](./agent-skill) | 面向外部 harness 的自助安装、工具 schema、会话绕行 hook 与自测。 | `bash agent-skill/scripts/selftest.sh` |
 | 部署 | [`deploy`](./deploy) | Gateway Docker 镜像、Compose 拓扑与支持环境变量展开的示例配置。 | `docker compose -f deploy/docker-compose.yml config` |
 | 自动化脚本 | [`scripts`](./scripts) | 跨会话 demo、发布构建器和 Go 引导工具，供本地与发布流程使用。 | 在干净工作区运行对应 demo 或发布脚本。 |
+| 规范与证据 | [`docs`](./docs) | 架构、安全、路线图、规格与验收报告，用于区分设计目标和实测结果。 | 每个已交付单元均核对对应验收报告。 |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -212,6 +212,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 |---|---|---|---|
 | CLI | [`cmd/semantix`](./cmd/semantix) | 命令注册、统一 JSON 信封、退出码契约、维护与评估命令。 | `go test ./cmd/semantix -race` |
 | Agent 可执行入口 | [`cmd/semantix-agent`](./cmd/semantix-agent) | 打包后的 Reasonix 衍生 Agent 入口，包含崩溃捕获与构建版本接线。 | `go test ./cmd/semantix-agent` |
+| Gateway | [`gateway`](./gateway)、[`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI 兼容代理、Anthropic 转换、SSE 转发、检索注入与 fail-open 上游路由。 | `go test ./gateway ./cmd/semantix-gateway -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -224,6 +224,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | L3 缓存 | [`kernel/cache`](./kernel/cache) | 保守的结果复用判定接口与 L3 decider；无法证明安全时回退正常执行。 | `go test ./kernel/cache -race` |
 | 依赖指纹 | [`kernel/fingerprint`](./kernel/fingerprint) | 捕获并验证文件依赖；项目状态变化时使原本可复用的结果失效。 | `go test ./kernel/fingerprint -race` |
 | 复用 Judge | [`kernel/judge`](./kernel/judge) | 规则门、可选 LLM judge、提示清洗和判定统计，用于高风险 L3 候选。 | `go test ./kernel/judge -race` |
+| 结果提升 | [`kernel/promote`](./kernel/promote) | 保存 judge 批准的可复用结果，记录内容版本，并按来源切片级联失效。 | `go test ./kernel/promote -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,6 +217,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 事件摄取 | [`kernel/ingest`](./kernel/ingest) | 读取 harness JSONL 事件流，将规范化会话送入提取流程，无需依赖在线 harness。 | `go test ./kernel/ingest -race` |
 | 语义切片 | [`kernel/slice`](./kernel/slice) | 切片类型、作用域、元数据、提取、文件存储、追加日志、压缩与维护。 | `go test ./kernel/slice -race` |
 | BM25 检索 | [`kernel/bm25`](./kernel/bm25) | 本地搜索与混合检索使用的词法索引和 CJK 感知分词器。 | `go test ./kernel/bm25 -race` |
+| 向量嵌入 | [`kernel/embed`](./kernel/embed) | Embedder 契约、确定性 hash embedder、模型嵌入与内存余弦向量索引。 | `go test ./kernel/embed -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -239,6 +239,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 集成补丁 | [`patches`](./patches) | 面向外部 Reasonix fork 的版本化交付补丁，包含漂移说明和明确预检步骤。 | `git apply --check patches/semantix-sched-prefetch.patch` |
 | 博客源文件 | [`blog`](./blog) | 技术文章的版本化 Markdown 源；网站内容测试校验元数据、链接和编码。 | `cd site && npm run test:content` |
 | 官网 | [`site`](./site) | Next.js 产品站、文档、博客渲染、结构化数据、生成的 `llms-full.txt` 与内容质量测试。 | `cd site && npm run check` |
+| CI 与工作流 | [`.github/workflows`](./.github/workflows) | 运行 Go vet/race 测试、完整网站检查和站点部署流程，并配置并发控制。 | GitHub 必需检查：`Go checks` 与 `Website checks`。 |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -236,6 +236,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 部署 | [`deploy`](./deploy) | Gateway Docker 镜像、Compose 拓扑与支持环境变量展开的示例配置。 | `docker compose -f deploy/docker-compose.yml config` |
 | 自动化脚本 | [`scripts`](./scripts) | 跨会话 demo、发布构建器和 Go 引导工具，供本地与发布流程使用。 | 在干净工作区运行对应 demo 或发布脚本。 |
 | 规范与证据 | [`docs`](./docs) | 架构、安全、路线图、规格与验收报告，用于区分设计目标和实测结果。 | 每个已交付单元均核对对应验收报告。 |
+| 集成补丁 | [`patches`](./patches) | 面向外部 Reasonix fork 的版本化交付补丁，包含漂移说明和明确预检步骤。 | `git apply --check patches/semantix-sched-prefetch.patch` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -231,6 +231,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 事件契约 | [`kernel/event`](./kernel/event) | 类型化 kernel 事件、payload、wire format 与同步进程内总线。 | `go test ./kernel/event -race` |
 | 用量核算 | [`kernel/usage`](./kernel/usage) | 记录逐轮 token/cache 事件，汇总基线成本、实际成本与估算节省。 | `go test ./kernel/usage -race` |
 | Reasonix harness | [`harness`](./harness) | 随仓 Agent runtime：provider、工具、权限、扩展、会话、恢复、远程执行和 UI 契约。 | `go test ./harness/... -race` |
+| Harness 桥接 | [`harness/semantix`](./harness/semantix) | 将 harness 事件镜像为会话 JSONL，并输出复用摘要，同时保持 Semantix fail-open。 | `go test ./harness/semantix -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,6 +225,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 依赖指纹 | [`kernel/fingerprint`](./kernel/fingerprint) | 捕获并验证文件依赖；项目状态变化时使原本可复用的结果失效。 | `go test ./kernel/fingerprint -race` |
 | 复用 Judge | [`kernel/judge`](./kernel/judge) | 规则门、可选 LLM judge、提示清洗和判定统计，用于高风险 L3 候选。 | `go test ./kernel/judge -race` |
 | 结果提升 | [`kernel/promote`](./kernel/promote) | 保存 judge 批准的可复用结果，记录内容版本，并按来源切片级联失效。 | `go test ./kernel/promote -race` |
+| 调度器 | [`kernel/sched`](./kernel/sched) | 为每轮生成并行分组、预算动作、模型层级提示、注入 ID 与预取提示。 | `go test ./kernel/sched -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -232,6 +232,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 用量核算 | [`kernel/usage`](./kernel/usage) | 记录逐轮 token/cache 事件，汇总基线成本、实际成本与估算节省。 | `go test ./kernel/usage -race` |
 | Reasonix harness | [`harness`](./harness) | 随仓 Agent runtime：provider、工具、权限、扩展、会话、恢复、远程执行和 UI 契约。 | `go test ./harness/... -race` |
 | Harness 桥接 | [`harness/semantix`](./harness/semantix) | 将 harness 事件镜像为会话 JSONL，并输出复用摘要，同时保持 Semantix fail-open。 | `go test ./harness/semantix -race` |
+| Agent Skill | [`agent-skill`](./agent-skill) | 面向外部 harness 的自助安装、工具 schema、会话绕行 hook 与自测。 | `bash agent-skill/scripts/selftest.sh` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -227,6 +227,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 结果提升 | [`kernel/promote`](./kernel/promote) | 保存 judge 批准的可复用结果，记录内容版本，并按来源切片级联失效。 | `go test ./kernel/promote -race` |
 | 调度器 | [`kernel/sched`](./kernel/sched) | 为每轮生成并行分组、预算动作、模型层级提示、注入 ID 与预取提示。 | `go test ./kernel/sched -race` |
 | 预取 | [`kernel/prefetch`](./kernel/prefetch) | 离线规划器、转移矩阵学习、浪费感知在线预测与只读执行 runner。 | `go test ./kernel/prefetch -race` |
+| 参数演化 | [`kernel/evolve`](./kernel/evolve) | 使用 EWMA 调整检索阈值和注入预算，参数变化有边界且可检查。 | `go test ./kernel/evolve -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,6 +230,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 参数演化 | [`kernel/evolve`](./kernel/evolve) | 使用 EWMA 调整检索阈值和注入预算，参数变化有边界且可检查。 | `go test ./kernel/evolve -race` |
 | 事件契约 | [`kernel/event`](./kernel/event) | 类型化 kernel 事件、payload、wire format 与同步进程内总线。 | `go test ./kernel/event -race` |
 | 用量核算 | [`kernel/usage`](./kernel/usage) | 记录逐轮 token/cache 事件，汇总基线成本、实际成本与估算节省。 | `go test ./kernel/usage -race` |
+| Reasonix harness | [`harness`](./harness) | 随仓 Agent runtime：provider、工具、权限、扩展、会话、恢复、远程执行和 UI 契约。 | `go test ./harness/... -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -220,6 +220,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 向量嵌入 | [`kernel/embed`](./kernel/embed) | Embedder 契约、确定性 hash embedder、模型嵌入与内存余弦向量索引。 | `go test ./kernel/embed -race` |
 | Lookup 工具 | [`kernel/lookup`](./kernel/lookup) | 只读 `semantix_lookup` schema 与执行器，向 Agent harness 暴露排序后的切片命中。 | `go test ./kernel/lookup` |
 | L2 注入 | [`kernel/inject`](./kernel/inject) | 在预算内选择完整切片，输出确定、经过 marker 转义的复用块。 | `go test ./kernel/inject -race` |
+| 检索分区 | [`kernel/zone`](./kernel/zone) | 检索、验证和演化共用的 hit、grey、miss 三区分类器。 | `go test ./kernel/zone -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,6 +221,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | Lookup 工具 | [`kernel/lookup`](./kernel/lookup) | 只读 `semantix_lookup` schema 与执行器，向 Agent harness 暴露排序后的切片命中。 | `go test ./kernel/lookup` |
 | L2 注入 | [`kernel/inject`](./kernel/inject) | 在预算内选择完整切片，输出确定、经过 marker 转义的复用块。 | `go test ./kernel/inject -race` |
 | 检索分区 | [`kernel/zone`](./kernel/zone) | 检索、验证和演化共用的 hit、grey、miss 三区分类器。 | `go test ./kernel/zone -race` |
+| L3 缓存 | [`kernel/cache`](./kernel/cache) | 保守的结果复用判定接口与 L3 decider；无法证明安全时回退正常执行。 | `go test ./kernel/cache -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -215,6 +215,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | Gateway | [`gateway`](./gateway)、[`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI 兼容代理、Anthropic 转换、SSE 转发、检索注入与 fail-open 上游路由。 | `go test ./gateway ./cmd/semantix-gateway -race` |
 | 配置 | [`kernel/config`](./kernel/config) | 按内置值、TOML、环境变量、CLI 覆盖顺序解析配置，并保留来源与类型化错误。 | `go test ./kernel/config -race` |
 | 事件摄取 | [`kernel/ingest`](./kernel/ingest) | 读取 harness JSONL 事件流，将规范化会话送入提取流程，无需依赖在线 harness。 | `go test ./kernel/ingest -race` |
+| 语义切片 | [`kernel/slice`](./kernel/slice) | 切片类型、作用域、元数据、提取、文件存储、追加日志、压缩与维护。 | `go test ./kernel/slice -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -216,6 +216,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 配置 | [`kernel/config`](./kernel/config) | 按内置值、TOML、环境变量、CLI 覆盖顺序解析配置，并保留来源与类型化错误。 | `go test ./kernel/config -race` |
 | 事件摄取 | [`kernel/ingest`](./kernel/ingest) | 读取 harness JSONL 事件流，将规范化会话送入提取流程，无需依赖在线 harness。 | `go test ./kernel/ingest -race` |
 | 语义切片 | [`kernel/slice`](./kernel/slice) | 切片类型、作用域、元数据、提取、文件存储、追加日志、压缩与维护。 | `go test ./kernel/slice -race` |
+| BM25 检索 | [`kernel/bm25`](./kernel/bm25) | 本地搜索与混合检索使用的词法索引和 CJK 感知分词器。 | `go test ./kernel/bm25 -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,6 +213,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | CLI | [`cmd/semantix`](./cmd/semantix) | 命令注册、统一 JSON 信封、退出码契约、维护与评估命令。 | `go test ./cmd/semantix -race` |
 | Agent 可执行入口 | [`cmd/semantix-agent`](./cmd/semantix-agent) | 打包后的 Reasonix 衍生 Agent 入口，包含崩溃捕获与构建版本接线。 | `go test ./cmd/semantix-agent` |
 | Gateway | [`gateway`](./gateway)、[`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI 兼容代理、Anthropic 转换、SSE 转发、检索注入与 fail-open 上游路由。 | `go test ./gateway ./cmd/semantix-gateway -race` |
+| 配置 | [`kernel/config`](./kernel/config) | 按内置值、TOML、环境变量、CLI 覆盖顺序解析配置，并保留来源与类型化错误。 | `go test ./kernel/config -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -237,6 +237,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 自动化脚本 | [`scripts`](./scripts) | 跨会话 demo、发布构建器和 Go 引导工具，供本地与发布流程使用。 | 在干净工作区运行对应 demo 或发布脚本。 |
 | 规范与证据 | [`docs`](./docs) | 架构、安全、路线图、规格与验收报告，用于区分设计目标和实测结果。 | 每个已交付单元均核对对应验收报告。 |
 | 集成补丁 | [`patches`](./patches) | 面向外部 Reasonix fork 的版本化交付补丁，包含漂移说明和明确预检步骤。 | `git apply --check patches/semantix-sched-prefetch.patch` |
+| 博客源文件 | [`blog`](./blog) | 技术文章的版本化 Markdown 源；网站内容测试校验元数据、链接和编码。 | `cd site && npm run test:content` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,6 +228,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 调度器 | [`kernel/sched`](./kernel/sched) | 为每轮生成并行分组、预算动作、模型层级提示、注入 ID 与预取提示。 | `go test ./kernel/sched -race` |
 | 预取 | [`kernel/prefetch`](./kernel/prefetch) | 离线规划器、转移矩阵学习、浪费感知在线预测与只读执行 runner。 | `go test ./kernel/prefetch -race` |
 | 参数演化 | [`kernel/evolve`](./kernel/evolve) | 使用 EWMA 调整检索阈值和注入预算，参数变化有边界且可检查。 | `go test ./kernel/evolve -race` |
+| 事件契约 | [`kernel/event`](./kernel/event) | 类型化 kernel 事件、payload、wire format 与同步进程内总线。 | `go test ./kernel/event -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -210,7 +210,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 
 | 模块 | 路径 | 职责 | 聚焦验证 |
 |---|---|---|---|
-
+| CLI | [`cmd/semantix`](./cmd/semantix) | 命令注册、统一 JSON 信封、退出码契约、维护与评估命令。 | `go test ./cmd/semantix -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,6 +219,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | BM25 检索 | [`kernel/bm25`](./kernel/bm25) | 本地搜索与混合检索使用的词法索引和 CJK 感知分词器。 | `go test ./kernel/bm25 -race` |
 | 向量嵌入 | [`kernel/embed`](./kernel/embed) | Embedder 契约、确定性 hash embedder、模型嵌入与内存余弦向量索引。 | `go test ./kernel/embed -race` |
 | Lookup 工具 | [`kernel/lookup`](./kernel/lookup) | 只读 `semantix_lookup` schema 与执行器，向 Agent harness 暴露排序后的切片命中。 | `go test ./kernel/lookup` |
+| L2 注入 | [`kernel/inject`](./kernel/inject) | 在预算内选择完整切片，输出确定、经过 marker 转义的复用块。 | `go test ./kernel/inject -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -233,6 +233,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | Reasonix harness | [`harness`](./harness) | 随仓 Agent runtime：provider、工具、权限、扩展、会话、恢复、远程执行和 UI 契约。 | `go test ./harness/... -race` |
 | Harness 桥接 | [`harness/semantix`](./harness/semantix) | 将 harness 事件镜像为会话 JSONL，并输出复用摘要，同时保持 Semantix fail-open。 | `go test ./harness/semantix -race` |
 | Agent Skill | [`agent-skill`](./agent-skill) | 面向外部 harness 的自助安装、工具 schema、会话绕行 hook 与自测。 | `bash agent-skill/scripts/selftest.sh` |
+| 部署 | [`deploy`](./deploy) | Gateway Docker 镜像、Compose 拓扑与支持环境变量展开的示例配置。 | `docker compose -f deploy/docker-compose.yml config` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -222,6 +222,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | L2 注入 | [`kernel/inject`](./kernel/inject) | 在预算内选择完整切片，输出确定、经过 marker 转义的复用块。 | `go test ./kernel/inject -race` |
 | 检索分区 | [`kernel/zone`](./kernel/zone) | 检索、验证和演化共用的 hit、grey、miss 三区分类器。 | `go test ./kernel/zone -race` |
 | L3 缓存 | [`kernel/cache`](./kernel/cache) | 保守的结果复用判定接口与 L3 decider；无法证明安全时回退正常执行。 | `go test ./kernel/cache -race` |
+| 依赖指纹 | [`kernel/fingerprint`](./kernel/fingerprint) | 捕获并验证文件依赖；项目状态变化时使原本可复用的结果失效。 | `go test ./kernel/fingerprint -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -226,6 +226,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 复用 Judge | [`kernel/judge`](./kernel/judge) | 规则门、可选 LLM judge、提示清洗和判定统计，用于高风险 L3 候选。 | `go test ./kernel/judge -race` |
 | 结果提升 | [`kernel/promote`](./kernel/promote) | 保存 judge 批准的可复用结果，记录内容版本，并按来源切片级联失效。 | `go test ./kernel/promote -race` |
 | 调度器 | [`kernel/sched`](./kernel/sched) | 为每轮生成并行分组、预算动作、模型层级提示、注入 ID 与预取提示。 | `go test ./kernel/sched -race` |
+| 预取 | [`kernel/prefetch`](./kernel/prefetch) | 离线规划器、转移矩阵学习、浪费感知在线预测与只读执行 runner。 | `go test ./kernel/prefetch -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -211,6 +211,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 模块 | 路径 | 职责 | 聚焦验证 |
 |---|---|---|---|
 | CLI | [`cmd/semantix`](./cmd/semantix) | 命令注册、统一 JSON 信封、退出码契约、维护与评估命令。 | `go test ./cmd/semantix -race` |
+| Agent 可执行入口 | [`cmd/semantix-agent`](./cmd/semantix-agent) | 打包后的 Reasonix 衍生 Agent 入口，包含崩溃捕获与构建版本接线。 | `go test ./cmd/semantix-agent` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -229,6 +229,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 预取 | [`kernel/prefetch`](./kernel/prefetch) | 离线规划器、转移矩阵学习、浪费感知在线预测与只读执行 runner。 | `go test ./kernel/prefetch -race` |
 | 参数演化 | [`kernel/evolve`](./kernel/evolve) | 使用 EWMA 调整检索阈值和注入预算，参数变化有边界且可检查。 | `go test ./kernel/evolve -race` |
 | 事件契约 | [`kernel/event`](./kernel/event) | 类型化 kernel 事件、payload、wire format 与同步进程内总线。 | `go test ./kernel/event -race` |
+| 用量核算 | [`kernel/usage`](./kernel/usage) | 记录逐轮 token/cache 事件，汇总基线成本、实际成本与估算节省。 | `go test ./kernel/usage -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -234,6 +234,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | Harness 桥接 | [`harness/semantix`](./harness/semantix) | 将 harness 事件镜像为会话 JSONL，并输出复用摘要，同时保持 Semantix fail-open。 | `go test ./harness/semantix -race` |
 | Agent Skill | [`agent-skill`](./agent-skill) | 面向外部 harness 的自助安装、工具 schema、会话绕行 hook 与自测。 | `bash agent-skill/scripts/selftest.sh` |
 | 部署 | [`deploy`](./deploy) | Gateway Docker 镜像、Compose 拓扑与支持环境变量展开的示例配置。 | `docker compose -f deploy/docker-compose.yml config` |
+| 自动化脚本 | [`scripts`](./scripts) | 跨会话 demo、发布构建器和 Go 引导工具，供本地与发布流程使用。 | 在干净工作区运行对应 demo 或发布脚本。 |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -238,6 +238,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 规范与证据 | [`docs`](./docs) | 架构、安全、路线图、规格与验收报告，用于区分设计目标和实测结果。 | 每个已交付单元均核对对应验收报告。 |
 | 集成补丁 | [`patches`](./patches) | 面向外部 Reasonix fork 的版本化交付补丁，包含漂移说明和明确预检步骤。 | `git apply --check patches/semantix-sched-prefetch.patch` |
 | 博客源文件 | [`blog`](./blog) | 技术文章的版本化 Markdown 源；网站内容测试校验元数据、链接和编码。 | `cd site && npm run test:content` |
+| 官网 | [`site`](./site) | Next.js 产品站、文档、博客渲染、结构化数据、生成的 `llms-full.txt` 与内容质量测试。 | `cd site && npm run check` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -218,6 +218,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 语义切片 | [`kernel/slice`](./kernel/slice) | 切片类型、作用域、元数据、提取、文件存储、追加日志、压缩与维护。 | `go test ./kernel/slice -race` |
 | BM25 检索 | [`kernel/bm25`](./kernel/bm25) | 本地搜索与混合检索使用的词法索引和 CJK 感知分词器。 | `go test ./kernel/bm25 -race` |
 | 向量嵌入 | [`kernel/embed`](./kernel/embed) | Embedder 契约、确定性 hash embedder、模型嵌入与内存余弦向量索引。 | `go test ./kernel/embed -race` |
+| Lookup 工具 | [`kernel/lookup`](./kernel/lookup) | 只读 `semantix_lookup` schema 与执行器，向 Agent harness 暴露排序后的切片命中。 | `go test ./kernel/lookup` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,6 +203,16 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 
 另有 **Semantix Gateway**（`cmd/semantix-gateway`）：OpenAI 兼容网关，为任意支持自定义 base URL 的客户端透明加上跨会话复用层。
 
+<!-- repository-module-guide:start -->
+## 仓库模块地图
+
+下表按当前仓库结构说明可观察职责与聚焦验证方式；设计目标不会在这里被写成已经验证的生产性能。
+
+| 模块 | 路径 | 职责 | 聚焦验证 |
+|---|---|---|---|
+
+<!-- repository-module-guide:end -->
+
 ---
 
 ## 项目状态

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,6 +223,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | 检索分区 | [`kernel/zone`](./kernel/zone) | 检索、验证和演化共用的 hit、grey、miss 三区分类器。 | `go test ./kernel/zone -race` |
 | L3 缓存 | [`kernel/cache`](./kernel/cache) | 保守的结果复用判定接口与 L3 decider；无法证明安全时回退正常执行。 | `go test ./kernel/cache -race` |
 | 依赖指纹 | [`kernel/fingerprint`](./kernel/fingerprint) | 捕获并验证文件依赖；项目状态变化时使原本可复用的结果失效。 | `go test ./kernel/fingerprint -race` |
+| 复用 Judge | [`kernel/judge`](./kernel/judge) | 规则门、可选 LLM judge、提示清洗和判定统计，用于高风险 L3 候选。 | `go test ./kernel/judge -race` |
 <!-- repository-module-guide:end -->
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,6 +214,7 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 | Agent 可执行入口 | [`cmd/semantix-agent`](./cmd/semantix-agent) | 打包后的 Reasonix 衍生 Agent 入口，包含崩溃捕获与构建版本接线。 | `go test ./cmd/semantix-agent` |
 | Gateway | [`gateway`](./gateway)、[`cmd/semantix-gateway`](./cmd/semantix-gateway) | OpenAI 兼容代理、Anthropic 转换、SSE 转发、检索注入与 fail-open 上游路由。 | `go test ./gateway ./cmd/semantix-gateway -race` |
 | 配置 | [`kernel/config`](./kernel/config) | 按内置值、TOML、环境变量、CLI 覆盖顺序解析配置，并保留来源与类型化错误。 | `go test ./kernel/config -race` |
+| 事件摄取 | [`kernel/ingest`](./kernel/ingest) | 读取 harness JSONL 事件流，将规范化会话送入提取流程，无需依赖在线 harness。 | `go test ./kernel/ingest -race` |
 <!-- repository-module-guide:end -->
 
 ---


### PR DESCRIPTION
## Summary

Adds a bilingual, code-grounded repository module guide to both root READMEs.

- 30 real modules documented across CLI, kernel packages, Gateway, Reasonix harness, integration, deployment, content and CI.
- Every module lists its repository path, observable responsibility and focused verification command.
- English and Chinese rows stay aligned in the same module commit.
- Design targets are explicitly separated from measured production claims.

## Commit discipline

This branch contains **31 new commits** for this update:

- 1 scaffold commit for the bilingual module-guide structure.
- 30 module commits, exactly one commit per documented module.

The branch ref was updated only after the full commit chain was built, so CI runs once rather than once per commit.

## Scope

Changed files only:

- `README.md`
- `README.zh-CN.md`

No product code, generated assets, API credentials or experiment data changed.

## Verification

- Both module tables contain 30 aligned module rows.
- All 31 relative repository links resolve on the branch.
- Both files preserve their final newline.
- Compared with current `main`, the diff is README-only.

## Context

PR #243 was merged while this larger update was being prepared. These commits are the follow-up module-map update and do not modify the already-merged provider-cache evidence entry.