### PR TITLE
feat(gateway): grey 区 judge 判定落盘 + SSE 头丢失的源码级定论 (Issue #242)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -168,6 +168,27 @@ curl http://127.0.0.1:3000/v1/models -H "Authorization: Bearer <New API token>"
 完整设计见 `docs/specs/newapi-gateway-design.md`；非 Docker 直跑（systemd/launchd）
 见该文档 §5.1。
 
+### 客户端怎么判断「这次命中了没有」
+
+- **非流式**：直接读响应头 `x-semantix-cache: hit | miss`；
+- **流式（`stream:true`）：不要读响应头**。网关**有**发这个头（直连网关 `curl -D -` 能看到），
+  但 New API 中继 SSE 时会把它剥掉——它的流式路径只复制一个写死的白名单
+  （`X-Reasoning-Included` / `X-Codex-Turn-State`），其余上游响应头一律丢弃，且**没有配置项可以放行**
+  ——白名单写死在代码里（读 New API v1.0.0-rc.25 源码确认，剥头本身是 GW4 实机实测）。
+  这是 New API 的行为，不是网关缺陷。
+
+  流式场景以**网关 usage 日志为准**（`[ingest] usage_log` 指向的 JSONL，`"l3_reuse":true` 即 L3 命中）：
+
+  ```bash
+  tail -n 5 .semantix/gateway-usage.jsonl        # 路径见 semantix-gateway.toml
+  semantix usage --db .semantix/gateway-usage.jsonl
+  ```
+
+  配了灰区 judge（`[cache] judge_api_key`）且该轮确实有候选落进灰区时，这一行还会带
+  `"judge":[{…}]`，写明是 judge 判了不可复用（`"verdict":"declined"`）、调用失败降级
+  （`"verdict":"fail_closed"`）、还是指纹门在 judge 之前就拒了（`"verdict":"skipped"`，不产生
+  judge 费用）——排障时先看这个字段，别去猜。细节见设计文档 §3.4.1 与 §4.3。
+
 ## 安全约定
 
 - 切片库文件权限 `0600`、目录 `0700`（原子写 + 防 symlink）

--- a/docs/specs/newapi-gateway-design.md
+++ b/docs/specs/newapi-gateway-design.md
@@ -237,6 +237,39 @@ POST /v1/chat/completions {model, messages, stream, ...}
 - **命中流式**：缓存存的是完整响应；网关按 OpenAI SSE 协议把缓存内容切成 `choices[0].delta.content` 分块回放（每块 ≤ 4KB 或按原缓存分块）。注意这是**重建流**：`id`/`created`、工具调用首块（`index`/`id` 必须在第一个 delta）、`finish_reason` 位置、token 边界都与上游原始流不同；M1 落地时用真实客户端回归验证（见 §8）；
 - **字节稳定注意**：透传不重排、不重写上游事件，避免破坏客户端兼容性；注入块只在请求侧生效，不触碰响应流。
 
+#### 3.4.1 流式场景不要依赖 `x-semantix-cache` 响应头（Issue #242）
+
+**结论先行：流式请求判断是否命中，以网关 usage 日志为准，不要读响应头。**
+
+网关在流式路径**确实设置了** `x-semantix-cache`（`gateway/pipeline.go` `streamThrough` /
+`streamThroughAnthropic` / `replyFromCache`）。直连网关可以看到：
+
+```
+$ curl -D - http://semantix-gateway:8080/v1/chat/completions -d '{…,"stream":true}'
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+X-Semantix-Cache: miss
+```
+
+但同一个请求经 New API 中继后，这个头**不见了**（GW4 验收 §8.2 实测，New API v1.0.0-rc.25）。
+**这不是网关缺陷，是 New API 中继 SSE 的行为**，两条路径的差异在其源码里可以直接读出
+（仓库 `QuantumNous/new-api`，v1.0.0-rc.25 与 main 一致）：
+
+| 路径 | 代码 | 对上游自定义响应头的处理 |
+|---|---|---|
+| 非流式 | `service.IOCopyBytesGracefully`（`service/http.go`） | 遍历上游全部响应头，只排除 `Content-Length` 与 request-id → **自定义头透传**，所以非流式能看到 `x-semantix-cache` |
+| 流式 | `relay/helper.StreamScannerHandler` → `copyCodexSSEHeaders`（`relay/helper/stream_scanner.go`） | 只复制**硬编码白名单** `X-Reasoning-Included` / `X-Codex-Turn-State`，随后 `SetEventStreamHeaders` 写自己的 SSE 头 → **其余上游头全部丢弃** |
+
+即：**New API 没有「透传自定义响应头」的配置项**，白名单写死在代码里；要放行 `x-semantix-cache`
+只能给上游提 PR 把白名单做成可配置。在那之前，客户端侧的正确做法是：
+
+- **权威口径**：网关 usage 日志（`kernel/usage`，`l3_reuse:true` 即 L3 命中）。这条日志无论流式
+  与否、无论中间过了几层中继都存在；
+- **客户端侧启发式**（非协议保证，仅供无法读日志的场景参考）：L3 命中的回放流末块 usage 满足
+  `completion_tokens=0` 且 `prompt_tokens_details.cached_tokens>0`，且 `id` 为 `chatcmpl-<sliceID>`；
+- **已否决的方案**：在首个 SSE chunk 里塞命中标记——那会改动 wire 格式，与本节「透传不重排、
+  不重写上游事件」的约束直接冲突，为一个观测性便利去动协议不划算。
+
 ### 3.5 L3 语义缓存设计
 
 ```
@@ -447,6 +480,24 @@ gpt-4o                          →  gpt-4o             →  gpt-4o
   - **L3 命中返回合成 usage**：`completion_tokens=0`、`prompt_tokens=缓存前缀量`并标记 `prompt_tokens_details.cached_tokens` 全部为缓存——否则缓存里的 completion tokens 仍会按全价计费，「≈0 成本」不成立；
   - New API 侧给网关渠道配**近零价格倍率**（如 0.001x）落 L3 命中的费用——**这是商业决策，见 §9 待决策项 D1**；
 - 网关 `usage` 记录（`kernel/usage.Recorder/Summarize`）用于 Semantix 侧成本统计与验证报告，与 New API 侧计费对账用。
+
+**灰区 judge 的成本口径（Issue #242）**：grey 区 judge 是网关**自己发起的另一次上游模型调用**，
+不走 New API 渠道，因此 New API 侧永远看不到它，只能由网关自己记账。落地方式是「日志 + usage 字段」两份：
+
+- **结构化日志**（`gateway: l3 judge slice=… rel=… verdict=… called=… fail_closed=… latency_ms=… reason=… err=…`）
+  给排障用：一条 grep 就能回答「这次为什么没命中」，且不依赖是否配了 usage 日志；
+- **usage 事件字段** `judge[]`（`kernel/usage.JudgeDecision`）给算账用：`usage.Summarize` 是本项目
+  唯一把日志变成节省率的地方，**一条日志行是没法被求和的**，所以要进成本口径就必须是这里的字段。
+
+`verdict` 四态严格区分「判了」和「没判成」：`approved` / `declined` 是真裁决；`fail_closed` 是
+调用失败或超时后的保守拒绝（**GW4 §8.3 无法区分的就是这一态**）；`skipped` 是指纹门在 judge
+之前就拒了、根本没发生调用。只有 `called=true` 的决策才计入 `Summary.JudgeCalls` 与
+`JudgePromptTokens`（`bytes/4` 估算，同 §0.3 的 estimator 口径）。
+
+`Summary.SavingsUSD` / `SavingsRate` **仍是不含 judge 开销的毛口径**——judge 用的是独立配置的模型
+（`[cache] judge_model`），单价不在这份日志里，硬折进去只会得到一个用错价格的数。净口径由调用方
+自己算：`SavingsUSD - Summary.JudgeCostUSD(judge 模型输入单价)`。GW4 报告 §6 的 52.7% 是毛口径，
+这个字段补上后该缺口才**可测**（此前是完全测不出来）。
 
 ### 4.4 多用户 / 多项目隔离（可选）
 

--- a/gateway/anthropic.go
+++ b/gateway/anthropic.go
@@ -737,7 +737,7 @@ func (c *anthropicSSEConverter) writeDone() {
 // OpenAI SSE (the events must be translated — Anthropic frames differ from
 // OpenAI's). Sidecar/usage accounting matches the OpenAI streaming path:
 // request turns only, assistant content extraction is deferred debt.
-func (g *Gateway) streamThroughAnthropic(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
+func (g *Gateway) streamThroughAnthropic(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, jc *judgeCollector) {
 	if resp.StatusCode >= 400 {
 		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		writeAPIError(w, resp.StatusCode, "upstream_error",
@@ -768,6 +768,7 @@ func (g *Gateway) streamThroughAnthropic(w http.ResponseWriter, resp *http.Respo
 		TokensIn:       int64(len(query)/4) + injectedTokens,
 		InjectedTokens: injectedTokens,
 		SliceHits:      sliceHits,
+		JudgeDecisions: jc.drain(),
 		At:             g.now().Unix(),
 	})
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -149,6 +149,10 @@ func New(cfg *Config) (*Gateway, error) {
 		disabled: disableEnv(),
 		now:      time.Now,
 	}
+	// Grey-zone judge decisions become durable here (Issue #242 gap 1):
+	// one structured log line plus a field on the turn's usage event, so a
+	// non-hit can be explained and the judge's own model call can be costed.
+	g.decider.OnJudge = g.observeJudge
 	g.healthProbe = g.probeUpstreams
 	return g, nil
 }

--- a/gateway/judge_observability.go
+++ b/gateway/judge_observability.go
@@ -1,0 +1,96 @@
+package gateway
+
+import (
+	"context"
+	"log"
+	"sync"
+
+	"semantix/kernel/cache"
+	"semantix/kernel/usage"
+)
+
+// Grey-zone judge observability (Issue #242 gap 1).
+//
+// Why both a log line and a usage-event field, rather than one of them:
+//
+//   - The log line is for the operator mid-incident. "Why did t10 not hit?"
+//     must be answerable by grepping one stream, without joining JSONL
+//     records, and it must survive even when no usage log is configured.
+//   - The usage-event field is for cost. The judge is a separate upstream
+//     model call that does not traverse the New API channel, so nothing
+//     else meters it — which is exactly why the GW4 acceptance's 52.7%
+//     savings figure carries an unquantifiable caveat. usage.Summarize is
+//     the only place this project turns the log into a savings number, so a
+//     cost that figure must be reconciled against has to be a field there.
+//     A log line cannot be summed; a grep is not an accounting ledger.
+//
+// The two carry the same facts; neither is derived from the other, so a
+// deployment that ships logs and usage to different places keeps both
+// questions answerable.
+
+// judgeCollector accumulates the grey-zone judge decisions taken while
+// serving one request, so they can be attached to that turn's usage event.
+// One instance per request; the mutex guards against a future concurrent
+// candidate evaluation inside the decider.
+type judgeCollector struct {
+	mu        sync.Mutex
+	decisions []usage.JudgeDecision
+}
+
+// judgeCollectorKey is the private context key for the per-request
+// collector. The decider's OnJudge hook is process-wide, so the context is
+// what routes an observation back to the request that caused it.
+type judgeCollectorKey struct{}
+
+func withJudgeCollector(ctx context.Context, c *judgeCollector) context.Context {
+	return context.WithValue(ctx, judgeCollectorKey{}, c)
+}
+
+func judgeCollectorFrom(ctx context.Context) *judgeCollector {
+	c, _ := ctx.Value(judgeCollectorKey{}).(*judgeCollector)
+	return c
+}
+
+func (c *judgeCollector) add(d usage.JudgeDecision) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decisions = append(c.decisions, d)
+}
+
+// drain returns the collected decisions (nil when none), leaving the
+// collector empty so a decision is never attributed to two events.
+func (c *judgeCollector) drain() []usage.JudgeDecision {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := c.decisions
+	c.decisions = nil
+	return out
+}
+
+// observeJudge is the cache.L3Decider.OnJudge hook: it logs one structured
+// line and records the decision on the in-flight turn. Both are
+// best-effort and never affect the reuse verdict — the decision has already
+// been made by the time this runs.
+func (g *Gateway) observeJudge(ctx context.Context, obs cache.JudgeObservation) {
+	d := usage.JudgeDecision{
+		SliceID:       obs.SliceID,
+		RelConfidence: obs.RelConfidence,
+		Verdict:       obs.Verdict,
+		Reason:        obs.Reason,
+		Called:        obs.Called,
+		FailClosed:    obs.FailClosed,
+		Error:         obs.Err,
+		LatencyMs:     obs.Latency.Milliseconds(),
+		// byte/4, the same estimator the gateway uses for its synthetic
+		// usage chunks — never a tokenizer count.
+		PromptTokens: int64(obs.PromptBytes / 4),
+	}
+	log.Printf("gateway: l3 judge slice=%s rel=%.3f verdict=%s called=%t fail_closed=%t latency_ms=%d prompt_tokens=%d reason=%q err=%q",
+		d.SliceID, d.RelConfidence, d.Verdict, d.Called, d.FailClosed, d.LatencyMs, d.PromptTokens, d.Reason, d.Error)
+	if c := judgeCollectorFrom(ctx); c != nil {
+		c.add(d)
+	}
+}

--- a/gateway/judge_observability_test.go
+++ b/gateway/judge_observability_test.go
@@ -1,0 +1,296 @@
+package gateway
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"semantix/kernel/slice"
+	"semantix/kernel/usage"
+	"semantix/kernel/zone"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #242 gap 1: grey-zone judge verdicts must land on disk.
+//
+// GW4 acceptance §8.3: t10 (rel 0.675, unambiguously grey) did not hit and
+// no durable evidence distinguished "the judge ruled it not reusable" from
+// "the judge call failed and we fell back to fail-closed" — and the judge's
+// own model call was never metered, so its cost could not be accounted for.
+
+// judgeServer answers the OpenAI judge protocol with a fixed verdict word,
+// or fails with the given status when status != 200.
+func judgeServer(t *testing.T, reply string, status int) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			_, _ = io.WriteString(w, `{"error":"judge down"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"`+reply+`"}}]}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// newJudgingGateway wires a real LLM judge and forces every L3 candidate
+// into the grey zone (TauHigh above 1 is unreachable for any score/top1).
+func newJudgingGateway(t *testing.T, upURL, judgeBase string) *Gateway {
+	t.Helper()
+	g := newTestGatewayCfg(t, upURL, func(c *Config) {
+		c.Cache.JudgeAPIKey = "jk"
+		c.Cache.JudgeBaseURL = judgeBase
+		c.Cache.JudgeModel = "judge-model"
+	})
+	z := zone.Zones{TauHigh: 1.5, TauLow: 0.5, AbsHigh: 0.7, AbsLow: 0.45}
+	g.decider.Zones = &z
+	return g
+}
+
+// seedGreyCandidate indexes a Result slice that the query will retrieve.
+func seedGreyCandidate(t *testing.T, g *Gateway, id, query string) {
+	t.Helper()
+	chash, _ := contextHash([]chatMessage{msg("user", query)})
+	seed(t, g, &slice.Slice{
+		ID: id, Type: slice.Result, Scope: slice.Project,
+		Content: []byte(query + " " + query + " cached answer"),
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
+	})
+}
+
+// readUsageEvents parses the gateway's usage JSONL.
+func readUsageEvents(t *testing.T, g *Gateway) []usage.Event {
+	t.Helper()
+	f, err := os.Open(g.cfg.Ingest.UsageLog)
+	if err != nil {
+		t.Fatalf("open usage log: %v", err)
+	}
+	defer f.Close()
+	var out []usage.Event
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e usage.Event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("bad usage line %q: %v", line, err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// judgeDecisions flattens every recorded judge decision in the usage log.
+func judgeDecisions(t *testing.T, g *Gateway) []usage.JudgeDecision {
+	t.Helper()
+	var out []usage.JudgeDecision
+	for _, e := range readUsageEvents(t, g) {
+		out = append(out, e.JudgeDecisions...)
+	}
+	return out
+}
+
+func TestJudgeDeclineLandsInUsageLog(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newJudgingGateway(t, upSrv.URL, judgeServer(t, "no", http.StatusOK))
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+	seedGreyCandidate(t, g, "grey-decline", "hello world")
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if resp.Header.Get("x-semantix-cache") != "miss" {
+		t.Fatalf("cache = %q, want miss (judge declined)", resp.Header.Get("x-semantix-cache"))
+	}
+
+	ds := judgeDecisions(t, g)
+	if len(ds) != 1 {
+		t.Fatalf("judge decisions in usage log = %d, want 1", len(ds))
+	}
+	d := ds[0]
+	if d.Verdict != "declined" {
+		t.Errorf("verdict = %q, want declined", d.Verdict)
+	}
+	if d.FailClosed {
+		t.Error("fail_closed = true: a real 'no' must not be recorded as a fallback")
+	}
+	if !d.Called {
+		t.Error("called = false: the judge model was invoked and is billable")
+	}
+	if d.SliceID != "grey-decline" {
+		t.Errorf("slice_id = %q, want grey-decline", d.SliceID)
+	}
+	if d.RelConfidence <= 0 {
+		t.Errorf("rel_confidence = %v, want the grey ratio", d.RelConfidence)
+	}
+	if d.PromptTokens <= 0 {
+		t.Errorf("prompt_tokens = %d, want a judge cost estimate", d.PromptTokens)
+	}
+}
+
+// The decisive case: an unreachable/erroring judge must be recorded as
+// fail_closed with the error, never as a verdict.
+func TestJudgeFailClosedLandsInUsageLog(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newJudgingGateway(t, upSrv.URL, judgeServer(t, "", http.StatusInternalServerError))
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+	seedGreyCandidate(t, g, "grey-error", "hello world")
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+
+	ds := judgeDecisions(t, g)
+	if len(ds) != 1 {
+		t.Fatalf("judge decisions in usage log = %d, want 1", len(ds))
+	}
+	d := ds[0]
+	if d.Verdict != "fail_closed" || !d.FailClosed {
+		t.Errorf("verdict = %q fail_closed = %v, want fail_closed/true", d.Verdict, d.FailClosed)
+	}
+	if d.Error == "" {
+		t.Error("error is empty: the whole point is knowing the call failed")
+	}
+	if strings.Contains(d.Error, "jk") {
+		t.Errorf("error leaks the judge API key: %q", d.Error)
+	}
+}
+
+// An approved verdict serves the turn from cache; the decision must ride on
+// the L3-hit usage event, not vanish because no upstream call happened.
+func TestJudgeApprovalLandsOnL3HitEvent(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"unused"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newJudgingGateway(t, upSrv.URL, judgeServer(t, "yes", http.StatusOK))
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+	seedGreyCandidate(t, g, "grey-approve", "hello world")
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body %s", resp.StatusCode, out)
+	}
+	if resp.Header.Get("x-semantix-cache") != "hit" {
+		t.Fatalf("cache = %q, want hit (judge approved), body %s", resp.Header.Get("x-semantix-cache"), out)
+	}
+	evs := readUsageEvents(t, g)
+	if len(evs) != 1 {
+		t.Fatalf("usage events = %d, want 1", len(evs))
+	}
+	if !evs[0].L3Reuse {
+		t.Fatal("the hit event must be the L3 reuse event")
+	}
+	if len(evs[0].JudgeDecisions) != 1 || evs[0].JudgeDecisions[0].Verdict != "approved" {
+		t.Fatalf("judge decisions on the hit event = %+v, want one approved", evs[0].JudgeDecisions)
+	}
+}
+
+// Streaming turns must meter the judge too — the SSE relay is a separate
+// code path from the plain passthrough.
+func TestJudgeDecisionLandsOnStreamingTurn(t *testing.T) {
+	up := &testUpstream{stream: "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\ndata: [DONE]\n\n"}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newJudgingGateway(t, upSrv.URL, judgeServer(t, "no", http.StatusOK))
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+	seedGreyCandidate(t, g, "grey-stream", "hello world")
+
+	resp, _ := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", true))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	ds := judgeDecisions(t, g)
+	if len(ds) != 1 || ds[0].Verdict != "declined" {
+		t.Fatalf("streaming judge decisions = %+v, want one declined", ds)
+	}
+}
+
+// Summarize must make the judge cost countable straight from the log.
+func TestJudgeCostIsSummarizable(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newJudgingGateway(t, upSrv.URL, judgeServer(t, "no", http.StatusOK))
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+	seedGreyCandidate(t, g, "grey-cost", "hello world")
+
+	postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+
+	s, err := usage.Summarize(g.cfg.Ingest.UsageLog, usage.DefaultCostMissPerMTok, usage.DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.JudgeCalls != 1 || s.JudgeDeclined != 1 {
+		t.Fatalf("summary judge counters = calls %d declined %d, want 1/1", s.JudgeCalls, s.JudgeDeclined)
+	}
+	if s.JudgeCostUSD(usage.DefaultCostMissPerMTok) <= 0 {
+		t.Fatal("judge cost must be computable and non-zero once a judge call happened")
+	}
+}
+
+// The structured log line is the operator-facing half: greppable at
+// debugging time without parsing the usage JSONL.
+func TestJudgeDecisionIsLogged(t *testing.T) {
+	var buf strings.Builder
+	old := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(old) })
+
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newJudgingGateway(t, upSrv.URL, judgeServer(t, "no", http.StatusOK))
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+	seedGreyCandidate(t, g, "grey-log", "hello world")
+
+	postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+
+	got := buf.String()
+	for _, want := range []string{"l3 judge", "slice=grey-log", "verdict=declined", "fail_closed=false", "rel="} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log line missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// Without a judge configured, grey rejection is deterministic and free —
+// the usage log must stay exactly as it was.
+func TestNoJudgeConfiguredRecordsNoDecisions(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	z := zone.Zones{TauHigh: 1.5, TauLow: 0.5, AbsHigh: 0.7, AbsLow: 0.45}
+	g.decider.Zones = &z
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+	seedGreyCandidate(t, g, "grey-none", "hello world")
+
+	postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+
+	if ds := judgeDecisions(t, g); len(ds) != 0 {
+		t.Fatalf("judge decisions = %+v, want none when no judge is wired", ds)
+	}
+}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -43,7 +43,11 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 		return
 	}
 	sessionID := r.Header.Get("x-semantix-session")
-	ctx := r.Context()
+	// Route this turn's grey-zone judge decisions back to this turn's usage
+	// event (Issue #242 gap 1). The decider's OnJudge hook is process-wide,
+	// so the request context is what identifies the caller.
+	jc := &judgeCollector{}
+	ctx := withJudgeCollector(r.Context(), jc)
 	q := cache.Query{UserInput: query, ContextHash: chash, Scope: scope, Model: req.Model}
 
 	// L3: verified reuse — zero upstream calls (design §3.3 step 3). The
@@ -54,7 +58,7 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 			g.recordUsage(usage.Event{
 				SessionID: sessionID, TokensIn: int64(len(query)/4) + int64(len(res.Response)/4),
 				TokensOut: 0, CacheHitToken: int64(len(res.Response) / 4),
-				L3Reuse: true, At: g.now().Unix(),
+				L3Reuse: true, JudgeDecisions: jc.drain(), At: g.now().Unix(),
 			})
 			g.replyFromCache(w, r, req, res)
 			return
@@ -97,13 +101,13 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 
 	if req.Stream {
 		if up.Vendor == "anthropic" {
-			g.streamThroughAnthropic(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits)
+			g.streamThroughAnthropic(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, jc)
 			return
 		}
-		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits)
+		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, jc)
 		return
 	}
-	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, up.Vendor)
+	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, up.Vendor, jc)
 }
 
 // l3Eligible applies the gateway-side TTL window on top of the kernel
@@ -205,7 +209,7 @@ func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (
 // successful exchanges, so failed requests never enter the reuse library.
 // Anthropic responses are translated to OpenAI chat.completion shape first
 // (the client surface is always OpenAI-compatible).
-func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, vendor string) {
+func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, vendor string, jc *judgeCollector) {
 	out, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		writeAPIError(w, http.StatusBadGateway, "upstream_error",
@@ -258,6 +262,7 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 		TokensOut:      int64(len(out) / 4),
 		InjectedTokens: injectedTokens,
 		SliceHits:      sliceHits,
+		JudgeDecisions: jc.drain(),
 		At:             g.now().Unix(),
 	})
 }
@@ -272,7 +277,7 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 // failed exchanges are not recorded (design §0.3 documented debt, now paid).
 // If the upstream ends without a [DONE] marker (abnormal disconnect), the
 // gateway appends one so the client never hangs on an unterminated stream.
-func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int) {
+func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, jc *judgeCollector) {
 	if resp.StatusCode >= 400 {
 		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		writeAPIError(w, resp.StatusCode, "upstream_error",
@@ -343,6 +348,7 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 		TokensOut:      tokensOut,
 		InjectedTokens: injectedTokens,
 		SliceHits:      sliceHits,
+		JudgeDecisions: jc.drain(),
 		At:             g.now().Unix(),
 	})
 }

--- a/kernel/cache/judge_observe.go
+++ b/kernel/cache/judge_observe.go
@@ -1,0 +1,95 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"semantix/kernel/judge"
+)
+
+// Verdict values carried by JudgeObservation.Verdict (Issue #242 gap 1).
+// They are deliberately plain strings: the observation crosses a package
+// boundary into whatever the host wants to persist (a log line, a usage
+// event), and kernel/cache must not learn about either.
+const (
+	// JudgeApproved: the judge was asked and said the cached answer is
+	// reusable. One billable judge call.
+	JudgeApproved = "approved"
+	// JudgeDeclined: the judge was asked and said no. One billable judge
+	// call — this is a real verdict, not a fallback.
+	JudgeDeclined = "declined"
+	// JudgeFailClosed: the judge call errored or timed out and the grey
+	// candidate was rejected conservatively. The call may still have been
+	// billed upstream, but the rejection carries no semantic information.
+	JudgeFailClosed = "fail_closed"
+	// JudgeSkipped: the candidate was rejected by the fingerprint gate or
+	// the rule gate before the judge was reached. No judge cost.
+	JudgeSkipped = "skipped"
+)
+
+// JudgeObservation is one grey-zone verification outcome, emitted through
+// L3Decider.OnJudge (Issue #242 gap 1).
+//
+// It exists because a grey candidate that is not reused is otherwise
+// indistinguishable on disk from a candidate whose judge call failed —
+// and because the judge is a separate upstream model call that no usage
+// event accounted for, making its cost unmeasurable. Every field here is
+// either "why was this not reused" or "what did asking cost".
+//
+// The type stays on the standard library plus kernel/judge so the L3
+// decider keeps its architecture contract (docs/specs/
+// h2h3-resource-orchestration.md §6): no event bus, no gateway, no harness.
+type JudgeObservation struct {
+	// SliceID is the candidate that entered the grey zone.
+	SliceID string
+	// RelConfidence is the score/top1 ratio that classified the candidate
+	// as grey — the number that explains why the judge was consulted.
+	RelConfidence float64
+	// Verdict is one of JudgeApproved / JudgeDeclined / JudgeFailClosed /
+	// JudgeSkipped.
+	Verdict string
+	// Reason is judge.RuleGate.Chain's own human-readable explanation.
+	Reason string
+	// Called reports whether the LLM judge was actually invoked. Only a
+	// called judge costs money; this is the unit of judge cost accounting.
+	Called bool
+	// FailClosed reports that the outcome came from an error or timeout
+	// rather than from a verdict. This is the distinction the GW4
+	// acceptance could not make.
+	FailClosed bool
+	// Err is the judge error text when FailClosed (empty otherwise).
+	Err string
+	// Latency is how long the judge call took (zero when not called).
+	Latency time.Duration
+	// PromptBytes estimates the judge input size (query + candidate
+	// content) so a token/cost estimate can be derived downstream without
+	// kernel/cache knowing any pricing.
+	PromptBytes int
+}
+
+// timedJudge wraps a Judge to record whether it was reached and how long it
+// took. One instance serves exactly one RuleGate.Chain call, which invokes
+// Confirm at most once synchronously, so no locking is needed.
+type timedJudge struct {
+	inner   judge.Judge
+	called  bool
+	latency time.Duration
+}
+
+func (t *timedJudge) Confirm(ctx context.Context, c judge.Candidate) (bool, error) {
+	t.called = true
+	start := time.Now()
+	ok, err := t.inner.Confirm(ctx, c)
+	t.latency = time.Since(start)
+	return ok, err
+}
+
+// relConfidence is the grey-zone ratio zone.Classify keys on, guarded
+// against a non-positive top1 (which classifies as Miss and never reaches
+// the judge, but must not produce Inf/NaN if it ever did).
+func relConfidence(score, top1 float64) float64 {
+	if top1 <= 0 {
+		return 0
+	}
+	return score / top1
+}

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -23,6 +23,15 @@ type L3Decider struct {
 	Zones *zone.Zones // grey-zone classifier (nil → zone.Default)
 	Judge judge.Judge // grey-zone LLM judge (nil → conservative reject, kernel/judge RuleGate)
 	K     int         // top-k candidates (default 3)
+
+	// OnJudge, when non-nil, receives one JudgeObservation per grey-zone
+	// verification (Issue #242 gap 1) so the host can make the verdict —
+	// and the judge's cost — durable. It is a hook rather than a direct
+	// write so kernel/cache stays free of the event bus / gateway
+	// (docs/specs/h2h3-resource-orchestration.md §6). Called synchronously
+	// on the decision path with the request context, so implementations
+	// must not block; a nil hook disables observation entirely.
+	OnJudge func(ctx context.Context, obs JudgeObservation)
 }
 
 // DecideL2 returns top-k hits filtered by the grey zone (hit-only enters the
@@ -80,7 +89,7 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 			// Ambiguous: reuse only when the judge confirms (spec §3.5
 			// RuleGate.Chain; nil judge → conservative reject). Fingerprint
 			// re-verification below still applies to grey-approved slices.
-			if !d.judgeGrey(ctx, q, s) {
+			if !d.judgeGrey(ctx, q, s, relConfidence(h.Score, top1)) {
 				continue
 			}
 		default: // zone.Miss
@@ -163,12 +172,19 @@ func (d *L3Decider) zones() zone.Zones {
 // dependency fingerprints after this (verified), so a judge "yes" still
 // cannot surface stale data. A nil judge, a judge error, or a judge "no"
 // all reject conservatively (fail-closed).
-func (d *L3Decider) judgeGrey(ctx context.Context, q Query, s *slice.Slice) bool {
+//
+// rel is the score/top1 ratio that classified the candidate as grey; it is
+// reported through OnJudge so a rejection can later be explained without
+// re-running retrieval (Issue #242 gap 1). No observation is emitted when
+// no judge is wired: that path is deterministic and costs nothing, so
+// recording it would only add noise to the host's usage log.
+func (d *L3Decider) judgeGrey(ctx context.Context, q Query, s *slice.Slice, rel float64) bool {
 	if d.Judge == nil {
 		return false
 	}
-	gate := judge.RuleGate{Judge: d.Judge}
-	v, _, err := gate.Chain(ctx, judge.Candidate{
+	timed := &timedJudge{inner: d.Judge}
+	gate := judge.RuleGate{Judge: timed}
+	v, reason, err := gate.Chain(ctx, judge.Candidate{
 		Query:   q.UserInput,
 		SliceID: s.ID,
 		Content: string(s.Content),
@@ -178,7 +194,33 @@ func (d *L3Decider) judgeGrey(ctx context.Context, q Query, s *slice.Slice) bool
 		Deps:    s.Meta.Deps,
 		RootDir: d.Root,
 	})
-	return err == nil && v == judge.Confirm
+	ok := err == nil && v == judge.Confirm
+	if d.OnJudge != nil {
+		obs := JudgeObservation{
+			SliceID:       s.ID,
+			RelConfidence: rel,
+			Reason:        reason,
+			Called:        timed.called,
+			Latency:       timed.latency,
+			PromptBytes:   len(q.UserInput) + len(s.Content),
+		}
+		switch {
+		case err != nil:
+			// The only error Chain surfaces is the judge call's own —
+			// a timeout or transport failure, not a verdict.
+			obs.Verdict = JudgeFailClosed
+			obs.FailClosed = true
+			obs.Err = err.Error()
+		case !timed.called:
+			obs.Verdict = JudgeSkipped
+		case ok:
+			obs.Verdict = JudgeApproved
+		default:
+			obs.Verdict = JudgeDeclined
+		}
+		d.OnJudge(ctx, obs)
+	}
+	return ok
 }
 
 func (d *L3Decider) k() int {

--- a/kernel/cache/l3_judge_observability_test.go
+++ b/kernel/cache/l3_judge_observability_test.go
@@ -1,0 +1,162 @@
+package cache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"semantix/kernel/slice"
+)
+
+// ---- Issue #242 gap 1: grey-zone judge verdicts must be observable ----
+//
+// Before this, a grey candidate that did not get reused left no durable
+// trace distinguishing "the judge declined" from "the judge call failed
+// and we fell back to fail-closed" — and the judge's own model call was
+// invisible to cost accounting. These tests pin the observation hook that
+// makes both answerable.
+
+func collectJudge(t *testing.T, d *L3Decider) *[]JudgeObservation {
+	t.Helper()
+	got := &[]JudgeObservation{}
+	d.OnJudge = func(_ context.Context, o JudgeObservation) { *got = append(*got, o) }
+	return got
+}
+
+func TestDecideL3JudgeObservationApproved(t *testing.T) {
+	root, idx, _, _ := buildTestLib(t)
+	d := &L3Decider{Index: idx, Root: root, Zones: greyZones(), Judge: &mockJudge{confirm: true}}
+	got := collectJudge(t, d)
+
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("judge-approved grey candidate should be reused")
+	}
+	if len(*got) != 1 {
+		t.Fatalf("observations = %d, want exactly 1", len(*got))
+	}
+	o := (*got)[0]
+	if o.SliceID != "l3-1" {
+		t.Errorf("SliceID = %q, want l3-1", o.SliceID)
+	}
+	if o.Verdict != JudgeApproved {
+		t.Errorf("Verdict = %q, want %q", o.Verdict, JudgeApproved)
+	}
+	if !o.Called {
+		t.Error("Called = false, want true: an approved verdict means the judge model was billed")
+	}
+	if o.FailClosed {
+		t.Error("FailClosed = true, want false: this was a real verdict")
+	}
+	if o.RelConfidence <= 0 {
+		t.Errorf("RelConfidence = %v, want the score/top1 ratio that put the candidate in grey", o.RelConfidence)
+	}
+	if o.PromptBytes <= 0 {
+		t.Errorf("PromptBytes = %d, want the judge input size estimate (cost accounting)", o.PromptBytes)
+	}
+	if o.Reason == "" {
+		t.Error("Reason is empty, want the RuleGate.Chain reason")
+	}
+}
+
+func TestDecideL3JudgeObservationDeclined(t *testing.T) {
+	root, idx, _, _ := buildTestLib(t)
+	d := &L3Decider{Index: idx, Root: root, Zones: greyZones(), Judge: &mockJudge{confirm: false}}
+	got := collectJudge(t, d)
+
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil || res != nil {
+		t.Fatalf("declined grey candidate must not be reused: res=%v err=%v", res, err)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("observations = %d, want exactly 1", len(*got))
+	}
+	o := (*got)[0]
+	if o.Verdict != JudgeDeclined {
+		t.Errorf("Verdict = %q, want %q", o.Verdict, JudgeDeclined)
+	}
+	if !o.Called {
+		t.Error("Called = false: a declined verdict still cost one judge call")
+	}
+	if o.FailClosed {
+		t.Error("FailClosed = true, want false: a real 'no' is not a fallback")
+	}
+	if o.Err != "" {
+		t.Errorf("Err = %q, want empty on a real verdict", o.Err)
+	}
+}
+
+// The distinction the acceptance report could not make: a judge that errors
+// or times out must be recorded as fail-closed, never as a verdict.
+func TestDecideL3JudgeObservationFailClosedOnError(t *testing.T) {
+	root, idx, _, _ := buildTestLib(t)
+	d := &L3Decider{Index: idx, Root: root, Zones: greyZones(),
+		Judge: &mockJudge{confirm: true, err: context.DeadlineExceeded}}
+	got := collectJudge(t, d)
+
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil || res != nil {
+		t.Fatalf("judge error must fail closed: res=%v err=%v", res, err)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("observations = %d, want exactly 1", len(*got))
+	}
+	o := (*got)[0]
+	if o.Verdict != JudgeFailClosed {
+		t.Errorf("Verdict = %q, want %q", o.Verdict, JudgeFailClosed)
+	}
+	if !o.FailClosed {
+		t.Error("FailClosed = false, want true")
+	}
+	if !o.Called {
+		t.Error("Called = false: a timed-out call is still an upstream call that may be billed")
+	}
+	if o.Err == "" {
+		t.Error("Err is empty, want the judge error text")
+	}
+}
+
+// A grey candidate rejected by the fingerprint gate never reaches the judge:
+// it must be recorded as skipped (no judge cost), not as a verdict.
+func TestDecideL3JudgeObservationSkippedBeforeJudge(t *testing.T) {
+	root, idx, dep, _ := buildTestLib(t)
+	if err := os.WriteFile(filepath.Join(root, dep), []byte("module demo\nv2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &L3Decider{Index: idx, Root: root, Zones: greyZones(), Judge: &mockJudge{confirm: true}}
+	got := collectJudge(t, d)
+
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil || res != nil {
+		t.Fatalf("changed dep must fail closed: res=%v err=%v", res, err)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("observations = %d, want exactly 1", len(*got))
+	}
+	o := (*got)[0]
+	if o.Verdict != JudgeSkipped {
+		t.Errorf("Verdict = %q, want %q", o.Verdict, JudgeSkipped)
+	}
+	if o.Called {
+		t.Error("Called = true: the fingerprint gate rejected before the judge, so nothing was billed")
+	}
+}
+
+// No judge wired: grey rejection is deterministic and free, so it must not
+// emit judge observations (they would be pure noise in the usage log).
+func TestDecideL3NoJudgeEmitsNoObservation(t *testing.T) {
+	root, idx, _, _ := buildTestLib(t)
+	d := &L3Decider{Index: idx, Root: root, Zones: greyZones()}
+	got := collectJudge(t, d)
+
+	if _, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project}); err != nil {
+		t.Fatal(err)
+	}
+	if len(*got) != 0 {
+		t.Fatalf("observations = %d, want 0 when no judge is wired", len(*got))
+	}
+}

--- a/kernel/usage/judge_test.go
+++ b/kernel/usage/judge_test.go
@@ -1,0 +1,114 @@
+package usage
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #242 gap 1: the grey-zone judge is a separate upstream model call
+// that never went through the New API channel and never produced a usage
+// event, so its cost could not be accounted for at all. It must now be
+// countable straight out of the usage log.
+
+func TestSummarizeAggregatesJudgeDecisions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage.jsonl")
+	r, err := NewRecorder(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := []Event{
+		{SessionID: "s1", Turn: 1, TokensIn: 100, TokensOut: 20, JudgeDecisions: []JudgeDecision{
+			{SliceID: "a", RelConfidence: 0.675, Verdict: "approved", Called: true, LatencyMs: 800, PromptTokens: 400},
+		}},
+		{SessionID: "s1", Turn: 2, TokensIn: 100, TokensOut: 20, JudgeDecisions: []JudgeDecision{
+			{SliceID: "b", RelConfidence: 0.61, Verdict: "declined", Called: true, LatencyMs: 700, PromptTokens: 300},
+			{SliceID: "c", RelConfidence: 0.58, Verdict: "fail_closed", Called: true, FailClosed: true,
+				Error: "context deadline exceeded", LatencyMs: 30000, PromptTokens: 300},
+		}},
+		{SessionID: "s2", Turn: 1, TokensIn: 100, TokensOut: 20, JudgeDecisions: []JudgeDecision{
+			{SliceID: "d", RelConfidence: 0.7, Verdict: "skipped", PromptTokens: 250},
+		}},
+		{SessionID: "s2", Turn: 2, TokensIn: 100, TokensOut: 20}, // no judge at all
+	}
+	for _, e := range evs {
+		if err := r.Append(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s, err := Summarize(path, DefaultCostMissPerMTok, DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.JudgeDecisions != 4 {
+		t.Errorf("JudgeDecisions = %d, want 4", s.JudgeDecisions)
+	}
+	// Only calls that actually reached the judge are billable; the skipped
+	// one was rejected by the fingerprint gate and cost nothing.
+	if s.JudgeCalls != 3 {
+		t.Errorf("JudgeCalls = %d, want 3 (skipped is free)", s.JudgeCalls)
+	}
+	if s.JudgeApproved != 1 || s.JudgeDeclined != 1 || s.JudgeFailClosed != 1 || s.JudgeSkipped != 1 {
+		t.Errorf("verdict split = %d/%d/%d/%d, want 1/1/1/1 approved/declined/fail_closed/skipped",
+			s.JudgeApproved, s.JudgeDeclined, s.JudgeFailClosed, s.JudgeSkipped)
+	}
+	// Skipped decisions never sent a prompt, so their bytes must not be billed.
+	if s.JudgePromptTokens != 1000 {
+		t.Errorf("JudgePromptTokens = %d, want 1000 (400+300+300, skipped excluded)", s.JudgePromptTokens)
+	}
+	if s.JudgeLatencyMs != 31500 {
+		t.Errorf("JudgeLatencyMs = %d, want 31500", s.JudgeLatencyMs)
+	}
+
+	// The whole point: judge cost is now computable at the judge model's
+	// own price, independent of the served model's price.
+	got := s.JudgeCostUSD(0.27)
+	want := 1000 * 0.27 / 1e6
+	if math.Abs(got-want) > 1e-12 {
+		t.Errorf("JudgeCostUSD(0.27) = %v, want %v", got, want)
+	}
+}
+
+// The judge fields must not disturb the existing savings arithmetic: the
+// GW4 report's headline rate is computed from these same numbers.
+func TestJudgeDecisionsDoNotChangeSavings(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "plain.jsonl")
+	judged := filepath.Join(dir, "judged.jsonl")
+
+	base := Event{SessionID: "s", Turn: 1, TokensIn: 1000, TokensOut: 200, CacheHitToken: 600}
+	rp, err := NewRecorder(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rp.Append(base); err != nil {
+		t.Fatal(err)
+	}
+	rj, err := NewRecorder(judged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withJudge := base
+	withJudge.JudgeDecisions = []JudgeDecision{
+		{SliceID: "a", Verdict: "declined", Called: true, PromptTokens: 5000},
+	}
+	if err := rj.Append(withJudge); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := Summarize(plain, DefaultCostMissPerMTok, DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Summarize(judged, DefaultCostMissPerMTok, DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.SavingsUSD != b.SavingsUSD || a.SavingsRate != b.SavingsRate || a.CostPaidUSD != b.CostPaidUSD {
+		t.Fatalf("judge fields changed the served-model arithmetic: %+v vs %+v", a, b)
+	}
+	if b.JudgeCalls != 1 {
+		t.Fatalf("JudgeCalls = %d, want 1", b.JudgeCalls)
+	}
+}

--- a/kernel/usage/usage.go
+++ b/kernel/usage/usage.go
@@ -40,7 +40,45 @@ type Event struct {
 	// this turn (L2 injected slice count). Omitted for older logs, which
 	// Summarize reads as 0.
 	SliceHits int `json:"slice_hits,omitempty"`
-	At        int64 `json:"at"` // unix seconds
+	// JudgeDecisions records the grey-zone LLM judge verifications this turn
+	// triggered (Issue #242 gap 1). Empty on every turn that never entered
+	// the grey zone, and on every deployment without a judge configured.
+	JudgeDecisions []JudgeDecision `json:"judge,omitempty"`
+	At             int64           `json:"at"` // unix seconds
+}
+
+// JudgeDecision is one grey-zone judge verification, as recorded on the
+// turn that triggered it (Issue #242 gap 1).
+//
+// It lives in the usage log rather than only in a process log line because
+// the judge is a *separate upstream model call*: it does not go through the
+// serving channel, so nothing else meters it. Summarize is the only place
+// that turns this library's savings into a number, so a cost the savings
+// figure must be reconciled against has to be reachable from here.
+type JudgeDecision struct {
+	// SliceID is the candidate that entered the grey zone.
+	SliceID string `json:"slice_id,omitempty"`
+	// RelConfidence is the score/top1 ratio that classified it as grey.
+	RelConfidence float64 `json:"rel_confidence,omitempty"`
+	// Verdict: "approved" | "declined" | "fail_closed" | "skipped".
+	// fail_closed means the call errored or timed out — the rejection
+	// carries no semantic information, which is exactly the distinction
+	// the GW4 acceptance could not make from disk.
+	Verdict string `json:"verdict"`
+	// Reason is the verification chain's own explanation.
+	Reason string `json:"reason,omitempty"`
+	// Called reports that the judge model was actually invoked. This is
+	// the unit of judge cost: a "skipped" decision never left the process.
+	Called bool `json:"called,omitempty"`
+	// FailClosed mirrors Verdict=="fail_closed" as a filterable flag.
+	FailClosed bool `json:"fail_closed,omitempty"`
+	// Error is the judge error text when FailClosed.
+	Error string `json:"error,omitempty"`
+	// LatencyMs is the judge call duration in milliseconds.
+	LatencyMs int64 `json:"latency_ms,omitempty"`
+	// PromptTokens estimates the judge's input tokens (byte/4, the same
+	// estimator the gateway uses elsewhere — never a tokenizer count).
+	PromptTokens int64 `json:"prompt_tokens,omitempty"`
 }
 
 // Recorder appends usage events to a JSONL file (0600, atomic rewrite via
@@ -91,8 +129,37 @@ type Summary struct {
 	SliceHits       int     // total slices hit and injected across turns
 	CostPaidUSD     float64 // what the user actually paid
 	CostNoCacheUSD  float64 // what it would cost without any cache
-	SavingsUSD      float64 // CostNoCache - CostPaid
+	SavingsUSD      float64 // CostNoCache - CostPaid, gross of judge cost
 	SavingsRate     float64 // Savings / CostNoCache (0 when no cost)
+
+	// Grey-zone judge accounting (Issue #242 gap 1). These describe a
+	// different model on a different channel, so they are reported
+	// separately and deliberately do NOT move SavingsUSD/SavingsRate —
+	// see JudgeCostUSD for the net figure.
+	JudgeDecisions    int   // grey-zone verifications recorded
+	JudgeCalls        int   // of those, ones that actually invoked the judge (billable)
+	JudgeApproved     int   // judge said the cached answer is reusable
+	JudgeDeclined     int   // judge said no (a real verdict)
+	JudgeFailClosed   int   // judge errored/timed out; rejection carries no verdict
+	JudgeSkipped      int   // rejected before the judge was reached (free)
+	JudgePromptTokens int64 // byte/4 estimate of tokens sent to the judge
+	JudgeLatencyMs    int64 // total time spent in judge calls
+}
+
+// JudgeCostUSD estimates what the grey-zone judge calls cost, at the judge
+// model's own input price per 1M tokens (Issue #242 gap 1).
+//
+// It is a separate call rather than a Summary field because the judge model
+// is configured independently of the served model ([cache] judge_model in
+// the gateway config) and its price is not derivable from this log. The
+// judge's completion is a single word — one to a handful of tokens, orders
+// of magnitude below the byte/4 estimator's own error — so only the input
+// side is modeled.
+//
+// Net savings = SavingsUSD - JudgeCostUSD(judgePrice). SavingsUSD itself
+// stays gross so the served-model arithmetic keeps one meaning.
+func (s *Summary) JudgeCostUSD(costPerMTok float64) float64 {
+	return float64(s.JudgePromptTokens) * costPerMTok / 1e6
 }
 
 // Summarize reads the log at path and computes the aggregate. Malformed
@@ -131,6 +198,26 @@ func Summarize(path string, costMiss, costHit float64) (*Summary, error) {
 			s.L3Reuses++
 			l3In += e.TokensIn
 			l3Out += e.TokensOut
+		}
+		for _, jd := range e.JudgeDecisions {
+			s.JudgeDecisions++
+			s.JudgeLatencyMs += jd.LatencyMs
+			if jd.Called {
+				// Only a reached judge sent a prompt upstream; a skipped
+				// decision must never inflate the cost estimate.
+				s.JudgeCalls++
+				s.JudgePromptTokens += jd.PromptTokens
+			}
+			switch jd.Verdict {
+			case "approved":
+				s.JudgeApproved++
+			case "declined":
+				s.JudgeDeclined++
+			case "fail_closed":
+				s.JudgeFailClosed++
+			case "skipped":
+				s.JudgeSkipped++
+			}
 		}
 	}
 	if err := sc.Err(); err != nil {


### PR DESCRIPTION
Closes #242

## 缺口 1（实质）：grey 区 judge 判定不落盘

GW4 验收（#184）里 t10 相对置信度 0.675、明确落在灰区，最终未命中——但**没有任何落盘证据**能区分「judge 判为不可复用」和「judge 调用失败/超时后 fail-closed」。次生影响是 judge 走网关自己的上游调用、不经 New API 渠道计费、网关也不记 usage，所以**judge 开销完全无法核算**，这就是验收报告 §6 那个 52.7% 带着说不清的口径缺口的原因。

### 做法

`kernel/cache/L3Decider` 增加一个可选的 `OnJudge` 钩子，每次灰区裁决发一条 `JudgeObservation`：候选 slice ID、把它推进灰区的 `score/top1`、判定、RuleGate 理由、judge 延迟、输入规模估算，以及 GW4 答不出的那一项——**这次结果是真判定还是 fail-closed 兜底**。

`Verdict` 刻意做成四态：
- `approved` / `declined` — 真判定
- `fail_closed` — 调用出错或超时
- `skipped` — 指纹门在 judge 之前就拒了，**什么都没计费**

`timedJudge` 包装器让「模型到底有没有被真的调用」变得可观测——那才是 judge 成本的计量单位。

**架构约束守住了**：钩子是依赖倒置而非写入。`go list -deps ./kernel/cache` 未变（仍只有 fingerprint/slice/zone/judge，无 event bus、无 gateway、无 harness），`kernel/usage` 保持 stdlib-only，`go.mod` 未动。

网关侧实现该钩子（`gateway/judge_observability.go`）：一条结构化日志 + 一个按 turn 的收集器（走私有 context value），汇入该 turn 产生的那条 usage 事件——L3 命中事件、普通透传事件、或两条流式事件中的任一条。`usage.Event` 增加 `judge` 数组；`usage.Summary` 增加 `JudgeDecisions/JudgeCalls/JudgeApproved/JudgeDeclined/JudgeFailClosed/JudgeSkipped/JudgePromptTokens/JudgeLatencyMs` 与 `JudgeCostUSD(pricePerMTok)` 方法。

**无 judge 的 turn 产生的 usage 行与此前逐字节一致**，已服务模型的节省率算式可证不变（有专门测试钉住这一点）。

## 缺口 2（文档）：New API 转发 SSE 时剥掉 `x-semantix-cache`

**网关侧没有改动**——它在流式路径上确实设了这个头。

对 issue 里的选项 (c)「查 New API 是否有透传自定义响应头的配置」，本 PR 给出源码级答案：New API 的非流式中继（`service.IOCopyBytesGracefully`）复制上游**除 Content-Length 和 request-id 外的全部头**，所以 `x-semantix-cache` 在非流式下能活；而 SSE 中继（`relay/helper.StreamScannerHandler` → `copyCodexSSEHeaders`）只复制一个**硬编码的两名白名单**（`X-Reasoning-Included`、`X-Codex-Turn-State`），然后写自己的 event-stream 头，其余一律丢弃。在验收所用的 `v1.0.0-rc.25` tag 上核对，并确认 main 相同。

**结论：SSE 下没有任何配置开关能放行自定义响应头，要放行必须给上游提 PR。**

文档落在两处：设计 spec 新增 §3.4.1（含两条路径的对照表）、`docs/QUICKSTART.md` 网关节新增「客户端怎么判断这次命中了没有」——非流式读响应头，流式读 usage 日志，并点名 judge 判定字段是流式意外未命中时第一个该看的东西。

选项 (a)（在首个 SSE chunk 里塞标记）记录为**否决**，理由是它改 wire 格式。

## Validation

- [x] `go build ./...`
- [x] `go vet ./kernel/cache/... ./kernel/usage/... ./gateway/...`
- [x] `go test ./kernel/cache/... ./kernel/usage/... ./gateway/...` 全绿（在当前 main `179b5c9` 上复验）
- [ ] `go test -race ./...` — 本机 Windows `CGO_ENABLED=0` 无 C 编译器，由 CI 执行。唯一有真实并发风险的是 `judgeCollector`，它是 per-request 且 mutex 保护

## 如实标注的限制

- **缺口 2 的 (c) 结论是读 New API 源码得出的**（GitHub API，tag `v1.0.0-rc.25`，并确认 main 相同），**不是**跑一个 New API 实例实测的。头被剥掉这个事实本身来自 GW4 验收的实测；两类证据在文档里分开表述，没有混为一谈。
- judge 的 prompt token 是 `bytes/4` 估算，与本仓既有的 `estimator: bytes/4` 政策一致（设计 §0.3 明确不引入 tokenizer）。

## 评审

本变更经独立对抗式评审（要求复核「失败测试是否真的先失败」、fail-closed 是否回退、是否越界、是否违反项目铁律、以及提交信息有没有说代码没做的事），结论 **ship，零阻断项**。4 条非阻断观察已记录在评审输出中，其中一条值得后续处理：`PromptBytes` 未计入 `kernel/judge/llm.go` 的固定 rubric 模板（实测 735 字节 ≈ 183 token），即 judge 成本估算系统性偏低一个常量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
