### PR TITLE
fix(gateway): bound pending SSE event data

### DIFF
--- a/gateway/sse.go
+++ b/gateway/sse.go
@@ -13,6 +13,12 @@ import (
 // without bound.
 const maxSSEAggregateBytes = 1 << 20 // 1 MiB
 
+// maxSSEPendingBytes bounds the data payload lines collected for one SSE
+// event before its terminating blank line. Without this separate bound, an
+// upstream could send many individually valid lines and grow pending without
+// ever reaching flushEvent.
+const maxSSEPendingBytes = maxSSEAggregateBytes
+
 // maxSSELineBytes bounds a single buffered SSE line. A pathological
 // upstream emitting one endless line (no newline) would otherwise grow
 // lineBuf without bound; crossing the bound also fails closed.
@@ -28,15 +34,16 @@ const maxSSELineBytes = 64 * 1024
 // affecting the relay. Only two facts matter to the caller — Complete()
 // (clean termination AND no overflow) and Content().
 type sseAggregator struct {
-	lineBuf  bytes.Buffer // partial line carried across Feed calls
-	pending  []string     // data payload lines of the event being assembled
-	content  strings.Builder
-	overflow bool
-	done     bool
-	sawUsage bool // a data event carried a top-level "usage" field
-	eventID  string // id of the first chat.completion.chunk event
-	limit    int // content aggregation bound
-	lineMax  int // per-line buffer bound
+	lineBuf      bytes.Buffer // partial line carried across Feed calls
+	pending      []string     // data payload lines of the event being assembled
+	pendingBytes int          // pending payload bytes, including join newlines
+	content      strings.Builder
+	overflow     bool
+	done         bool
+	sawUsage     bool   // a data event carried a top-level "usage" field
+	eventID      string // id of the first chat.completion.chunk event
+	limit        int    // content aggregation bound
+	lineMax      int    // per-line buffer bound
 }
 
 func newSSEAggregator(limit int) *sseAggregator {
@@ -66,6 +73,10 @@ func (a *sseAggregator) Feed(p []byte) {
 			return
 		}
 		a.handleLine(strings.TrimRight(line, "\r\n"))
+		if a.overflow {
+			a.lineBuf.Reset()
+			return
+		}
 	}
 }
 
@@ -75,7 +86,19 @@ func (a *sseAggregator) handleLine(line string) {
 		a.flushEvent()
 	case strings.HasPrefix(line, "data:"):
 		payload := strings.TrimPrefix(line, "data:")
-		a.pending = append(a.pending, strings.TrimPrefix(payload, " "))
+		payload = strings.TrimPrefix(payload, " ")
+		additional := len(payload)
+		if len(a.pending) > 0 {
+			additional++ // strings.Join inserts one newline between data lines
+		}
+		if a.pendingBytes+additional > maxSSEPendingBytes {
+			a.pending = nil
+			a.pendingBytes = 0
+			a.overflow = true
+			return
+		}
+		a.pending = append(a.pending, payload)
+		a.pendingBytes += additional
 	}
 	// event:/id:/retry: lines carry no payload; ignored.
 }
@@ -86,12 +109,13 @@ func (a *sseAggregator) flushEvent() {
 	}
 	payload := strings.Join(a.pending, "\n") // SSE joins multi-line data with \n
 	a.pending = nil
+	a.pendingBytes = 0
 	if payload == "[DONE]" {
 		a.done = true
 		return
 	}
 	var evt struct {
-		ID string `json:"id"`
+		ID      string `json:"id"`
 		Choices []struct {
 			Delta struct {
 				Content string `json:"content"`

--- a/gateway/sse_test.go
+++ b/gateway/sse_test.go
@@ -143,6 +143,33 @@ func TestSSEAggregatorLineOverflow(t *testing.T) {
 	}
 }
 
+func TestSSEAggregatorPendingOverflow(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	payload := strings.Repeat("x", maxSSELineBytes/2)
+
+	// Each data line stays below the per-line bound, but one event without a
+	// terminating blank line must not let pending payloads grow without bound.
+	for i := 0; i <= maxSSEAggregateBytes/(len(payload)+1); i++ {
+		feedAll(a, "data: "+payload+"\n")
+	}
+
+	if !a.Overflowed() {
+		t.Fatal("Overflowed() = false past the pending event bound, want true")
+	}
+	if a.Complete() {
+		t.Error("Complete() = true past the pending event bound, want false")
+	}
+	if len(a.pending) != 0 {
+		t.Errorf("len(pending) = %d after overflow, want 0", len(a.pending))
+	}
+
+	// Once overflowed, a later terminator must not make the stream complete.
+	feedAll(a, "\ndata: [DONE]\n\n")
+	if a.Complete() {
+		t.Error("Complete() = true after pending overflow, want false")
+	}
+}
+
 func TestSSEAggregatorSawUsage(t *testing.T) {
 	cases := []struct {
 		name   string


### PR DESCRIPTION
## Summary
- cap the accumulated `data:` payload for one unfinished SSE event at 1 MiB
- fail closed and release pending payloads when that bound is exceeded
- stop parsing the current buffer after any aggregator overflow
- add a regression test using many sub-64-KiB lines without a blank event terminator

## Validation
- `go test ./gateway -count=1 -race`
- `go vet ./...`
- `go test ./... -count=1` *(gateway passes; existing Windows-only failures remain in journal cleanup/POSIX permission tests outside this change)*
- `go test ./... -count=1 -race` *(gateway passes; same existing Windows journal cleanup/POSIX permission failures outside this change)*

Fixes #244