### PR TITLE
fix(harness): RoundPlan hard_stop 接上执行点——100% 档不再虚设 (#250)

### DIFF
--- a/harness/agent/budget_controller.go
+++ b/harness/agent/budget_controller.go
@@ -111,12 +111,15 @@ func (b *BudgetController) classify() string {
 	}
 }
 
-// budgetHardStopError returns the user-visible hard_stop message (U41 C3).
-// It is an explicit, non-silent error: the harness refuses the next tool round
-// and tells the user exactly how much was spent against the cap.
+// budgetHardStopError returns the user-visible hard_stop message (U41 C3),
+// shared by the local-account guard and the kernel RoundPlan path. It is an
+// explicit, non-silent error: the harness refuses the tool round and tells
+// the user exactly how much was spent against the cap. Without a local
+// controller (kernel-only wiring) the spend snapshot is unavailable, so the
+// message names the scheduler as the source instead.
 func (a *Agent) budgetHardStopError() error {
 	if a == nil || a.budgetCtrl == nil {
-		return fmt.Errorf("budget exhausted")
+		return fmt.Errorf("budget exhausted: scheduler issued hard_stop; no further tool calls will be issued")
 	}
 	snap := a.budgetCtrl.Snapshot()
 	return fmt.Errorf("budget exhausted: spent $%.4f of the $%.4f %s limit; no further tool calls will be issued",

--- a/harness/agent/budget_controller_test.go
+++ b/harness/agent/budget_controller_test.go
@@ -101,7 +101,7 @@ func TestBudgetHardStopErrorNoController(t *testing.T) {
 	if err := (&Agent{}).budgetHardStopError(); err == nil {
 		t.Fatal("expected a fallback error without a controller")
 	}
-	if err := (&Agent{}).budgetHardStopError(); err.Error() != "budget exhausted" {
+	if err := (&Agent{}).budgetHardStopError(); err.Error() != "budget exhausted: scheduler issued hard_stop; no further tool calls will be issued" {
 		t.Errorf("fallback error = %q", err.Error())
 	}
 }

--- a/harness/agent/execute_batch.go
+++ b/harness/agent/execute_batch.go
@@ -105,6 +105,11 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 	// scheduler is wired (nil), the static grouping is used unchanged.
 	plan := a.decideRound(ctx, calls)
 	suspended := suspendedToolSet(plan.SuspendTools)
+	// U41 C3 hard_stop (kernel path): a plan-issued hard_stop blocks every
+	// call in this round before any tool runs. Outcomes stay paired with the
+	// stored assistant tool calls; handleToolRound terminates the run after
+	// persisting them.
+	planHardStop := plan.BudgetAction == sched.BudgetActionHardStop
 
 	results := make([]string, len(calls))
 	outcomes := make([]toolOutcome, len(calls))
@@ -124,6 +129,12 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 	earlierWriterRan := false
 	surfaceWriters := make([]bool, len(calls))
 	run := func(i int) {
+		if planHardStop {
+			const msg = "blocked: window budget exhausted (scheduler hard_stop)"
+			outcomes[i] = toolOutcome{output: msg, blocked: true, errMsg: msg}
+			results[i] = msg
+			return
+		}
 		if _, blocked := suspended[calls[i].Name]; blocked {
 			const msg = "suspended by scheduler"
 			outcomes[i] = toolOutcome{output: msg, blocked: true, errMsg: msg}

--- a/harness/agent/run_loop.go
+++ b/harness/agent/run_loop.go
@@ -642,10 +642,11 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 		return false, boundaryErr
 	}
 
-	// U41 C3 hard_stop: the window budget is exhausted — refuse the new tool
-	// round and surface a user-visible error (never swallowed silently). The
-	// local controller is the fallback; the kernel scheduler may have already
-	// issued the same action via DecideRound (whoever fires first wins).
+	// U41 C3 hard_stop, local-account path: the window budget is exhausted —
+	// refuse the new tool round before dispatch and surface a user-visible
+	// error (never swallowed silently). The kernel path is separate: a
+	// hard_stop carried on the RoundPlan blocks the round inside executeBatch
+	// and terminates below, after the paired tool results are stored.
 	if a.budgetCtrl != nil && a.budgetCtrl.Action() == sched.BudgetActionHardStop {
 		return false, a.budgetHardStopError()
 	}
@@ -655,7 +656,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 		receiptMark = a.task.ledger.Len()
 	}
 	batch := a.executeBatch(ctx, state, calls)
-	if batch.Tier != "" {
+	if batch.Tier != "" && batch.BudgetAction != sched.BudgetActionHardStop {
 		a.applyScheduledTier(batch.Tier, batch.BudgetAction)
 	}
 	results, images := batch.results, batch.images
@@ -682,6 +683,13 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 	if ctx.Err() != nil {
 		a.recordInterruptedDisplay("", "", nil, true, state.workDurationMs())
 		return false, ctx.Err()
+	}
+	// U41 C3 hard_stop, kernel path: the scheduler's RoundPlan carried
+	// hard_stop, so executeBatch blocked every call in this round without
+	// executing tools. Paired tool results are stored above; terminate the
+	// run with the same user-visible budget error as the local path.
+	if batch.BudgetAction == sched.BudgetActionHardStop {
+		return false, a.budgetHardStopError()
 	}
 	if len(unavailableContextTools) > 0 {
 		if hasVisibleFinalAnswer(text) {

--- a/harness/agent/scheduler_integration_test.go
+++ b/harness/agent/scheduler_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -73,6 +74,52 @@ func TestSchedulerSuspendThenRecover(t *testing.T) {
 	recovered := a.executeBatch(context.Background(), &turnRuntime{}, []provider.ToolCall{{ID: "c2", Name: "read_file", Arguments: `{}`}})
 	if recovered.results[0] != "ok" || target.runs.Load() != 1 {
 		t.Fatalf("tool did not recover: result=%q runs=%d", recovered.results[0], target.runs.Load())
+	}
+}
+
+// TestPlanHardStopBlocksRound is the Issue #250 regression: a hard_stop
+// carried on the scheduler's RoundPlan must block every call in the round
+// before any tool executes — not just be copied into the batch and ignored.
+func TestPlanHardStopBlocksRound(t *testing.T) {
+	reg := tool.NewRegistry()
+	target := &testTool{name: "read_file"}
+	reg.Add(target)
+	d := &sequenceDecider{plans: []sched.RoundPlan{
+		{BudgetAction: sched.BudgetActionHardStop},
+		{}, // control round: no budget action
+	}}
+	a := New(nil, reg, NewSession(""), Options{Decider: d}, event.Discard)
+
+	calls := []provider.ToolCall{
+		{ID: "c1", Name: "read_file", Arguments: `{}`},
+		{ID: "c2", Name: "read_file", Arguments: `{}`},
+	}
+	stopped := a.executeBatch(context.Background(), &turnRuntime{}, calls)
+	if stopped.BudgetAction != sched.BudgetActionHardStop {
+		t.Fatalf("batch did not carry hard_stop: %+v", stopped.BudgetAction)
+	}
+	if target.runs.Load() != 0 {
+		t.Fatalf("hard_stop round executed %d tool calls", target.runs.Load())
+	}
+	for i, o := range stopped.outcomes {
+		if !o.blocked || o.errMsg == "" {
+			t.Fatalf("call %d not blocked under hard_stop: %+v", i, o)
+		}
+	}
+
+	control := a.executeBatch(context.Background(), &turnRuntime{}, []provider.ToolCall{{ID: "c3", Name: "read_file", Arguments: `{}`}})
+	if control.results[0] != "ok" || target.runs.Load() != 1 {
+		t.Fatalf("control round did not execute: result=%q runs=%d", control.results[0], target.runs.Load())
+	}
+}
+
+// TestPlanHardStopError covers the kernel-only wiring: no local controller,
+// so the terminal error names the scheduler as the source.
+func TestPlanHardStopError(t *testing.T) {
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	err := a.budgetHardStopError()
+	if err == nil || !strings.Contains(err.Error(), "scheduler issued hard_stop") {
+		t.Fatalf("kernel-path error missing scheduler attribution: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 问题

#250：kernel 调度器经 `RoundPlan.BudgetAction` 下发的 `hard_stop` 全仓无人读取——`executeBatch` 只把它透传进返回值，工具照常执行整轮；`run_loop.go` 的守卫只读本地 `budgetCtrl`，注释却声称 kernel 路径存在（「谁先触发谁生效」）。

## 修复

- **executeBatch**：plan 携带 `hard_stop` 时在任何工具执行前拦截整轮——每个 call 记 blocked outcome（`blocked: window budget exhausted (scheduler hard_stop)`），与已入会话的 assistant tool_call 保持配对（沿用 suspended 通路的形态）
- **handleToolRound**：配对结果写入会话后以 `budgetHardStopError` 终止 run（user-visible，非静默）；`hard_stop` 下跳过 `applyScheduledTier`
- **注释修正**：本地账守卫（批前）与 kernel plan 路径（批内拦截+批后终止）各自写实
- **budgetHardStopError**：无控制器分支（仅 kernel-only 接线可达）文案改为指明调度器来源

## 测试

- `TestPlanHardStopBlocksRound`：hard_stop 轮零工具执行、全 call blocked、下一轮正常（回归 #250）
- `TestPlanHardStopError`：kernel-only 接线的错误归因
- `go test ./harness/agent/ -race` 全绿（含既有 fallback 文案断言同步）

Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)