### PR TITLE
fix(harness): attribute each multi-tool result to its own call ID

### DIFF
--- a/harness/semantix/sink.go
+++ b/harness/semantix/sink.go
@@ -63,9 +63,9 @@ type HarnessSink struct {
 	first  string // user text of the current turn
 	text   string // assistant text buffer
 	reason string // reasoning buffer
-	tools  []toolCallLine
-	output string // last tool output (filled by ToolResult)
-	err    error
+	tools   []toolCallLine
+	outputs map[string]string // tool output keyed by tool call ID (filled by ToolResult)
+	err     error
 }
 
 // NewHarnessSink creates the sink, creating the sessions dir (0700).
@@ -126,10 +126,14 @@ func (s *HarnessSink) Emit(e event.Event) {
 		}
 		s.tools = append(s.tools, toolCallLine{ID: e.Tool.ID, Name: e.Tool.Name, Arguments: args})
 	case event.ToolResult:
-		s.output = e.Tool.Output
+		out := e.Tool.Output
 		if e.Tool.Err != "" {
-			s.output = e.Tool.Err
+			out = e.Tool.Err
 		}
+		if s.outputs == nil {
+			s.outputs = make(map[string]string)
+		}
+		s.outputs[e.Tool.ID] = out
 	case event.TurnDone:
 		s.flushLocked()
 		s.turn = false
@@ -149,14 +153,14 @@ func (s *HarnessSink) flushLocked() {
 		lines = append(lines, sessionLine{Role: "assistant", Content: s.text, ToolCalls: s.tools})
 	}
 	for _, t := range s.tools {
-		content := s.output
+		content := s.outputs[t.ID]
 		if content == "" {
 			content = "(tool output)"
 		}
 		lines = append(lines, sessionLine{Type: "tool", ToolCall: t.ID, Name: t.Name, Content: content})
 	}
 	s.first = ""
-	s.output = ""
+	s.outputs = nil
 	for _, ln := range lines {
 		b, err := json.Marshal(ln)
 		if err != nil {

--- a/harness/semantix/sink_test.go
+++ b/harness/semantix/sink_test.go
@@ -1,0 +1,109 @@
+package semantix
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/harness/event"
+)
+
+// readSessionLines reads a session JSONL file back into sessionLine values.
+func readSessionLines(t *testing.T, path string) []sessionLine {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var lines []sessionLine
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) == "" {
+			continue
+		}
+		var ln sessionLine
+		if err := json.Unmarshal(sc.Bytes(), &ln); err != nil {
+			t.Fatalf("line %q: %v", sc.Text(), err)
+		}
+		lines = append(lines, ln)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return lines
+}
+
+// toolLine picks the tool line with the given call ID from its turn's lines.
+func toolLine(t *testing.T, lines []sessionLine, callID string) sessionLine {
+	t.Helper()
+	for _, ln := range lines {
+		if ln.Type == "tool" && ln.ToolCall == callID {
+			return ln
+		}
+	}
+	t.Fatalf("no tool line for call ID %q in %d lines", callID, len(lines))
+	return sessionLine{}
+}
+
+// TestSinkMultipleToolResultsEachCarryOwnOutput is the regression for #252: a
+// turn with several tool calls must emit one tool line per call, each carrying
+// that call's own result — not the last result for every call.
+func TestSinkMultipleToolResultsEachCarryOwnOutput(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewHarnessSink(dir, "multi-tool", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	emit := func(k event.Kind, tool event.Tool) {
+		s.Emit(event.Event{Kind: k, Tool: tool})
+	}
+	emit(event.TurnStarted, event.Tool{})
+	// readA gets its own result, then readB gets a different one.
+	emit(event.ToolDispatch, event.Tool{ID: "ta", Name: "readA", Args: "{}"})
+	emit(event.ToolResult, event.Tool{ID: "ta", Output: "OUTPUT-A"})
+	emit(event.ToolDispatch, event.Tool{ID: "tb", Name: "readB", Args: "{}"})
+	emit(event.ToolResult, event.Tool{ID: "tb", Output: "OUTPUT-B"})
+	emit(event.TurnDone, event.Tool{})
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := readSessionLines(t, filepath.Join(dir, "multi-tool.jsonl"))
+	if got := toolLine(t, lines, "ta").Content; got != "OUTPUT-A" {
+		t.Errorf("readA content = %q, want %q (must not be overwritten by readB)", got, "OUTPUT-A")
+	}
+	if got := toolLine(t, lines, "tb").Content; got != "OUTPUT-B" {
+		t.Errorf("readB content = %q, want %q", got, "OUTPUT-B")
+	}
+}
+
+// TestSinkToolResultErrorUsesErrText verifies an errored tool stores the Err
+// text on its own line and a call without a result falls back to the placeholder.
+func TestSinkToolResultErrorUsesErrText(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewHarnessSink(dir, "tool-err", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Emit(event.Event{Kind: event.TurnStarted})
+	s.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "t1", Name: "failing", Args: "{}"}})
+	s.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "t1", Output: "partial", Err: "boom"}})
+	s.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "t2", Name: "nominal", Args: "{}"}})
+	// t2 is dispatched but gets no ToolResult before the turn ends.
+	s.Emit(event.Event{Kind: event.TurnDone})
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := readSessionLines(t, filepath.Join(dir, "tool-err.jsonl"))
+	if got := toolLine(t, lines, "t1").Content; got != "boom" {
+		t.Errorf("t1 content = %q, want %q (Err text)", got, "boom")
+	}
+	if got := toolLine(t, lines, "t2").Content; got != "(tool output)" {
+		t.Errorf("t2 content = %q, want %q (placeholder for missing result)", got, "(tool output)")
+	}
+}


### PR DESCRIPTION
﻿fix(harness): attribute each multi-tool result to its own call ID

Closes #252

## Problem

`HarnessSink` used a single shared `s.output` field, overwritten by every
`ToolResult`. `flushLocked` then wrote that one field onto **every** tool
line, so when a turn had multiple tool calls (`readA` → `OUT-A` → `readB`
→ `OUT-B`) both tool lines ended up carrying the **last** result
(`OUT-B`), mis-attributing tool output to the wrong tool call.

## Fix

Replace the shared `s.output` field with a per-call-ID map
(`outputs[callID]`):
- `ToolResult` stores its content under `e.Tool.ID`.
- `flushLocked` reads `outputs[t.ID]` for each tool line.
- The map is reset at the end of each turn, so results never leak across
  turns.

## Tests

Added `harness/semantix/sink_test.go` (regression for #252):
- two calls with distinct results emit their own content on each tool
  line;
- an errored call stores its `Err` text;
- a dispatched call with no `ToolResult` falls back to the
  `(tool output)` placeholder.

The multi-tool test is confirmed to **fail on the pre-fix sink.go**
(`readA content = "OUTPUT-B"`) and pass after the fix.

## Note

`TestBridgeReuse*` in the same package fail on Windows with a SQLite
`project.db.journal` temp-dir lock; that reproduces identically on a
clean `origin/main` and is unrelated to this change.
