### PR TITLE
fix(prefetch): age complementary hit and waste feedback

### DIFF
--- a/docs/specs/issue-255-prefetch-feedback-decay.md
+++ b/docs/specs/issue-255-prefetch-feedback-decay.md
@@ -1,0 +1,48 @@
+# Spec: prefetch feedback decay (Issue 255)
+
+Issue 62 defines the offline Planner MVP. This addendum defines the online
+`MatrixPrefetcher` hit/waste feedback semantics without changing the frozen
+`Prefetcher` interface.
+
+## Problem
+
+Hit and waste were previously updated as independent positive-only EWMAs. A
+candidate with an old hit EWMA above `1 / WasteHitLimit` could therefore never
+be demoted: repeated waste approached 1 while the hit value never aged.
+
+## Feedback stream
+
+For decay factor `alpha`, every observation updates both sides of one binary
+feedback stream:
+
+```text
+hit:   hit = EWMA(hit, 1, alpha); waste = EWMA(waste, 0, alpha)
+waste: hit = EWMA(hit, 0, alpha); waste = EWMA(waste, 1, alpha)
+```
+
+This mirrors the complementary EWMA already consumed by `kernel/evolve`.
+Unobserved candidates keep their current state.
+
+## Decision rule
+
+The existing N12 rule remains authoritative:
+
+- zero waste is never demoted;
+- waste with zero hits is demoted;
+- otherwise demote when `waste / hit > WasteHitLimit` (default `3.0`).
+
+The strict `>` comparison and public configuration defaults do not change.
+Repeated waste must eventually demote a formerly healthy candidate, while
+later hits may restore it once the ratio returns below the limit.
+
+## Acceptance
+
+- A candidate with established hit history is demoted after sustained waste.
+- One waste observation does not demote an otherwise healthy candidate.
+- Sustained hits can recover a candidate with prior waste history.
+- `go test -race ./kernel/prefetch` passes.
+
+## Non-goals
+
+This change does not add a sliding window, persist feedback, tune the default
+threshold, alter transition probabilities, or change scheduling interfaces.

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -210,6 +210,7 @@ func (m *MatrixPrefetcher) ObserveHit(key string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.hit[key] = ewma(m.hit[key], 1, m.cfg.Decay)
+	m.waste[key] = ewma(m.waste[key], 0, m.cfg.Decay)
 }
 
 // ObserveWaste marks a planned prefetch as wasted (the predicted tool was
@@ -217,6 +218,7 @@ func (m *MatrixPrefetcher) ObserveHit(key string) {
 func (m *MatrixPrefetcher) ObserveWaste(key string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.hit[key] = ewma(m.hit[key], 0, m.cfg.Decay)
 	m.waste[key] = ewma(m.waste[key], 1, m.cfg.Decay)
 }
 

--- a/kernel/prefetch/matrix_test.go
+++ b/kernel/prefetch/matrix_test.go
@@ -156,6 +156,46 @@ func TestWastePenaltyAllowsHealthyCandidate(t *testing.T) {
 	}
 }
 
+func TestWastePenaltyDemotesStaleHealthyCandidate(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{WasteHitLimit: 3.0})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "read_file", true)
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveHit("read_file")
+	}
+	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 1 {
+		t.Fatalf("healthy candidate must start eligible, got %v", tasks)
+	}
+
+	for i := 0; i < 15; i++ {
+		m.ObserveWaste("read_file")
+	}
+	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
+		t.Fatalf("sustained waste must age stale hits and demote candidate, got %v", tasks)
+	}
+}
+
+func TestWastePenaltyRecoversAfterSustainedHits(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{WasteHitLimit: 0.5})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "read_file", true)
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("read_file")
+	}
+	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
+		t.Fatalf("waste-only candidate must start demoted, got %v", tasks)
+	}
+
+	for i := 0; i < 15; i++ {
+		m.ObserveHit("read_file")
+	}
+	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 1 {
+		t.Fatalf("sustained hits must age stale waste and restore candidate, got %v", tasks)
+	}
+}
+
 // --- determinism & concurrency ---
 
 func TestPlanDeterministicOrder(t *testing.T) {


### PR DESCRIPTION
## Summary

- define complementary hit/waste EWMA semantics for the online prefetcher
- decay stale hit history on waste and stale waste history on hit
- cover both eventual demotion and recovery with regression tests

## Why

`ObserveHit` and `ObserveWaste` previously updated separate positive-only EWMAs. Once a candidate accumulated enough hit history, repeated waste could never make `waste / hit` exceed the N12 threshold because the hit value never aged.

## Verification

- confirmed both new regression tests fail on the old implementation
- `go test ./kernel/prefetch -count=1`
- `go test -race ./kernel/prefetch -count=1`
- `go test ./kernel/prefetch -count=20`
- `go vet ./kernel/prefetch`
- reviewed the complete base-to-head diff after implementation

`go test ./kernel/... -count=1` reaches an unrelated existing Windows file-lock failure in `kernel/slice.TestJournalForwardCompat`; all other kernel packages pass.

Closes #255