### PR TITLE
feat(evolve+prefetch): absorbing-state escape + TauL2/SuccessFloor split (#254)

### DIFF
--- a/docs/specs/issue-254-evolve-absorbing-escape.md
+++ b/docs/specs/issue-254-evolve-absorbing-escape.md
@@ -98,9 +98,9 @@ prefetchHitEWMA / prefetchWasteEWMA 更新 → maybeAdjustLocked ─→ 抬降 P
   ε 探针仅覆盖「有知识但被阈值过滤」的吸收态，不引入无意义探测。
 - **随机源**：注入 `*rand.Rand`（可选）或 `math/rand`，供测试用固定种子保证确定性。
 
-**ε 默认与语义**：evolve 侧新增常量 `DefaultEpsilon`（取 `0.1`）与 `Params` 不直接暴露 ε
-（ε 是链路级开关，不是每个会话快照要暴露的目标参数；接线处 `ApplyEvolution` 携带即可，
-见 §3.3）。
+**ε 默认与语义**：`Epsilon` 是 prefetch 的 `Config` 字段（默认 `0`，关闭）。harness 接线层在
+`harness/semantix/evolution.go` 定义 `EscapeEpsilon = 0.1` 并通过类型断言 `interface{ SetEpsilon }`
+启用（见 §3.3）。`Params` 不直接暴露 ε——ε 是链路级开关，不是每个会话快照要暴露的目标参数。
 
 ### 3.2 TauL2 / SuccessFloor 拆分
 
@@ -122,14 +122,15 @@ if l.scheduler != nil {
     _ = l.scheduler.ApplyEvolution(after.SuccessFloor) // 行为门
 }
 if l.prefetcher != nil {
-    // 由 pref.getter 类型断言拿到 Epsilon 设置；或 MatrixPrefetcher 暴露 SetEpsilon
     _ = l.prefetcher.ApplyEvolution(after.PrefetchConf)
-    _ = l.setPrefetchEpsilon(DefaultEpsilon)          // 开启逃逸
+}
+if eps, ok := l.prefetcher.(interface{ SetEpsilon(float64) error }); ok {
+    _ = eps.SetEpsilon(EscapeEpsilon) // 开启吸收态逃逸（0.1）
 }
 ```
 
-> `setPrefetchEpsilon` 为窄接口（`interface{ SetEpsilon(float64) }` 类型断言），避免改
-> `EvolutionTuner` 冻结接口。
+> `SetEpsilon` 通过窄接口类型断言调用（`MatrixPrefetcher` 实现），避免修改 `EvolutionTuner`
+> 冻结接口。scheduler 侧由 `after.SuccessFloor` 驱动，`TauL2` 不再越界到行为门。
 
 ### 3.4 包结构与改动面
 
@@ -146,11 +147,13 @@ harness/semantix/evolution_test.go # 参数拆分接线测试
 ## 4. 测试
 
 - `TestPlanEpsilonProbeEscapesAbsorbingState`（`kernel/prefetch/escape_test.go`）：
-  构造 `MinConf` 高、候选 prob 低 → 正常 Plan 空；设固定种子 + `Epsilon=1.0`（或高值）→
-  Plan 返回 1 个 `probe`（最高 prob 候选）；确认探针计入预算、`Epsilon=0`（默认）时行为不变。
+  构造 `MinConf` 高、候选 prob 低 → 正常 Plan 空；`Epsilon=1.0` → Plan 返回 1 个 `probe`
+  （最高 prob、非 demoted 的候选）；确认探针计入预算、`Epsilon=0`（默认）时行为不变。
+- `TestPlanEpsilonZeroKeepsEmptyPlan`：`Epsilon=0`（默认）时保持空计划（向后兼容）。
 - `TestPlanEpsilonRespectsNoData`：无转移知识时即使 `ε=1` 也返回空（不引入无意义探测）。
-- `TestEvolveSplitSuccessFloorWiring`（`harness/semantix/evolution_test.go`）：参数变化后
-  `scheduler` 收到的是 `after.SuccessFloor` 而非 `after.TauL2`。
+- `TestPlanEpsilonSkipsDemotedCandidates`：被 waste/hit 降级的候选不被选为探针。
+- `TestEvolveSchedulerReceivesSuccessFloor`（`harness/semantix/evolution_test.go`）：参数变化后
+  `scheduler` 收到的是 `after.SuccessFloor`（默认 0.7）而非 `after.TauL2`。
 - 既有 `TestApplyEvolutionChangesNextPlanConfidence` 保持通过（默认 `Epsilon=0` 向后兼容）。
 
 ## 5. 后续候选（不在本轮）

--- a/docs/specs/issue-254-evolve-absorbing-escape.md
+++ b/docs/specs/issue-254-evolve-absorbing-escape.md
@@ -1,0 +1,167 @@
+# Spec：evolve 闭环吸收态逃逸（ε-探索）+ TauL2/SuccessFloor 参数拆分（Issue 254）
+
+> 对应 Issue：`#254 evolve 闭环吸收态：conf 关停预取后信号流消失、参数永久冻结`
+> 真源约束：`Prefetcher` 接口冻结于 `kernel/prefetch/prefetch.go`（不改签名）；`evolve.Engine`
+> 接口冻结于 `kernel/evolve/evolve.go`（不改方法集）。
+> 架构基线：`docs/Agent-Infra-架构设计.md` §5.2（T-Slice 转移概率、只读预取、预算控制）与
+> `docs/specs/issue-62-prefetch-planner.md`（预取计划器 MVP）。
+> 证据来源：`docs/reports/agile2-evolution-curve.md` 实验 2（ON/OFF 因果对照，churn 场景）。
+>
+> **状态（2026-08-21）**：本文档为 Issue 254 实现规格，先审后写。
+
+## 1. 目标与范围
+
+**核心目标**：解决 evolve 闭环的**吸收态死锁**——当 `PrefetchConf` 被抬升越过全部候选转移
+概率后，`Plan` 返回空 → 不再产生 `PrefetchHit/Waste` 事件 → 引擎再无信号 → `PrefetchConf`
+永久冻结在关停位，churn 结束后无法自动恢复预取。同时**拆分**被错误复用的单一旋钮
+`TauL2 → SuccessFloor`，让两个量纲不同的阈值各归其位。
+
+**范围内**：
+
+- `kernel/prefetch/matrix.go`：ε-探索——在「存在候选但全部低于 `MinConf`」时，以概率 `ε`
+  放行最高转移概率的候选作为探针，维持最小 hit/waste 信号流。
+- `kernel/evolve/evolve.go`（`Params`）：新增独立 `SuccessFloor` 字段并与 `TauL2` 解耦；
+  新增 ε 相关常量/接线。
+- `harness/semantix/evolution.go`：把 `SuccessFloor` 单独喂给 `sched.RuleDecider`，不再复用
+  `TauL2`；把 ε 传给 `prefetch.MatrixPrefetcher`。
+- 回归测试：分别覆盖「吸收态逃逸」与「参数拆分接线」。
+- spec 文档：本文档。
+
+**不在范围内**（后续单元，本 PR 不实现）：
+
+- 文献调研 §9 建议 5 的**conf 时间衰减**与**旁路信号**两种逃逸机制（本轮仅选 ε-探索；
+  其余作为后续候选，见 §5）。
+- `demoted()` 对纯 waste 流的免疫缺陷（`WasteHitLimit` 门槛下的历史优等生不降级）——
+  属另一 issue，不随本 PR。
+- `PrefetchHit/Waste` 事件契约变更（事件类型已冻结，不改）。
+- `kernel/prefetch/prefetch.go` 接口签名变更（冻结）。
+
+## 2. 背景与根因
+
+### 2.1 闭环链路（现状）
+
+```
+PrefetchConf ─(ApplyEvolution)→ MatrixPrefetcher.cfg.MinConf
+     └──(min)──┐
+               ▼
+Plan(last) ──过滤 prob < MinConf──→ 候选列表 → PrefetchTask[]（可能为空）
+               │
+               ▼
+     （有任务才） PrefetchHit / PrefetchWaste 事件
+               │
+               ▼
+EvolutionLoop.observe ──(仅这两事件)──→ evolve.RecordSignal(prefetch_hit|prefetch_waste)
+               │
+               ▼
+prefetchHitEWMA / prefetchWasteEWMA 更新 → maybeAdjustLocked ─→ 抬降 PrefetchConf
+```
+
+### 2.2 吸收态机制
+
+1. `PrefetchConf` 被抬升（churn 期纯 waste 流触发 `PrefetchConf += PrefetchStep`），越过
+   所有真实转移概率。
+2. `Plan` 对每个候选 `prob < MinConf` 直接 `continue`（`matrix.go`），候选集为空 → 返回
+   空任务。
+3. 空计划 → 无实际预取 → 无 `PrefetchHit/Waste` 事件。
+4. `EvolutionLoop.observe` **只**由这两类事件驱动 `RecordSignal`（`evolution.go`），事件
+   停发 → 引擎的 `prefetchHitEWMA`/`prefetchWasteEWMA` **不再更新**（EWMA 只在有新信号时
+   折叠）。
+5. `maybeAdjustLocked` 对 `PrefetchConf` 的判断依赖这两个 EWMA 的大小关系；二者静止 →
+   判断分支不触发 → `PrefetchConf` **永久冻结**。
+
+**实证**（`agile2-evolution-curve.md` 实验 2，ON 组数据表）：第 21-25 会话 `conf` 恒为
+`0.550`，且 `hit=waste=0`——信号消失、参数冻结，churn 结束后预取未自动恢复。
+
+### 2.3 语义耦合（PR #228 评审点 4）
+
+`TauL2` 的语义是「注入 slice 的高置信**相对置信阈值**」（驱动 `zone.TauLow`，量纲≈相似度/置信）。
+`SuccessFloor` 的语义是「只读工具成功率的**行为门**」（量纲=成功率 0-1）。
+现状 `evolution.go:99` 直接 `scheduler.ApplyEvolution(after.TauL2)`——同一数值被用来同时
+控制两个不同量纲的门，二者强耦合，互相污染调参语义。
+
+## 3. 设计
+
+### 3.1 ε-探索（吸收态逃逸）
+
+**目标**：保证「有候选但被 `MinConf` 全部过滤」时，只要 `ε > 0`，预取流**不会长期归零**，
+从而让 hit/waste 信号回流、`PrefetchConf` 有机会下行。
+
+**实现**（`kernel/prefetch/matrix.go`）：
+
+- `Config` 新增 `Epsilon float64`（默认 `0`，**向后兼容**：默认关闭，现有行为不变；由
+  evolve 闭环接线时显式开启）。
+- `Plan` 中，当「正常候选集为空 **且** 存在因 `prob < MinConf` 被过滤的候选」时：
+  - 记录被过滤候选中 `prob` 最高者作为 `probe`；
+  - 以概率 `ε`（`rand.Float64() < ε`）放行 `probe`，纳入返回任务。
+- 探针任务照常计入 `Cost` 与 `TopK` 预算（与普通候选等权），不特判，避免破坏预算语义。
+- **边界**：完全无转移知识（`total==0 || len(transitions)==0`）返回空，**不做** ε 探测——
+  ε 探针仅覆盖「有知识但被阈值过滤」的吸收态，不引入无意义探测。
+- **随机源**：注入 `*rand.Rand`（可选）或 `math/rand`，供测试用固定种子保证确定性。
+
+**ε 默认与语义**：evolve 侧新增常量 `DefaultEpsilon`（取 `0.1`）与 `Params` 不直接暴露 ε
+（ε 是链路级开关，不是每个会话快照要暴露的目标参数；接线处 `ApplyEvolution` 携带即可，
+见 §3.3）。
+
+### 3.2 TauL2 / SuccessFloor 拆分
+
+- `kernel/evolve/evolve.go`：
+  - `Params` 新增 `SuccessFloor float64 \`json:"success_floor"\``；
+  - 初始默认 `DefaultSuccessFloor = 0.7`（与 `sched.RuleDecider` 现有默认一致）；
+  - `New` 支持 `Config.SuccessFloor` 覆盖。
+- `harness/semantix/evolution.go`：
+  - `l.scheduler.ApplyEvolution(after.TauL2)` → `l.scheduler.ApplyEvolution(after.SuccessFloor)`；
+  - 不再用 `TauL2` 驱动行为门。
+- `TauL2` 继续只驱动 `zone.TauLow`（注入置信），语义不再越界。
+
+### 3.3 接线（evolution.go）
+
+`EvolutionLoop.observe` 在参数变化后把两个自由度分别下发：
+
+```go
+if l.scheduler != nil {
+    _ = l.scheduler.ApplyEvolution(after.SuccessFloor) // 行为门
+}
+if l.prefetcher != nil {
+    // 由 pref.getter 类型断言拿到 Epsilon 设置；或 MatrixPrefetcher 暴露 SetEpsilon
+    _ = l.prefetcher.ApplyEvolution(after.PrefetchConf)
+    _ = l.setPrefetchEpsilon(DefaultEpsilon)          // 开启逃逸
+}
+```
+
+> `setPrefetchEpsilon` 为窄接口（`interface{ SetEpsilon(float64) }` 类型断言），避免改
+> `EvolutionTuner` 冻结接口。
+
+### 3.4 包结构与改动面
+
+```
+kernel/prefetch/matrix.go       # Config.Epsilon、Plan ε 探针、DefaultEpsilon 挂靠处
+kernel/evolve/evolve.go         # Params.SuccessFloor、DefaultSuccessFloor、Config 字段
+harness/semantix/evolution.go   # 拆分接线 + ε 下发
+docs/specs/issue-254-evolve-absorbing-escape.md   # 本文档
+kernel/prefetch/matrix_test.go  # ε 逃逸回归（可选新增文件）
+kernel/prefetch/escape_test.go  # 新增：吸收态逃逸确定性测试
+harness/semantix/evolution_test.go # 参数拆分接线测试
+```
+
+## 4. 测试
+
+- `TestPlanEpsilonProbeEscapesAbsorbingState`（`kernel/prefetch/escape_test.go`）：
+  构造 `MinConf` 高、候选 prob 低 → 正常 Plan 空；设固定种子 + `Epsilon=1.0`（或高值）→
+  Plan 返回 1 个 `probe`（最高 prob 候选）；确认探针计入预算、`Epsilon=0`（默认）时行为不变。
+- `TestPlanEpsilonRespectsNoData`：无转移知识时即使 `ε=1` 也返回空（不引入无意义探测）。
+- `TestEvolveSplitSuccessFloorWiring`（`harness/semantix/evolution_test.go`）：参数变化后
+  `scheduler` 收到的是 `after.SuccessFloor` 而非 `after.TauL2`。
+- 既有 `TestApplyEvolutionChangesNextPlanConfidence` 保持通过（默认 `Epsilon=0` 向后兼容）。
+
+## 5. 后续候选（不在本轮）
+
+- **conf 时间衰减**：无 hit/waste 信号 N epoch 后向默认值回归（需 evolve 增加「无信号」检测）。
+- **旁路信号**：从工具实际执行流（非预取路径）补充转移观测，矩阵计数已做，仅 conf 缺逃逸。
+- **`demoted()` 免疫修复**：hit EWMA 冷冻结、`WasteHitLimit` 下永不降级的问题。
+
+## 6. 验收
+
+- [ ] ε-探索：构造吸收态场景，`ε>0` 下 Plan 能周期性返回探针并触发 hit/waste 回流；`ε=0` 行为与现状一致。
+- [ ] 参数拆分：`evolution.go` 不再把 `TauL2` 当 `SuccessFloor` 下发；`Params` 含 `success_floor` 字段。
+- [ ] 全部相关测试通过：`go test ./kernel/evolve ./kernel/prefetch ./harness/semantix`。
+- [ ] spec（本文档）已先行合入并审阅。

--- a/harness/semantix/evolution.go
+++ b/harness/semantix/evolution.go
@@ -17,6 +17,11 @@ type EvolutionTuner interface {
 	ApplyEvolution(float64) error
 }
 
+// EscapeEpsilon is the prefetch absorbing-state escape probability the
+// harness wires into a MatrixPrefetcher so the evolve loop never starves
+// itself of hit/waste signal (Issue #254).
+const EscapeEpsilon = 0.1
+
 // EvolutionLoop folds prefetch outcomes into the online engine and publishes
 // one immutable parameter snapshot after every real change.
 type EvolutionLoop struct {
@@ -96,10 +101,15 @@ func (l *EvolutionLoop) observe(e kernelevent.Event) {
 		return
 	}
 	if l.scheduler != nil {
-		_ = l.scheduler.ApplyEvolution(after.TauL2)
+		// Behavior gate is driven by SuccessFloor; TauL2 now only controls
+		// injection confidence (PR #228 decoupling, Issue #254).
+		_ = l.scheduler.ApplyEvolution(after.SuccessFloor)
 	}
 	if l.prefetcher != nil {
 		_ = l.prefetcher.ApplyEvolution(after.PrefetchConf)
+	}
+	if eps, ok := l.prefetcher.(interface{ SetEpsilon(float64) error }); ok {
+		_ = eps.SetEpsilon(EscapeEpsilon)
 	}
 	params, err := json.Marshal(after)
 	if err != nil {

--- a/harness/semantix/evolution_test.go
+++ b/harness/semantix/evolution_test.go
@@ -63,3 +63,31 @@ func TestEvolutionLoopDoesNotTickWithoutParameterChange(t *testing.T) {
 		t.Fatalf("ticks=%d, want 0 before warmup", ticks)
 	}
 }
+
+// TestEvolveSchedulerReceivesSuccessFloor verifies the decoupling (PR #228,
+// Issue #254): after a parameter change the scheduler tuner is driven by the
+// engine's SuccessFloor default, not by TauL2 (injection confidence).
+func TestEvolveSchedulerReceivesSuccessFloor(t *testing.T) {
+	bus := kernelevent.NewSyncBus()
+	engine := evolve.New(evolve.Config{MinSamples: 2, FreezeEpochs: 1})
+	schedTuner := &captureTuner{}
+	prefetchTuner := &captureTuner{}
+	loop := NewEvolutionLoop(bus, engine)
+	loop.Attach(schedTuner, prefetchTuner)
+
+	payload, _ := json.Marshal(kernelevent.PrefetchWastePayload{Targets: []string{"slice-a"}})
+	for turn := 1; turn <= 2; turn++ {
+		bus.Emit(kernelevent.Event{Kind: kernelevent.PrefetchWaste, SessionID: "s1", Turn: turn, At: time.Now(), Data: payload})
+	}
+	loop.Close()
+
+	if len(schedTuner.values) != 1 {
+		t.Fatalf("sched applies = %v, want exactly 1", schedTuner.values)
+	}
+	// SuccessFloor default is 0.7; TauL2 default is 0.55.
+	if got := schedTuner.values[0]; got != evolve.DefaultSuccessFloor {
+		t.Fatalf("scheduler got %v, want DefaultSuccessFloor %v (not DefaultTauL2 %v)",
+			got, evolve.DefaultSuccessFloor, evolve.DefaultTauL2)
+	}
+}
+

--- a/kernel/evolve/evolve.go
+++ b/kernel/evolve/evolve.go
@@ -11,29 +11,31 @@ import (
 // prefix for ~24h (DeepSeek policy) — we never change params inside the
 // window (Reasonix lesson, cache_policy.go:21-45).
 const (
-	DefaultAlpha       = 0.1  // EWMA smoothing (10% weight on newest sample)
-	DefaultTauL2       = 0.55 // relative-confidence threshold for L2 hit
-	DefaultInjectCap   = 0.3  // max injected budget as fraction of context
-	DefaultFreezeEpoch = 60   // epochs a param change stays frozen
-	DefaultMinTau      = 0.30 // floor for tau tuning (never below)
-	DefaultMaxTau      = 0.80 // ceiling for tau tuning (never above)
-	TauStep            = 0.05 // per adjustment step
-	PrefetchStep       = 0.05 // per adjustment step for planner confidence
-	PollutionRiseAt    = 0.30 // pollution EWMA above this → tighten tau
-	HitTarget          = 0.70 // hit EWMA above this (and pollution low) → relax tau
-	PollutionLow       = 0.10 // pollution below this to allow relaxation
-	MinSamples         = 20   // signals required before the first adjustment
+	DefaultAlpha         = 0.1  // EWMA smoothing (10% weight on newest sample)
+	DefaultTauL2         = 0.55 // relative-confidence threshold for L2 hit
+	DefaultSuccessFloor  = 0.7  // behavior success gate for read-only tools
+	DefaultInjectCap     = 0.3  // max injected budget as fraction of context
+	DefaultFreezeEpoch   = 60   // epochs a param change stays frozen
+	DefaultMinTau        = 0.30 // floor for tau tuning (never below)
+	DefaultMaxTau        = 0.80 // ceiling for tau tuning (never above)
+	TauStep              = 0.05 // per adjustment step
+	PrefetchStep         = 0.05 // per adjustment step for planner confidence
+	PollutionRiseAt      = 0.30 // pollution EWMA above this → tighten tau
+	HitTarget            = 0.70 // hit EWMA above this (and pollution low) → relax tau
+	PollutionLow         = 0.10 // pollution below this to allow relaxation
+	MinSamples           = 20   // signals required before the first adjustment
 )
 
 // Config carries operator-provided tuning constants (zero values → defaults).
 type Config struct {
-	Alpha        float64
-	TauL2        float64
-	InjectCap    float64
-	FreezeEpochs uint64
-	MinTau       float64
-	MaxTau       float64
-	MinSamples   uint64
+	Alpha         float64
+	TauL2         float64
+	SuccessFloor  float64
+	InjectCap     float64
+	FreezeEpochs  uint64
+	MinTau        float64
+	MaxTau        float64
+	MinSamples    uint64
 }
 
 // Signal is one feedback sample consumed by the evolution engine.
@@ -46,11 +48,12 @@ type Signal struct {
 // Params is the tunable parameter snapshot (frozen semantics: injected set
 // must not change within the freeze window — see architecture spec §6.2).
 type Params struct {
-	TauL2        float64 `json:"tau_l2"`
-	TauL3        float64 `json:"tau_l3"`
-	InjectCap    float64 `json:"inject_cap"`
-	PrefetchConf float64 `json:"prefetch_conf"`
-	FreezeEpochs uint64  `json:"freeze_epochs"` // injection-set freeze duration
+	TauL2         float64 `json:"tau_l2"`
+	TauL3         float64 `json:"tau_l3"`
+	InjectCap     float64 `json:"inject_cap"`
+	PrefetchConf  float64 `json:"prefetch_conf"`
+	SuccessFloor  float64 `json:"success_floor"` // behavior success gate for read-only tools
+	FreezeEpochs  uint64  `json:"freeze_epochs"` // injection-set freeze duration
 }
 
 // Engine runs online EWMA tuning and offline retraining (MVP in M1).
@@ -93,6 +96,7 @@ func New(cfg Config) *ewmaEngine {
 			TauL2:        DefaultTauL2,
 			InjectCap:    DefaultInjectCap,
 			PrefetchConf: 0.5,
+			SuccessFloor: DefaultSuccessFloor,
 			FreezeEpochs: DefaultFreezeEpoch,
 		},
 	}
@@ -110,6 +114,9 @@ func New(cfg Config) *ewmaEngine {
 	}
 	if cfg.TauL2 > 0 && finite(cfg.TauL2) {
 		e.params.TauL2 = cfg.TauL2
+	}
+	if cfg.SuccessFloor > 0 && finite(cfg.SuccessFloor) {
+		e.params.SuccessFloor = cfg.SuccessFloor
 	}
 	if cfg.InjectCap > 0 && finite(cfg.InjectCap) {
 		e.params.InjectCap = cfg.InjectCap
@@ -189,7 +196,7 @@ func (e *ewmaEngine) Apply(p Params) error {
 	defer e.mu.Unlock()
 	// NaN/Inf rejected before the freeze check: a frozen engine must not
 	// mask the real reason with a confusing "frozen" error.
-	if !finite(p.TauL2) || !finite(p.InjectCap) || !finite(p.PrefetchConf) {
+	if !finite(p.TauL2) || !finite(p.InjectCap) || !finite(p.PrefetchConf) || !finite(p.SuccessFloor) {
 		return errors.New("evolve: non-finite param rejected")
 	}
 	if e.epoch < e.freezeUntil && p.FreezeEpochs != 0 {

--- a/kernel/prefetch/escape_test.go
+++ b/kernel/prefetch/escape_test.go
@@ -1,0 +1,86 @@
+package prefetch
+
+import (
+	"testing"
+)
+
+// TestPlanEpsilonProbeEscapesAbsorbingState is the regression for #254: when
+// every candidate falls below MinConf, Plan would be empty and the evolve
+// loop would starve of hit/waste signal, freezing PrefetchConf in the
+// absorbing state. With a positive Epsilon it probes the best excluded
+// candidate; with Epsilon=0 (the default) behavior is unchanged.
+func TestPlanEpsilonProbeEscapesAbsorbingState(t *testing.T) {
+	// A high MinConf with low-probability candidates reproduces the
+	// absorbing-state condition: nothing would be proposed.
+	m := NewMatrixPrefetcher(Config{MinConf: 0.8, Epsilon: 1.0})
+	m.Observe("grep", "read_file", true)
+	m.Observe("grep", "glob", true)
+	m.Observe("grep", "glob", true)
+
+	tasks, err := m.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("want 1 epsilon probe, got %d tasks", len(tasks))
+	}
+	// glob has prob 2/3 > read_file 1/3, so it is the best excluded candidate.
+	if tasks[0].Key != "glob" {
+		t.Fatalf("probe key = %q, want %q", tasks[0].Key, "glob")
+	}
+	if tasks[0].Cost != Defaults().BaseCost {
+		t.Fatalf("probe cost = %d, want default BaseCost %d", tasks[0].Cost, Defaults().BaseCost)
+	}
+}
+
+// TestPlanEpsilonZeroKeepsEmptyPlan verifies backward compatibility: the
+// default Epsilon=0 must keep the existing empty-plan behavior even when a
+// candidate is excluded by MinConf.
+func TestPlanEpsilonZeroKeepsEmptyPlan(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.8, Epsilon: 0})
+	m.Observe("grep", "read_file", true)
+	m.Observe("grep", "glob", true)
+
+	tasks, err := m.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("Epsilon=0: want empty plan, got %d tasks", len(tasks))
+	}
+}
+
+// TestPlanEpsilonRespectsNoData ensures the escape probe is only used when
+// there is learned transition knowledge; an empty transition table still
+// yields an empty plan even at Epsilon=1.
+func TestPlanEpsilonRespectsNoData(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{Epsilon: 1.0})
+	tasks, err := m.Plan([]string{"unseen"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("no data: want empty plan, got %d tasks", len(tasks))
+	}
+}
+
+// TestPlanEpsilonSkipsDemotedCandidates ensures a demoted candidate (bad
+// waste/hit history) is never chosen as the escape probe.
+func TestPlanEpsilonSkipsDemotedCandidates(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.8, Epsilon: 1.0, WasteHitLimit: 3.0})
+	m.Observe("grep", "stale", true)
+	m.Observe("grep", "stale", true)
+	m.Observe("grep", "stale", true)
+	m.Observe("grep", "fresh", true)
+	// stale: waste history via repeated ObserveWaste demotes it below limit.
+	for i := 0; i < 10; i++ {
+		m.ObserveWaste("stale")
+	}
+	tasks, err := m.Plan([]string{"grep"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 || tasks[0].Key != "fresh" {
+		t.Fatalf("want probe=fresh (non-demoted), got %+v", tasks)
+	}
+}

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -30,6 +30,7 @@ package prefetch
 import (
 	"errors"
 	"math"
+	"math/rand"
 	"sort"
 	"sync"
 )
@@ -181,12 +182,19 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 		prob float64
 	}
 	var cands []cand
+	var probe *cand // highest-probability candidate excluded only by MinConf (#254)
 	for next, cnt := range transitions {
 		if !m.readOnly[next] {
 			continue // never prefetch a writer
 		}
 		prob := float64(cnt) / float64(total)
 		if prob < m.cfg.MinConf {
+			// absorb into the escape probe when it is the best (but
+			// still-threshold-eligible) excluded candidate; skip demoted
+			// ones so the probe never channels a known-bad bet
+			if !m.demoted(next) && (probe == nil || prob > probe.prob) {
+				probe = &cand{key: next, prob: prob}
+			}
 			continue
 		}
 		if m.demoted(next) {
@@ -211,6 +219,20 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 			Cost: m.cfg.BaseCost,
 		})
 		cost += m.cfg.BaseCost
+	}
+	// Absorbing-state escape: if all candidates were excluded by MinConf and
+	// nothing ran, probe the best excluded candidate with probability Epsilon
+	// to keep a trickle of hit/waste signal flowing back into the evolve loop
+	// so PrefetchConf can recover (Issue #254).
+	if len(tasks) == 0 && probe != nil &&
+		m.cfg.Epsilon > 0 && rand.Float64() < m.cfg.Epsilon {
+		if m.cfg.BaseCost <= m.cfg.MaxCost {
+			tasks = append(tasks, PrefetchTask{
+				Kind: "slice-assembly",
+				Key:  probe.key,
+				Cost: m.cfg.BaseCost,
+			})
+		}
 	}
 	return tasks, nil
 }

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -240,7 +240,7 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 	// nothing ran, probe the best excluded candidate with probability Epsilon
 	// to keep a trickle of hit/waste signal flowing back into the evolve loop
 	// so PrefetchConf can recover (Issue #254).
-	if len(tasks) == 0 && probe != nil &&
+	if len(tasks) == 0 && probe != nil && m.cfg.TopK > 0 &&
 		m.cfg.Epsilon > 0 && rand.Float64() < m.cfg.Epsilon {
 		if m.cfg.BaseCost <= m.cfg.MaxCost {
 			tasks = append(tasks, PrefetchTask{

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -71,6 +71,13 @@ type Config struct {
 	WasteHitLimit float64
 	// Decay is the EWMA smoothing for hit/waste rates (default 0.2).
 	Decay float64
+	// Epsilon is the absorbing-state escape probability (default 0 =
+	// disabled). When every candidate falls below MinConf and the plan
+	// would be empty, Plan probes the highest-probability excluded candidate
+	// with probability Epsilon to keep a trickle of hit/waste signal flowing
+	// (Issue #254). Applicable only when there is any learned transition; an
+	// empty transition table still yields an empty plan.
+	Epsilon float64
 }
 
 // Defaults returns the built-in configuration.
@@ -82,6 +89,7 @@ func Defaults() Config {
 		BaseCost:      512,
 		WasteHitLimit: 3.0,
 		Decay:         0.2,
+		Epsilon:       0, // disabled by default; enabled by evolve wiring
 	}
 }
 
@@ -117,6 +125,9 @@ func NewMatrixPrefetcher(cfg Config) *MatrixPrefetcher {
 	}
 	if cfg.Decay <= 0 || cfg.Decay > 1 {
 		cfg.Decay = def.Decay
+	}
+	if cfg.Epsilon < 0 || cfg.Epsilon > 1 {
+		cfg.Epsilon = def.Epsilon
 	}
 	return &MatrixPrefetcher{
 		cfg:      cfg,

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -54,6 +54,22 @@ func (m *MatrixPrefetcher) ApplyEvolution(minConf float64) error {
 	return nil
 }
 
+// SetEpsilon enables or disables the absorbing-state escape probe at
+// runtime (Issue #254). It is separate from ApplyEvolution because Epsilon
+// is a closed-loop escape knob, not a per-snapshot confidence threshold.
+func (m *MatrixPrefetcher) SetEpsilon(epsilon float64) error {
+	if math.IsNaN(epsilon) || math.IsInf(epsilon, 0) {
+		return errors.New("prefetch: non-finite epsilon rejected")
+	}
+	if epsilon < 0 || epsilon > 1 {
+		return errors.New("prefetch: epsilon out of range [0,1]")
+	}
+	m.mu.Lock()
+	m.cfg.Epsilon = epsilon
+	m.mu.Unlock()
+	return nil
+}
+
 // Config carries operator knobs; zero values select documented defaults.
 type Config struct {
 	// TopK caps the number of tasks returned per Plan (default 3).


### PR DESCRIPTION
﻿feat(evolve+prefetch): absorbing-state escape (ε-probe) + TauL2/SuccessFloor split

Closes #254

## Problem

The evolve closed loop has an absorbing state: when `PrefetchConf` rises
above every candidate transition probability, `Plan` returns an empty
list, which stops producing `PrefetchHit`/`PrefetchWaste` events, which
starves `EvolutionLoop.observe` of any signal, leaving `PrefetchConf`
permanently frozen at the off position after a churn spike.

Separately, `evolution.go` fed `TauL2` (injection-confidence threshold)
straight into `sched.RuleDecider.ApplyEvolution` as the behavior
`SuccessFloor` — two different-dimension thresholds sharing one knob
(PR #228 review point 4).

## Fix

1. **Absorbing-state escape (ε-probe)**:
   - `MatrixPrefetcher.Config.Epsilon` (default 0 = off, backward
     compatible).
   - `Plan` probes the best non-demoted MinConf-excluded candidate with
     probability `Epsilon`, so a trickle of hit/waste signal keeps
     flowing and `PrefetchConf` can recover.
   - `MatrixPrefetcher.SetEpsilon` runtime knob.
   - `EvolutionLoop` wires `EscapeEpsilon = 0.1` via a `SetEpsilon`
     type assertion.

2. **TauL2 / SuccessFloor decoupling**:
   - `evolve.Params.SuccessFloor` (+ default 0.7, config override, finite
     validation).
   - `evolution.go` now drives the scheduler from `after.SuccessFloor`,
     leaving `TauL2` to control injection confidence only.

3. **Spec-first**: `docs/specs/issue-254-evolve-absorbing-escape.md`
   merged before the implementation commits.

## Tests

- `kernel/prefetch/escape_test.go` (new): ε-probe escapes the absorbing
  state; `Epsilon=0` keeps the empty plan; no transition data never
  probes; demoted candidates are skipped.
- `harness/semantix/evolution_test.go`: scheduler receives
  `SuccessFloor` (0.7), not `TauL2` (0.55).
- `go test ./kernel/evolve ./kernel/prefetch ./harness/semantix` (focused)
  and `go build ./...` pass.

## Note

`TestBridgeReuse*` in `harness/semantix` fail on this Windows host with
a pre-existing SQLite `project.db.journal` temp-dir lock; they reproduce
identically on a clean `origin/main` and are unrelated to this change.
