### PR TITLE
feat(gateway): usage 缓存命中 per-provider×per-路径适配器 (GLM-P0-3, #291)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -33,7 +33,7 @@
 | Kind | 序号 | 语义 | Payload 字段 | 触发方 |
 |---|---|---|---|---|
 | `TurnStarted` | 0 | 一个用户 turn 开始 | （无，SessionID/Turn 在信封） | harness 会话 |
-| `Usage` | 1 | 模型调用 token 用量，含缓存命中明细 | `prompt_tokens`, `cache_hit`, `cache_miss`, `completion_tokens`, `cost_usd` | harness 模型层 |
+| `Usage` | 1 | 模型调用 token 用量，含缓存命中明细 | `prompt_tokens`, `cache_hit`, `cache_miss`, `completion_tokens`, `cost_usd`；可选（#291 只增）：`provider`（端点名）, `vendor`（"openai"\|"anthropic"…）, `model`, `exact`（true=真实 provider 计量，false/缺省=bytes/4 估算） | harness 模型层 |
 | `ToolDispatch` | 2 | 一个工具调用被派发 | `call_id`, `name`, `args`(raw), `read_only` | harness 工具执行器 |
 | `ToolResult` | 3 | 一个工具调用结果 | `call_id`, `ok`, `latency_ns`, `err_msg`(omitempty) | harness 工具执行器 |
 | `ToolRoundEnd` | 4 | 一批工具执行汇总 | `dispatched`, `succeeded` | harness 工具执行器 |

--- a/gateway/anthropic.go
+++ b/gateway/anthropic.go
@@ -421,9 +421,10 @@ type anthropicResponse struct {
 		Input any    `json:"input"`
 	} `json:"content"`
 	Usage struct {
-		InputTokens          int `json:"input_tokens"`
-		OutputTokens         int `json:"output_tokens"`
-		CacheReadInputTokens int `json:"cache_read_input_tokens"`
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 	} `json:"usage"`
 }
 
@@ -454,10 +455,15 @@ func anthropicToOpenAIResponse(body []byte, model string) ([]byte, error) {
 	if len(toolCalls) > 0 {
 		msg["tool_calls"] = toolCalls
 	}
+	// Anthropic-style input_tokens is incremental — it excludes cache reads
+	// and writes (measured: cache_read + input = full input, glm-spike-week.md
+	// §2). OpenAI prompt_tokens is the full input, so reconcile here or the
+	// translated usage under-reports every cache hit by its cached portion.
+	prompt := a.Usage.InputTokens + a.Usage.CacheCreationInputTokens + a.Usage.CacheReadInputTokens
 	usage := map[string]any{
-		"prompt_tokens":     a.Usage.InputTokens,
+		"prompt_tokens":     prompt,
 		"completion_tokens": a.Usage.OutputTokens,
-		"total_tokens":      a.Usage.InputTokens + a.Usage.OutputTokens,
+		"total_tokens":      prompt + a.Usage.OutputTokens,
 	}
 	if a.Usage.CacheReadInputTokens > 0 {
 		usage["prompt_tokens_details"] = map[string]any{"cached_tokens": a.Usage.CacheReadInputTokens}
@@ -537,6 +543,13 @@ type anthropicSSEConverter struct {
 	model      string
 	created    int64
 	finishSent bool // a real finish_reason already went out
+	// Usage counters harvested from message_start/message_delta frames.
+	// Counters are cumulative; max-merge tolerates gateways that repeat
+	// partial usage across both frames (GLM-P0-3 / #291). usageSent guards
+	// the single translated usage chunk emitted before [DONE].
+	inTok, outTok, cacheCreate, cacheRead int
+	sawUsage                              bool
+	usageSent                             bool
 }
 
 func newAnthropicSSEConverter(w io.Writer, flusher http.Flusher) *anthropicSSEConverter {
@@ -576,6 +589,7 @@ func (c *anthropicSSEConverter) feed(line []byte) bool {
 		c.done = true
 		return true
 	case "message_stop":
+		c.writeUsageChunk()
 		c.writeDone()
 		c.done = true
 		return true
@@ -595,16 +609,20 @@ func (c *anthropicSSEConverter) finish() {
 	if !c.finishSent {
 		c.writeChunk(map[string]any{}, "stop")
 	}
+	c.writeUsageChunk()
 	c.writeDone()
 }
 
 // messageStart captures the message id/model so every OpenAI chunk carries
-// the stable identity the OpenAI SDKs validate on.
+// the stable identity the OpenAI SDKs validate on, plus the input/cache
+// usage counters the native stream reports here (message_start carries
+// input-side accounting; message_delta carries output_tokens).
 func (c *anthropicSSEConverter) messageStart(payload []byte) {
 	var ev struct {
 		Message struct {
-			ID    string `json:"id"`
-			Model string `json:"model"`
+			ID    string        `json:"id"`
+			Model string        `json:"model"`
+			Usage *wireSSEUsage `json:"usage"`
 		} `json:"message"`
 	}
 	if err := json.Unmarshal(payload, &ev); err != nil {
@@ -615,6 +633,76 @@ func (c *anthropicSSEConverter) messageStart(payload []byte) {
 	}
 	if ev.Message.Model != "" {
 		c.model = ev.Message.Model
+	}
+	c.mergeUsage(ev.Message.Usage)
+}
+
+// wireSSEUsage is the usage fragment carried on Anthropic stream frames.
+type wireSSEUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// mergeUsage folds one frame's counters in. Counters are cumulative and
+// non-negative, so keeping the max also tolerates gateways that repeat
+// partial usage on both message_start and message_delta.
+func (c *anthropicSSEConverter) mergeUsage(u *wireSSEUsage) {
+	if u == nil {
+		return
+	}
+	c.sawUsage = true
+	c.inTok = max(c.inTok, u.InputTokens)
+	c.outTok = max(c.outTok, u.OutputTokens)
+	c.cacheCreate = max(c.cacheCreate, u.CacheCreationInputTokens)
+	c.cacheRead = max(c.cacheRead, u.CacheReadInputTokens)
+}
+
+// usage returns the harvested provider accounting normalized to the full
+// prompt convention (input + cache_creation + cache_read; see
+// anthropicToOpenAIResponse). ok is false when no frame carried usage.
+func (c *anthropicSSEConverter) usage() (normUsage, bool) {
+	if !c.sawUsage {
+		return normUsage{}, false
+	}
+	return normalizeUpstreamUsage(&upstreamUsage{
+		InputTokens:              c.inTok,
+		OutputTokens:             c.outTok,
+		CacheCreationInputTokens: c.cacheCreate,
+		CacheReadInputTokens:     c.cacheRead,
+	})
+}
+
+// writeUsageChunk emits one OpenAI stream-usage event (empty choices +
+// usage) carrying the translated provider accounting, before [DONE], so
+// OpenAI-surface clients receive real usage instead of nothing.
+func (c *anthropicSSEConverter) writeUsageChunk() {
+	nu, ok := c.usage()
+	if !ok || c.usageSent {
+		return
+	}
+	c.usageSent = true
+	usage := map[string]any{
+		"prompt_tokens":     nu.Prompt,
+		"completion_tokens": nu.Completion,
+		"total_tokens":      nu.Prompt + nu.Completion,
+	}
+	if nu.CacheHit > 0 {
+		usage["prompt_tokens_details"] = map[string]any{"cached_tokens": nu.CacheHit}
+	}
+	evt := map[string]any{
+		"id":      c.id,
+		"object":  "chat.completion.chunk",
+		"created": c.created,
+		"model":   c.model,
+		"choices": []any{},
+		"usage":   usage,
+	}
+	raw, _ := json.Marshal(evt)
+	_, _ = fmt.Fprintf(c.w, "data: %s\n\n", raw)
+	if c.flusher != nil {
+		c.flusher.Flush()
 	}
 }
 
@@ -698,10 +786,12 @@ func (c *anthropicSSEConverter) messageDelta(payload []byte) {
 		Delta struct {
 			StopReason string `json:"stop_reason"`
 		} `json:"delta"`
+		Usage *wireSSEUsage `json:"usage"`
 	}
 	if err := json.Unmarshal(payload, &ev); err != nil {
 		return
 	}
+	c.mergeUsage(ev.Usage)
 	if ev.Delta.StopReason == "" {
 		return
 	}
@@ -737,7 +827,7 @@ func (c *anthropicSSEConverter) writeDone() {
 // OpenAI SSE (the events must be translated — Anthropic frames differ from
 // OpenAI's). Sidecar/usage accounting matches the OpenAI streaming path:
 // request turns only, assistant content extraction is deferred debt.
-func (g *Gateway) streamThroughAnthropic(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, jc *judgeCollector) {
+func (g *Gateway) streamThroughAnthropic(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, up UpstreamConfig, jc *judgeCollector) {
 	if resp.StatusCode >= 400 {
 		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		writeAPIError(w, resp.StatusCode, "upstream_error",
@@ -763,12 +853,24 @@ func (g *Gateway) streamThroughAnthropic(w http.ResponseWriter, resp *http.Respo
 	}
 	conv.finish() // no-op when message_stop already seen
 	g.recordSession(sessionID, ctxHash, req.Model, turns(req, ""))
-	g.recordUsage(usage.Event{
+	ev := usage.Event{
 		SessionID:      sessionID,
+		Provider:       up.Name,
+		Vendor:         up.Vendor,
+		Model:          req.Model,
 		TokensIn:       int64(len(query)/4) + injectedTokens,
 		InjectedTokens: injectedTokens,
 		SliceHits:      sliceHits,
 		JudgeDecisions: jc.drain(),
 		At:             g.now().Unix(),
-	})
+	}
+	// message_start/message_delta carried real provider accounting: prefer
+	// it over the bytes/4 estimate (GLM-P0-3 / #291).
+	if nu, ok := conv.usage(); ok {
+		ev.TokensIn = nu.Prompt
+		ev.TokensOut = nu.Completion
+		ev.CacheHitToken = nu.CacheHit
+		ev.Exact = true
+	}
+	g.recordUsage(ev)
 }

--- a/gateway/anthropic_test.go
+++ b/gateway/anthropic_test.go
@@ -265,8 +265,12 @@ func TestAnthropicToOpenAIResponse(t *testing.T) {
 	if out.Choices[0].Message.Content != "the answer" || out.Choices[0].FinishReason != "stop" {
 		t.Errorf("choice = %#v (end_turn must map to stop)", out.Choices[0])
 	}
-	if out.Usage.PromptTokens != 100 || out.Usage.CompletionTokens != 25 || out.Usage.TotalTokens != 125 {
-		t.Errorf("usage = %#v (input/output tokens must map)", out.Usage)
+	// Anthropic input_tokens is incremental (excludes cache reads/writes):
+	// OpenAI prompt_tokens must carry the reconciled full input, or every
+	// cache hit under-reports by its cached portion (#291; measured
+	// cache_read + input = full input, glm-spike-week.md §2).
+	if out.Usage.PromptTokens != 160 || out.Usage.CompletionTokens != 25 || out.Usage.TotalTokens != 185 {
+		t.Errorf("usage = %#v (prompt must be input+cache_read reconciled)", out.Usage)
 	}
 	if out.Usage.PromptDetails.CachedTokens != 60 {
 		t.Errorf("cached_tokens = %d, want 60 (cache_read_input_tokens)", out.Usage.PromptDetails.CachedTokens)
@@ -387,6 +391,44 @@ data: {"type":"message_stop"}`,
 	}
 	if strings.Contains(got, "message_start") || strings.Contains(got, "ping") {
 		t.Errorf("raw anthropic events leaked through:\n%s", got)
+	}
+}
+
+// TestAnthropicSSEConverterUsage covers the #291 harvest: message_start
+// carries input/cache counters (Tencent-style: cache_read only on a hit,
+// input_tokens incremental), message_delta carries output_tokens; the
+// converter reconciles to the full-prompt convention and emits one
+// translated usage chunk before [DONE].
+func TestAnthropicSSEConverterUsage(t *testing.T) {
+	var out strings.Builder
+	conv := newAnthropicSSEConverter(&out, nil)
+	frames := []string{
+		`data: {"type":"message_start","message":{"id":"msg_u","model":"glm-5.3","usage":{"input_tokens":64,"cache_read_input_tokens":2556}}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`,
+		`data: {"type":"message_stop"}`,
+	}
+	for _, f := range frames {
+		conv.feed([]byte(f))
+	}
+	nu, ok := conv.usage()
+	if !ok {
+		t.Fatal("converter harvested no usage")
+	}
+	if nu.Prompt != 2620 || nu.CacheHit != 2556 || nu.Completion != 15 {
+		t.Fatalf("usage = %+v (want reconciled prompt 2620, hit 2556, out 15)", nu)
+	}
+	got := out.String()
+	usageIdx := strings.Index(got, `"prompt_tokens":2620`)
+	doneIdx := strings.LastIndex(got, "data: [DONE]")
+	if usageIdx < 0 {
+		t.Fatalf("no translated usage chunk in stream:\n%s", got)
+	}
+	if !strings.Contains(got, `"cached_tokens":2556`) {
+		t.Errorf("usage chunk missing cached_tokens:\n%s", got)
+	}
+	if doneIdx >= 0 && usageIdx > doneIdx {
+		t.Errorf("usage chunk must precede [DONE]:\n%s", got)
 	}
 }
 

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -56,7 +56,8 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	if !g.disabled {
 		if res, lerr := g.decider.DecideL3(ctx, q); lerr == nil && res != nil && g.l3Eligible(res.SliceID, up.Vendor) {
 			g.recordUsage(usage.Event{
-				SessionID: sessionID, TokensIn: int64(len(query)/4) + int64(len(res.Response)/4),
+				SessionID: sessionID, Provider: up.Name, Vendor: up.Vendor, Model: req.Model,
+				TokensIn: int64(len(query)/4) + int64(len(res.Response)/4),
 				TokensOut: 0, CacheHitToken: int64(len(res.Response) / 4),
 				L3Reuse: true, JudgeDecisions: jc.drain(), At: g.now().Unix(),
 			})
@@ -101,13 +102,13 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 
 	if req.Stream {
 		if up.Vendor == "anthropic" {
-			g.streamThroughAnthropic(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, jc)
+			g.streamThroughAnthropic(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, up, jc)
 			return
 		}
-		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, jc)
+		g.streamThrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, up, jc)
 		return
 	}
-	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, up.Vendor, jc)
+	g.passthrough(w, resp, sessionID, req, chash, query, injectedTokens, sliceHits, up, jc)
 }
 
 // l3Eligible applies the gateway-side TTL window on top of the kernel
@@ -209,7 +210,8 @@ func (g *Gateway) forward(ctx context.Context, up UpstreamConfig, body []byte) (
 // successful exchanges, so failed requests never enter the reuse library.
 // Anthropic responses are translated to OpenAI chat.completion shape first
 // (the client surface is always OpenAI-compatible).
-func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, vendor string, jc *judgeCollector) {
+func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, up UpstreamConfig, jc *judgeCollector) {
+	vendor := up.Vendor
 	out, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 	if err != nil {
 		writeAPIError(w, http.StatusBadGateway, "upstream_error",
@@ -256,15 +258,27 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(out)
 
-	g.recordUsage(usage.Event{
+	// Real provider accounting when the upstream carried usage (GLM-P0-3 /
+	// #291); the bytes/4 estimate stays as the fallback, marked Exact=false.
+	ev := usage.Event{
 		SessionID:      sessionID,
+		Provider:       up.Name,
+		Vendor:         vendor,
+		Model:          req.Model,
 		TokensIn:       int64(len(query)/4) + injectedTokens,
 		TokensOut:      int64(len(out) / 4),
 		InjectedTokens: injectedTokens,
 		SliceHits:      sliceHits,
 		JudgeDecisions: jc.drain(),
 		At:             g.now().Unix(),
-	})
+	}
+	if nu, ok := parseUsageBody(out); ok {
+		ev.TokensIn = nu.Prompt
+		ev.TokensOut = nu.Completion
+		ev.CacheHitToken = nu.CacheHit
+		ev.Exact = true
+	}
+	g.recordUsage(ev)
 }
 
 // streamThrough relays a streaming upstream response chunk by chunk (SSE),
@@ -277,7 +291,7 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 // failed exchanges are not recorded (design §0.3 documented debt, now paid).
 // If the upstream ends without a [DONE] marker (abnormal disconnect), the
 // gateway appends one so the client never hangs on an unterminated stream.
-func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, jc *judgeCollector) {
+func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sessionID string, req *chatRequest, ctxHash string, query string, injectedTokens int64, sliceHits int, up UpstreamConfig, jc *judgeCollector) {
 	if resp.StatusCode >= 400 {
 		out, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes))
 		writeAPIError(w, resp.StatusCode, "upstream_error",
@@ -342,15 +356,28 @@ func (g *Gateway) streamThrough(w http.ResponseWriter, resp *http.Response, sess
 	if agg.Complete() {
 		tokensOut = int64(len(agg.Content()) / 4)
 	}
-	g.recordUsage(usage.Event{
+	ev := usage.Event{
 		SessionID:      sessionID,
+		Provider:       up.Name,
+		Vendor:         up.Vendor,
+		Model:          req.Model,
 		TokensIn:       int64(len(query)/4) + injectedTokens,
 		TokensOut:      tokensOut,
 		InjectedTokens: injectedTokens,
 		SliceHits:      sliceHits,
 		JudgeDecisions: jc.drain(),
 		At:             g.now().Unix(),
-	})
+	}
+	// The relayed stream's own usage frame is the real provider accounting
+	// (GLM-P0-3 / #291): prefer it over the bytes/4 estimate. writeUsageChunk
+	// syntheses never land here — the aggregator only captured upstream frames.
+	if nu, ok := parseUsageRaw(agg.UsageRaw()); ok {
+		ev.TokensIn = nu.Prompt
+		ev.TokensOut = nu.Completion
+		ev.CacheHitToken = nu.CacheHit
+		ev.Exact = true
+	}
+	g.recordUsage(ev)
 }
 
 // isHopByHopHeader reports connection-scoped headers that must never be

--- a/gateway/sse.go
+++ b/gateway/sse.go
@@ -41,6 +41,7 @@ type sseAggregator struct {
 	overflow     bool
 	done         bool
 	sawUsage     bool   // a data event carried a top-level "usage" field
+	usageRaw     []byte // raw bytes of the last non-null usage object seen
 	eventID      string // id of the first chat.completion.chunk event
 	limit        int    // content aggregation bound
 	lineMax      int    // per-line buffer bound
@@ -136,6 +137,10 @@ func (a *sseAggregator) flushEvent() {
 	}
 	if len(evt.Usage) > 0 && string(evt.Usage) != "null" {
 		a.sawUsage = true
+		// Keep the raw object (last frame wins: OpenAI-style streams put the
+		// authoritative usage on the terminal chunk) so the relay can meter
+		// real provider accounting instead of bytes/4 (GLM-P0-3 / #291).
+		a.usageRaw = append(a.usageRaw[:0], evt.Usage...)
 	}
 	if len(evt.Choices) == 0 {
 		return // usage-only (or empty) event
@@ -170,6 +175,13 @@ func (a *sseAggregator) Complete() bool {
 // must not synthesize a usage chunk.
 func (a *sseAggregator) SawUsage() bool {
 	return a.sawUsage
+}
+
+// UsageRaw returns the raw JSON of the last non-null usage object relayed,
+// or nil when the stream carried none. Callers normalize it with
+// parseUsageRaw for real provider accounting (GLM-P0-3 / #291).
+func (a *sseAggregator) UsageRaw() []byte {
+	return a.usageRaw
 }
 
 // Overflowed reports whether an aggregation bound was crossed. Callers

--- a/gateway/sse_test.go
+++ b/gateway/sse_test.go
@@ -193,3 +193,26 @@ func TestSSEAggregatorSawUsage(t *testing.T) {
 		})
 	}
 }
+
+// TestSSEAggregatorUsageRaw covers the #291 capture: the raw usage object of
+// the last usage-bearing frame is retained for real-accounting metering.
+func TestSSEAggregatorUsageRaw(t *testing.T) {
+	a := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(a, "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}],\"usage\":{\"prompt_tokens\":1}}\n\n"+
+		"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":2620,\"completion_tokens\":15,\"prompt_tokens_details\":{\"cached_tokens\":2560}}}\n\n"+
+		"data: [DONE]\n\n")
+	nu, ok := parseUsageRaw(a.UsageRaw())
+	if !ok {
+		t.Fatalf("UsageRaw did not parse: %q", a.UsageRaw())
+	}
+	// Last frame wins: OpenAI streams put the authoritative usage last.
+	if nu.Prompt != 2620 || nu.CacheHit != 2560 || nu.Completion != 15 {
+		t.Fatalf("normalized usage = %+v", nu)
+	}
+
+	empty := newSSEAggregator(maxSSEAggregateBytes)
+	feedAll(empty, "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n\ndata: [DONE]\n\n")
+	if empty.UsageRaw() != nil {
+		t.Fatalf("stream without usage must return nil raw, got %q", empty.UsageRaw())
+	}
+}

--- a/gateway/usagewire.go
+++ b/gateway/usagewire.go
@@ -1,0 +1,99 @@
+package gateway
+
+import "encoding/json"
+
+// upstreamUsage is the union of the cache-usage wire shapes observed across
+// upstreams (GLM-P0-3 / Issue #291; measured in docs/reports/glm-spike-week.md
+// §2, §3A.2, §3B):
+//
+//   - OpenAI style: prompt_tokens is the full input;
+//     prompt_tokens_details.cached_tokens is the prefix-cache-served subset.
+//   - Anthropic style: input_tokens EXCLUDES cache reads and writes
+//     (incremental accounting) — the full input is
+//     input_tokens + cache_creation_input_tokens + cache_read_input_tokens.
+//     Tencent-style gateways emit cache_read_input_tokens only on a hit;
+//     AtomClub-style gateways always carry the cache field family.
+//   - DeepSeek style: top-level prompt_cache_{hit,miss}_tokens.
+type upstreamUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	// DeepSeek
+	PromptCacheHitTokens  int `json:"prompt_cache_hit_tokens"`
+	PromptCacheMissTokens int `json:"prompt_cache_miss_tokens"`
+	// Anthropic style
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	// OpenAI style
+	PromptTokensDetails *struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+	// Estimator marks usage synthesized by a semantix gateway (bytes/4).
+	// It must never be re-ingested as exact provider accounting.
+	Estimator string `json:"estimator"`
+}
+
+// normUsage is provider usage normalized to one accounting convention:
+// Prompt is the complete input (cache hits included), CacheHit the subset
+// served from the provider prefix cache, Completion the full output.
+type normUsage struct {
+	Prompt     int64
+	Completion int64
+	CacheHit   int64
+}
+
+// normalizeUpstreamUsage folds one wire usage into normUsage. ok is false
+// when the object carries no token accounting at all, or is a semantix
+// bytes/4 synthesis (Estimator set).
+func normalizeUpstreamUsage(u *upstreamUsage) (normUsage, bool) {
+	if u == nil || u.Estimator != "" {
+		return normUsage{}, false
+	}
+	prompt := u.PromptTokens
+	if prompt == 0 && (u.InputTokens != 0 || u.CacheCreationInputTokens != 0 || u.CacheReadInputTokens != 0) {
+		// Anthropic-style incremental input: reconcile to the full prompt
+		// (measured: cache_read + input = full input, glm-spike-week.md §2).
+		prompt = u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+	}
+	completion := u.CompletionTokens
+	if completion == 0 {
+		completion = u.OutputTokens
+	}
+	hit := u.PromptCacheHitTokens
+	if hit == 0 && u.PromptTokensDetails != nil {
+		hit = u.PromptTokensDetails.CachedTokens
+	}
+	if hit == 0 {
+		hit = u.CacheReadInputTokens
+	}
+	if prompt == 0 && completion == 0 && hit == 0 {
+		return normUsage{}, false
+	}
+	return normUsage{Prompt: int64(prompt), Completion: int64(completion), CacheHit: int64(hit)}, true
+}
+
+// parseUsageRaw normalizes a bare usage JSON object (e.g. the aggregated
+// usage frame of an SSE stream).
+func parseUsageRaw(raw []byte) (normUsage, bool) {
+	if len(raw) == 0 {
+		return normUsage{}, false
+	}
+	var u upstreamUsage
+	if err := json.Unmarshal(raw, &u); err != nil {
+		return normUsage{}, false
+	}
+	return normalizeUpstreamUsage(&u)
+}
+
+// parseUsageBody normalizes the usage object of a complete non-streaming
+// response body ({"usage": {...}}).
+func parseUsageBody(body []byte) (normUsage, bool) {
+	var envelope struct {
+		Usage *upstreamUsage `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Usage == nil {
+		return normUsage{}, false
+	}
+	return normalizeUpstreamUsage(envelope.Usage)
+}

--- a/gateway/usagewire_test.go
+++ b/gateway/usagewire_test.go
@@ -1,0 +1,80 @@
+package gateway
+
+import "testing"
+
+// Fixtures follow the measured wire shapes in docs/reports/glm-spike-week.md
+// §2/§3A.2/§3B (GLM-P0-3 / Issue #291).
+func TestNormalizeUpstreamUsageShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want normUsage
+		ok   bool
+	}{
+		{
+			// Tencent TokenHub OpenAI path: full prompt + details.cached_tokens
+			// (measured: prompt 2620, cached 2560).
+			name: "openai-style full prompt",
+			raw:  `{"prompt_tokens":2620,"completion_tokens":15,"total_tokens":2635,"prompt_tokens_details":{"cached_tokens":2560}}`,
+			want: normUsage{Prompt: 2620, Completion: 15, CacheHit: 2560},
+			ok:   true,
+		},
+		{
+			// Tencent TokenHub Anthropic path: incremental input_tokens, the
+			// cache_read field appears only on a hit; full input reconciles as
+			// input + cache_read (measured §2).
+			name: "anthropic-style incremental hit",
+			raw:  `{"input_tokens":64,"output_tokens":15,"cache_read_input_tokens":2556}`,
+			want: normUsage{Prompt: 2620, Completion: 15, CacheHit: 2556},
+			ok:   true,
+		},
+		{
+			// AtomClub Anthropic path: the cache field family is always
+			// present, zero-valued on a miss.
+			name: "anthropic-style constant fields miss",
+			raw:  `{"input_tokens":2620,"output_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}`,
+			want: normUsage{Prompt: 2620, Completion: 20, CacheHit: 0},
+			ok:   true,
+		},
+		{
+			name: "deepseek top-level counters",
+			raw:  `{"prompt_tokens":100,"completion_tokens":9,"prompt_cache_hit_tokens":64,"prompt_cache_miss_tokens":36}`,
+			want: normUsage{Prompt: 100, Completion: 9, CacheHit: 64},
+			ok:   true,
+		},
+		{
+			// A semantix gateway's own bytes/4 synthesis must never be
+			// re-ingested as exact accounting (cascaded gateways).
+			name: "estimator marked synthesis rejected",
+			raw:  `{"prompt_tokens":40,"completion_tokens":10,"estimator":"bytes/4"}`,
+			ok:   false,
+		},
+		{
+			name: "empty object rejected",
+			raw:  `{}`,
+			ok:   false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parseUsageRaw([]byte(c.raw))
+			if ok != c.ok {
+				t.Fatalf("ok = %v, want %v", ok, c.ok)
+			}
+			if ok && got != c.want {
+				t.Fatalf("normUsage = %+v, want %+v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseUsageBody(t *testing.T) {
+	body := `{"id":"x","choices":[{"message":{"content":"hi"}}],"usage":{"prompt_tokens":2620,"completion_tokens":64,"prompt_tokens_details":{"cached_tokens":2560}}}`
+	nu, ok := parseUsageBody([]byte(body))
+	if !ok || nu.Prompt != 2620 || nu.CacheHit != 2560 || nu.Completion != 64 {
+		t.Fatalf("parseUsageBody = %+v ok=%v", nu, ok)
+	}
+	if _, ok := parseUsageBody([]byte(`{"choices":[]}`)); ok {
+		t.Fatal("body without usage must not parse")
+	}
+}

--- a/kernel/event/event.go
+++ b/kernel/event/event.go
@@ -60,12 +60,18 @@ type Event struct {
 type TurnStartedPayload struct{}
 
 // UsagePayload reports model-call token usage including cache breakdown.
+// Provider/Vendor/Model/Exact are optional per-endpoint calibration keys
+// (GLM-P0-3 / #291; wire: append-only) matching kernel/usage.Event.
 type UsagePayload struct {
 	PromptTokens  int     `json:"prompt_tokens"`
 	CacheHit      int     `json:"cache_hit"`
 	CacheMiss     int     `json:"cache_miss"`
 	CompletionTok int     `json:"completion_tokens"`
 	CostUSD       float64 `json:"cost_usd"`
+	Provider      string  `json:"provider,omitempty"` // upstream endpoint name
+	Vendor        string  `json:"vendor,omitempty"`   // wire shape: "openai" | "anthropic" | ...
+	Model         string  `json:"model,omitempty"`
+	Exact         bool    `json:"exact,omitempty"` // real provider accounting vs bytes/4 estimate
 }
 
 // ToolDispatchPayload describes one dispatched tool call.

--- a/kernel/usage/usage.go
+++ b/kernel/usage/usage.go
@@ -26,8 +26,19 @@ const (
 
 // Event is one LLM turn's usage observation.
 type Event struct {
-	SessionID     string  `json:"session_id,omitempty"`
-	Turn          uint64  `json:"turn"`
+	SessionID string `json:"session_id,omitempty"`
+	Turn      uint64 `json:"turn"`
+	// Provider is the upstream endpoint's configured name and Vendor its wire
+	// shape ("openai" | "anthropic" | ...). Together with Model they key the
+	// per-provider L1 hit-rate calibration (GLM-P0-3 / #291; spec §4.2).
+	// Empty on logs written before these fields existed (wire: append-only).
+	Provider string `json:"provider,omitempty"`
+	Vendor   string `json:"vendor,omitempty"`
+	Model    string `json:"model,omitempty"`
+	// Exact marks token counts relayed from real provider usage accounting;
+	// false means the gateway's bytes/4 estimate (pre-#291 logs are all
+	// estimates and unmarshal to false).
+	Exact         bool    `json:"exact,omitempty"`
 	TokensIn      int64   `json:"tokens_in"`
 	TokensOut     int64   `json:"tokens_out"`
 	CacheHitToken int64   `json:"cache_hit_tokens"`
@@ -144,6 +155,31 @@ type Summary struct {
 	JudgeSkipped      int   // rejected before the judge was reached (free)
 	JudgePromptTokens int64 // byte/4 estimate of tokens sent to the judge
 	JudgeLatencyMs    int64 // total time spent in judge calls
+
+	// ByProvider groups per-endpoint L1 telemetry (GLM-P0-3 / #291). The key
+	// is Event.Provider; events from pre-#291 logs land under "". Hit-rate
+	// calibration must use ExactEvents-backed figures — estimated events
+	// never observed provider cache accounting and would read as 0% hits.
+	ByProvider map[string]*ProviderStats
+}
+
+// ProviderStats aggregates one upstream endpoint's usage telemetry.
+type ProviderStats struct {
+	Events         int   // turns recorded against this endpoint
+	ExactEvents    int   // of those, ones carrying real provider usage
+	TokensIn       int64 // exact-only input tokens (cache hits included)
+	TokensOut      int64 // exact-only output tokens
+	CacheHitTokens int64 // exact-only prefix-cache-served input tokens
+	L3Reuses       int   // turns served without an upstream call
+}
+
+// L1HitRate is the prefix-cache hit share of exact-metered input tokens.
+// Zero when the endpoint has no exact events yet.
+func (p *ProviderStats) L1HitRate() float64 {
+	if p == nil || p.TokensIn == 0 {
+		return 0
+	}
+	return float64(p.CacheHitTokens) / float64(p.TokensIn)
 }
 
 // JudgeCostUSD estimates what the grey-zone judge calls cost, at the judge
@@ -176,7 +212,7 @@ func Summarize(path string, costMiss, costHit float64) (*Summary, error) {
 	}
 	defer f.Close()
 
-	s := &Summary{}
+	s := &Summary{ByProvider: map[string]*ProviderStats{}}
 	var l3In, l3Out int64 // tokens of L3-reused turns (not billed)
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
@@ -194,6 +230,24 @@ func Summarize(path string, costMiss, costHit float64) (*Summary, error) {
 		s.CacheHitTokens += e.CacheHitToken
 		s.InjectedTokens += e.InjectedTokens
 		s.SliceHits += e.SliceHits
+		p := s.ByProvider[e.Provider]
+		if p == nil {
+			p = &ProviderStats{}
+			s.ByProvider[e.Provider] = p
+		}
+		p.Events++
+		if e.L3Reuse {
+			p.L3Reuses++
+		}
+		if e.Exact {
+			// Only exact events feed the calibration figures: an estimated
+			// event never saw provider cache accounting, so folding it in
+			// would drag every hit-rate toward zero.
+			p.ExactEvents++
+			p.TokensIn += e.TokensIn
+			p.TokensOut += e.TokensOut
+			p.CacheHitTokens += e.CacheHitToken
+		}
 		if e.L3Reuse {
 			s.L3Reuses++
 			l3In += e.TokensIn

--- a/kernel/usage/usage_test.go
+++ b/kernel/usage/usage_test.go
@@ -59,6 +59,57 @@ func TestRecorderAppendAndSummarize(t *testing.T) {
 	}
 }
 
+// TestSummarizeByProvider covers the #291 per-endpoint grouping: exact
+// events feed the calibration figures, estimated events count presence only
+// (they never observed provider cache accounting), and pre-#291 lines land
+// under the "" key.
+func TestSummarizeByProvider(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage.jsonl")
+	r, err := NewRecorder(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := []Event{
+		{Provider: "tokenhub", Vendor: "openai", Model: "glm-5.3", Exact: true,
+			TokensIn: 2620, TokensOut: 15, CacheHitToken: 2560},
+		{Provider: "tokenhub", Vendor: "anthropic", Model: "glm-5.3", Exact: true,
+			TokensIn: 2620, TokensOut: 15, CacheHitToken: 2556},
+		{Provider: "tokenhub", TokensIn: 999, TokensOut: 9}, // estimated turn
+		{Provider: "tokenhub", TokensIn: 40, L3Reuse: true, CacheHitToken: 30},
+		{TokensIn: 500, TokensOut: 50}, // pre-#291 line: no provider
+	}
+	for _, e := range evs {
+		if err := r.Append(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s, err := Summarize(path, DefaultCostMissPerMTok, DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	th := s.ByProvider["tokenhub"]
+	if th == nil || th.Events != 4 || th.ExactEvents != 2 {
+		t.Fatalf("tokenhub stats = %+v, want 4 events / 2 exact", th)
+	}
+	// Estimated + L3 turns must not pollute the exact-metered figures.
+	if th.TokensIn != 5240 || th.CacheHitTokens != 5116 || th.TokensOut != 30 {
+		t.Fatalf("tokenhub exact meters = %+v", th)
+	}
+	if th.L3Reuses != 1 {
+		t.Fatalf("tokenhub L3 = %d, want 1", th.L3Reuses)
+	}
+	if got := th.L1HitRate(); got <= 0.97 || got >= 0.98 {
+		t.Fatalf("L1HitRate = %v, want ≈0.976 (5116/5240)", got)
+	}
+	legacy := s.ByProvider[""]
+	if legacy == nil || legacy.Events != 1 || legacy.ExactEvents != 0 || legacy.TokensIn != 0 {
+		t.Fatalf("legacy bucket = %+v", legacy)
+	}
+	if (&ProviderStats{}).L1HitRate() != 0 {
+		t.Fatal("empty stats hit rate must be 0")
+	}
+}
+
 func TestSummarizeToleratesBadLines(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "usage.jsonl")
 	if _, err := NewRecorder(path); err != nil {


### PR DESCRIPTION
## 问题

GLM spec §4.2-1 说「命中遥测是一切标定的前提」，但 gateway 四个计量点全部 bytes/4 估算、从不解析上游返回的真实 usage——**L1 前缀缓存命中在计量里完全不存在**。

## 实现

- **`usagewire.go`（新）**：五种 usage 形态归一为统一口径（Prompt=全量输入 / CacheHit=前缀缓存部分），fixture 直接用 `glm-spike-week.md` §2 双网关实测数值：
  - OpenAI 风格（恒有 `prompt_tokens_details.cached_tokens`，prompt 全量）
  - Anthropic·腾讯云型（命中才出 `cache_read_input_tokens`、input 增量 → 对账 input+cache_creation+cache_read）
  - Anthropic·AtomClub 型（恒含 cache 字段族）
  - DeepSeek（顶层 `prompt_cache_hit_tokens`）
  - `estimator` 标记的 semantix 合成 usage 拒收（级联网关不回灌估算）
- **SSE 聚合器**捕获上游 usage 帧原文（末帧胜出）；**anthropic 流式转换器**收割 message_start/message_delta 计数（max-merge），并在 [DONE] 前向客户端下发翻译后的真实 usage chunk（OpenAI 面客户端此前拿不到任何 usage）
- **顺手修正一个既有口径 bug**：anthropic 非流式转换把增量 `input_tokens` 直接当 `prompt_tokens`——每次缓存命中都少报其缓存部分
- **四计量点**（L3 hit / passthrough / streamThrough / streamThroughAnthropic）填 `Provider/Vendor/Model` 维度与 `Exact` 标志，真实 usage 可得时替代估算
- **kernel/usage**：`Event` 加 provider/vendor/model/exact（wire 只增，旧日志兼容解析为 ""/false）；`Summary.ByProvider` per-endpoint 分组 + `L1HitRate()`，**仅按 exact 事件计算**（估算事件从未观测过缓存字段，混入会把命中率拉向 0）；`kernel/event.UsagePayload` 与 `docs/events.md` 同步可选字段

## 测试

五形态归一 fixture、SSE 捕获（末帧胜出/无 usage 返 nil）、conv 收割+usage chunk 时序（先 usage 后 [DONE]）、ByProvider 分组含 legacy 空 key 桶、非流式口径回归。`go vet && go test ./... -race` 全绿（`harness/tool` 子进程测试为预先存在的负载敏感 flaky，与本改动无关，已挂 #296）。

为 #292（usage 面板 + doctor 告警）铺平数据面。

Fixes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)