### PR TITLE
feat(cache): add age-aware L3 freshness zones

### DIFF
--- a/docs/specs/issue-261-l3-freshness.md
+++ b/docs/specs/issue-261-l3-freshness.md
@@ -29,8 +29,9 @@ For every Result candidate, `L3Decider` applies:
 1. semantic Hit/Grey/Miss classification;
 2. freshness Hit/Grey/Miss classification;
 3. the stricter of the two verdicts;
-4. context and model isolation;
-5. dependency mtime and fingerprint verification.
+4. the existing judge path when the combined verdict is Grey;
+5. context and model isolation;
+6. dependency mtime and fingerprint verification.
 
 A freshness Grey candidate follows the existing grey-zone judge path. A Miss
 continues to the next candidate, so one stale high-ranked result cannot hide a

--- a/docs/specs/issue-261-l3-freshness.md
+++ b/docs/specs/issue-261-l3-freshness.md
@@ -1,0 +1,59 @@
+# Spec: L3 age-aware freshness zones (Issue 261)
+
+This increment replaces the gateway's binary post-lookup TTL check with an
+age-aware policy inside the L3 candidate loop. Dependency fingerprints remain
+the authoritative content-change gate.
+
+## Policy input
+
+The gateway supplies the request's resolved vendor TTL and one request-scoped
+Unix timestamp through `cache.Query.Freshness`. A zero or negative TTL keeps
+the legacy behavior and disables age classification.
+
+When the policy is active, candidate age is classified as follows:
+
+| Candidate age | Freshness zone | L3 behavior |
+|---|---|---|
+| `0 <= age <= TTL/2` | Hit | Continue through the normal L3 gates |
+| `TTL/2 < age <= TTL` | Grey | Require the configured judge |
+| `age > TTL` | Miss | Reject without calling the judge |
+| Missing or future `CreatedAt` | Miss | Reject fail-closed |
+
+The 50% boundary is deliberately fixed for this first implementation. It adds
+no operator knob before replay data exists to justify one.
+
+## Decision order
+
+For every Result candidate, `L3Decider` applies:
+
+1. semantic Hit/Grey/Miss classification;
+2. freshness Hit/Grey/Miss classification;
+3. the stricter of the two verdicts;
+4. context and model isolation;
+5. dependency mtime and fingerprint verification.
+
+A freshness Grey candidate follows the existing grey-zone judge path. A Miss
+continues to the next candidate, so one stale high-ranked result cannot hide a
+fresh lower-ranked result.
+
+## Compatibility and safety
+
+- Queries without a freshness policy retain legacy CLI behavior.
+- Vendor TTL precedence and existing defaults do not change.
+- The hard TTL remains a fail-closed upper bound.
+- No new dependency, persistence field, or public interface method is added.
+
+## Deferred dependency
+
+Repeated fingerprint failure feedback is not implemented in this increment.
+It depends on Issue 267's `SliceReject` producer-to-score channel, which is not
+present on `main`. Once that channel lands, fingerprint Miss outcomes can feed
+it without changing the freshness verdict defined here.
+
+## Acceptance
+
+- Unknown and expired timestamps fail closed when TTL is active.
+- Candidates in the second half of TTL require judge approval.
+- Expired candidates never spend a judge call.
+- A rejected stale candidate does not block a later fresh candidate.
+- Existing callers with no freshness policy remain unchanged.

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -55,11 +55,12 @@ type RetrievalConfig struct {
 	VectorDim int    `toml:"vector_dim"` // HashEmbedder dimension (<=0 -> 256)
 }
 
-// CacheConfig holds L3 policy. TTL is a gateway-side time window over
-// Slice.CreatedAt (CreatedAt==0 never expires); the kernel dep-fingerprint
-// chain remains the authority for staleness. TTLSeconds is the generic
-// window; VendorTTL overrides it per vendor (design §3.5: DeepSeek 24h /
-// Anthropic 5m) and wins over the built-in vendor defaults in TTLFor.
+// CacheConfig holds L3 policy. TTL is resolved by the gateway and passed to
+// the kernel's age-aware L3 gate: candidates in the second half of the window
+// require a judge, while expired or unstamped candidates fail closed. The
+// dependency-fingerprint chain remains the content-change authority.
+// TTLSeconds is the generic window; VendorTTL overrides it per vendor (design
+// §3.5: DeepSeek 24h / Anthropic 5m) and wins over the built-in defaults.
 type CacheConfig struct {
 	TTLSeconds    int64            `toml:"ttl_seconds"`
 	VendorTTL     map[string]int64 `toml:"vendor_ttl"`

--- a/gateway/e2e_test.go
+++ b/gateway/e2e_test.go
@@ -218,6 +218,37 @@ func TestE2EL3HitZeroUpstreamCalls(t *testing.T) {
 	}
 }
 
+func TestE2EL3UnknownCreatedAtFailsClosed(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"fresh upstream"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	chash, _ := contextHash([]chatMessage{msg("user", "hello world")})
+	s := &slice.Slice{
+		ID: "l3-legacy", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("hello world legacy cached answer"),
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
+	}
+	// Bypass seed: it intentionally backfills CreatedAt for ordinary tests.
+	if err := g.store.Put(s); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.index.Insert(s); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, out := postChat(t, srv, "test-key", chatBody("deepseek-chat", "hello world", false))
+	if resp.Header.Get("x-semantix-cache") != "miss" {
+		t.Fatalf("cache = %q, want miss for unknown CreatedAt (%s)", resp.Header.Get("x-semantix-cache"), out)
+	}
+	if n := up.callCount(); n != 1 {
+		t.Fatalf("upstream calls = %d, want 1", n)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // L2 injection: forwarded request carries the reuse block (acceptance #2)
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -248,16 +248,19 @@ func (g *Gateway) resolveScope(r *http.Request) (slice.Scope, error) {
 	return parseScope(v)
 }
 
-// cacheFresh applies the vendor-aware TTL window over Slice.CreatedAt
-// (design §3.5: DeepSeek 24h / Anthropic 5m, resolved by Config.TTLFor).
-// ttl<=0 or unknown age (CreatedAt==0) never expire (kernel gc semantics);
-// the kernel dep-fingerprint chain stays the staleness authority.
+// cacheFresh is the gateway's final defensive TTL check after the kernel's
+// age-aware candidate gate. An active window treats unknown, future and
+// expired timestamps as stale; ttl<=0 explicitly disables the time policy.
 func (g *Gateway) cacheFresh(s *slice.Slice, vendor string) bool {
 	ttl := g.cfg.TTLFor(vendor)
-	if ttl <= 0 || s.CreatedAt == 0 {
+	if ttl <= 0 {
 		return true
 	}
-	return g.now().Unix()-s.CreatedAt <= ttl
+	now := g.now().Unix()
+	if s.CreatedAt <= 0 || s.CreatedAt > now {
+		return false
+	}
+	return now-s.CreatedAt <= ttl
 }
 
 // randomID returns a hex id for sidecar session files.

--- a/gateway/l3eligible_test.go
+++ b/gateway/l3eligible_test.go
@@ -11,13 +11,13 @@ import (
 // exactly the contract fileStore.Get uses for a slice that left the store.
 type lazyStore struct{}
 
-func (lazyStore) Get(_ string) (*slice.Slice, error)         { return nil, nil }
-func (lazyStore) Put(*slice.Slice) error                     { return nil }
-func (lazyStore) List(slice.Scope) ([]*slice.Slice, error)   { return nil, nil }
-func (lazyStore) ListAll() ([]*slice.Slice, error)           { return nil, nil }
-func (lazyStore) UpdateStats(string, slice.SliceStats) error { return nil }
+func (lazyStore) Get(_ string) (*slice.Slice, error)                 { return nil, nil }
+func (lazyStore) Put(*slice.Slice) error                             { return nil }
+func (lazyStore) List(slice.Scope) ([]*slice.Slice, error)           { return nil, nil }
+func (lazyStore) ListAll() ([]*slice.Slice, error)                   { return nil, nil }
+func (lazyStore) UpdateStats(string, slice.SliceStats) error         { return nil }
 func (lazyStore) UpdateStatsBatch(map[string]slice.SliceStats) error { return nil }
-func (lazyStore) Delete(string) error                        { return nil }
+func (lazyStore) Delete(string) error                                { return nil }
 
 // TestL3EligibleFailClosedOnMissingSlice guards the nil-dereference in
 // l3Eligible: a candidate slice that disappeared from the store (Get returns
@@ -35,5 +35,27 @@ func TestL3EligibleFailClosedOnMissingSlice(t *testing.T) {
 	// closed without panicking in cacheFresh.
 	if g.l3Eligible("gone", "deepseek") {
 		t.Fatal("l3Eligible must fail closed when the slice is missing from the store")
+	}
+}
+
+func TestCacheFreshFailsClosedOnInvalidTimestamps(t *testing.T) {
+	const now = int64(1_000)
+	g := &Gateway{cfg: &Config{}, now: func() time.Time { return time.Unix(now, 0) }}
+	tests := []struct {
+		name      string
+		createdAt int64
+		want      bool
+	}{
+		{"missing", 0, false},
+		{"future", now + 1, false},
+		{"fresh", now - 10, true},
+		{"expired", now - 24*60*60 - 1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := g.cacheFresh(&slice.Slice{CreatedAt: tt.createdAt}, "deepseek"); got != tt.want {
+				t.Fatalf("cacheFresh(%d) = %v, want %v", tt.createdAt, got, tt.want)
+			}
+		})
 	}
 }

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -48,7 +48,10 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	// so the request context is what identifies the caller.
 	jc := &judgeCollector{}
 	ctx := withJudgeCollector(r.Context(), jc)
-	q := cache.Query{UserInput: query, ContextHash: chash, Scope: scope, Model: req.Model}
+	q := cache.Query{
+		UserInput: query, ContextHash: chash, Scope: scope, Model: req.Model,
+		Freshness: cache.Freshness{NowUnix: g.now().Unix(), TTLSeconds: g.cfg.TTLFor(up.Vendor)},
+	}
 
 	// L3: verified reuse — zero upstream calls (design §3.3 step 3). The
 	// kernel gate enforces context/model isolation (fail closed) on top of

--- a/kernel/cache/cache.go
+++ b/kernel/cache/cache.go
@@ -17,6 +17,17 @@ type Query struct {
 	// cached slice to carry the same Model (cross-model reuse is never
 	// allowed, Issue #133). Empty disables the check for legacy entries.
 	Model string
+	// Freshness optionally applies an age gate to L3 candidates. Its zero
+	// value disables the gate so non-gateway callers keep legacy behavior.
+	Freshness Freshness
+}
+
+// Freshness is one request's L3 age policy. NowUnix is captured once by the
+// caller so every candidate sees the same clock; TTLSeconds <= 0 disables the
+// policy.
+type Freshness struct {
+	NowUnix    int64
+	TTLSeconds int64
 }
 
 // L3Result is a reusable cached outcome (verified, fail-closed).

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -12,10 +12,11 @@ import (
 )
 
 // L3Decider implements Decider with a fail-closed L3 path (Issue #59 / U16):
-// a Result slice is reusable only when (a) retrieval finds it clearly
-// relevant (zone Hit), (b) its dependency files still match the captured
-// mtimes (fast path) and (c) the sha256 fingerprint still matches (authority
-// path). Any failure in the chain rejects reuse — never returns stale data.
+// a Result slice is reusable only when (a) retrieval finds it relevant,
+// (b) an optional age policy keeps it in Hit or a judge approves its Grey
+// verdict, (c) its dependency files still match the captured mtimes (fast
+// path) and (d) the sha256 fingerprint still matches (authority path). Any
+// failure in the chain rejects reuse — never returns stale data.
 type L3Decider struct {
 	Index slice.Index
 	Store slice.Store // optional; used to re-read full slices by ID
@@ -59,12 +60,12 @@ func (d *L3Decider) DecideL2(ctx context.Context, q Query) ([]slice.Hit, error) 
 // DecideL3 returns a verified reusable result, or nil when any gate fails
 // (fail-closed). Verification chain, cheapest first:
 //
-//	1. retrieval: Result-typed slice, zone Hit — classified with the
-//	   two-axis L3 verdict (Issue #241): prominence among Result peers
-//	   (resultTop1) plus a scale anchor to the raw top-1 hit (globalTop1,
-//	   usually the byte-identical Prompt twin)
-//	2. mtime fast-fail: every captured dep's mtime unchanged
-//	3. fingerprint authority: Verify reports zero changed paths
+//  1. retrieval: Result-typed slice, classified with the two-axis L3 verdict
+//     (Issue #241) and the optional freshness policy; combined Grey verdicts
+//     require judge approval
+//  2. context/model isolation
+//  3. mtime fast-fail: every captured dep's mtime unchanged
+//  4. fingerprint authority: Verify reports zero changed paths
 //
 // A slice with no dependency capture (Deps nil) is eligible without
 // verification — it depended on nothing, so nothing can go stale.

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -105,7 +105,11 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 
 	for _, h := range cands {
 		s := h.Slice
-		switch z.ClassifyL3(h.Score, resultTop1, globalTop1) {
+		verdict := z.ClassifyL3(h.Score, resultTop1, globalTop1)
+		if fresh := q.Freshness.classify(s.CreatedAt); fresh < verdict {
+			verdict = fresh // freshness may only make reuse more conservative
+		}
+		switch verdict {
 		case zone.Hit:
 			// clear hit: reuse after the remaining gates below
 		case zone.Grey:
@@ -140,6 +144,26 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 		}, nil
 	}
 	return nil, nil
+}
+
+// classify maps candidate age onto the existing three-zone decision model.
+// A disabled policy is neutral (Hit); active policies reject timestamps they
+// cannot establish as valid rather than silently treating legacy data as new.
+func (f Freshness) classify(createdAt int64) zone.Zone {
+	if f.TTLSeconds <= 0 {
+		return zone.Hit
+	}
+	if f.NowUnix <= 0 || createdAt <= 0 || createdAt > f.NowUnix {
+		return zone.Miss
+	}
+	age := f.NowUnix - createdAt
+	if age > f.TTLSeconds {
+		return zone.Miss
+	}
+	if age > f.TTLSeconds/2 {
+		return zone.Grey
+	}
+	return zone.Hit
 }
 
 // verified runs the two-stage dependency check; false is fail-closed.

--- a/kernel/cache/l3_freshness_test.go
+++ b/kernel/cache/l3_freshness_test.go
@@ -1,0 +1,82 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"semantix/kernel/slice"
+	"semantix/kernel/zone"
+)
+
+func TestFreshnessClassifyBoundaries(t *testing.T) {
+	const now = int64(1_000)
+	policy := Freshness{NowUnix: now, TTLSeconds: 100}
+	tests := []struct {
+		name      string
+		createdAt int64
+		want      zone.Zone
+	}{
+		{"new", now, zone.Hit},
+		{"half ttl", now - 50, zone.Hit},
+		{"second half", now - 51, zone.Grey},
+		{"ttl boundary", now - 100, zone.Grey},
+		{"expired", now - 101, zone.Miss},
+		{"missing timestamp", 0, zone.Miss},
+		{"future timestamp", now + 1, zone.Miss},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := policy.classify(tt.createdAt); got != tt.want {
+				t.Fatalf("classify(%d) = %s, want %s", tt.createdAt, got, tt.want)
+			}
+		})
+	}
+	if got := (Freshness{}).classify(0); got != zone.Hit {
+		t.Fatalf("disabled policy = %s, want neutral hit", got)
+	}
+}
+
+func TestDecideL3AgedHitRequiresJudge(t *testing.T) {
+	const now = int64(1_000)
+	h := hitOf("aged", slice.Result, 1)
+	h.Slice.CreatedAt = now - 60
+	idx := &fixedIndex{hits: []slice.Hit{h}}
+	q := Query{UserInput: "same task", Scope: slice.Project,
+		Freshness: Freshness{NowUnix: now, TTLSeconds: 100}}
+
+	withoutJudge := &L3Decider{Index: idx, Root: t.TempDir()}
+	if got, err := withoutJudge.DecideL3(context.Background(), q); err != nil || got != nil {
+		t.Fatalf("aged hit without judge = %+v, %v; want nil, nil", got, err)
+	}
+
+	mj := &mockJudge{confirm: true}
+	withJudge := &L3Decider{Index: idx, Root: t.TempDir(), Judge: mj}
+	got, err := withJudge.DecideL3(context.Background(), q)
+	if err != nil || got == nil || got.SliceID != "aged" {
+		t.Fatalf("judge-approved aged hit = %+v, %v; want aged", got, err)
+	}
+	if mj.got == nil || mj.got.Zone != zone.Grey {
+		t.Fatalf("freshness downgrade did not enter grey judge path: %+v", mj.got)
+	}
+}
+
+func TestDecideL3ExpiredCandidateSkipsToFreshCandidate(t *testing.T) {
+	const now = int64(1_000)
+	expired := hitOf("expired", slice.Result, 1)
+	expired.Slice.CreatedAt = now - 101
+	fresh := hitOf("fresh", slice.Result, 0.95)
+	fresh.Slice.CreatedAt = now - 10
+	idx := &fixedIndex{hits: []slice.Hit{expired, fresh}}
+	mj := &mockJudge{confirm: true}
+	d := &L3Decider{Index: idx, Root: t.TempDir(), Judge: mj}
+	q := Query{UserInput: "same task", Scope: slice.Project,
+		Freshness: Freshness{NowUnix: now, TTLSeconds: 100}}
+
+	got, err := d.DecideL3(context.Background(), q)
+	if err != nil || got == nil || got.SliceID != "fresh" {
+		t.Fatalf("DecideL3 = %+v, %v; want fresh candidate", got, err)
+	}
+	if mj.got != nil {
+		t.Fatalf("expired candidate must not spend a judge call: %+v", mj.got)
+	}
+}


### PR DESCRIPTION
## Summary

- add a three-zone L3 freshness policy inside the per-candidate cache decision loop
- keep candidates fresh through the first half of TTL, judge-gate the second half, and fail closed after TTL
- reject missing/future `CreatedAt` values when a TTL is active
- preserve vendor TTL precedence and zero-value compatibility for non-gateway callers
- document that fingerprint-failure feedback remains deferred to #267

## Why

The old gateway applied TTL as a binary post-lookup filter. `CreatedAt == 0` bypassed it, and a stale top candidate could prevent the decider from considering a fresh lower-ranked result. Moving freshness into `L3Decider` makes age part of the candidate verdict and reuses the existing Grey judge path.

## Commit structure

1. freshness specification
2. kernel policy and regression tests
3. gateway wiring and E2E coverage
4. documentation correction found during the required review pass

## Verification

- `go test ./kernel/cache ./gateway -count=1`
- `go test -race ./kernel/cache ./gateway -count=1`
- `go vet ./kernel/cache ./gateway`
- freshness/L3 focused tests repeated 20 times
- full base-to-head review completed; one documentation-order mismatch fixed in commit 4

`go test ./kernel/... -count=1` passes every package except the existing Windows file-lock failure in `kernel/slice.TestJournalForwardCompat`. The PR branch is based on current `main` after #297 and preserves its gateway usage-adapter changes.

Partially addresses #261. Fingerprint failure feedback remains dependent on #267.