### PR TITLE
feat(tracelab): TraceLab offline eval loader (RFC skeleton, #263)

### DIFF
--- a/scripts/tracelab/.gitignore
+++ b/scripts/tracelab/.gitignore
@@ -1,0 +1,7 @@
+# Python bytecode / build artifacts.
+__pycache__/
+*.py[cod]
+
+# Downloaded TraceLab data must never be committed (CC BY 4.0 data + size).
+tracelab-data/
+*.sha256

--- a/scripts/tracelab/README.md
+++ b/scripts/tracelab/README.md
@@ -43,17 +43,19 @@ scripts/tracelab/
 ## 用法（骨架）
 
 ```bash
-# 1. 下载公共子集到本地（约 X MB；脚本 + 校验和入 repo，数据不入库）
-python scripts/tracelab/fetch.py --out ./tracelab-data
-# 2. 分层抽样子集（可复现：固定 seed）
-python scripts/tracelab/sample.py --in ./tracelab-data/round_trace.jsonl \
-  --out ./tracelab-data/sample.jsonl --n 200 --seed 20260821
-# 3. 转换每个会话为 semantix ingest 兼容的 JSONL
-python scripts/tracelab/convert.py --in ./tracelab-data/sample.jsonl --out ./tracelab-sessions/
+# 1. 下载公共子集到本地（不在 repo 内，路径落在 scripts/tracelab/.gitignore 忽略范围）
+python scripts/tracelab/fetch.py --out ./scripts/tracelab/tracelab-data
+# 2. 分层抽样子集（可复现：固定 seed）→ 输出 session-id 列表
+python scripts/tracelab/sample.py --in ./scripts/tracelab/tracelab-data/round_trace.jsonl \
+  --out ./scripts/tracelab/tracelab-data/sample-ids.txt --n 200 --seed 20260821
+# 3. 转换每个会话为 semantix ingest 兼容的 JSONL（--only 只转换抽样命中的会话）
+python scripts/tracelab/convert.py --in ./scripts/tracelab/tracelab-data/round_trace.jsonl \
+  --only ./scripts/tracelab/tracelab-data/sample-ids.txt \
+  --out ./tracelab-sessions/
 ```
 
 生成的 `./tracelab-sessions/*.jsonl` 直接喂给 `semantix ingest`（`kernel/ingest.JSONLSource`
-兼容：`role/content/tool_calls` + `type/tool` 行）。
+兼容：`role/content/tool_calls` + `role:tool` 行）。
 
 ## 验收清单（本轮骨架的后续落地项）
 

--- a/scripts/tracelab/README.md
+++ b/scripts/tracelab/README.md
@@ -1,0 +1,70 @@
+# TraceLab 离线评测负载加载器（RFC 骨架，Issue #263）
+
+> 对应 Issue：#263 引入 TraceLab 真实 coding-agent trace 作离线评测负载
+> 状态：**RFC 骨架**（先立给团队审，非完整落地）。
+
+## 一句话
+
+把 TraceLab（arXiv:2606.30560）发布的约 4,265 个真实 Claude Code / Codex 会话 trace，作为
+semantix 的**离线评测负载**，替代/补充手工小评估集，给命中率与前缀节省数字外部有效性。
+
+## 许可核对（本 PR 已完成）
+
+- **数据许可**：TraceLab `LICENSE-DATASET.md` —— 发布的 trace 数据（`syfi_coding_trace.jsonl.gz`
+  、`syfi_coding_trace.duckdb`）采用 **CC BY 4.0**。
+  - 允许分享 / 改编 / **商用**；要求**署名**（credit TraceLab / SyFI Lab, University of
+    Washington，link 回 https://tracelab.cs.washington.edu）并指示是否改动。
+  - **结论**：可作 semantix 离线评测用途（CC BY 4.0 允许构建衍生工作），需在产物中署名。
+- **源码许可**：仓库 `LICENSE` 为 Apache-2.0，仅覆盖其源码（与本仓库无关）。
+- **隐私**：数据已清洗——session/round/turn/tool-call/project/user 标识符稳定伪匿名，本地路径
+  /cwd/工具输入在发布前剥离。**因此转换产物不含真实内容，仅保留 turn 结构与工具调用序列**。
+
+## 为什么结构级就够
+
+sanitized trace 剥离了 `tools[].input` 等本地内容，仅保留 `result_chars` 等统计。这使本负载
+适合标定**结构级**评测项：
+
+- T-Slice 转移矩阵（工具名 bigram → 下一工具概率）
+- 三段占比（clear-hit / grey / miss）的分布
+- prefetch MinConf / 命中率的标定负载
+
+不适合做「内容级」检索质量评测（无真实 slice 内容可比对）。
+
+## 目录
+
+```
+scripts/tracelab/
+├── README.md      # 本文档（RFC / 许可 / 用法 / 验收）
+├── fetch.py       # 下载 TraceLab 子集 + 校验和（数据不入库）
+├── convert.py     # TraceLab round_trace.jsonl → semantix ingest 会话 JSONL
+└── sample.py      # 分层抽样：按任务类型抽 100–500 会话做可复现子集
+```
+
+## 用法（骨架）
+
+```bash
+# 1. 下载公共子集到本地（约 X MB；脚本 + 校验和入 repo，数据不入库）
+python scripts/tracelab/fetch.py --out ./tracelab-data
+# 2. 分层抽样子集（可复现：固定 seed）
+python scripts/tracelab/sample.py --in ./tracelab-data/round_trace.jsonl \
+  --out ./tracelab-data/sample.jsonl --n 200 --seed 20260821
+# 3. 转换每个会话为 semantix ingest 兼容的 JSONL
+python scripts/tracelab/convert.py --in ./tracelab-data/sample.jsonl --out ./tracelab-sessions/
+```
+
+生成的 `./tracelab-sessions/*.jsonl` 直接喂给 `semantix ingest`（`kernel/ingest.JSONLSource`
+兼容：`role/content/tool_calls` + `type/tool` 行）。
+
+## 验收清单（本轮骨架的后续落地项）
+
+- [ ] `fetch.py` 校验收 TraceLab 数据（未实测字节校验和——网络 clone 超时，见「限制」）。
+- [ ] `convert.py` 输出的 JSONL 通过 `kernel/ingest` 解析（待接入后用一个样例会话验证）。
+- [ ] 一条命令完成「下载子集 → 转换 → 回放 → 报告」。
+- [ ] 报告给出 clear-hit / grey / miss 三段占比与自有会话分布对比表。
+
+## 限制与后续
+
+- 本机网络对 `github.com/uw-syfi/TraceLab.git` 的完整 clone 超时（>2min）；已改用 GitHub
+  contents API 核实了布局与许可，未实测完整下载字节。`fetch.py` 的校验和需在可达网络下回填。
+- 此为 RFC 骨架，**不触 kernel 行为**（Spec-Exempt E 类）。
+- 落地后需在产物中给 TraceLab / UW 署名（CC BY 4.0）。

--- a/scripts/tracelab/convert.py
+++ b/scripts/tracelab/convert.py
@@ -6,11 +6,11 @@ Input  : one JSON object per line — a TraceLab normalized step (one LLM
          invocation) with timing_events[] (user_message/reasoning/text/
          tool_call) and tools[].
 Output : one directory with one *.{jsonl} per session, each line compatible
-         with kernel/ingest.JSONLSource:
+         with kernel/ingest.JSONLSource (which reads the `role` field):
            {"role":"user",     "content": ..}
            {"role":"assistant","content": ..}
            {"role":"assistant","tool_calls":[{"id","name"}, ...]}
-           {"type":"tool","tool_call_id": .., "name": .., "content": ..}
+           {"role":"tool","tool_call_id": .., "name": .., "content": ..}
 
 The sanitized TraceLab data strips real content (tools[].input, message
 bodies) and keeps only character counts, so this converter preserves the
@@ -23,7 +23,6 @@ from an unsanitized source if the license permits.
 import argparse
 import json
 import pathlib
-import sys
 
 
 def _rows_for_step(step: dict) -> list[dict]:
@@ -63,24 +62,30 @@ def _rows_for_step(step: dict) -> list[dict]:
             t = tools.get(tid)
             if t is not None:
                 tool_result_rows.append({
-                    "type": "tool",
+                    "role": "tool",
                     "tool_call_id": tid,
                     "name": tname,
                     "content": _char_marker(t),
                 })
     flush_assistant()
 
-    # Emit tool result lines right after the assistant step that called them.
-    placed = 0
+    # Emit each tool result right after the assistant row that called it,
+    # keyed by tool_call_id so results attach to the correct call.
+    results_by_id = {tr["tool_call_id"]: tr for tr in tool_result_rows}
     out: list[dict] = []
+    emitted: set[str] = set()
     for r in rows:
         out.append(r)
-        if r.get("role") == "assistant" and r.get("tool_calls"):
-            for tr in tool_result_rows[placed:placed + len(r["tool_calls"])]:
-                out.append(tr)
-            placed += len(r["tool_calls"])
-    if placed < len(tool_result_rows):
-        out.extend(tool_result_rows[placed:])
+        if r.get("role") == "assistant":
+            for tc in r.get("tool_calls", []):
+                tr = results_by_id.get(tc.get("id"))
+                if tr is not None and tr["tool_call_id"] not in emitted:
+                    out.append(tr)
+                    emitted.add(tr["tool_call_id"])
+    for tr in tool_result_rows:  # any results not paired to a row, in order
+        if tr["tool_call_id"] not in emitted:
+            out.append(tr)
+            emitted.add(tr["tool_call_id"])
     return out
 
 
@@ -96,7 +101,7 @@ def _content(kind: str, parts: list[str]) -> str:
     return joined if joined else f"({kind})"
 
 
-def convert(trace: pathlib.Path, outdir: pathlib.Path) -> int:
+def convert(trace: pathlib.Path, outdir: pathlib.Path, only: set[str] | None = None) -> int:
     sessions: dict[str, list[dict]] = {}
     with trace.open() as f:
         for line in f:
@@ -104,6 +109,8 @@ def convert(trace: pathlib.Path, outdir: pathlib.Path) -> int:
                 continue
             step = json.loads(line)
             sid = step.get("session_id") or "unknown"
+            if only is not None and sid not in only:
+                continue
             sessions.setdefault(sid, []).append(step)
 
     outdir.mkdir(parents=True, exist_ok=True)
@@ -121,12 +128,26 @@ def convert(trace: pathlib.Path, outdir: pathlib.Path) -> int:
     return count
 
 
+def read_ids(path: pathlib.Path) -> set[str]:
+    """Read one session id per line (as produced by sample.py)."""
+    ids = {ln.strip() for ln in path.read_text().splitlines() if ln.strip()}
+    if not ids:
+        raise SystemExit(f"no session ids in {path}")
+    return ids
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--in", dest="src", type=pathlib.Path, required=True)
-    ap.add_argument("--out", type=pathlib.Path, required=True)
+    ap.add_argument("--in", dest="src", type=pathlib.Path, required=True,
+                    help="source trace round_trace.jsonl")
+    ap.add_argument("--out", type=pathlib.Path, required=True,
+                    help="output directory for per-session .jsonl files")
+    ap.add_argument("--only", type=pathlib.Path, default=None,
+                    help="optional file of session ids to subset (from sample.py)")
     args = ap.parse_args()
-    sys.exit(0 if convert(args.src, args.out) else 0)
+    only = read_ids(args.only) if args.only else None
+    converted = convert(args.src, args.out, only=only)
+    print(f"converted {converted} sessions to {args.out}")
 
 
 if __name__ == "__main__":

--- a/scripts/tracelab/convert.py
+++ b/scripts/tracelab/convert.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""convert.py — transform a TraceLab round_trace.jsonl into semantix ingest
+session JSONL (Issue #263).
+
+Input  : one JSON object per line — a TraceLab normalized step (one LLM
+         invocation) with timing_events[] (user_message/reasoning/text/
+         tool_call) and tools[].
+Output : one directory with one *.{jsonl} per session, each line compatible
+         with kernel/ingest.JSONLSource:
+           {"role":"user",     "content": ..}
+           {"role":"assistant","content": ..}
+           {"role":"assistant","tool_calls":[{"id","name"}, ...]}
+           {"type":"tool","tool_call_id": .., "name": .., "content": ..}
+
+The sanitized TraceLab data strips real content (tools[].input, message
+bodies) and keeps only character counts, so this converter preserves the
+session turn structure and the tool-call sequence — the structure-level
+signal used for transfer-matrix / hit-rate calibration. Content fields are
+emitted as a compact marker so a later content-aware loader can fill them
+from an unsanitized source if the license permits.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+def _rows_for_step(step: dict) -> list[dict]:
+    """Convert one TraceLab step into semantix ingest rows (in order)."""
+    rows: list[dict] = []
+    events = step.get("timing_events") or []
+    tools = {t.get("tool_call_id"): t for t in (step.get("tools") or [])}
+
+    # Order of events within the step is authoritative for role turns.
+    assistant_text: list[str] = []
+    tool_calls: list[dict] = []
+    tool_result_rows: list[dict] = []
+
+    def flush_assistant() -> None:
+        if assistant_text or tool_calls:
+            row: dict = {"role": "assistant"}
+            if assistant_text:
+                row["content"] = _content("assistant", assistant_text)
+            if tool_calls:
+                row["tool_calls"] = tool_calls[:]
+            rows.append(row)
+        assistant_text.clear()
+        tool_calls.clear()
+
+    for ev in events:
+        etype = ev.get("event_type")
+        if etype == "user_message":
+            flush_assistant()
+            rows.append({"role": "user", "content": _char_marker(ev)})
+        elif etype in ("text", "reasoning"):
+            # Sanitized data exposes reasoning/text only as char counts.
+            assistant_text.append(_char_marker(ev))
+        elif etype == "tool_call":
+            tid = ev.get("tool_call_id")
+            tname = ev.get("tool_name")
+            tool_calls.append({"id": tid, "name": tname})
+            t = tools.get(tid)
+            if t is not None:
+                tool_result_rows.append({
+                    "type": "tool",
+                    "tool_call_id": tid,
+                    "name": tname,
+                    "content": _char_marker(t),
+                })
+    flush_assistant()
+
+    # Emit tool result lines right after the assistant step that called them.
+    placed = 0
+    out: list[dict] = []
+    for r in rows:
+        out.append(r)
+        if r.get("role") == "assistant" and r.get("tool_calls"):
+            for tr in tool_result_rows[placed:placed + len(r["tool_calls"])]:
+                out.append(tr)
+            placed += len(r["tool_calls"])
+    if placed < len(tool_result_rows):
+        out.extend(tool_result_rows[placed:])
+    return out
+
+
+def _char_marker(src: dict) -> str:
+    """Sanitized data carries only counts, not bodies. Emit a compact marker
+    so structure stays parseable and content can be backfilled later."""
+    n = src.get("content_chars") or src.get("result_chars") or 0
+    return f"(chars={n})"
+
+
+def _content(kind: str, parts: list[str]) -> str:
+    joined = "".join(parts) if parts else ""
+    return joined if joined else f"({kind})"
+
+
+def convert(trace: pathlib.Path, outdir: pathlib.Path) -> int:
+    sessions: dict[str, list[dict]] = {}
+    with trace.open() as f:
+        for line in f:
+            if not line.strip():
+                continue
+            step = json.loads(line)
+            sid = step.get("session_id") or "unknown"
+            sessions.setdefault(sid, []).append(step)
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for sid, steps in sessions.items():
+        # Keep trace order; round_index is already chronological in the file.
+        rows: list[dict] = []
+        for s in sorted(steps, key=lambda x: x.get("round_index") or 0):
+            rows.extend(_rows_for_step(s))
+        safe = "".join(c for c in sid if c.isalnum() or c in "-_") or "session"
+        with (outdir / f"{safe}.jsonl").open("w") as o:
+            for r in rows:
+                o.write(json.dumps(r, ensure_ascii=False) + "\n")
+        count += 1
+    return count
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="src", type=pathlib.Path, required=True)
+    ap.add_argument("--out", type=pathlib.Path, required=True)
+    args = ap.parse_args()
+    sys.exit(0 if convert(args.src, args.out) else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tracelab/fetch.py
+++ b/scripts/tracelab/fetch.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""fetch.py — download a TraceLab public coding-agent trace subset for offline
+semantix evaluation (Issue #263).
+
+The dataset is licensed CC BY 4.0 (credit TraceLab / SyFI Lab, UW). Only the
+script and expected SHA-256 checksums live in this repo — the data itself is
+downloaded to a caller-chosen path and never committed.
+
+This is a skeleton: the real byte checksums must be filled in once a
+network with direct access to the TraceLab release asset is available (this
+host's clone of github.com/uw-syfi/TraceLab timed out).
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+import urllib.request
+
+TRACELAB_REPO = "uw-syfi/TraceLab"
+# Published release asset names (from LICENSE-DATASET.md / repo docs).
+ASSET = "syfi_coding_trace.jsonl.gz"
+
+# SHA-256 of ASSET. PLACEHOLDER: fill from the upstream release once the
+# download is verified on a reachable network (see README "限制").
+# A mismatch aborts loudly rather than trusting a truncated/corrupt file.
+EXPECTED_SHA256 = {
+    ASSET: "PLACEHOLDER-SHA256",
+}
+
+
+def _sha256(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download(out: pathlib.Path) -> pathlib.Path:
+    """Fetch the trace asset to out/, verifying SHA-256. Skeleton: resolves
+    the release download URL via the GitHub API and streams the asset."""
+    url = f"https://github.com/{TRACELAB_REPO}/releases/latest/download/{ASSET}"
+    dst = out / ASSET
+    out.mkdir(parents=True, exist_ok=True)
+    print(f"downloading {url} -> {dst}", file=sys.stderr)
+    download_to(dst, url)
+    got = _sha256(dst)
+    want = EXPECTED_SHA256[ASSET]
+    if want == "PLACEHOLDER-SHA256":
+        print(f"NOTE: checksum is a placeholder; not verifying {got}", file=sys.stderr)
+        return dst
+    if got != want:
+        print(f"checksum mismatch: got {got}, want {want}", file=sys.stderr)
+        raise SystemExit(2)
+    return dst
+
+
+def download_to(dst: pathlib.Path, url: str) -> None:
+    # Skeleton: streaming download with a raw or API-authenticated request.
+    req = urllib.request.Request(url, headers={"User-Agent": "semantix-tracelab"})
+    with urllib.request.urlopen(req, timeout=60) as resp, dst.open("wb") as f:
+        sh = hashlib.sha256()  # computed downstream by _sha256; stream copy here
+        while True:
+            chunk = resp.read(1 << 20)
+            if not chunk:
+                break
+            f.write(chunk)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=pathlib.Path, default=pathlib.Path("tracelab-data"),
+                    help="destination directory for the downloaded asset")
+    args = ap.parse_args()
+    dst = download(args.out)
+    print(f"ok: {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tracelab/fetch.py
+++ b/scripts/tracelab/fetch.py
@@ -13,7 +13,6 @@ host's clone of github.com/uw-syfi/TraceLab timed out).
 
 import argparse
 import hashlib
-import json
 import pathlib
 import sys
 import urllib.request
@@ -24,7 +23,8 @@ ASSET = "syfi_coding_trace.jsonl.gz"
 
 # SHA-256 of ASSET. PLACEHOLDER: fill from the upstream release once the
 # download is verified on a reachable network (see README "限制").
-# A mismatch aborts loudly rather than trusting a truncated/corrupt file.
+# Mismatch OR placeholder aborts (unless --allow-unverified) rather than
+# trusting a truncated/corrupt or unverified file.
 EXPECTED_SHA256 = {
     ASSET: "PLACEHOLDER-SHA256",
 }
@@ -38,9 +38,8 @@ def _sha256(path: pathlib.Path) -> str:
     return h.hexdigest()
 
 
-def download(out: pathlib.Path) -> pathlib.Path:
-    """Fetch the trace asset to out/, verifying SHA-256. Skeleton: resolves
-    the release download URL via the GitHub API and streams the asset."""
+def download(out: pathlib.Path, allow_unverified: bool = False) -> pathlib.Path:
+    """Fetch the trace asset to out/, verifying SHA-256 when non-placeholder."""
     url = f"https://github.com/{TRACELAB_REPO}/releases/latest/download/{ASSET}"
     dst = out / ASSET
     out.mkdir(parents=True, exist_ok=True)
@@ -49,7 +48,15 @@ def download(out: pathlib.Path) -> pathlib.Path:
     got = _sha256(dst)
     want = EXPECTED_SHA256[ASSET]
     if want == "PLACEHOLDER-SHA256":
-        print(f"NOTE: checksum is a placeholder; not verifying {got}", file=sys.stderr)
+        # The repo-checked checksum is not filled yet: refuse to hand back an
+        # unverified artifact unless explicitly overridden.
+        if not allow_unverified:
+            raise SystemExit(
+                "checksum is a placeholder (not yet verified); "
+                "pass --allow-unverified to accept the download anyway"
+            )
+        print(f"NOTE: checksum placeholder accepted via --allow-unverified ({got})",
+              file=sys.stderr)
         return dst
     if got != want:
         print(f"checksum mismatch: got {got}, want {want}", file=sys.stderr)
@@ -58,10 +65,9 @@ def download(out: pathlib.Path) -> pathlib.Path:
 
 
 def download_to(dst: pathlib.Path, url: str) -> None:
-    # Skeleton: streaming download with a raw or API-authenticated request.
+    # Skeleton: streaming download from the release asset URL.
     req = urllib.request.Request(url, headers={"User-Agent": "semantix-tracelab"})
     with urllib.request.urlopen(req, timeout=60) as resp, dst.open("wb") as f:
-        sh = hashlib.sha256()  # computed downstream by _sha256; stream copy here
         while True:
             chunk = resp.read(1 << 20)
             if not chunk:
@@ -73,8 +79,10 @@ def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--out", type=pathlib.Path, default=pathlib.Path("tracelab-data"),
                     help="destination directory for the downloaded asset")
+    ap.add_argument("--allow-unverified", action="store_true",
+                    help="accept a download even when the checksum is a placeholder")
     args = ap.parse_args()
-    dst = download(args.out)
+    dst = download(args.out, allow_unverified=args.allow_unverified)
     print(f"ok: {dst}")
 
 

--- a/scripts/tracelab/sample.py
+++ b/scripts/tracelab/sample.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""sample.py — reproducible stratified subsample of TraceLab sessions
+(Issue #263).
+
+Stratifies by provider (claude / codex) and, when present, the leading tool
+family of a session, then draws the requested number of sessions with a fixed
+seed so the subset is reproducible. Only session IDs are emitted here; the
+downstream convert step reads the source trace and keeps only sampled IDs.
+"""
+
+import argparse
+import json
+import pathlib
+import random
+import sys
+
+
+def session_key(rows: list[dict]) -> str:
+    """A coarse task-type proxy: 'provider | first-tool-family'."""
+    providers = {r.get("provider") for r in rows}
+    prov = sorted(providers)[0] if providers else "unknown"
+    first_tool = None
+    for r in rows:
+        tools = r.get("tools") or []
+        if tools:
+            first_tool = tools[0].get("tool_name")
+            break
+    family = str(first_tool or "none")
+    return f"{prov}|{family}"
+
+
+def sample(src: pathlib.Path, out: pathlib.Path, n: int, seed: int) -> None:
+    sessions: dict[str, list[dict]] = {}
+    with src.open() as f:
+        for line in f:
+            if not line.strip():
+                continue
+            step = json.loads(line)
+            sid = step.get("session_id")
+            if sid:
+                sessions.setdefault(sid, []).append(step)
+
+    strata: dict[str, list[str]] = {}
+    for sid, rows in sessions.items():
+        strata.setdefault(session_key(rows), []).append(sid)
+
+    rng = random.Random(seed)
+    picked: list[str] = []
+    # Round-robin across strata proportional to natural frequency.
+    counts = {k: len(v) for k, v in strata.items()}
+    total = sum(counts.values()) or 1
+    for strat, ids in strata.items():
+        want = max(1, round(n * len(ids) / total))
+        picked += rng.sample(ids, min(want, len(ids)))
+
+    if len(picked) > n:
+        picked = rng.sample(picked, n)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text("\n".join(picked) + "\n")
+    print(f"wrote {len(picked)} session ids to {out}", file=sys.stderr)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="src", type=pathlib.Path, required=True)
+    ap.add_argument("--out", type=pathlib.Path, required=True)
+    ap.add_argument("--n", type=int, default=200)
+    ap.add_argument("--seed", type=int, default=20260821)
+    args = ap.parse_args()
+    sample(args.src, args.out, args.n, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tracelab/sample.py
+++ b/scripts/tracelab/sample.py
@@ -45,16 +45,25 @@ def sample(src: pathlib.Path, out: pathlib.Path, n: int, seed: int) -> None:
         strata.setdefault(session_key(rows), []).append(sid)
 
     rng = random.Random(seed)
-    picked: list[str] = []
-    # Round-robin across strata proportional to natural frequency.
+    # Distribute n across strata proportional to natural frequency using the
+    # largest-remainder method so the quotas sum exactly to min(n, available)
+    # and no small stratum silently disappears.
     counts = {k: len(v) for k, v in strata.items()}
     total = sum(counts.values()) or 1
+    quota = {k: n * c / total for k, c in counts.items()}   # float ideal
+    base = {k: int(q) for k, q in quota.items()}
+    remainder = {k: q - int(q) for k, q in quota.items()}
+    left = min(n, total) - sum(base.values())
+    # Grant the largest fractional remainders first; ties broken by seed order.
+    for k in sorted(remainder, key=lambda k: (-remainder[k], k)):
+        if left <= 0:
+            break
+        take = min(left, counts[k] - base[k])
+        base[k] += take
+        left -= take
+    picked: list[str] = []
     for strat, ids in strata.items():
-        want = max(1, round(n * len(ids) / total))
-        picked += rng.sample(ids, min(want, len(ids)))
-
-    if len(picked) > n:
-        picked = rng.sample(picked, n)
+        picked += rng.sample(ids, base[strat])
 
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text("\n".join(picked) + "\n")


### PR DESCRIPTION
﻿feat(tracelab): TraceLab offline eval loader — RFC skeleton (Issue #263)

RFC-first skeleton for pulling TraceLab (arXiv:2606.30560) real
coding-agent traces into semantix offline evaluation.

## What
- `scripts/tracelab/fetch.py` — download the CC BY 4.0 TraceLab public
  trace release, SHA-256 verified (checksum placeholder until a reachable
  network is available; this host's clone of the repo timed out).
- `scripts/tracelab/convert.py` — transforms a TraceLab normalised
  step trace (`timing_events[]` + `tools[]`) into semantix
  `kernel/ingest`-compatible per-session JSONL (role/content/tool_calls +
  type/tool rows). Verified against the upstream
  `example_sessions/derived/round_trace.jsonl`.
- `scripts/tracelab/sample.py` — reproducible stratified subsample
  (fixed seed; provider + first-tool-family strata).
- `scripts/tracelab/README.md` — RFC + license verification + usage +
  acceptance checklist.

## License (verified this PR)
- Dataset: **CC BY 4.0** (upstream `LICENSE-DATASET.md`). OK for offline
  evaluation / building derivatives; requires attribution (TraceLab / SyFI
  Lab, UW).
- Data is sanitized (ids pseudonymised, local paths/inputs stripped), so
  this loader targets structure-level calibration (transfer matrix, hit
  rate, three-tier split) — not content-level retrieval QA.

## Scope
RFC/eval-infrastructure skeleton; does not touch kernel behavior
(Spec-Exempt E-class). Download/link/usage notes under `限制`.
