### PR TITLE
fix(prefetch): probation probe frees demoted candidates (Issue #282)

### DIFF
--- a/docs/specs/issue-282-demote-probation.md
+++ b/docs/specs/issue-282-demote-probation.md
@@ -91,6 +91,40 @@ decision rule needs:
 Recovery therefore costs at most one slot per `ProbationInterval` rounds per
 tool and requires sustained evidence, not a single lucky hit.
 
+## Known cost: probe outcomes drive the global evolve knob
+
+A probe is an ordinary `PrefetchTask`, so its outcome is settled like any
+other: `harness/agent/prefetch_feedback.go` emits `PrefetchWaste`, which
+`harness/semantix/evolution.go` turns into `evolve.RecordSignal("prefetch_waste")`,
+which does `PrefetchConf += 0.05` and is pushed back through
+`ApplyEvolution` into `cfg.MinConf` for **every** candidate on **every**
+transition edge.
+
+A demoted candidate is by construction mostly-waste, so probation's expected
+output is a stream of global tightening steps. Measured on the U43 controlled
+experiment (`scripts/evolution-curve`, evolve-ON run, 25 sessions):
+
+```
+prefetch_conf trajectory
+  main:        … 0.250 0.300 0.350 0.350 0.350 0.350 … 0.350
+  + probation: … 0.250 0.300 0.350 0.350 0.400 0.450 … 0.500
+waste count 6 → 9, total cost 0.486 → 0.504 USD
+```
+
+The evolve loop's entire learned relaxation is undone by probe wastes.
+
+This is the exploration/exploitation confusion in its plainest form: the cost
+of an *explore* action is fed back as evidence that the *exploit* threshold
+should tighten. It is **not** specific to probation — the `Epsilon` escape of
+Issue 254 has the same property, since its probe tasks also become
+`PrefetchWaste` events. Separating probe outcomes from real outcomes requires
+distinguishing them along the event path, which is outside `kernel/prefetch`
+and outside this change. Tracked separately.
+
+The mitigation that *is* in scope here is the ordering fix above: probation
+ignores `MinConf`, so a ratcheted `PrefetchConf` can no longer strand a
+demoted candidate in the region neither probe reaches.
+
 ## Determinism
 
 The probe is driven by a counter and a totally-ordered rotation, not by

--- a/docs/specs/issue-282-demote-probation.md
+++ b/docs/specs/issue-282-demote-probation.md
@@ -1,0 +1,120 @@
+# Spec: prefetch demote probation (Issue 282)
+
+Issue 255 defined the complementary hit/waste feedback stream and Issue 254 the
+`Epsilon` escape from the `MinConf` exclusion. This addendum defines how a
+*demoted* candidate re-enters `MatrixPrefetcher.Plan` without changing the
+frozen `Prefetcher` interface.
+
+## Problem
+
+Demotion is an absorbing state. `Plan` skips demoted candidates, so a demoted
+key is never proposed, never reaches the harness feedback path
+(`harness/semantix/evolution.go` emits `PrefetchHit`/`PrefetchWaste` only for
+planned targets), and therefore never receives another `ObserveHit` or
+`ObserveWaste`. Both EWMAs freeze and `waste / hit` stays above
+`WasteHitLimit` forever.
+
+Issue 255 states that "later hits may restore it once the ratio returns below
+the limit". That promise is unreachable through the production feedback path:
+the only test covering it (`TestWastePenaltyRecoversAfterSustainedHits`) calls
+`ObserveHit` directly, which the running system can never do for a demoted key.
+The arithmetic recovers; the system does not.
+
+The consequence is a monotone decline in prefetch coverage: one bad window
+permanently removes a transition edge, and edges are never returned.
+
+## Probation probe
+
+`Config.ProbationInterval` (default 10) admits one demoted candidate every Nth
+eligible `Plan` call for that transition table:
+
+- a `Plan` call is *eligible* when the last tool has a learned transition
+  table; calls that return early (no history, unknown tool) do not advance the
+  counter;
+- **the counter is keyed by the last tool**, not global. The demoted set is
+  rebuilt per `last` from `m.bigrams[last]`, so a single global counter would
+  put each tool in its own residue class: under any periodic interleaving whose
+  period shares a factor with `ProbationInterval` — a two-tool alternation with
+  the default N=10, for instance — whole transition tables would never receive
+  a probation round and the absorbing state would survive verbatim;
+- on every Nth eligible call for that tool, one candidate excluded by demotion
+  is admitted as a probe. The slot rotates through that tool's demoted set, so
+  a leader that never recovers cannot starve the others out of the channel;
+- the rotation order is probability descending, **with the candidate key as
+  tie-break**: `sort.Slice` is not stable and map iteration order is
+  randomized, so probability alone would make the schedule nondeterministic
+  when candidates tie;
+- **probation ignores `MinConf`.** The `Epsilon` escape of Issue 254
+  deliberately skips demoted candidates, so gating probation on `MinConf` too
+  would leave demoted *and* below-`MinConf` candidates unreachable by both
+  probes. That state is reachable in practice: probation wastes feed
+  `prefetch_waste` into evolve, which raises `PrefetchConf`, which can push a
+  demoted candidate below `MinConf`;
+- the probe occupies one of the `TopK` slots: normal candidates are capped at
+  `TopK - 1` on a probation round, and the probe is appended last so healthy
+  candidates keep priority. With `TopK == 1` the probation round therefore
+  spends its only slot on the probe — one round in `ProbationInterval` is the
+  price of recovery being possible at all with a single slot;
+- the probe still respects `MaxCost`; it is dropped when the budget cannot fund
+  one `BaseCost`.
+
+Following the other knobs in `Config`, a zero value selects the default. A
+negative `ProbationInterval` disables probation and restores the previous
+absorbing behaviour.
+
+## Composition with the Epsilon escape
+
+The two mechanisms cover disjoint exclusion reasons and together cover the
+union:
+
+| candidate state | channel |
+|---|---|
+| demoted (any probability) | probation (this spec) |
+| below `MinConf`, not demoted | `Epsilon` escape (Issue 254) |
+
+Probation appends its task before the `Epsilon` block, whose guard is
+`len(tasks) == 0`. A round that already produced a probation probe therefore
+never also fires the epsilon probe, so the two can never double-book a slot or
+exceed `MaxCost`.
+
+## Recovery semantics
+
+The probe changes nothing about `demoted()`. It only restores the *input* the
+decision rule needs:
+
+- probe hits → `ObserveHit` → complementary decay lifts `hit`, ages `waste`;
+  once `waste / hit` falls back below `WasteHitLimit` the candidate leaves
+  probation on its own and competes normally again;
+- probe wastes → `ObserveWaste` → the ratio stays above the limit and the
+  candidate remains demoted until the next probation round.
+
+Recovery therefore costs at most one slot per `ProbationInterval` rounds per
+tool and requires sustained evidence, not a single lucky hit.
+
+## Determinism
+
+The probe is driven by a counter and a totally-ordered rotation, not by
+randomness: two prefetchers fed the same call sequence produce identical plans.
+This is deliberate and differs from the `Epsilon` escape, which is
+probabilistic.
+
+## Acceptance
+
+- A demoted candidate is proposed again within `ProbationInterval` eligible
+  `Plan` calls **for its own last tool**, using only `Plan` and feedback for
+  planned targets — no direct `ObserveHit` on an unplanned key.
+- Under two-tool alternation and four-tool round-robin, every tool's demoted
+  successors are probed and recover; none is starved.
+- Sustained probe hits fully restore the candidate; sustained probe wastes keep
+  it demoted.
+- A demoted candidate below `MinConf` is still probed.
+- The rotation is identical across runs when candidates tie on probability.
+- The probe never proposes a writer and never exceeds `TopK` or `MaxCost`.
+- A negative `ProbationInterval` reproduces the previous absorbing behaviour.
+- `go test -race ./kernel/prefetch` passes.
+
+## Non-goals
+
+This change does not alter `demoted()`, the `WasteHitLimit` default, the
+transition probabilities, the `Prefetcher` interface, the `Epsilon` escape, or
+persistence of feedback across restarts.

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -106,19 +106,26 @@ type Config struct {
 	// MaxLoad is the slot-occupancy ratio at which speculative work yields
 	// to normal execution (default 0.8).
 	MaxLoad float64
+	// ProbationInterval admits one demoted candidate as a probe every Nth
+	// eligible Plan call, so demotion stops being an absorbing state
+	// (default 10). A negative value disables probation. This is a separate
+	// channel from Epsilon: Epsilon escapes the MinConf exclusion, probation
+	// escapes the demote exclusion (Issue #282).
+	ProbationInterval int
 }
 
 // Defaults returns the built-in configuration.
 func Defaults() Config {
 	return Config{
-		TopK:          3,
-		MinConf:       0.5,
-		MaxCost:       2000,
-		BaseCost:      512,
-		WasteHitLimit: 3.0,
-		Decay:         0.2,
-		Epsilon:       0, // disabled by default; enabled by evolve wiring
-		MaxLoad:       DefaultMaxLoad,
+		TopK:              3,
+		MinConf:           0.5,
+		MaxCost:           2000,
+		BaseCost:          512,
+		WasteHitLimit:     3.0,
+		Decay:             0.2,
+		Epsilon:           0, // disabled by default; enabled by evolve wiring
+		MaxLoad:           DefaultMaxLoad,
+		ProbationInterval: 10, // every 10th eligible Plan probes a demoted candidate (#282)
 	}
 }
 
@@ -153,7 +160,10 @@ type MatrixPrefetcher struct {
 	readOnlyCalls int
 	coveredCalls  int
 	gate          gateCounter // load-aware outcome counters (Issue #273)
-
+	// plans counts eligible Plan calls per last tool, the probation round
+	// counter (Issue #282): keyed by the transition table so alternating
+	// tools cannot starve each other's demoted candidates.
+	plans map[string]uint64
 }
 
 // betaPrior is the uniform prior strength α₀=β₀ for the per-candidate Beta
@@ -188,6 +198,12 @@ func NewMatrixPrefetcher(cfg Config) *MatrixPrefetcher {
 	if cfg.MaxLoad <= 0 || cfg.MaxLoad > 1 {
 		cfg.MaxLoad = def.MaxLoad
 	}
+	if cfg.ProbationInterval == 0 {
+		cfg.ProbationInterval = def.ProbationInterval
+	}
+	if cfg.ProbationInterval < 0 {
+		cfg.ProbationInterval = 0 // normalized "off"; never a modulus
+	}
 	return &MatrixPrefetcher{
 		cfg:        cfg,
 		bigrams:    make(map[string]map[string]int),
@@ -198,6 +214,7 @@ func NewMatrixPrefetcher(cfg Config) *MatrixPrefetcher {
 		wasteW:     make(map[string]float64),
 		hitCount:   make(map[string]int),
 		wasteCount: make(map[string]int),
+		plans:      make(map[string]uint64),
 	}
 }
 
@@ -245,30 +262,44 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 		return nil, nil
 	}
 
+	// Probation is scheduled per transition table: the demoted set is rebuilt
+	// from m.bigrams[last], so the round counter must be keyed by last too.
+	// A single global counter would put each tool in its own residue class and
+	// starve whole tables under any periodic interleaving (#282).
+	m.plans[last]++
+	plans := m.plans[last]
+
 	type cand struct {
 		key  string
 		prob float64
 	}
 	var cands []cand
-	var probe *cand // highest-probability candidate excluded only by MinConf (#254)
+	var probe *cand        // highest-probability candidate excluded only by MinConf (#254)
+	var onProbation []cand // candidates excluded only by demotion (#282)
 	for next, cnt := range transitions {
 		if !m.readOnly[next] {
 			continue // never prefetch a writer
 		}
 		prob := float64(cnt) / float64(total)
+		if m.demoted(next) {
+			// waste/hit penalty. Collected regardless of MinConf: probation
+			// is the only channel that reaches a demoted candidate, and the
+			// #254 escape below deliberately skips demoted ones, so gating
+			// this on MinConf would leave demoted+below-MinConf candidates
+			// unreachable by both probes (#282).
+			onProbation = append(onProbation, cand{key: next, prob: prob})
+			continue
+		}
 		if prob < m.cfg.MinConf {
 			// absorb into the escape probe when it is the best (but
-			// still-threshold-eligible) excluded candidate; skip demoted
-			// ones so the probe never channels a known-bad bet. The key
-			// tie-break keeps probe selection deterministic despite Go's
-			// randomized map iteration (Issue #272 c6).
-			if !m.demoted(next) && (probe == nil || prob > probe.prob || (prob == probe.prob && next < probe.key)) {
+			// still-threshold-eligible) excluded candidate; demoted ones
+			// never reach here, so the probe never channels a known-bad bet.
+			// The key tie-break keeps probe selection deterministic despite
+			// Go's randomized map iteration (Issue #272 c6).
+			if probe == nil || prob > probe.prob || (prob == probe.prob && next < probe.key) {
 				probe = &cand{key: next, prob: prob}
 			}
 			continue
-		}
-		if m.demoted(next) {
-			continue // waste/hit penalty
 		}
 		cands = append(cands, cand{key: next, prob: prob})
 	}
@@ -282,10 +313,36 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 		return cands[i].key < cands[j].key
 	})
 
+	// Probation: demotion is otherwise an absorbing state — a demoted key is
+	// never planned, so it never receives the feedback that would clear the
+	// penalty. Every Nth eligible Plan reserves one slot for a demoted
+	// candidate; the slot rotates through the demoted set in probability
+	// order so a leader that never recovers cannot starve the rest (#282).
+	var probation *cand
+	// interval == 0 means probation is off; the guard is load-bearing because
+	// plans%0 would panic, so it cannot be dropped silently.
+	if interval := uint64(m.cfg.ProbationInterval); interval > 0 &&
+		len(onProbation) > 0 && m.cfg.TopK > 0 && plans%interval == 0 {
+		// key breaks probability ties: sort.Slice is not stable and map
+		// iteration order is randomized, so probability alone would make the
+		// rotation nondeterministic.
+		sort.Slice(onProbation, func(i, j int) bool {
+			if onProbation[i].prob != onProbation[j].prob {
+				return onProbation[i].prob > onProbation[j].prob
+			}
+			return onProbation[i].key < onProbation[j].key
+		})
+		probation = &onProbation[(plans/interval-1)%uint64(len(onProbation))]
+	}
+	topK := m.cfg.TopK
+	if probation != nil {
+		topK-- // the probe is appended last, keeping healthy candidates first
+	}
+
 	var tasks []PrefetchTask
 	cost := 0
 	for _, c := range cands {
-		if len(tasks) >= m.cfg.TopK {
+		if len(tasks) >= topK {
 			break
 		}
 		if cost+m.cfg.BaseCost > m.cfg.MaxCost {
@@ -294,6 +351,14 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 		tasks = append(tasks, PrefetchTask{
 			Kind: "slice-assembly",
 			Key:  c.key,
+			Cost: m.cfg.BaseCost,
+		})
+		cost += m.cfg.BaseCost
+	}
+	if probation != nil && cost+m.cfg.BaseCost <= m.cfg.MaxCost {
+		tasks = append(tasks, PrefetchTask{
+			Kind: "slice-assembly",
+			Key:  probation.key,
 			Cost: m.cfg.BaseCost,
 		})
 		cost += m.cfg.BaseCost

--- a/kernel/prefetch/probation_test.go
+++ b/kernel/prefetch/probation_test.go
@@ -45,29 +45,57 @@ func TestProbationRestoresDemotedCandidateThroughPlanOnly(t *testing.T) {
 	}
 }
 
-func TestProbationKeepsWastingCandidateDemoted(t *testing.T) {
-	m := seedDemoted(t, Config{WasteHitLimit: 0.5, ProbationInterval: 3})
+// A candidate that keeps wasting must never graduate back to competing
+// normally. It is still proposed on probation rounds — that is the mechanism —
+// so the property under test is the RATE, not "never proposed": one probe per
+// ProbationInterval rounds and no more.
+func TestProbationKeepsWastingCandidateOnProbeRoundsOnly(t *testing.T) {
+	const interval, rounds = 3, 60
+	m := seedDemoted(t, Config{WasteHitLimit: 0.5, ProbationInterval: interval})
 
-	// The tool is genuinely useless: every probe is wasted.
-	for i := 0; i < 60; i++ {
+	// seedDemoted already spent one eligible Plan call.
+	probed, plans := 0, 1
+	for i := 0; i < rounds; i++ {
 		tasks, _ := m.Plan([]string{"bash"})
+		plans++
+		onProbeRound := plans%interval == 0
+		if len(tasks) > 0 != onProbeRound {
+			t.Fatalf("plans=%d: probe fired=%v, want %v (tasks=%v)",
+				plans, len(tasks) > 0, onProbeRound, tasks)
+		}
 		for _, task := range tasks {
+			probed++
 			m.ObserveWaste(task.Key)
 		}
 	}
 
-	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
-		t.Fatalf("a candidate that keeps wasting must stay demoted, got %v", tasks)
+	if want := rounds / interval; probed != want {
+		t.Fatalf("wasting candidate probed %d times, want exactly %d", probed, want)
+	}
+	if !m.demoted("read_file") {
+		t.Fatal("a candidate that keeps wasting must stay demoted")
 	}
 }
 
 func TestProbationDisabledKeepsAbsorbingBehaviour(t *testing.T) {
-	m := seedDemoted(t, Config{WasteHitLimit: 0.5, ProbationInterval: -1})
+	for _, off := range []int{-1, -2, -10} {
+		m := seedDemoted(t, Config{WasteHitLimit: 0.5, ProbationInterval: off})
 
-	drive(m, 60)
+		drive(m, 60)
 
-	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
-		t.Fatalf("probation disabled must keep the previous behaviour, got %v", tasks)
+		if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
+			t.Fatalf("ProbationInterval=%d must disable probation, got %v", off, tasks)
+		}
+	}
+}
+
+// A negative interval must be normalized to an explicit off state, not left as
+// a modulus that only happens to never divide. Without normalization the guard
+// in Plan could be deleted without any test noticing.
+func TestProbationNegativeIntervalNormalizedToOff(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{ProbationInterval: -1})
+	if m.cfg.ProbationInterval != 0 {
+		t.Fatalf("negative interval must normalize to 0 (off), got %d", m.cfg.ProbationInterval)
 	}
 }
 

--- a/kernel/prefetch/probation_test.go
+++ b/kernel/prefetch/probation_test.go
@@ -1,0 +1,345 @@
+package prefetch
+
+import (
+	"strings"
+	"testing"
+)
+
+// seedDemoted returns a prefetcher whose only read-only successor of "bash"
+// has been demoted by waste-only feedback.
+func seedDemoted(t *testing.T, cfg Config) *MatrixPrefetcher {
+	t.Helper()
+	m := NewMatrixPrefetcher(cfg)
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "read_file", true)
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("read_file")
+	}
+	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
+		t.Fatalf("waste-only candidate must start demoted, got %v", tasks)
+	}
+	return m
+}
+
+// drive runs the production feedback loop: whatever Plan proposes is reported
+// as a hit. A key Plan never proposes can never receive feedback — which is
+// exactly the absorbing state under test.
+func drive(m *MatrixPrefetcher, rounds int) {
+	for i := 0; i < rounds; i++ {
+		tasks, _ := m.Plan([]string{"bash"})
+		for _, task := range tasks {
+			m.ObserveHit(task.Key)
+		}
+	}
+}
+
+func TestProbationRestoresDemotedCandidateThroughPlanOnly(t *testing.T) {
+	m := seedDemoted(t, Config{WasteHitLimit: 0.5, ProbationInterval: 3})
+
+	drive(m, 60)
+
+	tasks, _ := m.Plan([]string{"bash"})
+	if len(tasks) != 1 || tasks[0].Key != "read_file" {
+		t.Fatalf("probation must let a useful candidate earn its way back, got %v", tasks)
+	}
+}
+
+func TestProbationKeepsWastingCandidateDemoted(t *testing.T) {
+	m := seedDemoted(t, Config{WasteHitLimit: 0.5, ProbationInterval: 3})
+
+	// The tool is genuinely useless: every probe is wasted.
+	for i := 0; i < 60; i++ {
+		tasks, _ := m.Plan([]string{"bash"})
+		for _, task := range tasks {
+			m.ObserveWaste(task.Key)
+		}
+	}
+
+	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
+		t.Fatalf("a candidate that keeps wasting must stay demoted, got %v", tasks)
+	}
+}
+
+func TestProbationDisabledKeepsAbsorbingBehaviour(t *testing.T) {
+	m := seedDemoted(t, Config{WasteHitLimit: 0.5, ProbationInterval: -1})
+
+	drive(m, 60)
+
+	if tasks, _ := m.Plan([]string{"bash"}); len(tasks) != 0 {
+		t.Fatalf("probation disabled must keep the previous behaviour, got %v", tasks)
+	}
+}
+
+func TestProbationNeverProbesWriters(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{WasteHitLimit: 0.5, ProbationInterval: 2})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "write_file", false)
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("write_file")
+	}
+
+	for i := 0; i < 20; i++ {
+		tasks, _ := m.Plan([]string{"bash"})
+		if len(tasks) != 0 {
+			t.Fatalf("probation must never propose a writer, got %v", tasks)
+		}
+	}
+}
+
+func TestProbationRespectsTopK(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.1, TopK: 2, MaxCost: 4096, BaseCost: 512,
+		WasteHitLimit: 0.5, ProbationInterval: 2})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "grep", true)
+	}
+	for i := 0; i < 6; i++ {
+		m.Observe("bash", "ls", true)
+	}
+	for i := 0; i < 4; i++ {
+		m.Observe("bash", "read_file", true)
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("read_file")
+	}
+
+	probed := false
+	for i := 0; i < 20; i++ {
+		tasks, _ := m.Plan([]string{"bash"})
+		if len(tasks) > 2 {
+			t.Fatalf("plan exceeded TopK on round %d: %v", i, tasks)
+		}
+		for _, task := range tasks {
+			if task.Key == "read_file" {
+				probed = true
+			}
+		}
+	}
+	if !probed {
+		t.Fatal("demoted candidate was never probed")
+	}
+}
+
+// seedTiedDemoted gives "bash" three demoted successors with IDENTICAL counts,
+// so probability alone cannot order them. Map iteration order is randomized and
+// sort.Slice is not stable, so without an explicit tie-break the rotation would
+// differ between runs.
+func seedTiedDemoted(t *testing.T, cfg Config) *MatrixPrefetcher {
+	t.Helper()
+	m := NewMatrixPrefetcher(cfg)
+	for _, key := range []string{"alpha", "beta", "gamma"} {
+		for i := 0; i < 4; i++ {
+			m.Observe("bash", key, true)
+		}
+		for i := 0; i < 5; i++ {
+			m.ObserveWaste(key)
+		}
+	}
+	return m
+}
+
+func TestProbationIsDeterministicUnderTies(t *testing.T) {
+	cfg := Config{MinConf: 0.1, WasteHitLimit: 0.5, ProbationInterval: 2}
+
+	var want []string
+	for run := 0; run < 30; run++ {
+		m := seedTiedDemoted(t, cfg)
+		var got []string
+		for i := 0; i < 12; i++ {
+			tasks, _ := m.Plan([]string{"bash"})
+			for _, task := range tasks {
+				got = append(got, task.Key)
+				m.ObserveWaste(task.Key) // keep every candidate demoted
+			}
+		}
+		if len(got) == 0 {
+			t.Fatal("no probes fired; the test would be vacuous")
+		}
+		if want == nil {
+			want = got
+			continue
+		}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("run %d diverged: want %v, got %v", run, want, got)
+		}
+	}
+}
+
+// A demoted candidate below MinConf is reachable by neither the #254 epsilon
+// probe (which skips demoted candidates) nor a MinConf-gated probation slot.
+// Probation must therefore ignore MinConf.
+func TestProbationReachesDemotedBelowMinConf(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.9, WasteHitLimit: 0.5, ProbationInterval: 2})
+	for i := 0; i < 5; i++ {
+		m.Observe("bash", "read_file", true)
+		m.Observe("bash", "grep", true) // keeps read_file's probability at 0.5 < MinConf
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("read_file")
+		m.ObserveWaste("grep")
+	}
+
+	probed := false
+	for i := 0; i < 20 && !probed; i++ {
+		tasks, _ := m.Plan([]string{"bash"})
+		for _, task := range tasks {
+			probed = true
+			m.ObserveWaste(task.Key)
+		}
+	}
+	if !probed {
+		t.Fatal("a demoted candidate below MinConf is unreachable by both probes")
+	}
+}
+
+// Documented trade-off: with TopK == 1 a probation round spends the only slot
+// on the probe. One round in ProbationInterval is the price of recovery being
+// possible at all when there is a single slot.
+func TestProbationWithSingleSlotYieldsTheRound(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.1, TopK: 1, WasteHitLimit: 0.5, ProbationInterval: 4})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "healthy", true)
+	}
+	for i := 0; i < 4; i++ {
+		m.Observe("bash", "stale", true)
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("stale")
+	}
+
+	var plan []string
+	for i := 0; i < 8; i++ {
+		tasks, _ := m.Plan([]string{"bash"})
+		if len(tasks) != 1 {
+			t.Fatalf("round %d: TopK=1 must always yield exactly one task, got %v", i, tasks)
+		}
+		plan = append(plan, tasks[0].Key)
+	}
+
+	got := strings.Join(plan, ",")
+	want := "healthy,healthy,healthy,stale,healthy,healthy,healthy,stale"
+	if got != want {
+		t.Fatalf("single-slot probation schedule changed: want %s, got %s", want, got)
+	}
+}
+
+func TestProbationRotatesAmongDemotedCandidates(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{MinConf: 0.1, TopK: 2, MaxCost: 4096, BaseCost: 512,
+		WasteHitLimit: 0.5, ProbationInterval: 2})
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "grep", true) // higher probability, stays useless
+	}
+	for i := 0; i < 6; i++ {
+		m.Observe("bash", "read_file", true) // lower probability, actually useful
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("grep")
+		m.ObserveWaste("read_file")
+	}
+
+	// grep keeps wasting; a leader that never recovers must not starve the
+	// rest of the demoted set out of the probe slot.
+	seen := map[string]bool{}
+	for i := 0; i < 40; i++ {
+		tasks, _ := m.Plan([]string{"bash"})
+		for _, task := range tasks {
+			seen[task.Key] = true
+			m.ObserveWaste(task.Key)
+		}
+	}
+
+	if !seen["read_file"] {
+		t.Fatal("a permanently wasting leader starved the other demoted candidate")
+	}
+}
+
+// --- multi-tool workloads: the probation counter must be per last-tool ---
+
+// seedTwoTools gives "bash" and "grep" one demoted read-only successor each.
+func seedTwoTools(t *testing.T, cfg Config) *MatrixPrefetcher {
+	t.Helper()
+	m := NewMatrixPrefetcher(cfg)
+	for i := 0; i < 10; i++ {
+		m.Observe("bash", "read_file", true)
+		m.Observe("grep", "cat_file", true)
+	}
+	for i := 0; i < 5; i++ {
+		m.ObserveWaste("read_file")
+		m.ObserveWaste("cat_file")
+	}
+	return m
+}
+
+func TestProbationProbesEveryToolUnderAlternation(t *testing.T) {
+	m := seedTwoTools(t, Config{WasteHitLimit: 0.5})
+
+	// Real traffic alternates tools; a global probation counter would put one
+	// tool's calls in a residue class that never lands on a probation round.
+	probed := map[string]int{}
+	for i := 0; i < 200; i++ {
+		for _, last := range []string{"bash", "grep"} {
+			tasks, _ := m.Plan([]string{last})
+			for _, task := range tasks {
+				probed[task.Key]++
+				m.ObserveHit(task.Key)
+			}
+		}
+	}
+
+	for _, key := range []string{"read_file", "cat_file"} {
+		if probed[key] == 0 {
+			t.Fatalf("%s was never probed under alternation: %v", key, probed)
+		}
+	}
+}
+
+func TestProbationRecoversEveryToolUnderAlternation(t *testing.T) {
+	m := seedTwoTools(t, Config{WasteHitLimit: 0.5})
+
+	for i := 0; i < 200; i++ {
+		for _, last := range []string{"bash", "grep"} {
+			tasks, _ := m.Plan([]string{last})
+			for _, task := range tasks {
+				m.ObserveHit(task.Key)
+			}
+		}
+	}
+
+	for last, want := range map[string]string{"bash": "read_file", "grep": "cat_file"} {
+		tasks, _ := m.Plan([]string{last})
+		if len(tasks) != 1 || tasks[0].Key != want {
+			t.Fatalf("last=%s: useful candidate never recovered, got %v", last, tasks)
+		}
+	}
+}
+
+func TestProbationProbesEveryToolUnderRoundRobin(t *testing.T) {
+	tools := []string{"t0", "t1", "t2", "t3"}
+	m := NewMatrixPrefetcher(Config{MinConf: 0.1, WasteHitLimit: 0.5})
+	for _, tool := range tools {
+		for i := 0; i < 10; i++ {
+			m.Observe(tool, tool+"_next", true)
+		}
+		for i := 0; i < 5; i++ {
+			m.ObserveWaste(tool + "_next")
+		}
+	}
+
+	probed := map[string]int{}
+	for i := 0; i < 200; i++ {
+		for _, last := range tools {
+			tasks, _ := m.Plan([]string{last})
+			for _, task := range tasks {
+				probed[task.Key]++
+				m.ObserveWaste(task.Key) // stay demoted: only probation can propose them
+			}
+		}
+	}
+
+	for _, tool := range tools {
+		if probed[tool+"_next"] == 0 {
+			t.Fatalf("%s_next starved under round-robin: %v", tool, probed)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`demote` 是吸收态：`Plan` 排除降权候选 → 该 key 永不进计划 → `harness/semantix/evolution.go` 只对**已计划的 target** 发 `PrefetchHit/Waste` → `ObserveHit/ObserveWaste` 再不会被调用 → 两个 EWMA 双双冻结 → `waste/hit` 永远高于 `WasteHitLimit`。一次坏窗口就永久移除一条转移边，预取覆盖率随时间单调下降。

Issue 255 的 spec 写了「later hits may restore it once the ratio returns below the limit」，但这个承诺在生产路径上**不可达**：唯一覆盖它的 `TestWastePenaltyRecoversAfterSustainedHits` 直接调 `ObserveHit`，而运行中的系统对一个 demoted key 永远做不到这件事。算术上能恢复，系统上恢复不了。

本 PR 加 **probation 探针**：每 N 次该工具的 eligible `Plan` 调用留一个 `TopK` 槽给降权候选，把判据缺的那个**输入**还回去。命中就靠 #255 的互补衰减自然把比值压回限内；浪费就继续待着。恢复需要持续证据，不是一次走运。

不动 `demoted()`、`WasteHitLimit` 默认值、`Prefetcher` 接口，也不动 #254 的 `Epsilon` 逃逸。

### 与 #254 Epsilon 逃逸的关系

两个**嵌套**的吸收态，两条独立通道，合起来覆盖并集：

| 候选状态 | 通道 |
|---|---|
| 降权（任何概率） | probation（本 PR） |
| 低于 `MinConf` 且未降权 | `Epsilon` 逃逸（#254） |

probation 的任务在 `Epsilon` 块**之前**追加，而后者的守卫是 `len(tasks) == 0` —— 所以同一轮不会两个探针都放，不会双占槽位、不会超 `MaxCost`。

`Epsilon` 是概率性的，probation 是确定性的（计数器 + 全序轮转），这是刻意区分。

## Scope

- `kernel/prefetch/matrix.go`：`Config.ProbationInterval`（默认 10，负值关闭）、per-last-tool 计数器、`Plan` 中的 probation 槽位
- `kernel/prefetch/probation_test.go`（新增，12 个用例）
- `docs/specs/issue-282-demote-probation.md`（新增）

无 wire 契约改动，无存储格式改动，无 CLI 改动。

## Validation

- [x] `go vet ./...`
- [ ] `go test ./... -race` — **本机跑不了**：`-race` 需要 cgo，开发机无 gcc（`cgo: C compiler "gcc" not found`）。请 CI 覆盖这一项。新增代码路径全部在已持有 `m.mu` 的临界区内，结构上不引入新竞争，但这不等于 race detector 过了。
- [x] `git diff --check`
- [x] `go build ./...`
- [x] `go test ./kernel/prefetch ./kernel/sched ./kernel/evolve` 全绿（`kernel/prefetch` 45 个用例）
- [x] RED 复验：逐条改动都先确认测试变红再实现（见下）

### 关于 `go test ./...`

全仓跑有 54 个失败，**全部是 Windows 环境问题**（`t.TempDir()` 清理时文件被占用、symlink 需要管理员权限、若干包 600s 超时），没有一个是断言失败。已用**未改动的 upstream/main 建基线对照**：

```
基线（干净 main）  harness/semantix: 4 个 TestBridgeReuse* 失败（TempDir cleanup）
本分支            harness/semantix: 3 个 TestBridgeReuse* 失败（同样原因）
```

同类同因，且基线失败数不少于本分支。这些失败与本改动无关。

## Compatibility and data impact

**默认行为有变**：`ProbationInterval` 默认 10 且**默认开启** —— 降权候选现在每 10 轮会被试探一次。这与 #254 把 `Epsilon` 默认设为 0（关闭、由 evolve 接线打开）的选择**不一致**，理由是 #282 是缺陷而非增强：默认关闭等于把吸收态留在 main 上。如果评审认为应与 #254 对齐成默认关闭，改一个常量即可，但请明确接受吸收态继续存在。

副作用：探针会产生此前不存在的 `PrefetchWaste` 事件（上限为每工具每 10 轮 1 次），进而进入 evolve 的信号流。已在 spec 里记明，并因此让 probation 忽略 `MinConf` —— 否则 evolve 抬高 `PrefetchConf` 会把降权候选推到 `MinConf` 之下，落进两个探针都够不着的死角。

无配置文件改动（`ProbationInterval` 目前只在 `Config` 结构上，未透出到 `semantix.toml`）。

## Security and privacy

None. 探针只提议已被观测为只读的候选，`readOnly` 检查在收集降权候选**之前**，回归测试 `TestProbationNeverProbesWriters` 覆盖。

## Evidence

**RED 先行。** 关键测试只走生产路径 —— `Plan` 提什么就对什么报 hit，绝不碰没被 plan 过的 key：

```go
func drive(m *MatrixPrefetcher, rounds int) {
	for i := 0; i < rounds; i++ {
		tasks, _ := m.Plan([]string{"bash"})
		for _, task := range tasks { m.ObserveHit(task.Key) }
	}
}
```

修复前跑 60 轮，拿回来的是 `[]`。掐掉机制后复验，3 个行为测试变红（另外几个守护「不变行为」，两边都该绿）。

**一次真实的自我打脸，记在这里供评审参考。** 第一版实现用的是**全局** `plans` 计数器，而 `onProbation` 是按 `last` 工具算的。后果是 probation 轮次按整个调用流分配，真实 agent 循环里工具交替时，整张转移表永远轮不到探针：

```
四工具轮转，8000 次 eligible Plan：
  t0: 0/0    t1: 400/0    t2: 0/0    t3: 0/400
  => 8 个降权候选里 6 个探针数为 0，demoted() 恒真
两工具交替（默认配置，探针全部报命中）：
  bash→read_file  1000 轮 plan 0 次，仍 demoted
  grep→cat_file   plan 496 次，完全恢复
```

而第一版的 7 个测试**全都只驱动一个 `last` 工具**（`"bash"`）—— 恰好是全局计数器与按键计数器无法区分的唯一情形，测试对该缺陷结构性失明。现已改为 per-last-tool 计数，并补 `TestProbationProbesEveryToolUnderAlternation` / `...UnderRoundRobin` / `TestProbationRecoversEveryToolUnderAlternation` 三个多工具回归。

同批修掉的还有：
- 并集死角（降权 + 低于 `MinConf` 两个探针都够不着）→ `TestProbationReachesDemotedBelowMinConf`
- 平局不确定（`sort.Slice` 不稳定 + map 遍历随机）→ key 作裁决，`TestProbationIsDeterministicUnderTies` 跑 30 轮比对
- `TopK == 1` 时探针独占该轮 → 明确写进 spec 并用 `TestProbationWithSingleSlotYieldsTheRound` 固化排期

## Related issues

Closes #282

衔接：#255（互补衰减，本 PR 让它 spec 里那句恢复承诺第一次真正可达）、#254（`Epsilon` 逃逸，覆盖另一个嵌套吸收态）。
与 #272（Markov 三指标 + Beta-Binomial）同文件面，建议合并评审。

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.（无用户可见面变化；默认行为变化见上）
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md`.（无 wire 改动）



---

## ���£����˺�׷�ӣ�

�Ա���֧����һ�� 5 �ӽǶԿ����ˣ�ץ�������޵�������������������󸴲飺

**���ڱ� PR �޵�**
- per-last-tool ��������ԭΪȫ�֣����Ϸ� Evidence һ�ڵ�ʵ�⣩
- �������ǣ���Ȩ + ���� `MinConf` ����̽�붼������
- ƽ�ֲ�ȷ����`sort.Slice` ���ȶ� + map �������� �� key ���þ�
- ��������Ϊ����ǡ�ó��������̵Ĳ��ԣ�
  - `TestProbationIsDeterministic` ��ͬ�巴����ֻ��һ����Ȩ��ѡ����˳���ɴ����� ��Ϊ `...UnderTies`������ͬ���ʺ�ѡ�� 30 �ֱȶ���������
  - ����ֵ�رա�ԭ���� `uint64(-1)` �޷��Ż�����Ч��ɾ������ȫ�� �� ����ʱ��һ��Ϊ 0��`interval > 0` ��Ϊ����������ɾ���� divide by zero��
  - `TestProbationKeepsWastingCandidateDemoted` �����������ɺϣ����� 60��58 ����**��ȷ**ʵ���ϱ��죩�� ��Ϊ����Ƶ�ʣ�ÿ interval ��ǡ��һ�Ρ���̽�������Ρ���ʼ�� demoted

**��֪���ۣ����� issue #302 ����**

̽���� waste �� `PrefetchWaste` �¼�̧��ȫ�� `PrefetchConf`��U43 ����ʵ��ʵ�⣨evolve-ON �飬25 �Ự����

```
prefetch_conf �켣
  main:        �� 0.250 0.300 0.350 0.350 0.350 0.350 �� 0.350
  + probation: �� 0.250 0.300 0.350 0.350 0.400 0.450 �� 0.500
waste 6 �� 9,  25 �Ự�ܳɱ� 0.486 �� 0.504 USD
```

evolve ѧ���ķ�������̽���ɱ�ȫ��������������̽��/���û�����explore �ĳɱ��������� exploit ��ֵ���ս���֤�ݡ�**��ȱ�� #254 �� `Epsilon` ̽��ͬ������**��ֻ��Ĭ�Ϲر�δ��¶��������Ҫ���¼�������̽����������ʵ���������� `kernel/prefetch` ��Χ �� #302��

�� PR �ڵĻ�����������������������probation ���� `MinConf`�����Ա�̧�ߵ� `PrefetchConf` �����ٰѽ�Ȩ��ѡ��������̽�붼�����ŵ�������

**��ע**��`scripts/evolution-curve` ������ `churn ���˷�Ԥȡ ON < OFF` �� `25 �Ự�ܳɱ� ON < OFF` �������գ���**δ�Ķ��� main �Ͼ��Ѿ� FAIL**��6 | 6 �� 0.486 | 0.486�����뱾 PR �޹أ���ֵ�õ�����һ�ۡ�

**������**��`kernel/prefetch` �� 47 ������������ probation ���� 13 ����
