### PR TITLE
feat: wire per-slice reuse statistics and events

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"semantix/kernel/cache"
+	kernelevent "semantix/kernel/event"
 	"semantix/kernel/ingest"
 	"semantix/kernel/inject"
 	"semantix/kernel/judge"
@@ -315,6 +316,21 @@ func (g *Gateway) recordSession(sessionID string, ctxHash, model string, turns [
 		defer g.ingestWG.Done()
 		g.ingestSession(path, ctxHash, model)
 	}()
+}
+
+// recordKernelEvent writes one kernel event into the same session JSONL used
+// by the transcript ingest path. Keeping the original wire object makes the
+// observation available both to event consumers and to searchable projections.
+func (g *Gateway) recordKernelEvent(sessionID, ctxHash, model string, e kernelevent.Event) {
+	raw, err := kernelevent.ToJSON(e)
+	if err != nil {
+		return
+	}
+	var line map[string]any
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return
+	}
+	g.recordSession(sessionID, ctxHash, model, []map[string]any{line})
 }
 
 // ingestSession drains one sidecar file into the slice library via the

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -10,9 +10,12 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"semantix/kernel/cache"
+	kernelevent "semantix/kernel/event"
 	"semantix/kernel/inject"
+	"semantix/kernel/slice"
 	"semantix/kernel/usage"
 )
 
@@ -58,12 +61,18 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	// the dep-fingerprint chain. TTL is vendor-aware (design §3.5).
 	if !g.disabled {
 		if res, lerr := g.decider.DecideL3(ctx, q); lerr == nil && res != nil && g.l3Eligible(res.SliceID, up.Vendor) {
+			now := g.now()
 			g.recordUsage(usage.Event{
 				SessionID: sessionID, Provider: up.Name, Vendor: up.Vendor, Model: req.Model,
-				TokensIn: int64(len(query)/4) + int64(len(res.Response)/4),
+				TokensIn:  int64(len(query)/4) + int64(len(res.Response)/4),
 				TokensOut: 0, CacheHitToken: int64(len(res.Response) / 4),
-				L3Reuse: true, JudgeDecisions: jc.drain(), At: g.now().Unix(),
+				L3Reuse: true, JudgeDecisions: jc.drain(), At: now.Unix(),
 			})
+			g.recordSliceStats(map[string]slice.SliceStats{
+				res.SliceID: {Hits: 1, LastUsed: now.Unix()},
+			})
+			g.recordSliceEvent(sessionID, chash, req.Model, kernelevent.SliceHit,
+				kernelevent.SliceHitPayload{Layer: "L3", SliceIDs: []string{res.SliceID}}, now)
 			g.replyFromCache(w, r, req, res)
 			return
 		}
@@ -79,6 +88,23 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 	if inj != nil {
 		injectedTokens = int64(inj.Bytes / 4)
 		sliceHits = len(inj.Slices)
+		if len(inj.Slices) > 0 {
+			now := g.now()
+			ids := make([]string, 0, len(inj.Slices))
+			deltas := make(map[string]slice.SliceStats, len(inj.Slices))
+			for _, sl := range inj.Slices {
+				if sl == nil {
+					continue
+				}
+				ids = append(ids, sl.ID)
+				deltas[sl.ID] = slice.SliceStats{Injected: 1, LastUsed: now.Unix()}
+			}
+			if len(ids) > 0 {
+				g.recordSliceStats(deltas)
+				g.recordSliceEvent(sessionID, chash, req.Model, kernelevent.SliceInject,
+					kernelevent.SliceInjectPayload{SliceIDs: ids, Bytes: inj.Bytes}, now)
+			}
+		}
 	}
 	if up.Vendor == "anthropic" {
 		// Anthropic hop (design §0.5): translate the OpenAI body to the
@@ -537,6 +563,38 @@ func (g *Gateway) replyFromCache(w http.ResponseWriter, r *http.Request, req *ch
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(raw)
+}
+
+// recordSliceStats applies one request's per-slice deltas off the HTTP hot
+// path. Close waits for these tasks through the same lifecycle gate used by
+// asynchronous session ingestion, so accepted observations are not dropped.
+func (g *Gateway) recordSliceStats(deltas map[string]slice.SliceStats) {
+	if len(deltas) == 0 {
+		return
+	}
+	g.shutdownMu.Lock()
+	if g.closing {
+		g.shutdownMu.Unlock()
+		return
+	}
+	g.ingestWG.Add(1)
+	g.shutdownMu.Unlock()
+	go func() {
+		defer g.ingestWG.Done()
+		if err := slice.ApplyStats(g.store, deltas); err != nil {
+			log.Printf("gateway: slice stats: %v", err)
+		}
+	}()
+}
+
+func (g *Gateway) recordSliceEvent(sessionID, ctxHash, model string, kind kernelevent.Kind, payload any, at time.Time) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	g.recordKernelEvent(sessionID, ctxHash, model, kernelevent.Event{
+		Kind: kind, SessionID: sessionID, At: at.UTC(), Data: data,
+	})
 }
 
 // replayStream rebuilds an SSE stream from the cached response, chunking the

--- a/gateway/stats_test.go
+++ b/gateway/stats_test.go
@@ -1,0 +1,121 @@
+package gateway
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	kernelevent "semantix/kernel/event"
+	"semantix/kernel/slice"
+)
+
+func waitSliceStats(t *testing.T, g *Gateway, id string, ok func(slice.SliceStats) bool) slice.SliceStats {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := g.store.Get(id)
+		if err == nil && got != nil && ok(got.Stats) {
+			return got.Stats
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	got, err := g.store.Get(id)
+	if err != nil || got == nil {
+		t.Fatalf("get slice %q: slice=%v err=%v", id, got, err)
+	}
+	t.Fatalf("slice %q stats did not converge: %+v", id, got.Stats)
+	return slice.SliceStats{}
+}
+
+func readKernelEvents(t *testing.T, g *Gateway, sessionID string) []kernelevent.Event {
+	t.Helper()
+	f, err := os.Open(filepath.Join(g.cfg.Ingest.SessionsDir, sessionID+".jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var events []kernelevent.Event
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if e, err := kernelevent.FromJSON(sc.Bytes()); err == nil {
+			events = append(events, e)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return events
+}
+
+func TestE2EL3HitRecordsStatsAndEvent(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"unused"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	chash, _ := contextHash([]chatMessage{msg("user", "hello world")})
+	seed(t, g, &slice.Slice{
+		ID: "l3-stats", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("hello world hello world cached answer"),
+		Meta:    slice.SliceMeta{L3Safe: true, ContextHash: chash, Model: "deepseek-chat"},
+	})
+
+	resp, out := postChatWithHeaders(t, srv, "test-key", map[string]string{
+		"x-semantix-session": "stats-l3",
+	}, chatBody("deepseek-chat", "hello world", false))
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("x-semantix-cache") != "hit" {
+		t.Fatalf("expected L3 hit, got status %d cache %q body %s", resp.StatusCode, resp.Header.Get("x-semantix-cache"), out)
+	}
+	stats := waitSliceStats(t, g, "l3-stats", func(s slice.SliceStats) bool { return s.Hits == 1 && s.LastUsed > 0 })
+	if stats.Injected != 0 {
+		t.Fatalf("L3 hit counted as injection: %+v", stats)
+	}
+	events := readKernelEvents(t, g, "stats-l3")
+	if len(events) != 1 || events[0].Kind != kernelevent.SliceHit {
+		t.Fatalf("events=%+v, want one SliceHit", events)
+	}
+}
+
+func TestE2EL2InjectionRecordsStatsAndEvent(t *testing.T) {
+	up := &testUpstream{plain: `{"choices":[{"message":{"role":"assistant","content":"upstream reply"}}]}`}
+	upSrv := httptest.NewServer(up.handler())
+	defer upSrv.Close()
+	g := newTestGateway(t, upSrv.URL)
+	srv := httptest.NewServer(g)
+	defer srv.Close()
+
+	seed(t, g, &slice.Slice{
+		ID: "l2-stats", Type: slice.Prompt, Scope: slice.Project,
+		Content: []byte("prior knowledge about widgets"),
+	})
+	for _, content := range []string{"alpha", "bravo", "charlie", "delta"} {
+		seed(t, g, &slice.Slice{
+			ID: "distractor-" + content, Type: slice.Prompt, Scope: slice.Project,
+			Content: []byte(content),
+		})
+	}
+	resp, out := postChatWithHeaders(t, srv, "test-key", map[string]string{
+		"x-semantix-session": "stats-l2",
+	}, chatBody("deepseek-chat", "widgets", false))
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("x-semantix-cache") != "miss" {
+		t.Fatalf("expected forwarded miss, got status %d cache %q body %s", resp.StatusCode, resp.Header.Get("x-semantix-cache"), out)
+	}
+	stats := waitSliceStats(t, g, "l2-stats", func(s slice.SliceStats) bool { return s.Injected == 1 && s.LastUsed > 0 })
+	if stats.Hits != 0 {
+		t.Fatalf("L2 injection counted as hit: %+v", stats)
+	}
+	events := readKernelEvents(t, g, "stats-l2")
+	found := false
+	for _, e := range events {
+		found = found || e.Kind == kernelevent.SliceInject
+	}
+	if !found {
+		t.Fatalf("events=%+v, want SliceInject", events)
+	}
+}

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -314,7 +314,8 @@ func (b *Bridge) mirror(e event.Event) {
 }
 
 func (b *Bridge) mirrorKernel(e kernelevent.Event) {
-	if e.Kind != kernelevent.PrefetchHit && e.Kind != kernelevent.PrefetchWaste && e.Kind != kernelevent.EvolutionTick {
+	if e.Kind != kernelevent.SliceHit && e.Kind != kernelevent.SliceInject &&
+		e.Kind != kernelevent.PrefetchHit && e.Kind != kernelevent.PrefetchWaste && e.Kind != kernelevent.EvolutionTick {
 		return
 	}
 	hs := b.sessionSink()

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -66,6 +66,8 @@ type Bridge struct {
 	// attribute the incremental per-turn delta in Reuse.
 	lastSavings float64
 	evolution   *EvolutionLoop
+	statsWG     sync.WaitGroup
+	closing     bool
 }
 
 // NewBridge builds a Bridge from cfg.
@@ -148,10 +150,11 @@ func (b *Bridge) InjectDetailed(ctx context.Context, query string) InjectResult 
 	if !b.Enabled() || !b.cfg.Inject {
 		return InjectResult{}
 	}
-	idx, err := b.kernelIndex()
+	store, idx, err := b.kernelIndex()
 	if err != nil {
 		return InjectResult{}
 	}
+	closeSliceStore(store)
 	z := zone.Default()
 	inj, err := (&inject.Injector{
 		Index:  idx,
@@ -170,7 +173,43 @@ func (b *Bridge) InjectDetailed(ctx context.Context, query string) InjectResult 
 		}
 	}
 	sort.Strings(targets)
+	b.recordInjection(targets, inj.Bytes)
 	return InjectResult{Text: inj.Text, Targets: targets}
+}
+
+func (b *Bridge) recordInjection(ids []string, bytes int) {
+	if len(ids) == 0 {
+		return
+	}
+	ids = append([]string(nil), ids...)
+	now := time.Now().UTC()
+	projectDB := filepath.Join(b.projectDir(), ".semantix", "project.db")
+	b.mu.Lock()
+	if b.closing {
+		b.mu.Unlock()
+		return
+	}
+	b.statsWG.Add(1)
+	session := b.label
+	b.mu.Unlock()
+
+	data, err := json.Marshal(kernelevent.SliceInjectPayload{SliceIDs: ids, Bytes: bytes})
+	if err == nil {
+		b.events.Emit(kernelevent.Event{Kind: kernelevent.SliceInject, SessionID: session, At: now, Data: data})
+	}
+	go func() {
+		defer b.statsWG.Done()
+		store, err := slice.NewFileStore(projectDB)
+		if err != nil {
+			return
+		}
+		defer closeSliceStore(store)
+		deltas := make(map[string]slice.SliceStats, len(ids))
+		for _, id := range ids {
+			deltas[id] = slice.SliceStats{Injected: 1, LastUsed: now.Unix()}
+		}
+		_ = slice.ApplyStats(store, deltas)
+	}()
 }
 
 // RecordPrefetch emits one terminal outcome for a warmed result.
@@ -205,10 +244,11 @@ func (b *Bridge) Reuse(ctx context.Context, query string) ReuseSummary {
 	if !b.Enabled() || query == "" {
 		return ReuseSummary{}
 	}
-	idx, err := b.kernelIndex()
+	store, idx, err := b.kernelIndex()
 	if err != nil {
 		return ReuseSummary{}
 	}
+	defer closeSliceStore(store)
 	hits, err := idx.Search(query, 5, slice.Project)
 	if err != nil {
 		return ReuseSummary{}
@@ -236,24 +276,32 @@ func (b *Bridge) Reuse(ctx context.Context, query string) ReuseSummary {
 // covering every scope (kernel CLI lookup/inject parity). Rebuilt per call:
 // the store is a small JSONL file and indexing is millisecond-scale; caching
 // is deferred to the kernel wiring follow-up (U40).
-func (b *Bridge) kernelIndex() (slice.Index, error) {
+func (b *Bridge) kernelIndex() (slice.Store, slice.Index, error) {
 	store, err := slice.NewFileStore(filepath.Join(b.projectDir(), ".semantix", "project.db"))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	idx := bm25.New()
 	for _, scope := range []slice.Scope{slice.Session, slice.Project, slice.User} {
 		items, err := store.List(scope)
 		if err != nil {
-			return nil, err
+			closeSliceStore(store)
+			return nil, nil, err
 		}
 		for _, sl := range items {
 			if err := idx.Insert(sl); err != nil {
-				return nil, err
+				closeSliceStore(store)
+				return nil, nil, err
 			}
 		}
 	}
-	return idx, nil
+	return store, idx, nil
+}
+
+func closeSliceStore(store slice.Store) {
+	if closer, ok := store.(interface{ Close() error }); ok {
+		_ = closer.Close()
+	}
 }
 
 // projectDir resolves the kernel project directory for in-process store and
@@ -343,6 +391,10 @@ func (b *Bridge) sessionSink() *HarnessSink {
 
 // Close flushes and closes the mirror sink, if created.
 func (b *Bridge) Close() error {
+	b.mu.Lock()
+	b.closing = true
+	b.mu.Unlock()
+	b.statsWG.Wait()
 	if b.evolution != nil {
 		b.evolution.Close()
 	}

--- a/harness/semantix/closed_loop_test.go
+++ b/harness/semantix/closed_loop_test.go
@@ -2,9 +2,11 @@ package semantix
 
 import (
 	"bufio"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	kernelevent "semantix/kernel/event"
 )
@@ -13,6 +15,10 @@ func TestBridgePersistsPrefetchAndEvolutionEventsInSessionJSONL(t *testing.T) {
 	dir := t.TempDir()
 	b := NewBridge(Config{Enabled: true, SessionsDir: dir})
 	b.SetLabel("session-c4")
+	hitData, _ := json.Marshal(kernelevent.SliceHitPayload{Layer: "L3", SliceIDs: []string{"slice-hit"}})
+	injectData, _ := json.Marshal(kernelevent.SliceInjectPayload{SliceIDs: []string{"slice-inject"}, Bytes: 128})
+	b.Events().Emit(kernelevent.Event{Kind: kernelevent.SliceHit, SessionID: "session-c4", At: time.Now().UTC(), Data: hitData})
+	b.Events().Emit(kernelevent.Event{Kind: kernelevent.SliceInject, SessionID: "session-c4", At: time.Now().UTC(), Data: injectData})
 	for turn := 1; turn <= 60; turn++ {
 		b.RecordPrefetch(false, []string{"slice-a"}, turn)
 	}
@@ -40,5 +46,8 @@ func TestBridgePersistsPrefetchAndEvolutionEventsInSessionJSONL(t *testing.T) {
 	}
 	if counts[kernelevent.EvolutionTick] == 0 {
 		t.Fatalf("tick=%d, want >0", counts[kernelevent.EvolutionTick])
+	}
+	if counts[kernelevent.SliceHit] != 1 || counts[kernelevent.SliceInject] != 1 {
+		t.Fatalf("slice events: hit=%d inject=%d, want 1 each", counts[kernelevent.SliceHit], counts[kernelevent.SliceInject])
 	}
 }

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	kernelevent "semantix/kernel/event"
 	"semantix/kernel/slice"
 )
 
@@ -113,6 +114,7 @@ func writeKernelDir(t *testing.T, slicesIn []*slice.Slice, usageLines []string) 
 			t.Fatal(err)
 		}
 	}
+	closeSliceStore(store)
 	if usageLines != nil {
 		if err := os.WriteFile(filepath.Join(kernelDir, "usage.jsonl"),
 			[]byte(strings.Join(usageLines, "\n")+"\n"), 0o644); err != nil {
@@ -154,6 +156,50 @@ func TestBridgeReuseHitsAndSources(t *testing.T) {
 	}
 	if sum.SavingsUSD != 0.0054 {
 		t.Errorf("SavingsUSD = %v, want 0.0054 (first cumulative snapshot)", sum.SavingsUSD)
+	}
+}
+
+func TestBridgeInjectRecordsStatsAndEvent(t *testing.T) {
+	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
+	sessionsDir := t.TempDir()
+	b := NewBridge(Config{Enabled: true, Inject: true, ProjectDir: dir, SessionsDir: sessionsDir, Budget: 4096})
+	b.SetLabel("inject-stats")
+	result := b.InjectDetailed(context.Background(), "修复 go 测试")
+	if result.Text == "" || len(result.Targets) == 0 {
+		t.Fatalf("InjectDetailed() = %+v, want injected slices", result)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSliceStore(store)
+	for _, id := range result.Targets {
+		got, err := store.Get(id)
+		if err != nil || got == nil {
+			t.Fatalf("Get(%q) = %v, %v", id, got, err)
+		}
+		if got.Stats.Injected != 1 || got.Stats.LastUsed == 0 {
+			t.Fatalf("stats for %q = %+v, want one injection and LastUsed", id, got.Stats)
+		}
+	}
+
+	raw, err := os.ReadFile(filepath.Join(sessionsDir, "inject-stats.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		e, err := kernelevent.FromJSON([]byte(line))
+		if err == nil && e.Kind == kernelevent.SliceInject {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("session JSONL missing SliceInject: %s", raw)
 	}
 }
 

--- a/kernel/ingest/ingest.go
+++ b/kernel/ingest/ingest.go
@@ -188,11 +188,16 @@ func (s *JSONLSource) Next() (*SessionEvents, error) {
 }
 
 func isClosedLoopEvent(k event.Kind) bool {
-	return k == event.PrefetchHit || k == event.PrefetchWaste || k == event.EvolutionTick
+	return k == event.SliceHit || k == event.SliceInject ||
+		k == event.PrefetchHit || k == event.PrefetchWaste || k == event.EvolutionTick
 }
 
 func projectClosedLoopEvent(e event.Event) string {
 	switch e.Kind {
+	case event.SliceHit:
+		return "slice hit " + string(e.Data)
+	case event.SliceInject:
+		return "slice inject " + string(e.Data)
 	case event.PrefetchHit:
 		return "prefetch hit targets " + string(e.Data)
 	case event.PrefetchWaste:

--- a/kernel/ingest/ingest_test.go
+++ b/kernel/ingest/ingest_test.go
@@ -102,6 +102,8 @@ func TestJSONLSourcePreservesAndProjectsClosedLoopEvents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "closed-loop.jsonl")
 	lines := []string{
+		`{"kind":5,"session_id":"closed-loop","turn":1,"at":"2026-08-18T00:00:00Z","data":{"layer":"L3","slice_ids":["slice-hit"]}}`,
+		`{"kind":6,"session_id":"closed-loop","turn":1,"at":"2026-08-18T00:00:00Z","data":{"slice_ids":["slice-inject"],"bytes":128}}`,
 		`{"kind":8,"session_id":"closed-loop","turn":1,"at":"2026-08-18T00:00:00Z","data":{"targets":["slice-a"]}}`,
 		`{"kind":9,"session_id":"closed-loop","turn":2,"at":"2026-08-18T00:00:01Z","data":{"targets":["slice-b"]}}`,
 		`{"kind":11,"session_id":"closed-loop","turn":2,"at":"2026-08-18T00:00:02Z","data":{"params":{"tau_l2":0.55,"prefetch_conf":0.6}}}`,
@@ -117,11 +119,11 @@ func TestJSONLSourcePreservesAndProjectsClosedLoopEvents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(se.Events) != 3 {
-		t.Fatalf("events=%d, want 3", len(se.Events))
+	if len(se.Events) != 5 {
+		t.Fatalf("events=%d, want 5", len(se.Events))
 	}
 	text := string(se.Transcript)
-	for _, phrase := range []string{"prefetch hit", "prefetch waste", "evolution tick"} {
+	for _, phrase := range []string{"slice hit", "slice inject", "prefetch hit", "prefetch waste", "evolution tick"} {
 		if !strings.Contains(text, phrase) {
 			t.Fatalf("transcript missing %q:\n%s", phrase, text)
 		}

--- a/kernel/slice/extractor.go
+++ b/kernel/slice/extractor.go
@@ -98,6 +98,10 @@ func parseTranscript(data []byte) ([]transcriptLine, error) {
 		if tl.Role == "" {
 			if e, err := kernelevent.FromJSON(line); err == nil {
 				switch e.Kind {
+				case kernelevent.SliceHit:
+					tl = transcriptLine{Role: "user", Content: "slice hit " + string(e.Data)}
+				case kernelevent.SliceInject:
+					tl = transcriptLine{Role: "user", Content: "slice inject " + string(e.Data)}
 				case kernelevent.PrefetchHit:
 					tl = transcriptLine{Role: "user", Content: "prefetch hit targets " + string(e.Data)}
 				case kernelevent.PrefetchWaste:

--- a/kernel/slice/slice_test.go
+++ b/kernel/slice/slice_test.go
@@ -293,7 +293,9 @@ func TestFileStoreCorruptLine(t *testing.T) {
 
 func TestExtractorProjectsClosedLoopEventsForSearch(t *testing.T) {
 	input := []byte(
-		`{"kind":8,"session_id":"s","turn":1,"at":"2026-08-18T00:00:00Z","data":{"targets":["slice-a"]}}` + "\n" +
+		`{"kind":5,"session_id":"s","turn":1,"at":"2026-08-18T00:00:00Z","data":{"layer":"L3","slice_ids":["slice-hit"]}}` + "\n" +
+			`{"kind":6,"session_id":"s","turn":1,"at":"2026-08-18T00:00:00Z","data":{"slice_ids":["slice-inject"],"bytes":128}}` + "\n" +
+			`{"kind":8,"session_id":"s","turn":1,"at":"2026-08-18T00:00:00Z","data":{"targets":["slice-a"]}}` + "\n" +
 			`{"kind":9,"session_id":"s","turn":2,"at":"2026-08-18T00:00:01Z","data":{"targets":["slice-b"]}}` + "\n" +
 			`{"kind":11,"session_id":"s","turn":2,"at":"2026-08-18T00:00:02Z","data":{"params":{"tau_l2":0.55}}}` + "\n")
 	items, err := NewExtractor().Extract(input, SliceMeta{SourceSession: "s"})
@@ -304,7 +306,7 @@ func TestExtractorProjectsClosedLoopEventsForSearch(t *testing.T) {
 	for _, item := range items {
 		joined += string(item.Content) + "\n"
 	}
-	for _, phrase := range []string{"prefetch hit", "prefetch waste", "evolution tick"} {
+	for _, phrase := range []string{"slice hit", "slice inject", "prefetch hit", "prefetch waste", "evolution tick"} {
 		if !strings.Contains(joined, phrase) {
 			t.Fatalf("missing %q in %q", phrase, joined)
 		}


### PR DESCRIPTION
## Summary
- persist and project `SliceHit` / `SliceInject` kernel events through session JSONL so the observations are searchable
- asynchronously batch L3 hit and L2 injection deltas into per-slice `SliceStats` in the gateway
- record harness L2 injections with the same `Injected + LastUsed` semantics and close in-process stores deterministically

## Semantics
- L3 served response: `Hits += 1`, `LastUsed = max(LastUsed, observedAt)`, emit `SliceHit{layer:"L3"}`
- L2 block actually built: `Injected += 1`, `LastUsed = max(...)`, emit `SliceInject`
- no offline `verify` / `usage` write-back: neither path has evidence that a candidate was actually served or injected, and usage rows do not carry slice IDs

## Validation
- `go test ./gateway ./harness/semantix ./kernel/ingest -count=1`
- `go test ./kernel/slice -run TestExtractorProjectsClosedLoopEventsForSearch -count=1`
- `go test -race ./gateway -run 'TestE2E(L3HitRecordsStatsAndEvent|L2InjectionRecordsStatsAndEvent)$' -count=1`
- `go test -race ./harness/semantix -run TestBridgeInjectRecordsStatsAndEvent -count=1`
- `go vet ./gateway ./harness/semantix ./kernel/ingest ./kernel/slice`

## Platform note
The complete `./kernel/slice` package still hits the pre-existing Windows-only `TestJournalForwardCompat` open-handle rename failure. The changed extractor test passes directly; CI/Linux should exercise the full package.

Closes #264