### PR TITLE
feat(cache): lexical support gate for L3 Hit path (Issue #260)

### DIFF
--- a/deploy/semantix-gateway.toml.example
+++ b/deploy/semantix-gateway.toml.example
@@ -29,6 +29,7 @@ judge_api_key = ""                        # 可选：grey 区 LLM judge（GW6 #1
 # GW4 实测（Issue #184）：不启用 judge 时 L3 命中率 1/10，启用后 7/10。
 judge_base_url = ""                       # 例：https://api.deepseek.com/v1
 judge_model = ""                          # 例：deepseek-chat
+# lexical_floor = 0.05                      # Issue #260：L3 Hit 词面支持下限（0 = 关闭词面门）
 
 [ingest]
 sessions_dir = "/data/sessions"           # 会话旁路落盘目录（0600）

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -67,6 +67,10 @@ type CacheConfig struct {
 	JudgeBaseURL  string           `toml:"judge_base_url"`
 	JudgeModel    string           `toml:"judge_model"`
 	JudgeProtocol string           `toml:"judge_protocol"`
+	// LexicalFloor is the L3 lexical-support floor (Issue #260): a zone-Hit
+	// with less term overlap is downgraded to Grey (judge-gated). nil keeps
+	// the kernel default (0.05); explicit 0 disables the gate.
+	LexicalFloor *float64 `toml:"lexical_floor"`
 }
 
 // IngestConfig controls the session-sidecar write path.

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -277,3 +277,48 @@ func TestValidateAcceptsRetrieverKindsAndJudge(t *testing.T) {
 		t.Fatalf("wired judge rejected: %v", err)
 	}
 }
+// TestLexicalFloorConfigParse: lexical_floor maps to Cache.LexicalFloor
+// (Issue #260). Missing = nil (kernel default), 0 = gate disabled,
+// any other value = the configured floor.
+func TestLexicalFloorConfigParse(t *testing.T) {
+	base := `[server]
+	addr = "127.0.0.1:0"
+	gateway_key = "k"
+	[store]
+	db = "x.jsonl"
+	[retrieval]
+	[ingest]
+	[[upstreams]]
+	name = "d"
+	base_url = "https://api.deepseek.com"
+	api_key = "k"
+	model_alias = ["x"]
+	upstream_model = "y"
+	vendor = "deepseek"
+	`
+	load := func(floor string) *float64 {
+		body := base + "[cache]" + string([]byte{10}) + "ttl_seconds = 86400" + string([]byte{10})
+		if floor != "" {
+			body += "lexical_floor = " + floor + string([]byte{10})
+		}
+		p := filepath.Join(t.TempDir(), "gw.toml")
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(p)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		return cfg.Cache.LexicalFloor
+	}
+
+	if got := load(""); got != nil {
+		t.Fatalf("missing lexical_floor = %v, want nil", got)
+	}
+	if got := load("0"); got == nil || *got != 0 {
+		t.Fatalf("lexical_floor=0 = %v, want 0 (gate disabled)", got)
+	}
+	if got := load("0.2"); got == nil || *got != 0.2 {
+		t.Fatalf("lexical_floor=0.2 = %v, want 0.2", got)
+	}
+}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"semantix/kernel/cache"
@@ -51,6 +52,10 @@ type Gateway struct {
 	disabled   bool // SEMANTIX_GATEWAY_DISABLE ablation switch
 
 	now func() time.Time
+
+	// lexicalBlocks counts zone-Hit candidates downgraded by the lexical
+	// support gate (Issue #260), for hit-rate-loss accounting.
+	lexicalBlocks atomic.Int64
 }
 
 // disableEnv reports the ablation switch SEMANTIX_GATEWAY_DISABLE. Only
@@ -138,11 +143,17 @@ func New(cfg *Config) (*Gateway, error) {
 		}
 	}
 
+	decider := &cache.L3Decider{Index: idx, Store: store, Root: root, K: topK, Judge: llmJudge}
+	// Issue #260: lexical support floor for the L3 Hit path (0 disables the
+	// gate; nil keeps the kernel default).
+	if cfg.Cache.LexicalFloor != nil {
+		decider.LexicalFloor = cfg.Cache.LexicalFloor
+	}
 	g := &Gateway{
 		cfg:      cfg,
 		store:    store,
 		index:    idx,
-		decider:  &cache.L3Decider{Index: idx, Store: store, Root: root, K: topK, Judge: llmJudge},
+		decider:  decider,
 		injector: &inject.Injector{Index: idx, Store: store, Scope: scope, K: topK, Budget: budget, Zones: &z},
 		usageLog: rec,
 		client:   &http.Client{Timeout: 120 * time.Second},
@@ -153,6 +164,7 @@ func New(cfg *Config) (*Gateway, error) {
 	// one structured log line plus a field on the turn's usage event, so a
 	// non-hit can be explained and the judge's own model call can be costed.
 	g.decider.OnJudge = g.observeJudge
+	g.decider.OnLexicalGate = g.observeLexicalGate
 	g.healthProbe = g.probeUpstreams
 	return g, nil
 }

--- a/gateway/lexical_observability.go
+++ b/gateway/lexical_observability.go
@@ -1,0 +1,25 @@
+package gateway
+
+import (
+	"context"
+	"log"
+
+	"semantix/kernel/cache"
+)
+
+// Lexical-gate observability (Issue #260 step 4). The lexical support
+// gate downgrades zone-Hit candidates with no term overlap to Grey; the
+// only way to tell a real hit-rate drop from a gate over-blocking is to
+// count the blocks. One structured log line per evaluated candidate plus
+// a process-wide counter for the blocked ones.
+
+// observeLexicalGate is the cache.L3Decider.OnLexicalGate hook: it logs
+// one line per evaluated zone-Hit and increments the block counter. It
+// never affects the reuse verdict — the decision is already made.
+func (g *Gateway) observeLexicalGate(_ context.Context, obs cache.LexicalGateObservation) {
+	log.Printf("gateway: l3 lexical slice=%s score=%.3f lexical=%.3f blocked=%t zone=%s",
+		obs.SliceID, obs.Score, obs.Lexical, obs.Blocked, obs.Zone)
+	if obs.Blocked {
+		g.lexicalBlocks.Add(1)
+	}
+}

--- a/gateway/lexical_observability_test.go
+++ b/gateway/lexical_observability_test.go
@@ -1,0 +1,17 @@
+package gateway
+
+import (
+	"testing"
+
+	"semantix/kernel/cache"
+)
+
+func TestObserveLexicalGateCountsBlocks(t *testing.T) {
+	g := &Gateway{}
+	g.observeLexicalGate(t.Context(), cache.LexicalGateObservation{SliceID: "a", Score: 0.9, Lexical: 0, Blocked: true, Zone: "grey"})
+	g.observeLexicalGate(t.Context(), cache.LexicalGateObservation{SliceID: "b", Score: 0.9, Lexical: 1, Blocked: false, Zone: "hit"})
+	g.observeLexicalGate(t.Context(), cache.LexicalGateObservation{SliceID: "c", Score: 0.8, Lexical: 0, Blocked: true, Zone: "grey"})
+	if got := g.lexicalBlocks.Load(); got != 2 {
+		t.Fatalf("lexicalBlocks = %d, want 2 (only blocked candidates count)", got)
+	}
+}

--- a/gateway/retriever.go
+++ b/gateway/retriever.go
@@ -102,7 +102,10 @@ func (v *vectorIndex) Search(query string, k int, scope slice.Scope) ([]slice.Hi
 		if s == nil || s.Scope != scope {
 			continue
 		}
-		out = append(out, slice.Hit{Slice: s, Score: float64(h.Score)})
+		// Pure-vector route: no fused BM25 contribution exists, so lexical
+	// support degrades to query-token coverage (Issue #260). Zero overlap
+	// is the "pure-vector hit with no term support" signal for the L3 gate.
+	out = append(out, slice.Hit{Slice: s, Score: float64(h.Score), Lexical: bm25.QueryCoverage(query, string(s.Content)), LexicalValid: true})
 		if len(out) >= k {
 			break
 		}
@@ -200,7 +203,14 @@ func fuseHits(bm, vec []slice.Hit, k int) []slice.Hit {
 	out := make([]slice.Hit, 0, len(merged))
 	for id, s := range merged {
 		if score[id] > 0 { // drop no-signal candidates, like bm25's score<=0 filter
-			out = append(out, slice.Hit{Slice: s, Score: score[id]})
+			// Lexical support = the normalized BM25 route contribution; 0 means
+			// the candidate was a pure-vector hit with no term overlap (Issue
+			// #260). A fused index always evaluates it, so LexicalValid is set.
+			lx := 0.0
+			if v, ok := bmN[id]; ok {
+				lx = v
+			}
+			out = append(out, slice.Hit{Slice: s, Score: score[id], Lexical: lx, LexicalValid: true})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/gateway/retriever_test.go
+++ b/gateway/retriever_test.go
@@ -130,3 +130,67 @@ func scoresOf(hits []slice.Hit) []float64 {
 	}
 	return out
 }
+
+func TestFuseHitsCarriesLexicalRoute(t *testing.T) {
+	bm := []slice.Hit{
+		{Slice: projectSlice("a", "x"), Score: 5.0},
+		{Slice: projectSlice("b", "y"), Score: 3.0},
+	}
+	vec := []slice.Hit{
+		{Slice: projectSlice("a", "x"), Score: 0.9},
+		{Slice: projectSlice("b", "y"), Score: 0.8},
+		{Slice: projectSlice("c", "z"), Score: 0.7}, // pure-vector hit
+	}
+	got := fuseHits(bm, vec, 10)
+	byID := map[string]slice.Hit{}
+	for _, h := range got {
+		byID[h.Slice.ID] = h
+	}
+	if len(byID) != 3 {
+		t.Fatalf("fuseHits = %d candidates, want 3", len(byID))
+	}
+	if a := byID["a"]; !approx(a.Lexical, 1.0) || !a.LexicalValid {
+		t.Fatalf("a: lexical=%v valid=%v, want 1.0/true (top-1 both routes)", a.Lexical, a.LexicalValid)
+	}
+	if b := byID["b"]; !approx(b.Lexical, 0.6) || !b.LexicalValid {
+		t.Fatalf("b: lexical=%v valid=%v, want 0.6/true (normalized bm route)", b.Lexical, b.LexicalValid)
+	}
+	if c := byID["c"]; !approx(c.Lexical, 0.0) || !c.LexicalValid {
+		t.Fatalf("c: lexical=%v valid=%v, want 0.0/true (pure-vector hit)", c.Lexical, c.LexicalValid)
+	}
+}
+
+func TestVectorIndexFillsLexicalCoverage(t *testing.T) {
+	idx := newRetriever("vector", 0)
+	seedRetriever(t, idx, projectSlice("a", "deploy golang binary to linux server with systemd"))
+	got, err := idx.Search("deploy golang binary linux", 5, slice.Project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || !got[0].LexicalValid {
+		t.Fatalf("vector hit must carry LexicalValid, got %+v", got)
+	}
+	if !approx(got[0].Lexical, 1.0) {
+		t.Fatalf("lexical coverage = %v, want 1.0 (all query terms present)", got[0].Lexical)
+	}
+}
+
+func TestBM25HitsCarryLexicalSupport(t *testing.T) {
+	idx := newRetriever("bm25", 0)
+	seedRetriever(t, idx, projectSlice("a", "deploy golang binary to linux server"))
+	got, err := idx.Search("deploy golang", 5, slice.Project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0].Lexical != 1.0 || !got[0].LexicalValid {
+		t.Fatalf("bm25 hit must carry lexical=1/valid, got %+v", got)
+	}
+}
+
+func approx(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < 1e-9
+}

--- a/kernel/bm25/bm25.go
+++ b/kernel/bm25/bm25.go
@@ -56,7 +56,7 @@ func (ix *Index) Search(query string, k int, scope slice.Scope) ([]slice.Hit, er
 		return []slice.Hit{}, nil
 	}
 
-	queryTerms := uniqueTerms(tokenize(query))
+	queryTerms := uniqueTerms(Tokenize(query))
 	if len(queryTerms) == 0 {
 		return nil, errors.New("bm25: query must contain at least one letter or number")
 	}
@@ -141,7 +141,7 @@ func (ix *Index) Insert(s *slice.Slice) error {
 		return errors.New("bm25: empty slice ID")
 	}
 
-	terms := tokenize(string(s.Content))
+	terms := Tokenize(string(s.Content))
 	if len(terms) == 0 {
 		return errors.New("bm25: slice content must contain at least one letter or number")
 	}

--- a/kernel/bm25/bm25.go
+++ b/kernel/bm25/bm25.go
@@ -91,7 +91,9 @@ func (ix *Index) Search(query string, k int, scope slice.Scope) ([]slice.Hit, er
 		if score <= 0 {
 			continue
 		}
-		hits = append(hits, slice.Hit{Slice: cloneSlice(doc.value), Score: score})
+		// BM25 is lexical retrieval: a hit is lexical support by definition
+		// (Issue #260 lexical support gate).
+		hits = append(hits, slice.Hit{Slice: cloneSlice(doc.value), Score: score, Lexical: 1, LexicalValid: true})
 	}
 
 	sort.Slice(hits, func(i, j int) bool {

--- a/kernel/bm25/tokenizer.go
+++ b/kernel/bm25/tokenizer.go
@@ -5,8 +5,8 @@ import (
 	"unicode"
 )
 
-// tokenize lowercases word tokens and emits each CJK rune as its own token.
-func tokenize(text string) []string {
+// Tokenize lowercases word tokens and emits each CJK rune as its own token.
+func Tokenize(text string) []string {
 	var tokens []string
 	var word strings.Builder
 	flush := func() {
@@ -55,4 +55,22 @@ func uniqueTerms(terms []string) []string {
 		unique = append(unique, term)
 	}
 	return unique
+}
+
+// QueryCoverage returns the fraction of query terms that appear in content,
+// in [0,1]. A query with no terms (pure punctuation/symbols) returns 0
+// — fail-closed for the lexical support gate (Issue #260).
+func QueryCoverage(query, content string) float64 {
+	qt := uniqueTerms(Tokenize(query))
+	if len(qt) == 0 {
+		return 0
+	}
+	ct := countTerms(Tokenize(content))
+	covered := 0
+	for _, q := range qt {
+		if _, ok := ct[q]; ok {
+			covered++
+		}
+	}
+	return float64(covered) / float64(len(qt))
 }

--- a/kernel/bm25/tokenizer_test.go
+++ b/kernel/bm25/tokenizer_test.go
@@ -6,16 +6,16 @@ import (
 )
 
 func TestTokenizeLatinCJKAndPunctuation(t *testing.T) {
-	got := tokenize("BM25 检索 cache-first 日本語 한글 Cache_Key42")
+	got := Tokenize("BM25 检索 cache-first 日本語 한글 Cache_Key42")
 	want := []string{"bm25", "检", "索", "cache", "first", "日", "本", "語", "한", "글", "cache_key42"}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("tokenize() = %#v, want %#v", got, want)
+		t.Fatalf("Tokenize() = %#v, want %#v", got, want)
 	}
 }
 
 func TestTokenizeDropsOnlyPunctuation(t *testing.T) {
-	if got := tokenize(" !?，。--- "); len(got) != 0 {
-		t.Fatalf("tokenize() = %#v, want no tokens", got)
+	if got := Tokenize(" !?，。--- "); len(got) != 0 {
+		t.Fatalf("Tokenize() = %#v, want no tokens", got)
 	}
 }
 
@@ -24,5 +24,29 @@ func TestUniqueTermsKeepsFirstSeenOrder(t *testing.T) {
 	want := []string{"cache", "测", "试"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("uniqueTerms() = %#v, want %#v", got, want)
+	}
+}
+
+func TestQueryCoverageFull(t *testing.T) {
+	if got := QueryCoverage("fix failing go test", "run go test and fix failing tests"); got != 1.0 {
+		t.Fatalf("QueryCoverage = %v, want 1.0", got)
+	}
+}
+
+func TestQueryCoveragePartial(t *testing.T) {
+	if got := QueryCoverage("修复测试", "修复完成"); got != 0.5 {
+		t.Fatalf("QueryCoverage = %v, want 0.5", got)
+	}
+}
+
+func TestQueryCoverageNoTermsFailClosed(t *testing.T) {
+	if got := QueryCoverage("?!,。", "anything here"); got != 0 {
+		t.Fatalf("QueryCoverage = %v, want 0 (fail-closed)", got)
+	}
+}
+
+func TestQueryCoverageZeroOverlap(t *testing.T) {
+	if got := QueryCoverage("deploy kubernetes cluster", "画一只猫"); got != 0 {
+		t.Fatalf("QueryCoverage = %v, want 0", got)
 	}
 }

--- a/kernel/cache/judge_observe.go
+++ b/kernel/cache/judge_observe.go
@@ -93,3 +93,19 @@ func relConfidence(score, top1 float64) float64 {
 	}
 	return score / top1
 }
+// LexicalGateObservation is one zone-Hit candidate the lexical support
+// gate evaluated (Issue #260), emitted through L3Decider.OnLexicalGate.
+// It lets the host count gate blocks and measure the hit-rate loss the
+// gate introduces, without kernel/cache learning any sink.
+type LexicalGateObservation struct {
+	// SliceID is the candidate the gate evaluated.
+	SliceID string
+	// Score is the fused retrieval score that classified the candidate.
+	Score float64
+	// Lexical is the reported lexical-support score (BM25 route / coverage).
+	Lexical float64
+	// Blocked reports whether the gate downgraded this Hit to Grey.
+	Blocked bool
+	// Zone is the zone after the gate decision ("hit" or "grey").
+	Zone string
+}

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -32,6 +32,20 @@ type L3Decider struct {
 	// on the decision path with the request context, so implementations
 	// must not block; a nil hook disables observation entirely.
 	OnJudge func(ctx context.Context, obs JudgeObservation)
+
+	// LexicalFloor is the minimum lexical-support score for a zone Hit to
+	// reuse directly (Issue #260). A Hit whose index reports zero lexical
+	// support (pure-vector hit, no term overlap) is downgraded to Grey —
+	// judge-gated reuse, fail-closed without a judge. nil → default 0.05;
+	// an explicit 0 disables the gate (escape hatch). Hits with
+	// LexicalValid=false are never blocked (not measured).
+	LexicalFloor *float64
+
+	// OnLexicalGate, when non-nil, receives one LexicalGateObservation per
+	// zone-Hit candidate the lexical gate evaluated (Issue #260), so the
+	// host can count blocks and measure hit-rate loss. Hook-only, like
+	// OnJudge; nil disables observation.
+	OnLexicalGate func(ctx context.Context, obs LexicalGateObservation)
 }
 
 // DecideL2 returns top-k hits filtered by the grey zone (hit-only enters the
@@ -107,7 +121,18 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 		s := h.Slice
 		switch z.ClassifyL3(h.Score, resultTop1, globalTop1) {
 		case zone.Hit:
-			// clear hit: reuse after the remaining gates below
+			// Issue #260 lexical support gate: a Hit with no term overlap
+			// (pure-vector hit) is downgraded to Grey — judge-gated reuse,
+			// fail-closed without a judge. First mitigation against embedding
+			// key-collision attacks (CacheAttack, arXiv:2601.23088).
+			if !d.lexicalSupported(h) {
+				d.observeLexicalGate(ctx, h, true)
+				if !d.judgeGrey(ctx, q, s, relConfidence(h.Score, resultTop1)) {
+					continue
+				}
+				break
+			}
+			d.observeLexicalGate(ctx, h, false)
 		case zone.Grey:
 			// Ambiguous: reuse only when the judge confirms (spec §3.5
 			// RuleGate.Chain; nil judge → conservative reject). Fingerprint
@@ -251,4 +276,40 @@ func (d *L3Decider) k() int {
 		return d.K
 	}
 	return 3
+}
+// lexicalFloor returns the lexical-support floor: explicit override,
+// default 0.05 (a tiny epsilon above the strict zero of a pure-vector
+// hit), or 0 when the gate is explicitly disabled.
+func (d *L3Decider) lexicalFloor() float64 {
+	if d.LexicalFloor != nil {
+		return *d.LexicalFloor
+	}
+	return 0.05
+}
+
+// lexicalSupported reports whether a candidate carries enough lexical
+// support to reuse directly. LexicalValid=false means the index never
+// evaluated lexical support — not measured, never blocked.
+func (d *L3Decider) lexicalSupported(h slice.Hit) bool {
+	if !h.LexicalValid {
+		return true
+	}
+	return h.Lexical >= d.lexicalFloor()
+}
+
+func (d *L3Decider) observeLexicalGate(ctx context.Context, h slice.Hit, blocked bool) {
+	if d.OnLexicalGate == nil {
+		return
+	}
+	z := "hit"
+	if blocked {
+		z = "grey"
+	}
+	d.OnLexicalGate(ctx, LexicalGateObservation{
+		SliceID: h.Slice.ID,
+		Score:   h.Score,
+		Lexical: h.Lexical,
+		Blocked: blocked,
+		Zone:    z,
+	})
 }

--- a/kernel/cache/l3_test.go
+++ b/kernel/cache/l3_test.go
@@ -472,3 +472,106 @@ func TestDecideL3GreyZoneJudgeErrorFailsClosed(t *testing.T) {
 		t.Fatalf("judge error must fail closed, got %+v", res)
 	}
 }
+// fakeIndex returns a fixed hit list; used to exercise the lexical gate
+// independent of a real retriever.
+type fakeIndex struct {
+	hits []slice.Hit
+}
+
+func (f *fakeIndex) Insert(*slice.Slice) error { return nil }
+func (f *fakeIndex) Remove(string) error        { return nil }
+func (f *fakeIndex) Search(string, int, slice.Scope) ([]slice.Hit, error) {
+	return f.hits, nil
+}
+
+// l3Fixture is a dependency-captured Result slice that passes the
+// fingerprint gates when nothing changed. It returns the dep root so the
+// decider can verify against it.
+func l3Fixture(t *testing.T) (string, *slice.Slice) {
+	root := t.TempDir()
+	dep := "dep.txt"
+	if err := os.WriteFile(filepath.Join(root, dep), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deps, err := fingerprint.Capture(root, []string{dep})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root, &slice.Slice{ID: "l3-g", Type: slice.Result, Scope: slice.Project,
+		Content: []byte("复用结果：修复 go 测试失败"), Meta: slice.SliceMeta{SourceSession: "s1", Deps: deps}}
+}
+
+func TestL3LexicalGateBlocksPureVectorHit(t *testing.T) {
+	root, sl := l3Fixture(t)
+	idx := &fakeIndex{hits: []slice.Hit{{Slice: sl, Score: 0.9, Lexical: 0, LexicalValid: true}}}
+	d := &L3Decider{Index: idx, Root: root}
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != nil {
+		t.Fatal("pure-vector hit without judge must be downgraded and rejected")
+	}
+}
+func TestL3LexicalGateAllowsLexicalHit(t *testing.T) {
+	root, sl := l3Fixture(t)
+	idx := &fakeIndex{hits: []slice.Hit{{Slice: sl, Score: 0.9, Lexical: 1, LexicalValid: true}}}
+	d := &L3Decider{Index: idx, Root: root}
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.SliceID != "l3-g" {
+		t.Fatalf("lexically supported Hit must reuse, got %+v", res)
+	}
+}
+
+func TestL3LexicalGateIgnoresUnmeasured(t *testing.T) {
+	root, sl := l3Fixture(t)
+	// Zero-value LexicalValid=false: legacy/third-party index, not measured.
+	idx := &fakeIndex{hits: []slice.Hit{{Slice: sl, Score: 0.9}}}
+	d := &L3Decider{Index: idx, Root: root}
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("unmeasured lexical support must not block reuse")
+	}
+}
+
+func TestL3LexicalGateJudgeApprovesDowngrade(t *testing.T) {
+	root, sl := l3Fixture(t)
+	idx := &fakeIndex{hits: []slice.Hit{{Slice: sl, Score: 0.9, Lexical: 0, LexicalValid: true}}}
+	d := &L3Decider{Index: idx, Root: root, Judge: &mockJudge{confirm: true}}
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("judge-approved downgrade must reuse")
+	}
+}
+
+func TestL3LexicalGateObservations(t *testing.T) {
+	root, sl := l3Fixture(t)
+	idx := &fakeIndex{hits: []slice.Hit{
+		{Slice: sl, Score: 0.9, Lexical: 0, LexicalValid: true},
+		{Slice: sl, Score: 0.8, Lexical: 1, LexicalValid: true},
+	}}
+	var obs []LexicalGateObservation
+	d := &L3Decider{Index: idx, Root: root,
+		OnLexicalGate: func(_ context.Context, o LexicalGateObservation) { obs = append(obs, o) }}
+	if _, err := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project}); err != nil {
+		t.Fatal(err)
+	}
+	if len(obs) != 2 {
+		t.Fatalf("observations = %d, want 2 (blocked + allowed)", len(obs))
+	}
+	if !obs[0].Blocked || obs[0].Zone != "grey" || obs[0].Lexical != 0 {
+		t.Fatalf("obs[0] = %+v, want blocked grey lexical=0", obs[0])
+	}
+	if obs[1].Blocked || obs[1].Zone != "hit" || obs[1].Lexical != 1 {
+		t.Fatalf("obs[1] = %+v, want allowed hit lexical=1", obs[1])
+	}
+}

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -148,4 +148,14 @@ type Slice struct {
 type Hit struct {
 	Slice *Slice
 	Score float64
+	// Lexical is the lexical-support score in [0,1] contributed by the
+	// lexical (BM25) route of a fused retrieval: 0 means the candidate was
+	// a pure-vector hit with no term overlap (Issue #260 lexical support
+	// gate). In single-route modes it carries the query-token coverage
+	// (vector mode) or 1 (bm25 mode). LexicalValid=false (zero value)
+	// means the index did not evaluate lexical support — consumers must
+	// treat that as "not measured", not "unsupported", so legacy and
+	// third-party Index implementations are never blocked by default.
+	Lexical      float64 `json:"lexical,omitempty"`
+	LexicalValid bool    `json:"-"`
 }


### PR DESCRIPTION
## 动机

L3 Hit 区直通路径目前纯靠检索分数（embedding 相似度），词面检查不存在。文献（CacheAttack arXiv:2601.23088）表明 embedding 相似度键是模糊哈希，纯相似度触发的复用易被黑盒碰撞攻击劫持（86% 命中率）；GroundedCache（arXiv:2605.27494）要求"查询相似 × 证据重叠 × 源版本有效 × 词面/judge 支持"四道廉价门同时成立才允许复用。

## 改动

5 个最小 commit，425 行新增：

| Commit | 内容 |
|---|---|
| `267fa63` feat(slice) | `Hit` 加 `Lexical`/`LexicalValid`（零值 = 未评估，向后兼容） |
| `10f06c9` feat(bm25) | 导出 `Tokenize` + 新增 `QueryCoverage`（query-token 覆盖率，无词项 fail-closed 为 0） |
| `106cea5` feat(retrieval) | bm25=1 / vector=QueryCoverage / hybrid fuseHits 透出 BM25 路贡献（纯向量命中 = 0） |
| `9db5dd8` feat(cache) | L3 词面门：zone-Hit 无词面支持降级 Grey（judge 确认，无 judge fail-closed）；`LexicalFloor`（nil→0.05，0=禁用）；`OnLexicalGate` 观测 |
| `c517d93` feat(gateway) | `cache.lexical_floor` 配置接线 + 观测（日志 + 拦截计数）+ deploy 示例 |

## 设计要点

- `LexicalValid=false`（旧/第三方 Index）永不拦截
- 每次 O(候选数)、无新外呼；hybrid 路径零额外开销
- 与"逐条目自适应阈值"RFC 正交（独立信号维度）
- 与域 7 投毒测例 RFC 联动（CacheAttack 式碰撞测例可验证本门）

## 测试

- `go test ./kernel/bm25/... ./kernel/cache/... ./gateway/... -race` 全绿
- `go vet` 干净；全仓 `go build ./...` 通过
- 新增 12 个单测：QueryCoverage ×4、检索器词面信号 ×3、词面门 ×5、config 解析 ×1、观测计数 ×1
- 已知 Windows 平台文件锁问题（`TestJournalForwardCompat`，与本次无关，CI ubuntu 不受影响）

## 验收建议（后续）

1. 碰撞样例（hash embedder 确定性）：词面门拦截 ≥90%
2. verify 回放：clear-hit 率下降 ≤1 个百分点（`lexical_floor` + 拦截计数调参）