### PR TITLE
GLM-P0-2: gateway 前缀净化中间件 (#290)

### DIFF
--- a/agent-skill/SKILL.md
+++ b/agent-skill/SKILL.md
@@ -45,6 +45,22 @@ mkdir -p ~/.semantix/sessions
 | **Claude Code / 工具注册类** | 本 skill `tools/semantix-lookup.md` 的 schema 注册 `semantix_lookup`（+可选 `semantix_inject`） |
 | **任意自定义 agent** | 会话旁路三方式（`hooks/session-bypass.md`）：导出 / 事件旁路 / 直接调用 |
 
+### STEP 3.5 — Claude Code 接第三方 GLM 端点时的前缀卫生（可选，强烈推荐）
+
+Claude Code ≥2.1.36 会在 system prompt 最前端注入**逐请求变化的计费头**
+（`x-anthropic-billing-header` 的 cch 字段）。官方服务端会剥离它；第三方 GLM 端点
+（腾讯云 TokenHub 等）不剥离——**前缀从第一个 token 起失配，隐式缓存全灭**
+（社区实测命中差 133 倍；对照 TokenHub 官方 Claude Code 接入页推荐的环境变量组）。
+两道防线任开其一，同开更稳：
+
+```bash
+export CLAUDE_CODE_ATTRIBUTION_HEADER=0   # 客户端不再注入计费头（直连第三方端点时唯一有效的一道）
+```
+
+- 经 **semantix-gateway** 转发时：网关净化中间件默认剥离该计费头（`[sanitize]
+  strip_attribution`，见 `deploy/semantix-gateway.toml.example`），未设环境变量也受保护；
+- **直连**第三方端点（不过网关）时：只有上面的环境变量能救。
+
 ### STEP 4 — 闭环自测（必须通过）
 
 ```bash

--- a/deploy/semantix-gateway.toml.example
+++ b/deploy/semantix-gateway.toml.example
@@ -35,6 +35,15 @@ sessions_dir = "/data/sessions"           # 会话旁路落盘目录（0600）
 usage_log = "/data/gateway-usage.jsonl"   # usage 事件记录
 l3_safe_default = false                   # 无 deps 的网关结果默认不进 L3（true 需显式确认）
 
+[sanitize]                                # 前缀净化中间件（GLM-P0-2 #290）：第三方 GLM 栈缓存
+                                          # 逐字节严格（单空格差异即清零），且不像官方端点那样
+                                          # 服务端剥离 harness 计费头——净化默认开启
+# strip_attribution = true                # 剥离 system 首段的逐请求计费标记（默认 true）
+                                          # 关闭 = 客户端请求原样转发，缓存费最多多付 4–5 倍
+# attribution_markers = []                # 自定义标记行前缀，与内置合并（内置：x-anthropic-billing-header）
+# sort_tools = true                       # tools 数组按工具名固定序（默认 true；语义中性——
+                                          # 工具按名寻址，顺序只影响缓存字节）
+
 [[upstreams]]                             # 每个 New API 渠道模型对应一段
 name = "deepseek"
 base_url = "https://api.deepseek.com/v1"
@@ -42,3 +51,6 @@ api_key = "${DEEPSEEK_API_KEY}"           # 上游 key：只走环境变量
 model_alias = ["deepseek-chat"]           # 客户端可见模型名（New API 渠道模型名）
 upstream_model = "deepseek-chat"          # 上游真实模型名
 vendor = "deepseek"                       # deepseek | openai | moonshot（anthropic 需 M2 格式转换，未支持）
+# strip_cache_control = false             # per-upstream：剥离 body 内 cache_control 字段。
+                                          # 默认透传——双网关实测（glm-spike-week.md §2/§3A.2）
+                                          # 均容忍该字段；仅当上游明确报错时开启

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -24,7 +24,55 @@ type Config struct {
 	Retrieval RetrievalConfig  `toml:"retrieval"`
 	Cache     CacheConfig      `toml:"cache"`
 	Ingest    IngestConfig     `toml:"ingest"`
+	Sanitize  SanitizeConfig   `toml:"sanitize"`
 	Upstreams []UpstreamConfig `toml:"upstreams"`
+}
+
+// SanitizeConfig is the prefix-hygiene middleware (GLM-P0-2, Issue #290).
+// Third-party GLM-style caches are byte-exact over the whole prefix
+// (glm-spike-week.md §3), and unlike first-party endpoints they do not strip
+// harness billing markers server-side — a per-request marker in the system
+// head breaks the cache from the first token (133× hit-rate difference
+// reported for Claude Code's attribution header, spec §3.3/§4.1-1).
+type SanitizeConfig struct {
+	// StripAttribution removes attribution/billing marker lines from the head
+	// of the first system message before the body reaches the upstream.
+	// Default ON (nil = true); set strip_attribution = false to forward the
+	// client request untouched (documented cost: cache spend up to 4-5×).
+	StripAttribution *bool `toml:"strip_attribution"`
+	// AttributionMarkers are the line prefixes recognized as attribution
+	// segments. Merged with the built-in defaults (x-anthropic-billing-header).
+	AttributionMarkers []string `toml:"attribution_markers"`
+	// SortTools canonicalizes the request tools array by tool name so client
+	// enumeration order cannot break byte-exact prefix caches. Default ON
+	// (nil = true). Semantically neutral: tool choice is name-addressed.
+	SortTools *bool `toml:"sort_tools"`
+}
+
+// StripAttributionEnabled reports the effective default-on switch.
+func (s SanitizeConfig) StripAttributionEnabled() bool {
+	return s.StripAttribution == nil || *s.StripAttribution
+}
+
+// SortToolsEnabled reports the effective default-on switch.
+func (s SanitizeConfig) SortToolsEnabled() bool {
+	return s.SortTools == nil || *s.SortTools
+}
+
+// builtinAttributionMarkers match the known harness billing markers that
+// third-party endpoints do not strip server-side.
+var builtinAttributionMarkers = []string{"x-anthropic-billing-header"}
+
+// EffectiveAttributionMarkers merges configured markers with the built-ins.
+func (s SanitizeConfig) EffectiveAttributionMarkers() []string {
+	out := append([]string(nil), builtinAttributionMarkers...)
+	for _, m := range s.AttributionMarkers {
+		m = strings.TrimSpace(m)
+		if m != "" {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // ServerConfig is the listener and gateway-key settings.
@@ -87,6 +135,11 @@ type UpstreamConfig struct {
 	ModelAlias    []string `toml:"model_alias"`
 	UpstreamModel string   `toml:"upstream_model"`
 	Vendor        string   `toml:"vendor"`
+	// StripCacheControl removes cache_control fields from the outgoing body
+	// for this upstream. Default OFF: both measured GLM-hosting stacks accept
+	// cache_control without error (glm-spike-week.md §2/§3A.2), so the gateway
+	// forwards it untouched unless a provider is known to reject it.
+	StripCacheControl bool `toml:"strip_cache_control"`
 }
 
 // vendor names accepted by the v1 gateway. anthropic needs message-format

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -130,25 +130,54 @@ func (g *Gateway) l3Eligible(id, vendor string) bool {
 }
 
 // rewriteOutgoing rewrites the outgoing body in place: the client model
-// alias is mapped to the upstream model name, and (when an injection block
-// was assembled) the block is appended to the first system message
-// (byte-stable prefix tail, L1) or prepended as a new system message. All
-// other request fields pass through untouched.
+// alias is mapped to the upstream model name, the prefix-hygiene middleware
+// runs (GLM-P0-2, #290: attribution stripping / tools canonicalization /
+// per-upstream cache_control policy), and (when an injection block was
+// assembled) the block is appended to the first system message (byte-stable
+// prefix tail, L1) or prepended as a new system message. All other request
+// fields pass through untouched. Sanitation operates on the decoded body
+// before injection so both the injected and non-injected paths ship the
+// same sanitized prefix.
 func (g *Gateway) rewriteOutgoing(body []byte, req *chatRequest, up UpstreamConfig, inj *inject.Injection) []byte {
 	var raw map[string]any
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return body
 	}
 	raw["model"] = up.UpstreamModel
+	g.sanitizeOutgoing(raw, up)
 	if inj != nil && inj.Text != "" {
-		messages := append([]chatMessage(nil), req.Messages...)
-		raw["messages"] = attachBlock(messages, inj.Text)
+		if msgs, ok := raw["messages"].([]any); ok {
+			raw["messages"] = attachBlockRaw(msgs, inj.Text)
+		}
 	}
 	out, err := json.Marshal(raw)
 	if err != nil {
 		return body
 	}
 	return out
+}
+
+// attachBlockRaw is attachBlock over the decoded JSON form: it appends block
+// to the last string-content system message, or prepends a system message
+// when none exists. Operating on the decoded body (rather than re-encoding
+// req.Messages) preserves whatever the sanitizer just did to the prefix.
+func attachBlockRaw(messages []any, block string) []any {
+	last := -1
+	for i, m := range messages {
+		msg, ok := m.(map[string]any)
+		if !ok || msg["role"] != "system" {
+			continue
+		}
+		if _, ok := msg["content"].(string); ok {
+			last = i
+		}
+	}
+	if last >= 0 {
+		msg := messages[last].(map[string]any)
+		msg["content"] = msg["content"].(string) + "\n\n" + block
+		return messages
+	}
+	return append([]any{map[string]any{"role": "system", "content": block}}, messages...)
 }
 
 // attachBlock appends block to the last string-content system message (the

--- a/gateway/sanitize.go
+++ b/gateway/sanitize.go
@@ -1,0 +1,145 @@
+package gateway
+
+import (
+	"sort"
+	"strings"
+)
+
+// sanitizeOutgoing applies the prefix-hygiene middleware (GLM-P0-2, #290) to
+// the decoded request body, in place. Order matters for byte stability:
+// attribution stripping first (head of the system prefix), then tools
+// canonicalization, then the per-upstream cache_control policy.
+func (g *Gateway) sanitizeOutgoing(raw map[string]any, up UpstreamConfig) {
+	if g.cfg.Sanitize.StripAttributionEnabled() {
+		stripAttributionMarkers(raw, g.cfg.Sanitize.EffectiveAttributionMarkers())
+	}
+	if g.cfg.Sanitize.SortToolsEnabled() {
+		sortToolsArray(raw)
+	}
+	if up.StripCacheControl {
+		stripCacheControl(raw)
+	}
+}
+
+// stripAttributionMarkers removes attribution/billing marker lines from the
+// head of the FIRST system message only — that is where harnesses inject
+// per-request billing headers, and it is the first byte of the provider's
+// cache prefix. Marker lines are matched by prefix after trimming leading
+// whitespace; stripping stops at the first non-marker, non-empty line so
+// legitimate prompt text is never touched.
+func stripAttributionMarkers(raw map[string]any, markers []string) {
+	msgs, ok := raw["messages"].([]any)
+	if !ok {
+		return
+	}
+	for _, m := range msgs {
+		msg, ok := m.(map[string]any)
+		if !ok || msg["role"] != "system" {
+			continue
+		}
+		switch content := msg["content"].(type) {
+		case string:
+			msg["content"] = stripMarkerHead(content, markers)
+		case []any:
+			// OpenAI content-parts form: strip inside the first text part.
+			for _, p := range content {
+				part, ok := p.(map[string]any)
+				if !ok || part["type"] != "text" {
+					continue
+				}
+				if text, ok := part["text"].(string); ok {
+					part["text"] = stripMarkerHead(text, markers)
+				}
+				break
+			}
+		}
+		return // first system message only
+	}
+}
+
+// stripMarkerHead drops leading lines that begin with any marker prefix
+// (plus blank lines directly following them). The remainder is returned
+// unchanged, byte for byte.
+func stripMarkerHead(text string, markers []string) string {
+	rest := text
+	for {
+		line, tail, hasNL := strings.Cut(rest, "\n")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" && rest != text {
+			// swallow blank separator lines after a stripped marker
+			if hasNL {
+				rest = tail
+				continue
+			}
+			return ""
+		}
+		matched := false
+		for _, m := range markers {
+			if strings.HasPrefix(trimmed, m) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return rest
+		}
+		if !hasNL {
+			return ""
+		}
+		rest = tail
+	}
+}
+
+// sortToolsArray canonicalizes raw["tools"] by tool name using a stable sort,
+// covering both the OpenAI shape ({type:"function",function:{name}}) and the
+// Anthropic shape ({name}). Elements without a recognizable name keep their
+// relative order at the end.
+func sortToolsArray(raw map[string]any) {
+	tools, ok := raw["tools"].([]any)
+	if !ok || len(tools) < 2 {
+		return
+	}
+	sort.SliceStable(tools, func(i, j int) bool {
+		ni, oki := toolNameOf(tools[i])
+		nj, okj := toolNameOf(tools[j])
+		if oki != okj {
+			return oki // named tools sort before unnamed
+		}
+		return ni < nj
+	})
+	raw["tools"] = tools
+}
+
+func toolNameOf(v any) (string, bool) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	if fn, ok := m["function"].(map[string]any); ok {
+		if name, ok := fn["name"].(string); ok && name != "" {
+			return name, true
+		}
+	}
+	if name, ok := m["name"].(string); ok && name != "" {
+		return name, true
+	}
+	return "", false
+}
+
+// stripCacheControl removes every cache_control key nested anywhere in the
+// body. Used only for upstreams explicitly configured with
+// strip_cache_control = true; the default is pass-through (both measured
+// GLM-hosting stacks tolerate the field, glm-spike-week.md §2/§3A.2).
+func stripCacheControl(v any) {
+	switch node := v.(type) {
+	case map[string]any:
+		delete(node, "cache_control")
+		for _, child := range node {
+			stripCacheControl(child)
+		}
+	case []any:
+		for _, child := range node {
+			stripCacheControl(child)
+		}
+	}
+}

--- a/gateway/sanitize_test.go
+++ b/gateway/sanitize_test.go
@@ -1,0 +1,158 @@
+package gateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"semantix/kernel/inject"
+)
+
+func sanitizeGateway(t *testing.T, cfg SanitizeConfig) *Gateway {
+	t.Helper()
+	return &Gateway{cfg: &Config{Sanitize: cfg}}
+}
+
+func decodeBody(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return raw
+}
+
+const attributionBody = `{"model":"glm","messages":[{"role":"system","content":"x-anthropic-billing-header: cch=abc123-per-request\n\nYou are a coding agent."},{"role":"user","content":"hi"}]}`
+
+// TestSanitizeStripsAttributionByDefault: the per-request billing marker at
+// the head of the system prompt is removed with the default config, and the
+// remaining prompt is byte-identical to the original tail.
+func TestSanitizeStripsAttributionByDefault(t *testing.T) {
+	g := sanitizeGateway(t, SanitizeConfig{})
+	up := UpstreamConfig{UpstreamModel: "glm-5.3"}
+
+	out := g.rewriteOutgoing([]byte(attributionBody), nil, up, nil)
+	raw := decodeBody(t, out)
+	msgs := raw["messages"].([]any)
+	sys := msgs[0].(map[string]any)["content"].(string)
+	if strings.Contains(sys, "x-anthropic-billing-header") {
+		t.Fatalf("attribution marker survived: %q", sys)
+	}
+	if sys != "You are a coding agent." {
+		t.Fatalf("prompt tail mutated: %q", sys)
+	}
+}
+
+// TestSanitizeAttributionOffPreservesBytes: strip_attribution=false forwards
+// the system prompt untouched.
+func TestSanitizeAttributionOffPreservesBytes(t *testing.T) {
+	off := false
+	g := sanitizeGateway(t, SanitizeConfig{StripAttribution: &off})
+	up := UpstreamConfig{UpstreamModel: "glm-5.3"}
+
+	out := g.rewriteOutgoing([]byte(attributionBody), nil, up, nil)
+	raw := decodeBody(t, out)
+	sys := raw["messages"].([]any)[0].(map[string]any)["content"].(string)
+	if !strings.HasPrefix(sys, "x-anthropic-billing-header") {
+		t.Fatalf("marker was stripped with sanitizer off: %q", sys)
+	}
+}
+
+// TestSanitizeStripsMarkerInContentParts covers the OpenAI content-parts
+// system form.
+func TestSanitizeStripsMarkerInContentParts(t *testing.T) {
+	body := `{"model":"glm","messages":[{"role":"system","content":[{"type":"text","text":"x-anthropic-billing-header: cch=zzz\nReal prompt."},{"type":"text","text":"second part"}]},{"role":"user","content":"hi"}]}`
+	g := sanitizeGateway(t, SanitizeConfig{})
+	out := g.rewriteOutgoing([]byte(body), nil, UpstreamConfig{UpstreamModel: "m"}, nil)
+	raw := decodeBody(t, out)
+	parts := raw["messages"].([]any)[0].(map[string]any)["content"].([]any)
+	first := parts[0].(map[string]any)["text"].(string)
+	if first != "Real prompt." {
+		t.Fatalf("first part = %q", first)
+	}
+	if second := parts[1].(map[string]any)["text"].(string); second != "second part" {
+		t.Fatalf("second part touched: %q", second)
+	}
+}
+
+// TestSanitizeCustomMarkerAndMultiline: configured markers merge with
+// built-ins; consecutive marker lines and their blank separator all strip.
+func TestSanitizeCustomMarkerAndMultiline(t *testing.T) {
+	body := `{"model":"m","messages":[{"role":"system","content":"x-custom-billing: a=1\nx-anthropic-billing-header: cch=2\n\nPrompt."}]}`
+	g := sanitizeGateway(t, SanitizeConfig{AttributionMarkers: []string{"x-custom-billing"}})
+	out := g.rewriteOutgoing([]byte(body), nil, UpstreamConfig{UpstreamModel: "m"}, nil)
+	sys := decodeBody(t, out)["messages"].([]any)[0].(map[string]any)["content"].(string)
+	if sys != "Prompt." {
+		t.Fatalf("multi-marker head not fully stripped: %q", sys)
+	}
+}
+
+// TestSanitizeSortsToolsBothShapes: OpenAI and Anthropic tool shapes sort by
+// name; serialization becomes registration-order independent.
+func TestSanitizeSortsToolsBothShapes(t *testing.T) {
+	openaiBody := `{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"zeta"}},{"type":"function","function":{"name":"alpha"}}]}`
+	anthropicBody := `{"model":"m","messages":[],"tools":[{"name":"zeta"},{"name":"alpha"}]}`
+	g := sanitizeGateway(t, SanitizeConfig{})
+	for name, body := range map[string]string{"openai": openaiBody, "anthropic": anthropicBody} {
+		out := g.rewriteOutgoing([]byte(body), nil, UpstreamConfig{UpstreamModel: "m"}, nil)
+		tools := decodeBody(t, out)["tools"].([]any)
+		n0, _ := toolNameOf(tools[0])
+		n1, _ := toolNameOf(tools[1])
+		if n0 != "alpha" || n1 != "zeta" {
+			t.Fatalf("%s tools not sorted: %v, %v", name, n0, n1)
+		}
+	}
+}
+
+// TestSanitizeToolsOrderByteStable: two requests with the same tool set in
+// different client order serialize to byte-identical tools arrays.
+func TestSanitizeToolsOrderByteStable(t *testing.T) {
+	a := `{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"b"}},{"type":"function","function":{"name":"a"}}]}`
+	b := `{"model":"m","messages":[],"tools":[{"type":"function","function":{"name":"a"}},{"type":"function","function":{"name":"b"}}]}`
+	g := sanitizeGateway(t, SanitizeConfig{})
+	up := UpstreamConfig{UpstreamModel: "m"}
+	outA := g.rewriteOutgoing([]byte(a), nil, up, nil)
+	outB := g.rewriteOutgoing([]byte(b), nil, up, nil)
+	toolsA, _ := json.Marshal(decodeBody(t, outA)["tools"])
+	toolsB, _ := json.Marshal(decodeBody(t, outB)["tools"])
+	if string(toolsA) != string(toolsB) {
+		t.Fatalf("tools serialization order-dependent:\n a=%s\n b=%s", toolsA, toolsB)
+	}
+}
+
+// TestSanitizeCacheControlPerUpstream: default passes cache_control through;
+// strip_cache_control=true removes it at every depth.
+func TestSanitizeCacheControlPerUpstream(t *testing.T) {
+	body := `{"model":"m","cache_control":{"type":"ephemeral"},"messages":[{"role":"system","content":[{"type":"text","text":"p","cache_control":{"type":"ephemeral"}}]}]}`
+	g := sanitizeGateway(t, SanitizeConfig{})
+
+	kept := decodeBody(t, g.rewriteOutgoing([]byte(body), nil, UpstreamConfig{UpstreamModel: "m"}, nil))
+	if _, ok := kept["cache_control"]; !ok {
+		t.Fatal("default should pass cache_control through")
+	}
+
+	stripped := decodeBody(t, g.rewriteOutgoing([]byte(body), nil, UpstreamConfig{UpstreamModel: "m", StripCacheControl: true}, nil))
+	if _, ok := stripped["cache_control"]; ok {
+		t.Fatal("top-level cache_control survived strip")
+	}
+	part := stripped["messages"].([]any)[0].(map[string]any)["content"].([]any)[0].(map[string]any)
+	if _, ok := part["cache_control"]; ok {
+		t.Fatal("nested cache_control survived strip")
+	}
+}
+
+// TestSanitizeSurvivesInjectionPath: the L2 injection path must build on the
+// sanitized messages (regression for the raw-vs-req.Messages fork).
+func TestSanitizeSurvivesInjectionPath(t *testing.T) {
+	g := sanitizeGateway(t, SanitizeConfig{})
+	out := g.rewriteOutgoing([]byte(attributionBody), nil, UpstreamConfig{UpstreamModel: "m"},
+		&inject.Injection{Text: "[semantix-reuse]\nX\n[/semantix-reuse]"})
+	raw := decodeBody(t, out)
+	sys := raw["messages"].([]any)[0].(map[string]any)["content"].(string)
+	if strings.Contains(sys, "x-anthropic-billing-header") {
+		t.Fatalf("injection path lost sanitation: %q", sys)
+	}
+	if !strings.Contains(sys, "[semantix-reuse]") {
+		t.Fatalf("injection block missing: %q", sys)
+	}
+}


### PR DESCRIPTION
## 概要

第三方 GLM 栈缓存逐字节严格（单空格清零）且不像官方端点那样服务端剥离 harness 计费头（spec §3.3/§4.1-1，社区实测 133× 命中差）。本 PR 在 `rewriteOutgoing` 的解码体上挂前缀净化中间件，注入路径改走 `attachBlockRaw`，保证注入/非注入两条路径同享净化后前缀。

## 变更

- **`[sanitize] strip_attribution`**（默认开，可关）：剥离首条 system 消息头部的逐请求计费标记行（内置 `x-anthropic-billing-header`，`attribution_markers` 可扩展）；string 与 content-parts 两形态
- **`[sanitize] sort_tools`**（默认开）：tools 数组按工具名稳定排序（OpenAI/Anthropic 两 shape）——客户端枚举序不再影响缓存字节；语义中性（工具按名寻址）
- **per-upstream `strip_cache_control`**（默认关=透传）：双网关实测均容忍该字段（glm-spike-week.md §2/§3A.2），仅为报错型上游保留剥离开关
- example 配置注释文档化（含「不剥离 = 缓存费多付 4–5 倍」明示）
- agent-skill SKILL.md 新增 STEP 3.5：`CLAUDE_CODE_ATTRIBUTION_HEADER=0` 指引（直连第三方端点 vs 经网关两情形）

## 测试

8 项净化测试：默认开/显式关字节对照、多标记多行剥离、两 shape 排序、乱序注册字节稳定、cache_control 透传/剥离、**注入路径保净化回归**（raw-vs-req.Messages 分叉的回归锁）。`go test ./gateway/ -race` 全绿。

Fixes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)