### PR TITLE
feat: extract deterministic project Context slices

### DIFF
--- a/cmd/semantix/extract.go
+++ b/cmd/semantix/extract.go
@@ -122,6 +122,9 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 		if item == nil {
 			return fmt.Errorf("extractor returned nil slice at position %d", i)
 		}
+		if item.Type == slice.Context && scope != slice.Project {
+			continue
+		}
 		item.Scope = scope
 		if err := store.Put(item); err != nil {
 			return fmt.Errorf("store slice %q: %w", item.ID, err)

--- a/cmd/semantix/main_test.go
+++ b/cmd/semantix/main_test.go
@@ -129,6 +129,38 @@ func TestExtractStoresSlicesInSelectedScope(t *testing.T) {
 	}
 }
 
+func TestExtractDoesNotStoreProjectContextInUserScope(t *testing.T) {
+	input := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(input, []byte("{\"role\":\"user\"}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	extractor := &fakeExtractor{items: []*slice.Slice{
+		{ID: "prompt", Type: slice.Prompt, Scope: slice.Project, Content: []byte("question")},
+		{ID: "context", Type: slice.Context, Scope: slice.Project, Content: []byte("project paths")},
+	}}
+	store := newFakeStore()
+	deps := dependencies{
+		newExtractor: func() slice.Extractor { return extractor },
+		openStore:    func(string) (slice.Store, error) { return store, nil },
+		newIndex:     func() slice.Index { return bm25.New() },
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"extract", "--input", input, "--scope", "user", "--db", filepath.Join(t.TempDir(), "user.db")}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if store.items["context"] != nil {
+		t.Fatal("project Context slice was stored in user scope")
+	}
+	if store.items["prompt"] == nil || store.items["prompt"].Scope != slice.User {
+		t.Fatalf("prompt slice = %#v, want user scope", store.items["prompt"])
+	}
+	if !strings.Contains(stdout.String(), "extracted=2 stored=1 scope=user") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
 func TestSearchLoadsStoreAndRanksResults(t *testing.T) {
 	store := newFakeStore(
 		&slice.Slice{ID: "relevant", Scope: slice.Project, Content: []byte("BM25 cache retrieval")},

--- a/docs/specs/issue-265-context-slice-extraction.md
+++ b/docs/specs/issue-265-context-slice-extraction.md
@@ -1,0 +1,67 @@
+# Spec: deterministic project Context slice extraction (Issue 265)
+
+## Goal
+
+Generate one project-scoped Context slice from repeated, structured tool-call
+observations in a session transcript. The MVP is deterministic and rule based;
+it does not call an LLM or infer facts from tool output.
+
+## Input contract
+
+The extractor reads `tool_calls[].arguments` from the existing session JSONL.
+It observes only:
+
+- path fields: `path`, `paths`, `file`, `files`, `file_path`, `file_paths`,
+  `source_path`, `destination_path`, `directory`, `directories`, `dir`, `dirs`,
+  `cwd`, and `workdir`;
+- `command` from shell-like tools (`bash`, `shell`, `exec_command`, or
+  `run_command`).
+
+Unknown fields, tool output, file contents, URLs, home paths, absolute paths,
+and paths that escape through `..` are ignored. This keeps secrets and
+machine-specific workspace roots out of the reusable project summary.
+
+## Aggregation and wire text
+
+Paths, their immediate parent directories, and command heads are counted over
+the whole session. An observation must occur at least twice to be included.
+Each category keeps at most five entries, ordered by count descending and then
+lexicographically ascending.
+
+The emitted text is a fixed English block with only non-empty sections:
+
+```text
+Project context observed from repeated tool calls:
+Frequent paths:
+- kernel/slice/extractor.go (3)
+Frequent directories:
+- kernel/slice (4)
+Common command heads:
+- go test (2)
+```
+
+The Context slice uses the existing content-derived ID. Identical transcript
+bytes therefore produce identical Context content and ID. `CreatedAt` is not
+part of this byte-stability guarantee.
+
+## Scope
+
+Context summaries are project knowledge and may only be stored with
+`slice.Project` scope. Extracting into session or user scope skips Context
+slices while preserving the existing Prompt, ToolPattern, and Result behavior.
+
+## Acceptance
+
+- repeated extraction yields byte-identical Context content and the same ID;
+- frequency, Top-N, and tie ordering are deterministic;
+- sensitive/absolute paths and unrelated argument values do not enter output;
+- repeated shell commands produce stable command heads;
+- no Context slice is emitted when every observation occurs only once;
+- ingest and CLI extraction do not store Context slices outside project scope;
+- existing extraction and ingest tests remain green.
+
+## Non-goals
+
+This increment does not inspect tool output, summarize source code, aggregate
+across sessions, extract Memory slices, call an LLM, add configuration knobs,
+or claim a retrieval-quality improvement without a separate replay evaluation.

--- a/kernel/ingest/ingest.go
+++ b/kernel/ingest/ingest.go
@@ -244,6 +244,11 @@ func (p Pipeline) Run(src Source) (map[string]int, error) {
 		}
 		n := 0
 		for _, sl := range slices {
+			// Context slices summarize project structure. Never copy them into
+			// session- or user-scoped stores where project paths could leak.
+			if sl.Type == slice.Context && p.Scope != slice.Project {
+				continue
+			}
 			sl.Scope = p.Scope
 			if err := p.Store.Put(sl); err != nil {
 				return stats, fmt.Errorf("ingest %s: put %s: %w (persisted %d of %d slices before failure)",

--- a/kernel/ingest/ingest_test.go
+++ b/kernel/ingest/ingest_test.go
@@ -178,6 +178,55 @@ func TestPipelineExtractsAndPersists(t *testing.T) {
 	}
 }
 
+func TestPipelineDoesNotPersistProjectContextOutsideProjectScope(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "context.jsonl")
+	transcript := `{"role":"user","content":"inspect"}
+{"role":"assistant","tool_calls":[{"name":"read_file","arguments":{"path":"kernel/ingest/ingest.go"}}]}
+{"role":"assistant","tool_calls":[{"name":"read_file","arguments":{"path":"kernel/ingest/ingest.go"}}]}
+{"role":"assistant","content":"done"}
+`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src, err := NewJSONLSource(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := slice.NewFileStore(filepath.Join(t.TempDir(), "user.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if c, ok := store.(interface{ Close() error }); ok {
+			_ = c.Close()
+		}
+	})
+	pipeline := Pipeline{
+		Extractor: slice.NewExtractor(),
+		Store:     store,
+		Index:     bm25.New(),
+		Scope:     slice.User,
+		Project:   "semantix",
+	}
+	stats, err := pipeline.Run(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats["context"] == 0 {
+		t.Fatalf("expected non-context slices to be stored: %v", stats)
+	}
+	items, err := store.List(slice.User)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range items {
+		if item.Type == slice.Context {
+			t.Fatal("project Context slice was persisted in user scope")
+		}
+	}
+}
+
 func firstContent(hits []slice.Hit) string {
 	if len(hits) == 0 {
 		return ""

--- a/kernel/slice/context_extractor_test.go
+++ b/kernel/slice/context_extractor_test.go
@@ -1,0 +1,110 @@
+package slice
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractContextSliceDeterministicAndSanitized(t *testing.T) {
+	transcript := []byte(`{"role":"user","content":"inspect the extractor"}
+{"role":"assistant","tool_calls":[{"name":"read_file","arguments":{"path":"kernel/slice/extractor.go","token":"secret-value"}},{"name":"bash","arguments":{"command":"go test ./kernel/slice"}}]}
+{"role":"assistant","tool_calls":[{"name":"edit_file","arguments":{"path":"kernel/slice/extractor.go"}},{"name":"bash","arguments":{"command":"go test ./kernel/slice"}}]}
+{"role":"assistant","tool_calls":[{"name":"read_file","arguments":{"path":"/etc/passwd"}},{"name":"read_file","arguments":{"path":"C:\\Users\\secret\\key.txt"}},{"name":"read_file","arguments":{"path":"../escape.txt"}}]}
+{"role":"assistant","content":"done"}`)
+
+	first, err := NewExtractor().Extract(transcript, SliceMeta{ProjectSlug: "semantix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewExtractor().Extract(transcript, SliceMeta{ProjectSlug: "semantix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := contextFrom(first)
+	b := contextFrom(second)
+	if a == nil || b == nil {
+		t.Fatal("expected a Context slice")
+	}
+	if a.ID != b.ID || string(a.Content) != string(b.Content) {
+		t.Fatalf("context slice is not deterministic:\nfirst=%s %q\nsecond=%s %q", a.ID, a.Content, b.ID, b.Content)
+	}
+	if a.Scope != Project {
+		t.Fatalf("context scope = %v, want Project", a.Scope)
+	}
+	content := string(a.Content)
+	for _, want := range []string{
+		"- kernel/slice/extractor.go (2)",
+		"- kernel/slice (2)",
+		"- go test (2)",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("context missing %q:\n%s", want, content)
+		}
+	}
+	for _, forbidden := range []string{"secret-value", "/etc/passwd", "Users/secret", "escape.txt"} {
+		if strings.Contains(content, forbidden) {
+			t.Errorf("context leaked %q:\n%s", forbidden, content)
+		}
+	}
+}
+
+func TestExtractContextSliceRequiresRepeatedObservation(t *testing.T) {
+	transcript := []byte(`{"role":"assistant","tool_calls":[{"name":"read_file","arguments":{"path":"kernel/slice/extractor.go"}},{"name":"bash","arguments":{"command":"go test ./..."}}]}`)
+	got, err := NewExtractor().Extract(transcript, SliceMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contextFrom(got) != nil {
+		t.Fatal("one-off observations must not create a Context slice")
+	}
+}
+
+func TestExtractContextSliceTopNUsesLexicalTieBreak(t *testing.T) {
+	var lines strings.Builder
+	for _, name := range []string{"f.go", "e.go", "d.go", "c.go", "b.go", "a.go"} {
+		for range 2 {
+			lines.WriteString(`{"role":"assistant","tool_calls":[{"name":"read_file","arguments":{"path":"`)
+			lines.WriteString(name)
+			lines.WriteString(`"}}]}` + "\n")
+		}
+	}
+	got, err := NewExtractor().Extract([]byte(lines.String()), SliceMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	context := contextFrom(got)
+	if context == nil {
+		t.Fatal("expected a Context slice")
+	}
+	content := string(context.Content)
+	for _, want := range []string{"a.go", "b.go", "c.go", "d.go", "e.go"} {
+		if !strings.Contains(content, "- "+want+" (2)") {
+			t.Errorf("top-five output missing %s:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "- f.go (2)") {
+		t.Fatalf("top-five output retained sixth lexical tie:\n%s", content)
+	}
+}
+
+func TestExtractContextSliceAcceptsEncodedArguments(t *testing.T) {
+	transcript := []byte(`{"role":"assistant","tool_calls":[{"name":"read_file","arguments":"{\"path\":\"README.md\"}"}]}
+{"role":"assistant","tool_calls":[{"name":"read_file","arguments":"{\"path\":\"README.md\"}"}]}`)
+	got, err := NewExtractor().Extract(transcript, SliceMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	context := contextFrom(got)
+	if context == nil || !strings.Contains(string(context.Content), "- README.md (2)") {
+		t.Fatalf("encoded tool arguments were not extracted: %#v", context)
+	}
+}
+
+func contextFrom(items []*Slice) *Slice {
+	for _, item := range items {
+		if item.Type == Context {
+			return item
+		}
+	}
+	return nil
+}

--- a/kernel/slice/extractor.go
+++ b/kernel/slice/extractor.go
@@ -6,6 +6,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	pathpkg "path"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -26,16 +29,19 @@ type transcriptLine struct {
 	Role      string `json:"role"`
 	Content   string `json:"content"`
 	ToolCalls []struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
+		ID        string          `json:"id"`
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments,omitempty"`
 	} `json:"tool_calls,omitempty"`
 }
 
 // Limits for extracted slice content (kept modest for the MVP).
 const (
-	maxPromptLen = 4000 // bytes of a Prompt slice
-	maxResultLen = 8000 // bytes of a Result slice
-	minToolSeq   = 2    // minimum tool calls for a ToolPattern slice
+	maxPromptLen  = 4000 // bytes of a Prompt slice
+	maxResultLen  = 8000 // bytes of a Result slice
+	minToolSeq    = 2    // minimum tool calls for a ToolPattern slice
+	minContextUse = 2    // repeated observations only; one-off paths are noise
+	maxContextTop = 5    // entries retained per Context summary section
 )
 
 type extractor struct{}
@@ -47,6 +53,7 @@ func NewExtractor() Extractor { return extractor{} }
 // Extract parses one session JSONL transcript into slices:
 //   - Prompt slice: first user message of each turn (bounded)
 //   - ToolPattern slice: tool-name sequence of each turn (>= 2 calls)
+//   - Context slice: repeated project paths, directories, and command heads
 //   - Result slice: final assistant answer of the session (bounded)
 //
 // Malformed lines are skipped (tolerant). Duplicate content (same ID) is
@@ -74,12 +81,217 @@ func (extractor) Extract(sessionJSONL []byte, meta SliceMeta) ([]*Slice, error) 
 	if len(turn) > 0 {
 		flushTurn()
 	}
+	if s := contextSlice(lines, meta); s != nil {
+		out = append(out, s)
+	}
 	if s := finalResultSlice(lines, meta); s != nil {
 		out = append(out, s)
 	}
 	// Partial results are still returned; perr reports a truncated scan
 	// (oversized line) so callers can decide whether to retry/scale up.
 	return dedup(out), perr
+}
+
+var contextPathKeys = map[string]bool{
+	"path": true, "paths": true, "file": true, "files": true,
+	"file_path": true, "file_paths": true, "source_path": true, "destination_path": true,
+	"directory": true, "directories": true, "dir": true, "dirs": true,
+	"cwd": true, "workdir": true,
+}
+
+var shellToolNames = map[string]bool{
+	"bash": true, "shell": true, "exec_command": true, "run_command": true,
+}
+
+var commandFamilies = map[string]bool{
+	"cargo": true, "docker": true, "git": true, "go": true, "make": true,
+	"npm": true, "pnpm": true, "python": true, "python3": true, "uv": true, "yarn": true,
+}
+
+type contextEntry struct {
+	value string
+	count int
+}
+
+func contextSlice(lines []transcriptLine, meta SliceMeta) *Slice {
+	paths := map[string]int{}
+	dirs := map[string]int{}
+	commands := map[string]int{}
+	for _, line := range lines {
+		for _, call := range line.ToolCalls {
+			args := decodeToolArgs(call.Arguments)
+			for _, raw := range contextPaths(args) {
+				p, ok := normalizeContextPath(raw)
+				if !ok {
+					continue
+				}
+				paths[p]++
+				if dir := pathpkg.Dir(p); dir != "." {
+					dirs[dir]++
+				}
+			}
+			if shellToolNames[strings.ToLower(call.Name)] {
+				if head := commandHead(commandValue(args)); head != "" {
+					commands[head]++
+				}
+			}
+		}
+	}
+
+	pathTop := topContextEntries(paths)
+	dirTop := topContextEntries(dirs)
+	commandTop := topContextEntries(commands)
+	if len(pathTop)+len(dirTop)+len(commandTop) == 0 {
+		return nil
+	}
+	var b strings.Builder
+	b.WriteString("Project context observed from repeated tool calls:\n")
+	writeContextSection(&b, "Frequent paths:", pathTop)
+	writeContextSection(&b, "Frequent directories:", dirTop)
+	writeContextSection(&b, "Common command heads:", commandTop)
+	return newSlice(Context, Project, []byte(strings.TrimSpace(b.String())), meta)
+}
+
+func decodeToolArgs(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return nil
+	}
+	if encoded, ok := value.(string); ok {
+		if json.Unmarshal([]byte(encoded), &value) != nil {
+			return nil
+		}
+	}
+	return value
+}
+
+func contextPaths(value any) []string {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for key, field := range object {
+		if contextPathKeys[strings.ToLower(key)] {
+			out = append(out, stringValues(field)...)
+		}
+		if nested, ok := field.(map[string]any); ok {
+			out = append(out, contextPaths(nested)...)
+		}
+		if list, ok := field.([]any); ok {
+			for _, item := range list {
+				out = append(out, contextPaths(item)...)
+			}
+		}
+	}
+	return out
+}
+
+func stringValues(value any) []string {
+	switch value := value.(type) {
+	case string:
+		return []string{value}
+	case []any:
+		var out []string
+		for _, item := range value {
+			out = append(out, stringValues(item)...)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func normalizeContextPath(raw string) (string, bool) {
+	p := strings.TrimSpace(strings.Trim(raw, `"'`))
+	p = strings.ReplaceAll(p, `\`, "/")
+	if p == "" || p == "." || strings.HasPrefix(p, "/") || strings.HasPrefix(p, "~") ||
+		strings.Contains(p, "://") || (len(p) >= 2 && p[1] == ':') {
+		return "", false
+	}
+	p = pathpkg.Clean(p)
+	p = strings.TrimPrefix(p, "./")
+	if p == "" || p == "." || p == ".." || strings.HasPrefix(p, "../") {
+		return "", false
+	}
+	return p, true
+}
+
+func commandValue(value any) string {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return ""
+	}
+	command, _ := object["command"].(string)
+	return command
+}
+
+func commandHead(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	first := strings.Trim(fields[0], `"'`)
+	if !validCommandToken(first) {
+		return ""
+	}
+	head := first
+	if commandFamilies[strings.ToLower(first)] && len(fields) > 1 {
+		second := strings.Trim(fields[1], `"'`)
+		if !strings.HasPrefix(second, "-") && validCommandToken(second) {
+			head += " " + second
+		}
+	}
+	return head
+}
+
+func validCommandToken(token string) bool {
+	if token == "" || strings.ContainsAny(token, `/\\=:$`) {
+		return false
+	}
+	for _, r := range token {
+		if !(r == '-' || r == '_' || r == '.' || r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z') {
+			return false
+		}
+	}
+	return true
+}
+
+func topContextEntries(counts map[string]int) []contextEntry {
+	entries := make([]contextEntry, 0, len(counts))
+	for value, count := range counts {
+		if count >= minContextUse {
+			entries = append(entries, contextEntry{value: value, count: count})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].count != entries[j].count {
+			return entries[i].count > entries[j].count
+		}
+		return entries[i].value < entries[j].value
+	})
+	if len(entries) > maxContextTop {
+		entries = entries[:maxContextTop]
+	}
+	return entries
+}
+
+func writeContextSection(b *strings.Builder, title string, entries []contextEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	b.WriteString(title)
+	b.WriteByte('\n')
+	for _, entry := range entries {
+		b.WriteString("- ")
+		b.WriteString(entry.value)
+		b.WriteString(" (")
+		b.WriteString(strconv.Itoa(entry.count))
+		b.WriteString(")\n")
+	}
 }
 
 func parseTranscript(data []byte) ([]transcriptLine, error) {


### PR DESCRIPTION
## Summary

- specify the zero-LLM, deterministic project Context-slice contract
- aggregate repeated structured path fields, parent directories, and shell command heads from session tool calls
- keep only repeated Top-5 observations with stable ordering and reject absolute, escaping, URL, home, and unrelated argument values
- prevent project Context slices from being copied into session or user stores in both ingest and CLI extraction

## Commit structure

1. `docs(spec): define deterministic C-slice extraction`
2. `feat(slice): extract deterministic project context`
3. `fix(ingest): enforce project-only C-slice storage`

## Validation

- `go test ./kernel/slice -run "TestExtractContextSlice" -count=1`
- `go test ./kernel/ingest -run "TestPipeline(ExtractsAndPersists|DoesNotPersistProjectContextOutsideProjectScope)$" -count=1`
- `go test ./cmd/semantix -run "TestExtract(StoresSlicesInSelectedScope|DoesNotStoreProjectContextInUserScope)$" -count=1`
- `go test -race ./kernel/slice -run "TestExtractContextSlice" -count=1`
- `go vet ./kernel/slice ./kernel/ingest ./cmd/semantix`

Full Windows package runs still encounter the repository's existing open journal-file cleanup failures; focused changed-path tests and vet pass.

## Non-goals

No LLM insight extraction, tool-output/content parsing, cross-session aggregation, Memory-slice generation, configuration knobs, or unmeasured retrieval-quality claim.

Closes #265