### PR TITLE
GLM-P0-4: per-provider L1 面板 + doctor 告警 + verify 回归尾注 (#292)

### DIFF
--- a/cmd/semantix/doctor.go
+++ b/cmd/semantix/doctor.go
@@ -9,11 +9,15 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"semantix/kernel/slice"
+	"semantix/kernel/usage"
 )
 
 // cliVersion is the semantix CLI release reported in the --json envelope
@@ -71,6 +75,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	configPath := fs.String("config", "", "config file path (default: ./semantix.toml; skipped when absent)")
 	dbFlag := fs.String("db", "", "slice store path (overrides SEMANTIX_DB and [store] db)")
+	usageDB := fs.String("usage-db", filepath.Join(".semantix", "usage.jsonl"), "usage log for the L1 hit-rate check (missing = check skipped)")
 	jsonOutput := fs.Bool("json", false, "write the report as JSON (envelope per cli-v2-architecture §4.2)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -117,6 +122,8 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 			checkDoctorDB(dbPath),
 			checkDoctorEmbedder(cfg),
 			checkDoctorJudge(cfg),
+			checkDoctorL1HitRate(*usageDB),
+			checkDoctorModelCatalog(cfg),
 		},
 	}
 	summarizeDoctor(&report)
@@ -207,6 +214,8 @@ type doctorConfig struct {
 	judgeBaseURL  string   // [judge] base_url
 	judgeModel    string   // [judge] model
 	judgeProtocol string   // [judge] protocol
+	modelsURL     string   // [doctor] models_url (GLM-P0-4 #292; empty = check skipped)
+	watchModels   string   // [doctor] watch_models — comma list, e.g. "glm-5.3,deepseek-v4-flash"
 }
 
 // parseDoctorConfig reads the TOML subset doctor needs: [section] headers
@@ -275,6 +284,15 @@ func parseDoctorConfig(path string) (*doctorConfig, error) {
 				cfg.judgeModel = value
 			case "protocol":
 				cfg.judgeProtocol = value
+			}
+		case "doctor":
+			switch key {
+			case "models_url":
+				cfg.modelsURL = value
+			case "watch_models":
+				// Accept both a TOML array literal and a plain comma list;
+				// the light parser sees the raw value either way.
+				cfg.watchModels = strings.Trim(value, "[]")
 			}
 		}
 	}
@@ -548,6 +566,149 @@ func checkDoctorJudge(cfg *doctorConfig) doctorCheck {
 		ID: "judge", Name: "judge", Status: statusPass,
 		Detail: fmt.Sprintf("judge ready (%s, %s)", protocol, model),
 	}
+}
+
+// l1WarnThreshold is the spec §4.2-3 alert line: ≥90% is the acceptance
+// target (≈92% of the measured 97.6% reporting ceiling), 85% the
+// investigate-prefix-pollution floor. Sample floor keeps cold logs quiet.
+const (
+	l1WarnThreshold   = 0.85
+	l1MinExactEvents  = 20
+	modelsHTTPTimeout = 5 * time.Second
+)
+
+// checkDoctorL1HitRate reads the usage log and warns when any endpoint with
+// enough exact-metered samples sits below the prefix-pollution floor
+// (GLM-P0-4, Issue #292). Hit-rates use exact events only (#291): estimated
+// events never saw provider cache accounting.
+func checkDoctorL1HitRate(usagePath string) doctorCheck {
+	if _, err := os.Stat(usagePath); err != nil {
+		return doctorCheck{
+			ID: "l1-hit-rate", Name: "L1 hit rate", Status: statusPass,
+			Detail: "no usage log — check skipped",
+			Advice: "run traffic through the gateway (or agent) to populate " + usagePath,
+		}
+	}
+	s, err := usage.Summarize(usagePath, 0, 0)
+	if err != nil {
+		return doctorCheck{
+			ID: "l1-hit-rate", Name: "L1 hit rate", Status: statusWarn,
+			Detail: "usage log unreadable: " + err.Error(),
+		}
+	}
+	var low, measured []string
+	for name, p := range s.ByProvider {
+		if p.ExactEvents < l1MinExactEvents {
+			continue
+		}
+		label := name
+		if label == "" {
+			label = "(unattributed)"
+		}
+		measured = append(measured, fmt.Sprintf("%s %.1f%%", label, p.L1HitRate()*100))
+		if p.L1HitRate() < l1WarnThreshold {
+			low = append(low, fmt.Sprintf("%s %.1f%%", label, p.L1HitRate()*100))
+		}
+	}
+	sort.Strings(measured)
+	sort.Strings(low)
+	if len(low) > 0 {
+		return doctorCheck{
+			ID: "l1-hit-rate", Name: "L1 hit rate", Status: statusWarn,
+			Detail: fmt.Sprintf("below %.0f%% on: %s (exact-metered, ceiling ≈97.6%%, first-round seeds included)", l1WarnThreshold*100, strings.Join(low, ", ")),
+			Advice: "investigate prefix pollution: docs/reports/glm-p0-1-prefix-audit.md checklist; ensure the gateway [sanitize] middleware is on (strip_attribution / sort_tools)",
+		}
+	}
+	if len(measured) == 0 {
+		return doctorCheck{
+			ID: "l1-hit-rate", Name: "L1 hit rate", Status: statusPass,
+			Detail: fmt.Sprintf("no endpoint with ≥%d exact-metered events yet — check skipped", l1MinExactEvents),
+		}
+	}
+	return doctorCheck{
+		ID: "l1-hit-rate", Name: "L1 hit rate", Status: statusPass,
+		Detail: strings.Join(measured, ", "),
+	}
+}
+
+// checkDoctorModelCatalog probes the configured /v1/models endpoint and
+// warns when a watched model is missing or no longer online (GLM-P0-4:
+// TokenHub marks retiring models status=pre-offline before removal).
+// Unconfigured ⇒ skipped: doctor stays offline by default. Network errors
+// WARN rather than FAIL — an unreachable catalog is not a local defect.
+func checkDoctorModelCatalog(cfg *doctorConfig) doctorCheck {
+	if cfg == nil || strings.TrimSpace(cfg.modelsURL) == "" {
+		return doctorCheck{
+			ID: "model-catalog", Name: "model catalog", Status: statusPass,
+			Detail: "no [doctor] models_url configured — check skipped",
+			Advice: "set [doctor] models_url (e.g. https://tokenhub.tencentmaas.com/v1/models) and watch_models to track tier model availability",
+		}
+	}
+	req, err := http.NewRequest(http.MethodGet, cfg.modelsURL, nil)
+	if err != nil {
+		return doctorCheck{ID: "model-catalog", Name: "model catalog", Status: statusWarn, Detail: "invalid models_url: " + err.Error()}
+	}
+	if key := os.Getenv("SEMANTIX_MODELS_API_KEY"); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	client := &http.Client{Timeout: modelsHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return doctorCheck{
+			ID: "model-catalog", Name: "model catalog", Status: statusWarn,
+			Detail: "catalog unreachable: " + err.Error(),
+			Advice: "check network / SEMANTIX_MODELS_API_KEY; the check is advisory and does not block",
+		}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return doctorCheck{
+			ID: "model-catalog", Name: "model catalog", Status: statusWarn,
+			Detail: fmt.Sprintf("catalog returned HTTP %d", resp.StatusCode),
+			Advice: "set SEMANTIX_MODELS_API_KEY if the endpoint requires auth",
+		}
+	}
+	var payload struct {
+		Data []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&payload); err != nil {
+		return doctorCheck{ID: "model-catalog", Name: "model catalog", Status: statusWarn, Detail: "catalog response unparseable: " + err.Error()}
+	}
+	status := make(map[string]string, len(payload.Data))
+	for _, m := range payload.Data {
+		status[m.ID] = m.Status
+	}
+	var bad, good []string
+	for _, want := range strings.Split(cfg.watchModels, ",") {
+		want = strings.Trim(strings.TrimSpace(want), `"'`)
+		if want == "" {
+			continue
+		}
+		st, ok := status[want]
+		switch {
+		case !ok:
+			bad = append(bad, want+" missing")
+		case st != "" && st != "online":
+			bad = append(bad, want+" "+st)
+		default:
+			good = append(good, want)
+		}
+	}
+	if len(bad) > 0 {
+		return doctorCheck{
+			ID: "model-catalog", Name: "model catalog", Status: statusWarn,
+			Detail: strings.Join(bad, ", "),
+			Advice: "update the tier mapping before the provider retires the model (spec §4.3: tier models are per-endpoint config)",
+		}
+	}
+	detail := fmt.Sprintf("%d models online", len(status))
+	if len(good) > 0 {
+		detail = strings.Join(good, ", ") + " online"
+	}
+	return doctorCheck{ID: "model-catalog", Name: "model catalog", Status: statusPass, Detail: detail}
 }
 
 // missingArgs returns the sorted names of required settings with empty

--- a/cmd/semantix/doctor_test.go
+++ b/cmd/semantix/doctor_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +107,7 @@ protocol = "openai"
 	out := stdout.String()
 	for _, want := range []string{
 		"[PASS] config", "[PASS] slice store", "[PASS] embedder", "[PASS] judge",
-		"checks: pass=4 warn=0 fail=0",
+		"checks: pass=6 warn=0 fail=0",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("stdout missing %q:\n%s", want, out)
@@ -132,7 +134,7 @@ func TestDoctorWarnsOnMissingStoreAndConfig(t *testing.T) {
 			t.Errorf("stdout missing %q:\n%s", want, out)
 		}
 	}
-	if !strings.Contains(out, "checks: pass=1 warn=3 fail=0") {
+	if !strings.Contains(out, "checks: pass=3 warn=3 fail=0") {
 		t.Errorf("stdout missing summary:\n%s", out)
 	}
 }
@@ -156,7 +158,7 @@ func TestDoctorFailsOnCorruptStore(t *testing.T) {
 	if !strings.Contains(out, "[FAIL] slice store") || !strings.Contains(out, "corrupt JSONL line(s) [2]") {
 		t.Errorf("stdout missing corrupt-store report:\n%s", out)
 	}
-	if !strings.Contains(out, "checks: pass=1 warn=2 fail=1") {
+	if !strings.Contains(out, "checks: pass=3 warn=2 fail=1") {
 		t.Errorf("stdout missing summary:\n%s", out)
 	}
 }
@@ -279,7 +281,7 @@ func TestDoctorJSON(t *testing.T) {
 	if errEnv, ok := env.Error.(map[string]any); !ok || errEnv["code"] != float64(3) {
 		t.Fatalf("envelope.error = %v, want code 3", env.Error)
 	}
-	if len(env.Data.Checks) != 4 || env.Data.Fail == 0 || env.Data.DB != dbPath {
+	if len(env.Data.Checks) != 6 || env.Data.Fail == 0 || env.Data.DB != dbPath {
 		t.Fatalf("data = %+v", env.Data)
 	}
 
@@ -478,5 +480,80 @@ func TestDoctorEnvOverridesConfig(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "[PASS] slice store") || strings.Contains(stdout.String(), ".semantix/project.db") {
 		t.Errorf("env override not applied:\n%s", stdout.String())
+	}
+}
+
+// TestDoctorL1HitRateWarns: an endpoint with enough exact events below the
+// 85% floor triggers the prefix-pollution advisory (GLM-P0-4, #292).
+func TestDoctorL1HitRateWarns(t *testing.T) {
+	clearDoctorEnv(t)
+	dir := t.TempDir()
+	usagePath := filepath.Join(dir, "usage.jsonl")
+	var lines []string
+	// 25 exact events at 50% hit rate for provider "tokenhub-glm".
+	for range 25 {
+		lines = append(lines, `{"provider":"tokenhub-glm","exact":true,"tokens_in":1000,"tokens_out":10,"cache_hit_tokens":500}`)
+	}
+	writeJSONL(t, usagePath, lines...)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"doctor", "--usage-db", usagePath}, &stdout, &stderr, productionDependencies())
+	if code != 0 { // WARN does not fail doctor
+		t.Fatalf("doctor: code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "[WARN] L1 hit rate") || !strings.Contains(out, "tokenhub-glm 50.0%") {
+		t.Errorf("missing L1 warn row:\n%s", out)
+	}
+	if !strings.Contains(out, "glm-p0-1-prefix-audit") {
+		t.Errorf("advice does not point at the prefix audit:\n%s", out)
+	}
+}
+
+// TestDoctorL1HitRateHealthy: high hit rate with enough samples reports PASS
+// with the measured figure.
+func TestDoctorL1HitRateHealthy(t *testing.T) {
+	clearDoctorEnv(t)
+	dir := t.TempDir()
+	usagePath := filepath.Join(dir, "usage.jsonl")
+	var lines []string
+	for range 25 {
+		lines = append(lines, `{"provider":"tokenhub-glm","exact":true,"tokens_in":1000,"tokens_out":10,"cache_hit_tokens":960}`)
+	}
+	writeJSONL(t, usagePath, lines...)
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"doctor", "--usage-db", usagePath}, &stdout, &stderr, productionDependencies()); code != 0 {
+		t.Fatalf("doctor: code = %d; stderr=%q", code, stderr.String())
+	}
+	if out := stdout.String(); !strings.Contains(out, "[PASS] L1 hit rate: tokenhub-glm 96.0%") {
+		t.Errorf("missing healthy L1 row:\n%s", out)
+	}
+}
+
+// TestDoctorModelCatalog: a watched model in pre-offline status warns; an
+// online one passes (GLM-P0-4: TokenHub retirement flow).
+func TestDoctorModelCatalog(t *testing.T) {
+	clearDoctorEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":[{"id":"glm-5.3","status":"online"},{"id":"qwen3.5-flash","status":"pre-offline"}]}`)
+	}))
+	defer srv.Close()
+
+	cfgPath := writeConfig(t, fmt.Sprintf(`
+[doctor]
+models_url = %q
+watch_models = "glm-5.3,qwen3.5-flash,ghost-model"
+`, srv.URL))
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"doctor", "--config", cfgPath}, &stdout, &stderr, productionDependencies()); code != 0 {
+		t.Fatalf("doctor: code = %d; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "[WARN] model catalog") ||
+		!strings.Contains(out, "qwen3.5-flash pre-offline") ||
+		!strings.Contains(out, "ghost-model missing") {
+		t.Errorf("missing catalog warn detail:\n%s", out)
 	}
 }

--- a/cmd/semantix/usage.go
+++ b/cmd/semantix/usage.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"semantix/kernel/evolve"
@@ -16,18 +17,64 @@ import (
 )
 
 // usageJSON is the --json envelope payload for `semantix usage` (M2-U22).
+// by_provider is additive (GLM-P0-4, Issue #292): the envelope only grows.
 type usageJSON struct {
+	Events         int                 `json:"events"`
+	TokensIn       int64               `json:"tokens_in"`
+	TokensOut      int64               `json:"tokens_out"`
+	CacheHitTokens int64               `json:"cache_hit_tokens"`
+	L3Reuses       int                 `json:"l3_reuses"`
+	InjectedTokens int64               `json:"injected_tokens"`
+	SliceHits      int                 `json:"slice_hits"`
+	CostPaidUSD    float64             `json:"cost_paid_usd"`
+	CostNoCacheUSD float64             `json:"cost_no_cache_usd"`
+	SavingsUSD     float64             `json:"savings_usd"`
+	SavingsRate    float64             `json:"savings_rate"`
+	ByProvider     []usageProviderJSON `json:"by_provider,omitempty"`
+}
+
+// usageProviderJSON is one endpoint's L1 telemetry row.
+type usageProviderJSON struct {
+	Provider       string  `json:"provider"`
 	Events         int     `json:"events"`
+	ExactEvents    int     `json:"exact_events"`
 	TokensIn       int64   `json:"tokens_in"`
-	TokensOut      int64   `json:"tokens_out"`
 	CacheHitTokens int64   `json:"cache_hit_tokens"`
+	L1HitRate      float64 `json:"l1_hit_rate"`
 	L3Reuses       int     `json:"l3_reuses"`
-	InjectedTokens int64   `json:"injected_tokens"`
-	SliceHits      int     `json:"slice_hits"`
-	CostPaidUSD    float64 `json:"cost_paid_usd"`
-	CostNoCacheUSD float64 `json:"cost_no_cache_usd"`
-	SavingsUSD     float64 `json:"savings_usd"`
-	SavingsRate    float64 `json:"savings_rate"`
+	HitSavingsUSD  float64 `json:"hit_savings_usd"`
+}
+
+// providerRows prices each endpoint's hit savings with its own price pair
+// (cost.providers.<name>.* falling back to the global figures) and returns
+// rows sorted by provider name. The unnamed bucket ("" — pre-#291 logs)
+// sorts last and renders as "(unattributed)".
+func providerRows(s *usage.Summary, deps dependencies, globalMiss, globalHit float64) []usageProviderJSON {
+	names := make([]string, 0, len(s.ByProvider))
+	for name := range s.ByProvider {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if (names[i] == "") != (names[j] == "") {
+			return names[j] == ""
+		}
+		return names[i] < names[j]
+	})
+	rows := make([]usageProviderJSON, 0, len(names))
+	for _, name := range names {
+		p := s.ByProvider[name]
+		miss := cfgFloat(deps.resolved, "cost.providers."+name+".input_price_usd", globalMiss)
+		hit := cfgFloat(deps.resolved, "cost.providers."+name+".cache_price_usd", globalHit)
+		rows = append(rows, usageProviderJSON{
+			Provider: name, Events: p.Events, ExactEvents: p.ExactEvents,
+			TokensIn: p.TokensIn, CacheHitTokens: p.CacheHitTokens,
+			L1HitRate: p.L1HitRate(), L3Reuses: p.L3Reuses,
+			// Savings from prefix-cache hits alone: hit tokens billed at hit
+			// price instead of miss price. Exact-metered tokens only.
+			HitSavingsUSD: float64(p.CacheHitTokens) * (miss - hit) / 1e6,
+		})
+	}
+	return rows
 }
 
 // runUsage summarizes the usage log and reports cost savings (Issue #60 /
@@ -53,6 +100,7 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 		return 1 // runtime/IO error, not a usage mistake
 	}
 
+	rows := providerRows(s, deps, *costMiss, *costHit)
 	if *jsonOut {
 		data := usageJSON{
 			Events: s.Events, TokensIn: s.TokensIn, TokensOut: s.TokensOut,
@@ -60,6 +108,7 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 			SliceHits:   s.SliceHits,
 			CostPaidUSD: s.CostPaidUSD, CostNoCacheUSD: s.CostNoCacheUSD,
 			SavingsUSD: s.SavingsUSD, SavingsRate: s.SavingsRate,
+			ByProvider: rows,
 		}
 		if err := writeJSON(stdout, okEnvelope("usage", data)); err != nil {
 			fmt.Fprintln(os.Stderr, "usage:", err)
@@ -88,6 +137,26 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 	fmt.Fprintf(stdout, "cost_no_cache_usd\t%.6f\n", s.CostNoCacheUSD)
 	fmt.Fprintf(stdout, "savings_usd\t%.6f\n", s.SavingsUSD)
 	fmt.Fprintf(stdout, "savings_rate\t%.4f\n", s.SavingsRate)
+
+	// Per-provider L1 telemetry (GLM-P0-4, #292). Hit-rates come from
+	// exact-metered events only (#291); estimated-only endpoints show "—"
+	// so an unwired adapter is visible instead of reading as 0%.
+	if len(rows) > 0 {
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "🌐 Per-provider L1（exact 计量）")
+		for _, row := range rows {
+			name := row.Provider
+			if name == "" {
+				name = "(unattributed)"
+			}
+			rate := "—"
+			if row.ExactEvents > 0 {
+				rate = fmt.Sprintf("%s %.1f%%", barChart(row.L1HitRate, 10), row.L1HitRate*100)
+			}
+			fmt.Fprintf(stdout, "  %-22s hit %s  省 $%.6f  (exact %d/%d, L3 %d)\n",
+				name, rate, row.HitSavingsUSD, row.ExactEvents, row.Events, row.L3Reuses)
+		}
+	}
 
 	if *evolveDB != "" {
 		if err := feedEvolve(*evolveDB, *db, stdout); err != nil {

--- a/cmd/semantix/usage_test.go
+++ b/cmd/semantix/usage_test.go
@@ -201,3 +201,77 @@ func TestLoadEvolveState(t *testing.T) {
 		t.Fatal("corrupt file must surface an error")
 	}
 }
+
+// TestRunUsageByProvider (GLM-P0-4, #292): per-provider rows render with
+// exact-only hit rates, per-provider prices from [cost.providers.<name>]
+// override the global pair, and the --json envelope grows a by_provider list.
+func TestRunUsageByProvider(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "usage.jsonl")
+	r, err := usage.NewRecorder(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range []usage.Event{
+		{Turn: 1, Provider: "tokenhub-glm", Exact: true, TokensIn: 1_000_000, TokensOut: 10, CacheHitToken: 500_000},
+		{Turn: 2, Provider: "deepseek", TokensIn: 900, TokensOut: 10}, // estimated only
+	} {
+		if err := r.Append(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfgPath := filepath.Join(dir, "semantix.toml")
+	if err := os.WriteFile(cfgPath, []byte(`
+[cost.providers.tokenhub-glm]
+input_price_usd = 1.12   # ¥8/M ≈ $1.12
+cache_price_usd = 0.28   # ¥2/M ≈ $0.28
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SEMANTIX_CONFIG", cfgPath)
+
+	var out, errBuf bytes.Buffer
+	if code := run([]string{"usage", "--db", logPath}, &out, &errBuf, productionDependencies()); code != 0 {
+		t.Fatalf("usage exit = %d (stderr=%s)", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "tokenhub-glm") || !strings.Contains(s, "50.0%") {
+		t.Fatalf("missing provider hit-rate row:\n%s", s)
+	}
+	// 500k hit tokens × ($1.12−$0.28)/M = $0.42 priced from the provider table.
+	if !strings.Contains(s, "0.420000") {
+		t.Fatalf("provider-priced savings missing (want $0.420000):\n%s", s)
+	}
+	// The estimated-only endpoint renders an em-dash rate, not 0%.
+	if !strings.Contains(s, "deepseek") || !strings.Contains(s, "—") {
+		t.Fatalf("estimated-only endpoint should show — :\n%s", s)
+	}
+
+	out.Reset()
+	if code := run([]string{"usage", "--db", logPath, "--json"}, &out, &errBuf, productionDependencies()); code != 0 {
+		t.Fatalf("usage --json exit = %d", code)
+	}
+	var env struct {
+		Data struct {
+			ByProvider []struct {
+				Provider      string  `json:"provider"`
+				ExactEvents   int     `json:"exact_events"`
+				L1HitRate     float64 `json:"l1_hit_rate"`
+				HitSavingsUSD float64 `json:"hit_savings_usd"`
+			} `json:"by_provider"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("json: %v\n%s", err, out.String())
+	}
+	if len(env.Data.ByProvider) != 2 {
+		t.Fatalf("by_provider rows = %d, want 2", len(env.Data.ByProvider))
+	}
+	glm := env.Data.ByProvider[1] // sorted: deepseek, tokenhub-glm
+	if glm.Provider != "tokenhub-glm" || glm.ExactEvents != 1 || glm.L1HitRate != 0.5 {
+		t.Fatalf("glm row = %+v", glm)
+	}
+	if glm.HitSavingsUSD < 0.4199 || glm.HitSavingsUSD > 0.4201 {
+		t.Fatalf("glm savings = %v, want ≈0.42", glm.HitSavingsUSD)
+	}
+}

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -19,6 +19,7 @@ import (
 
 	"semantix/kernel/judge"
 	"semantix/kernel/slice"
+	"semantix/kernel/usage"
 	"semantix/kernel/zone"
 )
 
@@ -219,6 +220,7 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 	fs.StringVar(&scopeName, "scope", cfgString(deps.resolved, "store.scope", "project"), "scope: project|user|session")
 	greyTarget := fs.Float64("grey-target", 30.0, "grey-zone traffic ratio alarm threshold in percent (0 disables the alarm)")
 	strict := fs.Bool("strict", false, "return exit code 3 when the grey-zone ratio exceeds --grey-target")
+	usageDB := fs.String("usage-db", filepath.Join(".semantix", "usage.jsonl"), "usage log for the L1 hit-rate regression footer (missing = skipped)")
 	jsonOut := fs.Bool("json", false, "output as JSON envelope (summary + rows)")
 	zf := addZoneFlags(fs)
 	judgeProtocol := fs.String("judge-protocol", "", "LLM judge protocol: openai|anthropic (empty = rules only)")
@@ -453,7 +455,48 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 			return 3
 		}
 	}
+	printVerifyL1Footer(stdout, *usageDB)
 	return 0
+}
+
+// printVerifyL1Footer appends the L1 hit-rate regression rows to the replay
+// report (GLM-P0-4, Issue #292): per-provider exact-metered rates from the
+// usage log, flagged against the 85% prefix-pollution floor. Purely
+// informational — replay verdicts and exit codes are untouched. A missing
+// or unreadable log prints nothing (verify stays usable without traffic).
+func printVerifyL1Footer(stdout io.Writer, usagePath string) {
+	if usagePath == "" {
+		return
+	}
+	if _, err := os.Stat(usagePath); err != nil {
+		return
+	}
+	s, err := usage.Summarize(usagePath, 0, 0)
+	if err != nil {
+		return
+	}
+	names := make([]string, 0, len(s.ByProvider))
+	for name, p := range s.ByProvider {
+		if p.ExactEvents > 0 {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		p := s.ByProvider[name]
+		label := name
+		if label == "" {
+			label = "(unattributed)"
+		}
+		flag := ""
+		if p.L1HitRate() < l1WarnThreshold {
+			flag = fmt.Sprintf("  ⚠ below %.0f%% — prefix-pollution checklist: docs/reports/glm-p0-1-prefix-audit.md", l1WarnThreshold*100)
+		}
+		fmt.Fprintf(stdout, "# l1: %s hit=%.1f%% (exact %d/%d)%s\n", label, p.L1HitRate()*100, p.ExactEvents, p.Events, flag)
+	}
 }
 
 // classifyTop1 maps the top-1/top-2 scores to a zone for the replay table.

--- a/kernel/config/config.go
+++ b/kernel/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -33,6 +34,7 @@ type File struct {
 	Inject    fileInject    `toml:"inject"`
 	Verify    fileVerify    `toml:"verify"`
 	Cost      fileCost      `toml:"cost"`
+	Doctor    fileDoctor    `toml:"doctor"`
 }
 
 type fileProject struct {
@@ -66,6 +68,26 @@ type fileCost struct {
 	InputPriceUSD  *float64 `toml:"input_price_usd"`
 	CachePriceUSD  *float64 `toml:"cache_price_usd"`
 	OutputPriceUSD *float64 `toml:"output_price_usd"`
+	// Providers holds per-endpoint price overrides (GLM-P0-4, Issue #292):
+	// cloud-hosted GLM stacks price identically per model but differ per
+	// vendor, so hit-savings must be priced per provider key (the usage
+	// log's Event.Provider). Keys flatten to
+	// cost.providers.<name>.{input,cache,output}_price_usd.
+	Providers map[string]fileProviderCost `toml:"providers"`
+}
+
+type fileProviderCost struct {
+	InputPriceUSD  *float64 `toml:"input_price_usd"`
+	CachePriceUSD  *float64 `toml:"cache_price_usd"`
+	OutputPriceUSD *float64 `toml:"output_price_usd"`
+}
+
+// fileDoctor configures the optional doctor network checks (GLM-P0-4).
+// models_url unset ⇒ the model-catalog check reports SKIP (doctor stays
+// fully offline by default).
+type fileDoctor struct {
+	ModelsURL   *string  `toml:"models_url"`
+	WatchModels []string `toml:"watch_models"`
 }
 
 // Kind classifies a config error so the CLI can map it to an exit code.
@@ -191,10 +213,59 @@ func Load(opts Options) (*Resolved, error) {
 		return nil, err
 	}
 
+	// Per-provider price overrides flatten to dotted keys in sorted-name
+	// order so Fields stays deterministic (config list output, tests). Only
+	// present sub-keys are added: absent prices fall back to the global
+	// cost.* figures at the consumer.
+	providerNames := make([]string, 0, len(file.Cost.Providers))
+	for name := range file.Cost.Providers {
+		providerNames = append(providerNames, name)
+	}
+	sort.Strings(providerNames)
+	for _, name := range providerNames {
+		pc := file.Cost.Providers[name]
+		prefix := "cost.providers." + name + "."
+		for key, ptr := range map[string]*float64{
+			"input_price_usd":  pc.InputPriceUSD,
+			"cache_price_usd":  pc.CachePriceUSD,
+			"output_price_usd": pc.OutputPriceUSD,
+		} {
+			if ptr != nil {
+				r.Fields = append(r.Fields, Field{Key: prefix + key, Value: *ptr, Source: SourceFile})
+			}
+		}
+	}
+	// Map-range order is random; re-sort the provider block for determinism.
+	sort.SliceStable(r.Fields, func(i, j int) bool {
+		pi := strings.HasPrefix(r.Fields[i].Key, "cost.providers.")
+		pj := strings.HasPrefix(r.Fields[j].Key, "cost.providers.")
+		if pi != pj {
+			return !pi // non-provider fields keep their declaration order first
+		}
+		if !pi {
+			return false // stable: leave non-provider relative order alone
+		}
+		return r.Fields[i].Key < r.Fields[j].Key
+	})
+
+	if err := add(mergePtr("doctor.models_url", "", "SEMANTIX_DOCTOR_MODELS_URL", file.Doctor.ModelsURL, (*string)(nil))); err != nil {
+		return nil, err
+	}
+	watch := strings.Join(file.Doctor.WatchModels, ",")
+	r.Fields = append(r.Fields, Field{Key: "doctor.watch_models", Value: watch, Source: sourceOf(len(file.Doctor.WatchModels) > 0)})
+
 	if err := r.validate(); err != nil {
 		return nil, invalidErr(err)
 	}
 	return r, nil
+}
+
+// sourceOf maps "was it set in the file" to the Field source label.
+func sourceOf(fromFile bool) Source {
+	if fromFile {
+		return SourceFile
+	}
+	return SourceDefault
 }
 
 // configPath resolves the config file path and whether it was explicitly

--- a/semantix.example.toml
+++ b/semantix.example.toml
@@ -28,3 +28,14 @@ reuse_ratio = 0.8           # 注入替代重复步骤比例
 input_price_usd = 0.27      # 每 1M 输入 token（cache miss）
 cache_price_usd = 0.07      # 每 1M 输入 token（cache hit）
 output_price_usd = 1.10     # 每 1M 输出 token
+
+# Per-endpoint 价目覆盖（GLM-P0-4 #292）：`semantix usage` 的 per-provider
+# 命中节省按端点价目计算，键名 = usage 事件的 provider 字段；缺省回退上面的全局价。
+# [cost.providers.tokenhub-glm]
+# input_price_usd = 1.12    # TokenHub GLM-5.3 ¥8/M ≈ $1.12
+# cache_price_usd = 0.28    # 缓存命中 ¥2/M ≈ $0.28（折扣率 0.75）
+# output_price_usd = 3.92   # ¥28/M ≈ $3.92
+
+[doctor]                    # doctor 可选网络检查（GLM-P0-4 #292）；不配置 = 跳过、doctor 保持离线
+# models_url = "https://tokenhub.tencentmaas.com/v1/models"   # 型号目录端点（需要时配 SEMANTIX_MODELS_API_KEY）
+# watch_models = "glm-5.3,glm-5-turbo,deepseek-v4-flash"      # tier 映射所依赖的型号；pre-offline/下线时 WARN


### PR DESCRIPTION
## 概要

#297（P0-3 usage 适配器）备好的数据面接到三个展示面（spec §4.2-2/3）：

- **`semantix usage`**：新增 per-provider L1 区——exact 计量命中率（estimated-only 端点显 `—` 而非误导性 0%）、按 `[cost.providers.<name>]` 价目计算的命中节省额；`--json` 信封增列 `by_provider`（只增不改）
- **`semantix doctor`** 两个新检查：
  - `l1-hit-rate`：端点 ≥20 exact 样本且 <85%（spec 校准线）→ WARN，advice 指向 `glm-p0-1-prefix-audit.md` 排查清单与 gateway `[sanitize]` 中间件
  - `model-catalog`：`[doctor] models_url` 配置后探测 /v1/models，watch 型号 missing/pre-offline → WARN（TokenHub 退役流程；qwen3.5-flash 现已 pre-offline 即实例）；未配置=跳过、网络失败仅 WARN——doctor 默认保持离线
- **`semantix verify`**：报告尾注 per-provider L1 行（`--usage-db`，缺省跳过），不改判定与退出码
- **config**：`[cost.providers.<name>]` per-endpoint 价目（flatten 确定序）+ `[doctor]` 段；example toml 附 TokenHub GLM-5.3 换算示例（¥8/2/28 ≈ \$1.12/0.28/3.92）

## 测试

新增 4 项：低命中率 WARN 与健康 PASS、pre-offline/missing 型号 WARN（httptest）、per-provider 面板与 json 增列（价目覆盖生效断言 \$0.42）。既有 doctor 计数断言同步 4→6。`go test ./cmd/semantix/ ./kernel/config/ ./kernel/usage/ -race` 全绿。

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)