### PR TITLE
fix(release): build-full.sh 对齐合体后发布形态（三入口构建 + 完整版本注入）

### DIFF
--- a/cmd/semantix-agent/main.go
+++ b/cmd/semantix-agent/main.go
@@ -16,9 +16,10 @@ import (
 	_ "semantix/harness/tool/builtin"
 )
 
-// Build identity injected via -ldflags (see Makefile). version remains the
-// single-line contract for `semantix-agent --version`; gitCommit/buildTimeUTC feed
-// `semantix-agent version --verbose` / `--json` without embedding config paths.
+// Build identity injected via -ldflags (see scripts/release/build-full.sh).
+// version remains the single-line contract for `semantix-agent --version`;
+// gitCommit/buildTimeUTC feed `semantix-agent version --verbose` / `--json`
+// without embedding config paths.
 var (
 	version      = "dev"
 	gitCommit    = ""

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -1,0 +1,272 @@
+# Reasonix configuration.
+# Resolution order: flag > ./reasonix.toml > <Reasonix home>/config.toml > built-in defaults.
+# Fields marked user/global only are not overridden by ./reasonix.toml.
+# Provider entries name secrets via api_key_env; saved key values live in
+# Reasonix's global <Reasonix home>/.env. Never put API key values here.
+
+default_model = "deepseek"   # a provider name (→ its default model) or "provider/model"
+# language      = "zh"   # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
+
+[ui]
+theme = "auto"   # auto|dark|light; controls CLI colors only; REASONIX_THEME can override per run
+# theme_style = "semantix"   # semantix|semantix-light|graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
+# shortcut_layout = "desktop"   # classic|desktop; compatibility setting; Shift+Tab toggles Plan, Ctrl+Y toggles YOLO
+# cursor_shape = "bar"   # block|underline|bar; text input cursor shape; slim default avoids covering CJK characters
+show_turn_usage = true   # CLI/TUI: show per-request token and cost receipts in transcript scrollback
+
+[desktop]
+# language = "auto"   # auto|en|zh; auto follows the browser/OS locale
+# currency = "auto"   # auto|CNY|USD; explicitly set it independently from language
+layout_style = "classic"   # classic|workbench|creation; desktop layout style
+# theme = "auto"   # desktop only: auto|dark|light
+# terminal_theme = "auto"   # integrated terminal: auto|dark|light; auto follows the desktop app
+# theme_style = "semantix"   # semantix|semantix-light|graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
+
+[notifications]
+enabled = false   # system notifications for CLI and desktop turns; default off
+turn_done = true   # notify when a turn finishes
+approval_request = true   # notify when a tool approval is waiting
+ask_request = true   # notify when a question is waiting
+
+[agent]
+# system_prompt = "You are ..."   # custom persona/prompt; unset or empty = built-in default
+# system_prompt_file = "prompts/system.md"   # project paths stay in <workspace>; user paths may fall back to <reasonix home>
+temperature       = 0.0
+# recovery_model = ""               # optional reviewer for low-risk automatic recovery; falls back to guardian_model then main model
+# reasoning_language = "auto"   # visible reasoning text: auto|zh|en
+# plan_mode_read_only_commands = ["gh issue view"]   # legacy compatibility only; Plan bash uses Permissions
+soft_compact_ratio  = 0.5   # notice only; keeps the cache-first prefix intact
+tool_result_snip_ratio = 0.6   # snip stale tool results before summary compaction
+compact_ratio       = 0.8   # try compacting when prompt reaches this fraction
+compact_force_ratio = 0.9   # force compacting at this high-water mark
+# planner_model = "deepseek-pro"   # optional: enable two-model collaboration
+# subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }   # per-skill overrides
+# max_subagent_concurrency = 6   # session-wide sub-agent concurrency (task/fleet/skills)
+# max_parallel_writers = 3       # concurrent writers with non-overlapping write_paths
+# output_style = "explanatory"   # persona/tone folded into the prompt: explanatory | learning | concise,
+#                                  or a custom .reasonix/output-styles/<name>.md ; empty = default
+
+# A provider is a vendor endpoint (one base_url + key) that offers one or more
+# models. Use `models = [...]` to expose several under a single entry — switching
+# models reuses the same connection; no need to re-declare base_url/api_key.
+# In the desktop app, Settings -> Model -> Access -> Add provider includes
+# recommended editable presets for Kimi CN/Global, Kimi Coding Plan, MiMo API
+# and Anthropic/token-plan regions, MiniMax CN/Global API and Anthropic routes,
+# GLM/Z.AI CN/Global API and coding-plan routes, OpenCode Go/Zen, Qwen/DashScope
+# CN/Global API and coding-plan routes, Token Rhythm (基元律动), StepFun,
+# NovitaAI, GMI, Vercel AI Gateway, HuggingFace, NVIDIA, KiloCode, and Ollama Cloud.
+[[providers]]
+name        = "deepseek"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+models      = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default     = "deepseek-v4-flash"   # optional; defaults to the first of `models`
+api_key_env = "DEEPSEEK_API_KEY"
+context_window = 1000000
+# Optional per-model context budgets. Omitted models inherit context_window.
+# model_overrides = { "deepseek-v4-flash" = { context_window = 1000000 } }
+# Official DeepSeek providers use CNY or USD regional prices from
+# [desktop].currency; auto follows the selected language and defaults to USD.
+# Set prices explicitly only when you want to pin custom rates.
+# prices = { "deepseek-v4-flash" = { cache_hit = 0.02, input = 1, output = 2, currency = "¥" }, "deepseek-v4-pro" = { cache_hit = 0.025, input = 3, output = 6, currency = "¥" } }   # per 1M tokens
+# DeepSeek thinking is always on; effort: high | max. Omit for auto (provider default).
+effort      = "high"
+
+# A single-model provider still works (use `model = "..."`) — pick this form when
+# a model needs its own base_url. Use model_overrides when models share an endpoint
+# but need distinct context windows or capability settings.
+
+# Custom /effort levels for a provider. When supported_efforts is set, the
+# /effort command exposes these levels; default_effort is what "/effort auto"
+# (or unset) resolves to. Leave both commented to keep the built-in defaults
+# (DeepSeek models: high|max; Anthropic: low|medium|high|xhigh|max). DeepSeek
+# models behind a proxy are detected by model name; set reasoning_protocol =
+# "none" to disable that or "openai" to force ordinary reasoning_effort.
+# Other OpenAI-compatible providers don't expose /effort unless you opt in here.
+#
+# [[providers]]
+# name           = "openai-compatible-custom"
+# kind           = "openai"
+# base_url       = "https://api.example.com/v1"
+# model          = "example-reasoning-model"
+# api_key_env    = "EXAMPLE_API_KEY"
+# reasoning_protocol = "openai"   # auto|deepseek|openai|none
+# supported_efforts = ["low", "medium", "high"]
+# default_effort    = "high"
+
+# Anthropic (Claude) — the "anthropic" kind speaks the Messages API directly (no
+# OpenAI shim). base_url is optional (defaults to https://api.anthropic.com). Note:
+# this provider does not enable extended thinking and does not send temperature —
+# current Claude models reject sampling params (see internal/provider/anthropic).
+# Some Anthropic-compatible gateways use Bearer auth instead of x-api-key; set
+# auth_header = true for those (for example MiniMax Global or Vercel AI Gateway).
+[[providers]]
+name           = "claude"
+kind           = "anthropic"
+model          = "claude-opus-4-8"
+api_key_env    = "ANTHROPIC_API_KEY"
+context_window = 1000000
+price          = { cache_hit = 0.5, input = 5, output = 25, currency = "$" }   # per 1M tokens
+# Extended thinking (anthropic kind only; round-trips the signed reasoning block
+# across tool calls). Omit to disable. effort: low | medium | high | xhigh | max.
+thinking       = "adaptive"
+effort         = "high"
+
+[environment]
+enabled = true   # inject a stable startup summary of OS, shell, and common tools into the prompt
+offline = false  # set true when outbound network access is unavailable; prevents futile retries
+# [environment.tools]
+# go = "/opt/homebrew/bin/go"   # optional trusted executable path; workspace-local paths are not auto-executed
+
+[tools]
+enabled = []   # empty = all built-in tools
+bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
+mcp_startup_timeout_seconds = 30   # background initialize + tools/list safety cap; per-server overrides may raise it
+mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool overrides may raise it
+
+[tools.background_jobs]
+stalled_warning_seconds = 900   # warn once per background job after this many quiet seconds; 0 disables
+
+# Sandbox confinement bounds the blast radius of tool calls. Writers may only
+# modify workspace_root (empty = current directory) plus allow_write. forbid_read
+# hides sensitive directories from read/list/search tools and from sandboxed bash
+# while OS-level sandboxing is active. Use absolute paths or ${HOME}; "~" is not
+# expanded in config values.
+# [sandbox]
+# workspace_root = ""
+# allow_write    = ["/tmp"]
+# forbid_read    = ["${HOME}/.ssh"]
+# bash           = "enforce"   # enforce (default on macOS/Linux) | off; Windows fixes this to off because it has no OS-level Bash sandbox
+# network        = true
+
+# Skills are invokable playbooks (SKILL.md / <name>.md with frontmatter), found
+# under .reasonix/skills, .agents/skills, .agent/skills, .claude/skills (project)
+# and the same dirs under ~ (global). Built-ins (explore/research/review/security-review/test)
+# ship out of the box. The model invokes them via run_skill / explore / …; you
+# invoke them via /<name>. Manage with /skill (list, show, enable, disable, new, paths).
+# [skills]
+# paths = ["~/my-skills", "../shared/skills"]   # extra "custom"-scope skill roots
+# excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
+# disable_implicit_invocation = true             # keep /skill explicit; hide skill discovery and tools from the model
+# disabled_skills = ["review"]                  # hide from prompt, slash invocation, and skill tools
+
+# Hooks run shell commands around the loop (PreToolUse / PostToolUse /
+# PermissionRequest / UserPromptSubmit / Stop). They are NOT configured here — put them in
+# settings.json: <Reasonix home>/settings.json (global, always on) and
+# <project>/.reasonix/settings.json (project, loaded automatically).
+# Exit 0 = pass, exit 2 = block (PreToolUse / UserPromptSubmit only). Example
+# <Reasonix home>/settings.json:
+#   { "hooks": {
+#       "PreToolUse":  [ { "match": "bash", "command": "my-guard.sh" } ],
+#       "PermissionRequest": [ { "match": "bash", "command": "notify-send 'approval needed'" } ],
+#       "PostToolUse": [ { "match": ".*file", "command": "gofmt -w ." } ],
+#       "Stop":        [ { "command": "notify-send 'turn done'" } ] } }
+
+# A custom status line: a command whose first stdout line replaces the built-in
+# data row. It receives {"model","contextUsed","contextWindow"} as JSON on stdin.
+# [statusline]
+# command = "my-statusline.sh"
+
+# External stdio plugins (MCP-compatible); each is a standalone executable.
+# [[plugins]]
+# name    = "example"
+# command = "reasonix-plugin-example"
+# # Startup may continue in the background after the first caller stops waiting.
+# # startup_timeout_seconds = 60
+# # Per-server MCP call timeout; 0 keeps the global/default cap.
+# # call_timeout_seconds = 600
+# # Raw MCP tool names with per-tool call timeouts.
+# # tool_timeout_seconds = { "generate_video" = 1800 }
+# # Enabled MCP servers connect automatically in the background after session
+# # start. Use /mcp or the desktop MCP panel to refresh, reconnect, or disable.
+
+# Bot gateway: multi-channel IM bot for QQ, Feishu, and WeChat.
+# Start with `reasonix bot start --channels qq,feishu,weixin`.
+# All secrets are read from environment variables; never put keys here.
+# [bot]
+# enabled    = false
+# model      = ""        # 用于 bot 的模型，空则用 default_model
+# max_steps  = 25
+# debounce_ms = 1500      # 消息合并窗口（毫秒）
+# queue_mode = "steer"    # steer|followup|collect|interrupt
+# queue_cap  = 20         # 每个会话最多保留的排队消息数
+# queue_drop = "summarize" # summarize|old|new
+# ignore_self_messages = true # 忽略 bot 自己发出的回声消息
+#
+# [bot.self_user_ids]
+# qq = []                 # 可选：各平台 bot 自己的 user/open id
+# feishu = []
+# weixin = []
+#
+# [bot.control]
+# enabled = false         # 本机 loopback HTTP API：GET /status, GET /metrics, POST /send
+# addr = "127.0.0.1:37913"
+# token_env = "REASONIX_BOT_CONTROL_TOKEN"
+#
+# [[bot.routes]]
+# connection_id = "feishu-lark" # 可选；空字段表示通配
+# chat_type = "group"
+# chat_id = "oc_xxx"
+# workspace_root = "/path/to/project"
+# model = "deepseek-pro"
+# tool_approval_mode = "ask"
+#
+# [bot.pairing]
+# enabled = true
+# request_ttl_minutes = 60
+# max_pending_per_platform = 3
+#
+# [bot.allowlist]
+# enabled     = true
+# allow_all   = false     # true 会允许所有可触达用户远程触发 bot，仅限受控环境
+# qq_users    = []
+# feishu_users = []
+# weixin_users = []
+# qq_approvers = []       # 为空时沿用 allowlist 用户可审批的兼容行为
+# feishu_approvers = []
+# weixin_approvers = []
+# qq_admins = []          # 配置后 /yolo 和 /mode 仅限 admin
+# feishu_admins = []
+# weixin_admins = []
+# qq_groups   = []
+# feishu_groups = []
+# weixin_groups = []
+#
+# [bot.qq]
+# enabled        = false
+# app_id         = ""
+# app_secret_env  = "QQ_BOT_APP_SECRET"
+# sandbox        = false   # true 使用 QQ 沙箱 API / gateway
+#
+# [bot.feishu]
+# enabled             = false
+# app_id              = ""
+# app_secret_env       = "FEISHU_BOT_APP_SECRET"
+# verification_token   = ""
+# mode                = "webhook"   # webhook | websocket（websocket 需接官方 SDK 长连接）
+# webhook_port        = 8080
+# require_mention     = true
+#
+# [bot.weixin]
+# enabled   = false
+# account_id = "default"
+# token_env = "WEIXIN_BOT_TOKEN"
+# api_base  = "https://ilinkai.weixin.qq.com"   # Tencent iLink Bot API base URL
+
+[serve]
+# Authentication for the HTTP serve frontend (reasonix serve).
+# auth_mode = "none"      # none | token | password
+# token      = ""          # pre-shared token for auth_mode = "token" (auto-generated if empty)
+# password_hash = ""       # bcrypt hash for auth_mode = "password". Generate with: reasonix serve --hash-password <password>
+# behind_proxy = false      # set true when behind a trusted reverse proxy (nginx, Caddy, etc.) that sets X-Forwarded-* headers
+
+# --- Semantix memory kernel (v0.3.0+) -------------------------------------
+# Wire the cross-session memory kernel into this agent. All fields are
+# optional; the harness degrades silently when the kernel is unavailable.
+[semantix]
+enabled       = true     # mirror session events to the kernel
+binary        = "semantix" # kernel CLI (part of the agent bundle; on PATH after install)
+inject        = true     # append the [semantix-reuse] block to the system prompt
+budget        = 4096     # L2 injection budget in bytes
+sessions_dir  = ".semantix/sessions"  # session JSONL mirror (feed to: semantix extract -input)

--- a/scripts/release/build-full.sh
+++ b/scripts/release/build-full.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
-# build-full.sh — package the complete downloadable agent (v0.3.0+):
-#   reasonix (coding-agent harness, from the semantix fork) + semantix
-#   (memory kernel) + example configs + install.sh + README, per platform.
+# build-full.sh — package the downloadable semantix-agent bundle (v0.5.0+
+# merged-repo era): three binaries built from this repo's cmd/ entries
+#   semantix-agent   — merged coding agent (harness vendor, in-process kernel)
+#   semantix         — memory-kernel CLI
+#   semantix-gateway — OpenAI-compatible semantic-cache gateway
+# plus the two config templates (reasonix.example.toml, semantix.example.toml)
+# and a README, per platform.
 #
-# Usage: build-full.sh --version v0.3.0 [--platforms darwin-arm64,linux-amd64]
+# History: up to v0.4.1 this script built `reasonix` from the external fork
+# checkout (FORK_ROOT) + `semantix` from this repo. v0.5.0/v0.6.0 were packaged
+# by hand (`go build -trimpath -ldflags "-s -w -X main.version=..."` per entry
+# + manual tar): version was stamped but commit/build-time were not (`semantix
+# version --json` reports commit "unknown"). This rewrite restores scripted
+# builds with full version/commit/build-time stamping.
+#
+# Usage: build-full.sh --version v0.7.0 [--platforms darwin-arm64,linux-amd64]
 # Default platforms: darwin-arm64, darwin-amd64, linux-amd64, linux-arm64
-# Output: dist/semantix-agent-<version>-<platform>.tar.gz + SHA256SUMS
+# Output: dist/semantix-agent-<version>-<platform>.tar.gz + SHA256SUMS.txt
 set -euo pipefail
 
 VERSION=""
@@ -18,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --platforms)
       PLATFORMS="$2"; shift 2 ;;
     --version=*) VERSION="${1#*=}"; shift ;;
+    --platforms=*) PLATFORMS="${1#*=}"; shift ;;
     *)
       echo "unknown arg: $1" >&2; exit 2 ;;
   esac
@@ -30,11 +42,18 @@ if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
 fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-FORK_ROOT="${FORK_ROOT:-$ROOT/../DeepSeek-Reasonix}"
-GO="${GO:-/tmp/go2/go/bin/go}"
+GO="${GO:-go}"
 OUT="$ROOT/dist"
 rm -rf "$OUT"
 mkdir -p "$OUT"
+
+COMMIT="$(git -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# -buildvcs=false: the -ldflags stamps are the build-identity source of truth.
+# Go's own VCS detection walks to the primary checkout's .git when building
+# from a linked worktree (.claude/worktrees/*) and stamps the wrong revision.
+GOFLAGS_VCS="-buildvcs=false"
 
 for plat in ${PLATFORMS//,/ }; do
   os="${plat%-*}"; arch="${plat#*-}"
@@ -45,41 +64,54 @@ for plat in ${PLATFORMS//,/ }; do
   D="$OUT/$PKG"
   mkdir -p "$D"
 
-  echo "building reasonix ($os/$arch)..."
-  (cd "$FORK_ROOT" && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
-    "$GO" build -trimpath -ldflags "-s -w" -o "$OUT/reasonix-$plat" ./cmd/reasonix)
+  echo "building semantix-agent ($os/$arch)..."
+  (cd "$ROOT" && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" "$GO" build -trimpath "$GOFLAGS_VCS" \
+    -ldflags "-s -w -X main.version=$VERSION -X main.gitCommit=$COMMIT -X main.buildTimeUTC=$BUILD_TIME" \
+    -o "$D/semantix-agent" ./cmd/semantix-agent)
 
   echo "building semantix ($os/$arch)..."
-  (cd "$ROOT" && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
-    "$GO" build -trimpath -ldflags "-s -w -X main.version=$VERSION" -o "$OUT/semantix-$plat" ./cmd/semantix)
+  (cd "$ROOT" && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" "$GO" build -trimpath "$GOFLAGS_VCS" \
+    -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME" \
+    -o "$D/semantix" ./cmd/semantix)
 
-  mv "$OUT/reasonix-$plat" "$D/reasonix"
-  mv "$OUT/semantix-$plat" "$D/semantix"
-  cp "$FORK_ROOT/reasonix.example.toml" "$D/" 2>/dev/null || true
-  cp "$ROOT/semantix.example.toml" "$D/" 2>/dev/null || true
-  cp "$ROOT/agent-skill/scripts/install.sh" "$D/semantix-install.sh" 2>/dev/null || true
+  # semantix-gateway has no ldflags version vars yet; strip-only build.
+  echo "building semantix-gateway ($os/$arch)..."
+  (cd "$ROOT" && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" "$GO" build -trimpath "$GOFLAGS_VCS" \
+    -ldflags "-s -w" \
+    -o "$D/semantix-gateway" ./cmd/semantix-gateway)
+
+  # Config templates are required package content — fail loudly if missing.
+  cp "$ROOT/reasonix.example.toml" "$D/"
+  cp "$ROOT/semantix.example.toml" "$D/"
   cat > "$D/README.md" <<EOF
 # Semantix Agent $VERSION ($plat)
 
-Complete downloadable coding agent with cross-session memory:
-- \`reasonix\` — the coding-agent harness (fork of Reasonix, single-session
-  prefix-cache discipline inherited, ~90%+ cache-hit on long sessions)
-- \`semantix\` — the self-evolving memory kernel (L2 semantic injection,
-  L3 verified reuse, evolution engine, cost dashboard)
+合体 coding agent 与自进化 memory kernel——每一次会话，都让下一次会话更快、更便宜。
 
-## Quick start
-1. ./semantix-install.sh v$VERSION   # installs both binaries + configs
-2. edit reasonix.example.toml → set your provider + [semantix] section
-3. reasonix --config reasonix.toml   # start the agent
-4. semantix usage                    # cost dashboard after a session
+## 包内容
+- \`semantix-agent\` — 合体 coding agent（TUI/print/run/serve/ACP），进程内挂载
+  semantix kernel：L2 语义注入、每 turn 复用面板（📦 命中 / 💰 节省 / 🗂 来源）、
+  调度编排（并行分组 / tier / 预算阶梯 / 工具挂起）
+- \`semantix\` — memory kernel CLI（extract / search / lookup / verify / usage / dashboard）
+- \`semantix-gateway\` — OpenAI 兼容语义缓存网关（可选，任何 OpenAI 兼容客户端
+  把 base_url 指过来即可）
+- \`reasonix.example.toml\` — agent 配置模板（provider + [semantix] 段）
+- \`semantix.example.toml\` — kernel 配置模板
 
-## Memory
-Sessions are captured by the harness sink; run
+## 快速开始
+1. cp reasonix.example.toml ~/.reasonix/reasonix.toml，填 provider key，
+   确认 [semantix] enabled = true
+2. ./semantix-agent            # 交互 TUI（或 -p "task" 单发）
+3. 会话结束后 ./semantix usage # 成本与命中仪表盘
+
+## 记忆
+会话由 harness sink 落盘到 .semantix/sessions/；运行
     semantix extract -input <session>.jsonl -scope project
-to build the memory library, and the agent will inject relevant slices
-automatically on similar tasks.
+构建切片库，此后相似任务会自动注入相关切片。
+
+发布说明：https://github.com/Gnosil/semantix/releases/tag/$VERSION
 EOF
-  chmod +x "$D/reasonix" "$D/semantix" "$D/semantix-install.sh" 2>/dev/null || true
+  chmod +x "$D/semantix-agent" "$D/semantix" "$D/semantix-gateway"
 
   (cd "$OUT" && tar -czf "$PKG.tar.gz" "$PKG")
   rm -rf "$D"


### PR DESCRIPTION
## 背景：v0.5.0/v0.6.0 实际构建方式（调查结论）

`scripts/release/build-full.sh` 停留在 v0.3.0 时代（外部 FORK_ROOT 构建 `reasonix` + 本仓 `semantix`），而 v0.5.0/v0.6.0 的发布包并非它产出。对 v0.6.0 发布资产逐项取证（`go version -m`、strings、包内文件 diff、实测 released 二进制）还原出当时的手工流程：

- 逐入口手工 `go build -trimpath -ldflags "-s -w -X main.version=vX.Y.Z"`（三个 cmd/ 入口）+ 手工 tar——**version 有注入，commit/build-time 没有**（released `semantix version --json` 报 commit `"unknown"`、build_time 空），也无 VCS 元数据
- 包内 `reasonix.example.toml` 与本地 fork checkout（DeepSeek-Reasonix）当前副本逐字节一致——模板打包时取自 fork，本仓此前没有这个文件
- 包内 README 为每版手写（v0.6.0 专属内容），非脚本模板产物
- 仓库内无任何替代脚本（`build.sh` 是更老的 v0.2.0 时代、仅构建 semantix CLI 的扁平产物），docs 也未记录该手工流程 → 结论：**更新 build-full.sh 而非删除**

## 变更

- **build-full.sh 重写**：从本仓三个 cmd/ 入口（`semantix-agent` / `semantix` / `semantix-gateway`）构建打包，资产命名与现行发布一致（`semantix-agent-<version>-<platform>.tar.gz` + SHA256SUMS.txt），包布局与 v0.6.0 资产逐项一致（三二进制 + 两配置模板 + README，无 install.sh）
  - 完整注入 `version` / `commit` / `build-time`（semantix-agent 与 semantix 两套变量名各自对齐；gateway 尚无版本变量，仅 strip）
  - `-buildvcs=false`：实测在 `.claude/worktrees/*` linked worktree 里构建时，Go 的 VCS 探测会走到主 checkout 的 `.git` 并标错 revision（拿到的是主 checkout 的 6 天前 HEAD）；ldflags 是版本事实源
  - `GO` 默认从遗留的 `/tmp/go2/go/bin/go` 改为 PATH 中的 `go`（brew）
  - 头注释记录 v0.4.1 前旧行为与 v0.5.0/v0.6.0 手工流程，内嵌 README 模板对齐现行包内容
- **vendor `reasonix.example.toml` 到仓库根**：与 v0.6.0 发布包及 fork 当前副本逐字节一致；打包自此不再依赖外部 fork checkout
- **cmd/semantix-agent/main.go 注释修正**：构建注释原指 Makefile（上游 Reasonix 遗留；全仓确无 Makefile），改指 `scripts/release/build-full.sh`

## 验证

- `bash -n` 通过；`gofmt` / `go vet ./cmd/semantix-agent/` 干净
- 实跑 `--version v0.6.1-rc.0 --platforms darwin-arm64,linux-amd64` 两平台打包成功
- 抽包 darwin-arm64：tar 布局与 v0.6.0 资产一致；`./semantix-agent --version` → `semantix-agent v0.6.1-rc.0`；`./semantix version --json` 三字段齐全（version/commit/build_time）；`go version -m` 确认无 VCS 误标
- 与 released v0.6.0 二进制对比：尺寸几乎一致（同为 stripped），确认还原的手工命令成立

## 顺带发现（未在本 PR 处理）

- released v0.5.0/v0.6.0 的 `semantix version --json` commit 字段为 `"unknown"`（手工流程遗留，下一次发版起由本脚本修复）
- `agent-skill/scripts/install.sh` 仍按 v0.2.0 扁平资产命名（`semantix-vX.Y.Z-os-arch`）下载，对 v0.5.0+ 的 tar.gz 资产已失效；README 第 795/1033 行仍描述 "reasonix + semantix + install script" 旧包内容——已另开后台任务建议单独处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)