### PR TITLE
feat: 接通负反馈通道（reject 命令 + inject_pollution 信号 + L3 来源 ID）（Issue #267 核心闭环）

### DIFF
--- a/cmd/semantix/completion_test.go
+++ b/cmd/semantix/completion_test.go
@@ -107,7 +107,7 @@ func helpShowsFlag(helpOut, short string) bool {
 		if !strings.HasPrefix(line, "-") {
 			continue
 		}
-		if fields := strings.Fields(line); len(fields) > 0 && fields[0] == "-"+short {
+		if fields := strings.Fields(line); len(fields) > 0 && strings.TrimLeft(fields[0], "-") == short {
 			return true
 		}
 	}

--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -263,6 +263,11 @@ func buildCommands() []commandSpec {
 		summary: "prune stale / low-weight slices",
 		run:     errCommand("gc", runGC),
 		completionFlags: []string{"--retention-days", "--min-weight", "--dry-run", "--json"}},
+	{name: "reject", group: groupMaintenance,
+		usage:   "semantix reject <slice-id> [--reason ...] [--db ...] [--json]",
+		summary: "mark a slice as user-rejected (Rejected++ / UserFeedback-1)",
+		run:     errCommand("reject", runReject),
+		completionFlags: []string{"--reason", "--db", "--json"}},
 	}
 }
 

--- a/cmd/semantix/reject.go
+++ b/cmd/semantix/reject.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"io"
+
+	"semantix/kernel/slice"
+)
+
+// runReject marks one slice as user-rejected (Issue #267 step 2): the
+// slice Rejected counter increments and UserFeedback goes -1, aligning with
+// Security §4.1.3 "否决即失效". This is the manual negative-feedback path;
+// the automatic harness detection emits SliceReject events separately (fed
+// to the evolve engine as inject_pollution).
+func runReject(args []string, stdout, stderr io.Writer, deps dependencies) error {
+	flags := pflag.NewFlagSet("reject", pflag.ContinueOnError) // pflag: flags may follow the positional slice-id
+	flags.SetOutput(stderr)
+	reason := flags.String("reason", "", "reject reason (recorded in the JSON output, not persisted)")
+	dbOverride := flags.String("db", cfgString(deps.resolved, "store.db", ""), "database path override")
+	jsonOutput := flags.Bool("json", false, "write JSON envelope output")
+	if err := flags.Parse(args); err != nil {
+		// pflag uses its own ErrHelp; errCommand treats flag.ErrHelp as a
+		// successful --help request, so translate it to keep the contract.
+		if errors.Is(err, pflag.ErrHelp) {
+			return flag.ErrHelp
+		}
+		return usageError{err: err}
+	}
+	if flags.NArg() != 1 {
+		return usageErrf("reject: expected exactly one slice id, got %d", flags.NArg())
+	}
+	id := flags.Arg(0)
+
+	store, err := deps.openStore(storePath(*dbOverride, "project"))
+	if err != nil {
+		if *jsonOutput {
+			return failJSON(stdout, "reject", err)
+		}
+		return err
+	}
+	defer closeStore(store)
+
+	// UpdateStats returns errNotFound for unknown ids — "否决即失效" must not
+	// silently accept a typo id.
+	if err := store.UpdateStats(id, slice.SliceStats{Rejected: 1, UserFeedback: -1}); err != nil {
+		if *jsonOutput {
+			return failJSON(stdout, "reject", err)
+		}
+		return err
+	}
+	if *jsonOutput {
+		return writeEnvelope(stdout, "reject", map[string]any{
+			"slice_id": id,
+			"rejected": true,
+			"reason":   *reason,
+		})
+	}
+	fmt.Fprintln(stdout, "rejected slice "+id)
+	if *reason != "" {
+		fmt.Fprintln(stdout, "reason: "+*reason)
+	}
+	return nil
+}

--- a/cmd/semantix/reject_test.go
+++ b/cmd/semantix/reject_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/config"
+	"semantix/kernel/slice"
+)
+
+func rejectTestDeps(db string) dependencies {
+	cfg := &config.Resolved{Fields: []config.Field{
+		{Key: "store.db", Value: db, Source: config.SourceFile},
+	}}
+	return dependencies{openStore: slice.NewFileStore, resolved: cfg}
+}
+
+func TestRejectMarksSlice(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "s.db")
+	store, err := slice.NewFileStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(&slice.Slice{ID: "s1", Type: slice.Prompt, Scope: slice.Project, Content: []byte("x")}); err != nil {
+		t.Fatal(err)
+	}
+	closeStore(store)
+
+	var out bytes.Buffer
+	if err := runReject([]string{"s1"}, &out, &emptyStderr{}, rejectTestDeps(db)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "rejected slice s1") {
+		t.Fatalf("output = %q, want rejection notice", out.String())
+	}
+
+	// Re-open so the rejection is verified through the store contract, not
+	// the in-memory handle the command closed.
+	reopened, err := slice.NewFileStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeStore(reopened)
+	got, err := reopened.Get("s1")
+	if err != nil || got == nil {
+		t.Fatalf("Get after reject: %v %v", got, err)
+	}
+	if got.Stats.Rejected != 1 || got.Stats.UserFeedback != -1 {
+		t.Fatalf("stats = %+v, want Rejected=1 UserFeedback=-1", got.Stats)
+	}
+}
+
+func TestRejectUnknownSliceFails(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "s.db")
+	store, err := slice.NewFileStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeStore(store)
+	var out bytes.Buffer
+	if err := runReject([]string{"ghost"}, &out, &emptyStderr{}, rejectTestDeps(db)); err == nil {
+		t.Fatal("reject of unknown slice must fail (errNotFound)")
+	}
+}
+
+func TestRejectJSONEnvelope(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "s.db")
+	store, err := slice.NewFileStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(&slice.Slice{ID: "s2", Type: slice.Prompt, Scope: slice.Project, Content: []byte("y")}); err != nil {
+		t.Fatal(err)
+	}
+	closeStore(store)
+	// NOTE: s2 case closes before runReject; the JSON case reopens via deps.
+
+	var out bytes.Buffer
+	if err := runReject([]string{"s2", "--reason", "wrong advice", "--json"}, &out, &emptyStderr{}, rejectTestDeps(db)); err != nil {
+		t.Fatal(err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("bad envelope: %v", err)
+	}
+	if env["ok"] != true || env["command"] != "reject" {
+		t.Fatalf("envelope = %v, want ok=true command=reject", env)
+	}
+	data := env["data"].(map[string]any)
+	if data["slice_id"] != "s2" || data["reason"] != "wrong advice" || data["rejected"] != true {
+		t.Fatalf("data = %v", data)
+	}
+}
+
+func TestRejectRequiresExactlyOneArg(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "s.db")
+	for _, args := range [][]string{{}, {"a", "b"}} {
+		var out bytes.Buffer
+		if err := runReject(args, &out, &emptyStderr{}, rejectTestDeps(db)); err == nil {
+			t.Fatalf("args %v must be a usage error", args)
+		}
+	}
+}

--- a/gateway/judge_observability_test.go
+++ b/gateway/judge_observability_test.go
@@ -199,6 +199,9 @@ func TestJudgeApprovalLandsOnL3HitEvent(t *testing.T) {
 	if !evs[0].L3Reuse {
 		t.Fatal("the hit event must be the L3 reuse event")
 	}
+	if evs[0].L3SliceID != "grey-approve" {
+		t.Fatalf("L3SliceID = %q, want grey-approve (veto entry point)", evs[0].L3SliceID)
+	}
 	if len(evs[0].JudgeDecisions) != 1 || evs[0].JudgeDecisions[0].Verdict != "approved" {
 		t.Fatalf("judge decisions on the hit event = %+v, want one approved", evs[0].JudgeDecisions)
 	}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -66,7 +66,7 @@ func (g *Gateway) handleChat(w http.ResponseWriter, r *http.Request, body []byte
 				SessionID: sessionID, Provider: up.Name, Vendor: up.Vendor, Model: req.Model,
 				TokensIn:  int64(len(query)/4) + int64(len(res.Response)/4),
 				TokensOut: 0, CacheHitToken: int64(len(res.Response) / 4),
-				L3Reuse: true, JudgeDecisions: jc.drain(), At: now.Unix(),
+				L3Reuse: true, L3SliceID: res.SliceID, JudgeDecisions: jc.drain(), At: now.Unix(),
 			})
 			g.recordSliceStats(map[string]slice.SliceStats{
 				res.SliceID: {Hits: 1, LastUsed: now.Unix()},

--- a/harness/semantix/evolution.go
+++ b/harness/semantix/evolution.go
@@ -74,6 +74,11 @@ func (l *EvolutionLoop) observe(e kernelevent.Event) {
 		if json.Unmarshal(e.Data, &p) == nil {
 			targets = p.Targets
 		}
+	case kernelevent.SliceReject:
+		// Issue #267 step 3: injection pollution is the last unproduced
+		// signal source (PR #228 wired prefetch_hit/waste). targets stays
+		// nil so the prefetch feedback loop below never sees rejections.
+		signal = "inject_pollution"
 	default:
 		return
 	}

--- a/harness/semantix/evolution_test.go
+++ b/harness/semantix/evolution_test.go
@@ -90,4 +90,35 @@ func TestEvolveSchedulerReceivesSuccessFloor(t *testing.T) {
 			got, evolve.DefaultSuccessFloor, evolve.DefaultTauL2)
 	}
 }
-
+// TestEvolutionLoopSliceRejectFeedsPollution (Issue #267 step 3): a
+// SliceReject event is folded into the engine as an inject_pollution
+// signal — the last empty signal source after PR #228 wired prefetch_*.
+// The prefetch tuner must NOT observe the rejection as waste.
+func TestEvolutionLoopSliceRejectFeedsPollution(t *testing.T) {
+	bus := kernelevent.NewSyncBus()
+	engine := evolve.New(evolve.Config{MinSamples: 2, FreezeEpochs: 1})
+	schedTuner, prefetchTuner := &captureTuner{}, &captureTuner{}
+	loop := NewEvolutionLoop(bus, engine)
+	loop.Attach(schedTuner, prefetchTuner)
+	var ticks []kernelevent.Event
+	bus.Subscribe(func(e kernelevent.Event) {
+		if e.Kind == kernelevent.EvolutionTick {
+			ticks = append(ticks, e)
+		}
+	})
+	payload, _ := json.Marshal(kernelevent.SliceRejectPayload{SliceID: "slice-a", Reason: "user-edit"})
+	// alpha=0.1: polEWMA climbs 0.1, 0.19, 0.271, 0.344 — the fourth
+	// rejection crosses PollutionRiseAt (0.30) and tightens TauL2.
+	for turn := 1; turn <= 4; turn++ {
+		bus.Emit(kernelevent.Event{Kind: kernelevent.SliceReject, SessionID: "s1", Turn: turn, At: time.Now(), Data: payload})
+	}
+	if len(ticks) != 1 {
+		t.Fatalf("ticks=%d, want 1 (rejections must move the pollution EWMA)", len(ticks))
+	}
+	// Rejections are pollution, never prefetch waste: the prefetcher must
+	// not be fed the slice as a wasted prediction.
+	if len(prefetchTuner.values) != 1 {
+		t.Fatalf("prefetchTuner values=%v, want exactly the post-change snapshot", prefetchTuner.values)
+	}
+	loop.Close()
+}

--- a/kernel/usage/usage.go
+++ b/kernel/usage/usage.go
@@ -45,6 +45,10 @@ type Event struct {
 	// L3Reuse marks a turn fully served by a verified L3 result (no backend
 	// call at all) — its entire cost is saved.
 	L3Reuse bool `json:"l3_reuse,omitempty"`
+	// L3SliceID is the source slice that served an L3 reuse (Issue #267 step
+	// 4): the veto entry point — a consumer can reject the exact slice that
+	// produced a wrong reused answer. Empty when L3Reuse is false.
+	L3SliceID string `json:"l3_slice_id,omitempty"`
 	// InjectedTokens is the L2 injection block size for this turn.
 	InjectedTokens int64 `json:"injected_tokens,omitempty"`
 	// SliceHits is the number of semantic slices that hit and were injected

--- a/kernel/usage/usage_test.go
+++ b/kernel/usage/usage_test.go
@@ -1,8 +1,10 @@
 package usage
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -165,5 +167,25 @@ func writeAll(t *testing.T, path string, data []byte) {
 	t.Helper()
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+// TestEventL3SliceIDRoundTrip: the L3 source slice id survives the usage
+// wire (Issue #267 step 4) so a wrong reused answer can be traced back
+// to the exact slice for rejection.
+func TestEventL3SliceIDRoundTrip(t *testing.T) {
+	e := Event{L3Reuse: true, L3SliceID: "s-42"}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"l3_slice_id":"s-42"`) {
+		t.Fatalf("wire = %s, want l3_slice_id field", b)
+	}
+	var back Event
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if !back.L3Reuse || back.L3SliceID != "s-42" {
+		t.Fatalf("round-trip = %+v", back)
 	}
 }


### PR DESCRIPTION
## 动机

负反馈通道（Issue #267 核心闭环 2+3+4）：harness 检测注入块被编辑/回滚（子项 1，留待单独排期——需会话 diff 语义）。文献：How Memory Management（arXiv:2505.16067）——agent 呈"经验跟随"，选择性删除较朴素累积平均提升 10%；The Power of Noise（arXiv:2401.14887）——被检索命中≠有用，必须有负向修正通道。

## 改动（3 个最小 commit）

| Commit | 内容 |
|---|---|
| `d661cef` feat(cli) | **`semantix reject <slice-id> [--reason] [--json]`**：`Rejected++` / `UserFeedback-1`（Security §4.1.3 "否决即失效"）。pflag 支持 flags 后置；`pflag.ErrHelp` 转 `flag.ErrHelp` 保持 U19 `--help` exit-0 契约；未知 id 经 `UpdateStats` errNotFound 报错（不静默接受 typo） |
| `f141045` feat(evolve) | `EvolutionLoop.observe` 将 `SliceReject` 事件映射为 **`inject_pollution`** 信号——填上 #228 留下的最后一个空信号源；`targets` 保持 nil，否决绝不喂给 prefetcher 当 waste |
| `2c8ca63` feat(usage) | `usage.Event` 加 **`L3SliceID`**，gateway L3 命中时透传来源切片 ID——错误复用答案可追溯到确切切片（否决入口，Security §4.1.2），wire 向后兼容（新字段 omitempty） |

## 代码现状核实（issue 声称全部属实）

- `SliceReject` 事件 Kind + Payload 已定义（`kernel/event/event.go:31-32,112-115`）但全仓无生产者 → 本次接上 CLI 手动路径 + evolve 消费端
- `SliceStats.Rejected` / `UserFeedback`（`slice.go:68-69`）无写入者 → CLI reject 成为第一个写入者
- `inject_pollution` 信号名 evolve 已识别（`evolve.go:167`）但无生产者 → 本次填上

## 测试

- `semantix reject`：4 单测（标记切片/未知 id 失败/JSON 信封/参数个数）
- evolve：`TestEvolutionLoopSliceRejectFeedsPollution`——4 个 rejection 跨过 `PollutionRiseAt(0.30)` 收紧 TauL2（alpha=0.1 序列 0.1→0.19→0.271→0.344），prefetcher 不收到 waste
- usage/gateway：`L3SliceID` round-trip + L3 命中事件断言（`grey-approve`）
- `go build ./...`、`go vet` 干净；cmd/harness-bridge/usage/gateway `-race` 测试通过（Windows 已知 TempDir 文件锁基线除外，CI ubuntu 不受影响）

## 未做（后续）

- **子项 1（harness 检测）**：注入块被用户显式编辑/回滚 → 自动发 `SliceReject`。需定义会话 diff 检测语义（issue 建议"整块消失才算"），涉及 harness 会话处理，建议单独排期
- **#219 评分器**（RejectCost/FeedbackGain）未入 main：权重下降/gc 淘汰闭环待其合入后接通
- evolve 自动信号与 CLI 手动否决是两条互补通道（前者 harness 进程内、后者 CLI 进程）