### PR TITLE
feat: 注入经济学入账（InjectROI）+ 预算 degrade_inject 档（Issue #270 子项 1+2）

### DIFF
--- a/harness/agent/run_loop.go
+++ b/harness/agent/run_loop.go
@@ -264,7 +264,14 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// (DeepSeek prefix-cache friendly). Kernel unavailability degrades to
 	// an empty block — the harness never blocks on the kernel.
 	if a.semantix != nil && a.semantix.Enabled() {
+		// Issue #270 step 2: the degrade_inject tier shrinks the injection
+	// (halved block budget) instead of dropping it, so tight budgets still
+	// get some reuse context. Any other action keeps the full injection.
+	if a.budgetCtrl != nil && a.budgetCtrl.Action() == sched.BudgetActionDegradeInject {
+		state.injectBlock = a.semantix.InjectDegraded(ctx, input)
+	} else {
 		state.injectBlock = a.semantix.InjectDetailed(ctx, input).Text
+	}
 		// U33/H4a reuse panel: capture the kernel's per-turn reuse summary
 		// (hit slices + incremental cost savings + top source sessions)
 		// alongside the injection block. Same soft-degrade contract: a zero

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -143,10 +143,30 @@ func (b *Bridge) SetLabel(label string) {
 // degrade — the harness never blocks on the kernel). Semantics match the
 // kernel CLI `semantix inject` defaults (U39 in-process data source).
 func (b *Bridge) Inject(ctx context.Context, query string) string {
-	return b.InjectDetailed(ctx, query).Text
+	return b.inject(ctx, query, b.cfg.Budget)
+}
+
+// InjectDegraded builds a halved-budget injection block (Issue #270 step
+// 2): the harness calls this when the window budget crosses the
+// degrade_inject tier — shrink the injection instead of dropping it.
+func (b *Bridge) InjectDegraded(ctx context.Context, query string) string {
+	budget := b.cfg.Budget / 2
+	if budget <= 0 {
+		budget = 1 // never fall back to the full DefaultBudget via the <=0 path
+	}
+	return b.inject(ctx, query, budget)
+}
+
+// inject is the shared injection path with an explicit block budget.
+func (b *Bridge) inject(ctx context.Context, query string, budget int) string {
+	return b.injectResult(ctx, query, budget).Text
 }
 
 func (b *Bridge) InjectDetailed(ctx context.Context, query string) InjectResult {
+	return b.injectResult(ctx, query, b.cfg.Budget)
+}
+
+func (b *Bridge) injectResult(ctx context.Context, query string, budget int) InjectResult {
 	if !b.Enabled() || !b.cfg.Inject {
 		return InjectResult{}
 	}
@@ -160,7 +180,7 @@ func (b *Bridge) InjectDetailed(ctx context.Context, query string) InjectResult 
 		Index:  idx,
 		Scope:  slice.Project,
 		K:      5,
-		Budget: b.cfg.Budget,
+		Budget: budget,
 		Zones:  &z,
 	}).Build(query)
 	if err != nil || inj == nil || len(inj.Slices) == 0 {

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -269,3 +269,21 @@ func TestBridgeReuseEmptySources(t *testing.T) {
 		t.Errorf("Sources = %v, want empty (legacy slices)", sum.Sources)
 	}
 }
+// TestBridgeInjectDegradedShrinksBlock (Issue #270 step 2): the
+// degrade_inject tier halves the block budget. The degraded block must
+// never exceed the full-budget one (whole-slice truncation is monotone
+// in budget), so a tight window still gets reuse context without the
+// full injection cost.
+func TestBridgeInjectDegradedShrinksBlock(t *testing.T) {
+	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
+	b := NewBridge(Config{Enabled: true, Inject: true, ProjectDir: dir, Budget: 4096})
+	defer b.Close()
+	full := b.InjectDetailed(context.Background(), "修复 go 测试")
+	degraded := b.InjectDegraded(context.Background(), "修复 go 测试")
+	if full.Text == "" {
+		t.Fatal("full injection unexpectedly empty")
+	}
+	if len(degraded) > len(full.Text) {
+		t.Fatalf("degraded block (%d bytes) exceeds full block (%d bytes)", len(degraded), len(full.Text))
+	}
+}

--- a/kernel/sched/rule_decider.go
+++ b/kernel/sched/rule_decider.go
@@ -241,6 +241,11 @@ func decideBudgetAction(b BudgetState) string {
 		return BudgetActionHardStop
 	case ratio >= 0.9:
 		return BudgetActionDegradeTier
+	case ratio >= 0.8:
+		// Issue #270 step 2: shrink injection before dropping it. The tier
+		// stays on the default — only the injector budget is halved at the
+		// execution point.
+		return BudgetActionDegradeInject
 	case ratio >= 0.7:
 		return BudgetActionHaltPrefetch
 	default:

--- a/kernel/sched/rule_decider_test.go
+++ b/kernel/sched/rule_decider_test.go
@@ -251,6 +251,7 @@ func TestBudgetActions(t *testing.T) {
 	}{
 		{0.69, "", "pro"},
 		{0.70, BudgetActionHaltPrefetch, "pro"},
+	{0.80, BudgetActionDegradeInject, "pro"},
 		{0.90, BudgetActionDegradeTier, "flash"},
 		{1.00, BudgetActionHardStop, "pro"},
 	}

--- a/kernel/sched/sched.go
+++ b/kernel/sched/sched.go
@@ -47,6 +47,10 @@ type RoundPlan struct {
 
 const (
 	BudgetActionDegradeTier  = "degrade_tier"
+	// BudgetActionDegradeInject shrinks L2 injection instead of dropping it
+	// (Issue #270 step 2): inject half the block budget, keep the harness
+	// running. Sits between halt_prefetch (0.7) and degrade_tier (0.9).
+	BudgetActionDegradeInject = "degrade_inject"
 	BudgetActionHaltPrefetch = "halt_prefetch"
 	BudgetActionHardStop     = "hard_stop"
 )

--- a/kernel/usage/usage.go
+++ b/kernel/usage/usage.go
@@ -146,6 +146,7 @@ type Summary struct {
 	CostNoCacheUSD  float64 // what it would cost without any cache
 	SavingsUSD      float64 // CostNoCache - CostPaid, gross of judge cost
 	SavingsRate     float64 // Savings / CostNoCache (0 when no cost)
+	InjectROI       float64 // cache savings per 1M injected tokens (Issue #270 step 1)
 
 	// Grey-zone judge accounting (Issue #242 gap 1). These describe a
 	// different model on a different channel, so they are reported
@@ -294,6 +295,16 @@ func Summarize(path string, costMiss, costHit float64) (*Summary, error) {
 	s.SavingsUSD = noCache - paid
 	if noCache > 0 {
 		s.SavingsRate = s.SavingsUSD / noCache
+	}
+	// Issue #270 step 1: injection economics. The L2 injection is the
+	// only cache layer that spends tokens upfront; the ROI pairs the
+	// injection spend against the savings it participates in (L2 price
+	// delta + L3 full-turn savings). Reported per 1M injected tokens for
+	// readability.
+	if s.InjectedTokens > 0 {
+		l2Savings := float64(s.InjectedTokens) * (costMiss - costHit) / 1e6
+		l3Savings := (float64(l3In)*costMiss + float64(l3Out)*costMiss) / 1e6
+		s.InjectROI = (l2Savings + l3Savings) / float64(s.InjectedTokens) * 1e6
 	}
 	return s, nil
 }

--- a/kernel/usage/usage_test.go
+++ b/kernel/usage/usage_test.go
@@ -189,3 +189,55 @@ func TestEventL3SliceIDRoundTrip(t *testing.T) {
 		t.Fatalf("round-trip = %+v", back)
 	}
 }
+// TestSummarizeInjectROI (Issue #270 step 1): the injection economics
+// figure pairs the L2 injection spend against the savings it participates
+// in (L2 price delta + L3 full-turn savings), per 1M injected tokens.
+func TestSummarizeInjectROI(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage.jsonl")
+	r, err := NewRecorder(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := []Event{
+		{SessionID: "s1", Turn: 1, TokensIn: 5000, TokensOut: 300, CacheHitToken: 4000, InjectedTokens: 1000, SliceHits: 2},
+		{SessionID: "s1", Turn: 2, TokensIn: 20000, TokensOut: 500, L3Reuse: true},
+	}
+	for _, e := range evs {
+		if err := r.Append(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s, err := Summarize(path, DefaultCostMissPerMTok, DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.InjectedTokens != 1000 || s.L3Reuses != 1 {
+		t.Fatalf("baseline = injected %d l3 %d", s.InjectedTokens, s.L3Reuses)
+	}
+	// l2Savings = 1000*(0.27-0.07)/1e6 = 0.0002
+	// l3Savings = (20000*0.27 + 500*0.27)/1e6 = 0.005535
+	// InjectROI = (0.0002+0.005535)/1000*1e6 = 5.735 USD per 1M injected
+	want := 5.735
+	if diff := s.InjectROI - want; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("InjectROI = %v, want %v", s.InjectROI, want)
+	}
+}
+
+// TestSummarizeInjectROIZeroWhenNoInjection: no injection, no figure.
+func TestSummarizeInjectROIZeroWhenNoInjection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "usage.jsonl")
+	r, err := NewRecorder(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Append(Event{SessionID: "s", Turn: 1, TokensIn: 1000, TokensOut: 100}); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Summarize(path, DefaultCostMissPerMTok, DefaultCostHitPerMTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.InjectROI != 0 {
+		t.Fatalf("InjectROI = %v, want 0", s.InjectROI)
+	}
+}


### PR DESCRIPTION
## 动机

注入是无条件的：L2 注入的 token 成本已计入付费侧（`injectedTokens` 进 TokensIn）但无产出配对——`SliceHits` 记"注入了几片"没有"用上了几片"，无法区分有效注入与浪费注入（对照 prefetch 有 hit/waste 双向反馈）。文献：Are Online Skill and Memory Modules Always Worth Their Tokens?（arXiv:2606.15017）——注入消耗的 token 本可用于任务本身，价值必须按预算情境核算；Self-Route（arXiv:2407.16833）——"注入 vs 直给"应是成本感知路由决策。

## 改动（3 个最小 commit，子项 1+2）

| Commit | 内容 |
|---|---|
| `19de03f` feat(usage) | **子项 1**：`Summary.InjectROI` = (L2 价差节省 + L3 整轮节省) / 每 1M 注入 token。注入经济学入账——低 ROI 即浪费注入 |
| `1bdc90e` feat(sched) | **子项 2**：`BudgetActionDegradeInject`（0.8 档，位于 halt_prefetch 0.7 与 degrade_tier 0.9 之间）——预算紧时收缩注入而非无条件全量 |
| `5cd3c58` feat(harness) | **子项 2 执行点**：`Bridge.InjectDegraded`（块预算减半，防退化为默认值）+ run_loop 主注入点按 `budgetCtrl.Action()` 切换 |

## 代码现状核实（issue 声称属实）

- pipeline 注入无跳过判定；`inject.Injector.MinScore` 默认 0 禁用
- 预算阶梯 70%/90%/100% 无注入档
- `Summary` 已有 InjectedTokens/SliceHits/L3Reuses，l3In/l3Out 已累计可算回本率

## 测试

- `InjectROI`：2 单测（注入+L3 场景 = 5.735 USD/1M；无注入 = 0）
- `TestBudgetActions`：新增 0.80 → degrade_inject 用例
- `TestBridgeInjectDegradedShrinksBlock`：degraded 块 ≤ full 块（整切片截断对预算单调）
- `go build ./...`、`go vet` 干净；usage/sched/harness-bridge `-race` 全绿

## 未做（PR 外）

- **子项 3（保守门）**：`MinScore` 非零默认需 verify 回放校准（真实数据），留待后续
- gateway 侧执行点：gateway 无窗口预算状态（预算决策在 harness kernel），未改动
- 注入集冻结期语义：degraded 收缩只在 turn 边界生效（注入发生在 beginRunTurn），不破坏字节缓存