### PR TITLE
feat: route model tier from frozen turn intent (#269)

### DIFF
--- a/docs/specs/h2h3-resource-orchestration.md
+++ b/docs/specs/h2h3-resource-orchestration.md
@@ -5,7 +5,7 @@
 > `kernel/event/event.go`（12 种 Kind + `KindCount` 哨兵）、`patches/semantix-sched-prefetch.patch`（U13c 成果，本期作迁移素材）；
 > 架构基线：`docs/reports/harness-refactor-blueprint.md` §3/§4/§6、`docs/Agent-Infra-架构设计.md` §5。
 >
-> **状态（2026-08-17 评审后）**：v1.1（U37 评审意见已回写，见 §10，正文修订标注 R#）。
+> **状态（2026-08-21）**：v1.2-draft（#269 tier intent/近邻契约）；v1.1 的 U37 评审记录见 §10。
 > **先审后写**——本文档获批准前，U38-U43 不开工实现。
 > 判级：Spec-Required（新顶层目录/包结构 + 事件契约扩展 + 新配置面，多条命中）。
 
@@ -115,6 +115,7 @@ type ResourceCatalogPayload struct {
 type RoundPlan struct {
     ParallelGroups [][]string
     Tier           string
+    TierReason     string     `json:"tierReason,omitempty"`
     InjectIDs      []string
     PrefetchIDs    []string
     // 新增：
@@ -123,6 +124,24 @@ type RoundPlan struct {
     BudgetAction   string   `json:"budgetAction,omitempty"`   // "" | "degrade_tier" | "halt_prefetch" | "hard_stop"；未知值按无动作（fail-safe，R7）
 }
 ```
+
+`TierReason` 是机器可读、稳定的首个命中理由，供事件落盘与调度演示解释决策；它不参与执行。
+常规 tier 规则按以下优先级短路：
+
+1. 冻结的 turn intent 为 `mutation` / `persistent_action` → pro（`intent:<name>`）；
+2. 本轮存在 writer → pro（`writer:<tool>`）；
+3. 工具数超过 `ComplexTools` → pro（`complex:<count>`）；
+4. 否则使用默认 tier（`default`）。
+
+预算动作优先级仍高于上述规则；`degrade_tier` 覆盖 tier 时，理由为
+`budget:degrade_tier`。Intent 必须来自 `beginRunTurn` 已冻结的 `TaskPolicy`，不得在每个工具轮
+重复分类，避免同一 turn 内路由漂移。
+
+历史近邻信号分第二阶段接入。近邻投票的最小证据记录必须同时包含
+`session_id`、`tier`、`task_success` 与查询相似度；只有“在 flash 上失败”的近邻才可投升级票，
+且近邻合计只占一票。`SliceStats.Hits/Rejected/UserFeedback` 分别描述使用、注入污染和显式反馈，
+**不得**替代任务成败或历史 tier。当前持久化模型尚无上述二字段时，调度器必须按冷启动处理并
+退回前述确定性规则，不能从切片统计猜测结果。
 
 挂起语义：`SuspendTools` 是**声明式全量**（每轮下发当前应挂起集合），不是增量指令——
 harness 不维护指令历史，恢复 = 下一轮不在集合中。

--- a/harness/agent/execute_batch.go
+++ b/harness/agent/execute_batch.go
@@ -103,7 +103,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 	// P3 scheduler: decide parallel groups + tier once per round. The plan
 	// replaces the static partitionToolCalls grouping below; when no
 	// scheduler is wired (nil), the static grouping is used unchanged.
-	plan := a.decideRound(ctx, calls)
+	plan := a.decideRound(ctx, turn, calls)
 	suspended := suspendedToolSet(plan.SuspendTools)
 	// U41 C3 hard_stop (kernel path): a plan-issued hard_stop blocks every
 	// call in this round before any tool runs. Outcomes stay paired with the
@@ -588,7 +588,7 @@ launch:
 // decideRound runs the P3 scheduler for one tool round. Returns the zero
 // RoundPlan when no scheduler is wired so callers degrade to the static
 // grouping (partitionToolCalls).
-func (a *Agent) decideRound(ctx context.Context, calls []provider.ToolCall) sched.RoundPlan {
+func (a *Agent) decideRound(ctx context.Context, turn *turnRuntime, calls []provider.ToolCall) sched.RoundPlan {
 	if a.sched == nil {
 		return sched.RoundPlan{}
 	}
@@ -604,6 +604,7 @@ func (a *Agent) decideRound(ctx context.Context, calls []provider.ToolCall) sche
 	suspended, budget := a.resourceSchedulingState()
 	a.observePrefetchTransitions(info)
 	plan, err := a.sched.DecideRound(ctx, sched.RoundInput{
+		Intent:         intentName(turn.policy.Intent),
 		ToolCalls:      info,
 		SuspendedTools: suspended,
 		Budget:         sched.BudgetState{LimitUSD: budget.LimitUSD, SpentUSD: budget.SpentUSD, Window: budget.Window},

--- a/harness/agent/scheduler_integration_test.go
+++ b/harness/agent/scheduler_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"semantix/harness/event"
 	"semantix/harness/provider"
+	"semantix/harness/taskintent"
 	"semantix/harness/tool"
 	kernelevent "semantix/kernel/event"
 	"semantix/kernel/sched"
@@ -38,19 +39,39 @@ func (t *testTool) Execute(context.Context, json.RawMessage) (string, error) {
 }
 
 type sequenceDecider struct {
-	mu    sync.Mutex
-	plans []sched.RoundPlan
+	mu     sync.Mutex
+	plans  []sched.RoundPlan
+	inputs []sched.RoundInput
 }
 
-func (d *sequenceDecider) DecideRound(context.Context, sched.RoundInput) (sched.RoundPlan, error) {
+func (d *sequenceDecider) DecideRound(_ context.Context, in sched.RoundInput) (sched.RoundPlan, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	d.inputs = append(d.inputs, in)
 	if len(d.plans) == 0 {
 		return sched.RoundPlan{}, nil
 	}
 	p := d.plans[0]
 	d.plans = d.plans[1:]
 	return p, nil
+}
+
+func TestSchedulerReceivesFrozenTurnIntent(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(&testTool{name: "read_file"})
+	d := &sequenceDecider{}
+	a := New(nil, reg, NewSession(""), Options{Decider: d}, event.Discard)
+	turn := &turnRuntime{}
+	turn.policy.Intent = taskintent.Mutation
+	turn.policySet = true
+
+	a.decideRound(context.Background(), turn, []provider.ToolCall{{ID: "c1", Name: "read_file", Arguments: `{}`}})
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.inputs) != 1 || d.inputs[0].Intent != "mutation" {
+		t.Fatalf("scheduler input intent = %+v, want mutation", d.inputs)
+	}
 }
 
 func TestSchedulerSuspendThenRecover(t *testing.T) {

--- a/kernel/sched/rule_decider.go
+++ b/kernel/sched/rule_decider.go
@@ -9,8 +9,8 @@
 //   - behavior learning: a read-only tool whose recent success history is
 //     below the floor is treated as unsafe to parallelize (candidates must
 //     pass the behavior gate, per N04 "候选须过静态数据依赖检查");
-//   - tier: writer presence or a large round → pro, otherwise the default
-//     (flash) tier;
+//   - tier: the frozen turn intent is considered before writer presence and
+//     round size; every decision carries a stable explanation;
 //   - injection list: SliceHits ids in canonical (ID-ascending) order, so the
 //     byte-stable prefix-cache invariant is preserved.
 //
@@ -21,6 +21,7 @@ package sched
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"sort"
 	"strings"
@@ -176,9 +177,11 @@ func (d *RuleDecider) DecideRound(ctx context.Context, in RoundInput) (RoundPlan
 	suspended := canonicalNames(in.SuspendedTools)
 	active := withoutSuspended(in.ToolCalls, suspended)
 	action := decideBudgetAction(in.Budget)
+	tier, tierReason := decideTier(in.Intent, active, d.cfg)
 	plan := RoundPlan{
 		ParallelGroups: d.partition(active),
-		Tier:           decideTier(active, d.cfg),
+		Tier:           tier,
+		TierReason:     tierReason,
 		InjectIDs:      canonicalInjectIDs(in.SliceHits, d.cfg.InjectMax),
 		SuspendTools:   suspended,
 		MaxParallel:    d.cfg.MaxParallel,
@@ -192,6 +195,7 @@ func (d *RuleDecider) DecideRound(ctx context.Context, in RoundInput) (RoundPlan
 	}
 	if action == BudgetActionDegradeTier {
 		plan.Tier = d.cfg.DefaultTier
+		plan.TierReason = "budget:" + BudgetActionDegradeTier
 	}
 	return plan, nil
 }
@@ -370,18 +374,22 @@ func (d *RuleDecider) passesBehaviorGate(name string) bool {
 	return st.successRate() >= d.cfg.SuccessFloor
 }
 
-// decideTier maps a round to a model tier: any writer or a large round goes
-// to the pro tier, everything else to the default (flash) tier.
-func decideTier(calls []ToolCallInfo, cfg Config) string {
+// decideTier maps the turn's frozen intent and current round to a model tier.
+// The first matching rule wins so TierReason remains stable and auditable.
+func decideTier(intent string, calls []ToolCallInfo, cfg Config) (string, string) {
+	intent = strings.ToLower(strings.TrimSpace(intent))
+	if intent == "mutation" || intent == "persistent_action" {
+		return cfg.ProTier, "intent:" + intent
+	}
 	for _, c := range calls {
 		if !c.ReadOnly {
-			return cfg.ProTier
+			return cfg.ProTier, "writer:" + c.Name
 		}
 	}
 	if len(calls) > cfg.ComplexTools {
-		return cfg.ProTier
+		return cfg.ProTier, fmt.Sprintf("complex:%d", len(calls))
 	}
-	return cfg.DefaultTier
+	return cfg.DefaultTier, "default"
 }
 
 // canonicalInjectIDs returns hit slice ids in canonical (ID-ascending)

--- a/kernel/sched/rule_decider_test.go
+++ b/kernel/sched/rule_decider_test.go
@@ -211,15 +211,15 @@ func TestTierRules(t *testing.T) {
 	plan, _ := d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
 		call("a", "grep", true), call("b", "read_file", true),
 	}})
-	if plan.Tier != "flash" {
-		t.Fatalf("want flash, got %s", plan.Tier)
+	if plan.Tier != "flash" || plan.TierReason != "default" {
+		t.Fatalf("want flash/default, got %s/%s", plan.Tier, plan.TierReason)
 	}
 	// writer present → pro
 	plan, _ = d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
 		call("a", "grep", true), call("b", "bash", false),
 	}})
-	if plan.Tier != "pro" {
-		t.Fatalf("want pro (writer), got %s", plan.Tier)
+	if plan.Tier != "pro" || plan.TierReason != "writer:bash" {
+		t.Fatalf("want pro/writer:bash, got %s/%s", plan.Tier, plan.TierReason)
 	}
 	// many read-only calls → pro
 	var many []ToolCallInfo
@@ -227,8 +227,41 @@ func TestTierRules(t *testing.T) {
 		many = append(many, call(string(rune('a'+i)), "grep", true))
 	}
 	plan, _ = d.DecideRound(context.Background(), RoundInput{ToolCalls: many})
-	if plan.Tier != "pro" {
-		t.Fatalf("want pro (complex), got %s", plan.Tier)
+	if plan.Tier != "pro" || plan.TierReason != "complex:4" {
+		t.Fatalf("want pro/complex:4, got %s/%s", plan.Tier, plan.TierReason)
+	}
+}
+
+func TestTierIntentPrecedesRoundShape(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	for _, intent := range []string{"mutation", "persistent_action", " Mutation "} {
+		plan, err := d.DecideRound(context.Background(), RoundInput{
+			Intent:    intent,
+			ToolCalls: []ToolCallInfo{call("a", "read_file", true)},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantReason := "intent:" + strings.ToLower(strings.TrimSpace(intent))
+		if plan.Tier != "pro" || plan.TierReason != wantReason {
+			t.Fatalf("intent %q: got tier=%q reason=%q, want pro/%s", intent, plan.Tier, plan.TierReason, wantReason)
+		}
+	}
+}
+
+func TestTierReadOnlyIntentFallsBack(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	for _, intent := range []string{"", "conversation", "advisory", "observable_read", "unknown"} {
+		plan, err := d.DecideRound(context.Background(), RoundInput{
+			Intent:    intent,
+			ToolCalls: []ToolCallInfo{call("a", "read_file", true)},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if plan.Tier != "flash" || plan.TierReason != "default" {
+			t.Fatalf("intent %q: got tier=%q reason=%q, want flash/default", intent, plan.Tier, plan.TierReason)
+		}
 	}
 }
 
@@ -251,7 +284,7 @@ func TestBudgetActions(t *testing.T) {
 	}{
 		{0.69, "", "pro"},
 		{0.70, BudgetActionHaltPrefetch, "pro"},
-	{0.80, BudgetActionDegradeInject, "pro"},
+		{0.80, BudgetActionDegradeInject, "pro"},
 		{0.90, BudgetActionDegradeTier, "flash"},
 		{1.00, BudgetActionHardStop, "pro"},
 	}
@@ -266,6 +299,9 @@ func TestBudgetActions(t *testing.T) {
 		if plan.BudgetAction != tt.action || plan.Tier != tt.tier {
 			t.Fatalf("spent %.2f: got action=%q tier=%q", tt.spent, plan.BudgetAction, plan.Tier)
 		}
+		if tt.action == BudgetActionDegradeTier && plan.TierReason != "budget:degrade_tier" {
+			t.Fatalf("spent %.2f: got reason=%q", tt.spent, plan.TierReason)
+		}
 	}
 }
 
@@ -278,7 +314,7 @@ func TestRoundPlanJSONKeepsLegacyNamesAndOmitsZeroExtensions(t *testing.T) {
 	if !strings.Contains(text, `"ParallelGroups"`) || !strings.Contains(text, `"Tier"`) {
 		t.Fatalf("legacy field names changed: %s", text)
 	}
-	for _, field := range []string{"suspendTools", "maxParallel", "budgetAction"} {
+	for _, field := range []string{"tierReason", "suspendTools", "maxParallel", "budgetAction"} {
 		if strings.Contains(text, field) {
 			t.Fatalf("zero extension %q was not omitted: %s", field, text)
 		}

--- a/kernel/sched/sched.go
+++ b/kernel/sched/sched.go
@@ -38,6 +38,7 @@ type ToolCallInfo struct {
 type RoundPlan struct {
 	ParallelGroups [][]string // groups of call IDs to run concurrently
 	Tier           string     // "flash" | "pro"
+	TierReason     string     `json:"tierReason,omitempty"` // stable explanation; does not affect execution
 	InjectIDs      []string   // L2 slice IDs in canonical order
 	PrefetchIDs    []string   // prefetch targets (may be empty)
 	SuspendTools   []string   `json:"suspendTools,omitempty"`
@@ -46,13 +47,13 @@ type RoundPlan struct {
 }
 
 const (
-	BudgetActionDegradeTier  = "degrade_tier"
+	BudgetActionDegradeTier = "degrade_tier"
 	// BudgetActionDegradeInject shrinks L2 injection instead of dropping it
 	// (Issue #270 step 2): inject half the block budget, keep the harness
 	// running. Sits between halt_prefetch (0.7) and degrade_tier (0.9).
 	BudgetActionDegradeInject = "degrade_inject"
-	BudgetActionHaltPrefetch = "halt_prefetch"
-	BudgetActionHardStop     = "hard_stop"
+	BudgetActionHaltPrefetch  = "halt_prefetch"
+	BudgetActionHardStop      = "hard_stop"
 )
 
 // Decider plans each tool round (MVP implementation in M3).


### PR DESCRIPTION
## Summary

- freeze and pass the existing turn TaskPolicy.Intent into sched.RoundInput
- route mutation and persistent_action turns to the pro tier before tool-shape fallback rules
- add stable TierReason values for intent, writer, complexity, default, and budget override decisions
- document the kNN-lite evidence contract and explicitly forbid treating slice hits/rejections as task success at a historical tier

## Scope

This implements phase 1 of #269 and the explainability prerequisite for phase 2.

The kNN-lite vote is intentionally not fabricated in this PR: the current persisted model has no historical tier + task_success pair. The spec now defines those required fields and cold-start fallback behavior. A follow-up can add persistence and neighbor voting without changing the frozen Decider interface.

## Commits

1. docs(spec): define intent tier routing contract (#269)
2. feat(sched): route mutation intents to pro tier (#269)
3. feat(harness): pass frozen turn intent to scheduler (#269)

## Verification

- go test ./kernel/sched
- go test ./harness/agent
- focused turn-boundary regressions
- go vet ./kernel/sched ./harness/agent
- full diff review after tests; fixed the discovered global-turn read by passing *turnRuntime explicitly

Part of #269