### PR TITLE
feat: gate speculative prefetch on system load (#271)

### DIFF
--- a/docs/specs/issue-271-prefetch-load-gate.md
+++ b/docs/specs/issue-271-prefetch-load-gate.md
@@ -1,0 +1,73 @@
+# Spec: load-aware prefetch gating (Issue 271)
+
+The prefetch planner currently considers transition confidence, hit/waste
+feedback, task count, and cost. This addendum adds system load and useful wait
+window as independent gates without changing the frozen `Prefetcher.Plan`
+interface.
+
+## Contract evolution
+
+`Prefetcher.Plan([]string)` remains source compatible. Implementations may also
+implement the optional `LoadAwarePrefetcher` interface:
+
+```go
+type LoadHint struct {
+    ConcurrencyUsed  int
+    ConcurrencyLimit int
+    WaitWindow       time.Duration
+    TaskEstimate     time.Duration
+}
+
+type LoadAwarePrefetcher interface {
+    PlanWithLoad([]string, LoadHint) (PlanDecision, error)
+}
+```
+
+A zero or incomplete hint means "unknown", not "busy": the implementation
+falls back to the existing `Plan` behavior. This preserves cold-start and old
+adapter behavior.
+
+## Gate order
+
+The load-aware path evaluates these rules before candidate ranking:
+
+1. when both slot values are known and `used / limit >= 0.8`, return no tasks
+   with reason `load_saturated`;
+2. when both durations are known and `WaitWindow < TaskEstimate`, return no
+   tasks with reason `window_too_short`;
+3. otherwise run the existing planner and return `candidate` or
+   `no_candidate`.
+
+Budget remains authoritative. `halt_prefetch` and `hard_stop` clear any
+candidate and expose `budget:<action>` as the round reason. A skipped task was
+never executed, so it must not emit `PrefetchWaste`; load skip counters and the
+persisted `RoundPlan.PrefetchReason` are the observability surface.
+
+## Harness signals
+
+- slot use is the largest scheduled parallel group, capped by the scheduler's
+  configured slot limit;
+- wait window is the preceding provider stream duration;
+- task estimate is the preceding injection warm duration.
+
+The first stream has no history and keeps the legacy allow behavior. Explicit
+load/window/budget skip reasons block the next real injection warm;
+`no_candidate`, planner errors, and legacy callbacks remain fail-open so this
+change does not redefine candidate policy. Measurements are process-local and
+do not add a kernel dependency on the harness.
+
+## Acceptance
+
+- high slot occupancy and short windows independently produce an empty plan;
+- zero hints retain the existing plan;
+- normal candidates still reach `RoundPlan.PrefetchIDs`;
+- the actual harness warm is not started after a skip decision;
+- load-aware calls expose reason counts without creating false waste events;
+- `go test -race ./kernel/prefetch ./kernel/sched` and focused harness tests
+  pass.
+
+## Non-goals
+
+This change does not predict provider-wide fleet load, train a learned gate,
+cancel an already-running warm, change the 80% default dynamically, or treat a
+skip as hit/waste feedback.

--- a/harness/agent/agent.go
+++ b/harness/agent/agent.go
@@ -333,6 +333,9 @@ type Agent struct {
 	// during LLM wait time (N12); used as a fallback when the turn's
 	// synchronous injection produced nothing.
 	prefetchedInject atomic.Pointer[prefetchedInjectResult]
+	prefetchGate     atomic.Pointer[prefetchGateDecision]
+	prefetchWaitMS   atomic.Int64
+	prefetchTaskMS   atomic.Int64
 	semantixTurn     atomic.Int64
 
 	// mutationDependencyBarrier records the first durable-state write that
@@ -1120,7 +1123,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	if decider == nil {
 		rule := sched.NewRuleDecider(sched.Config{})
 		matrix = prefetch.NewMatrixPrefetcher(prefetch.Config{})
-		rule.SetPrefetchPlanFunc(prefetch.AsPlanFunc(matrix))
+		rule.SetLoadAwarePrefetchPlanFunc(prefetch.AsLoadAwarePlanFunc(matrix))
 		if opts.Semantix != nil {
 			opts.Semantix.AttachEvolution(rule, matrix)
 		}
@@ -1843,6 +1846,14 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 	if err != nil {
 		return streamedTurn{usage: provider.UsageWithRequestAttemptCount(ctx, nil), err: err}
 	}
+	streamStartedAt := time.Now()
+	defer func() {
+		elapsed := time.Since(streamStartedAt).Milliseconds()
+		if elapsed < 1 {
+			elapsed = 1
+		}
+		a.prefetchWaitMS.Store(elapsed)
+	}()
 
 	// N12 speculative prefetch: while the LLM streams, warm the next
 	// injection block in the background so a timed-out or missing
@@ -2943,6 +2954,9 @@ func (a *Agent) startInjectWarm(ctx context.Context) {
 	if a.budgetCtrl != nil && a.budgetCtrl.Action() != "" {
 		return
 	}
+	if !a.prefetchAllowed() {
+		return
+	}
 	input := a.turn.input
 	if input == "" {
 		return
@@ -2951,6 +2965,14 @@ func (a *Agent) startInjectWarm(ctx context.Context) {
 		// Detach from the stream context so cancellation of the current
 		// request does not cancel the warm-up; Inject applies its own 3s cap.
 		warmCtx := context.WithoutCancel(ctx)
+		startedAt := time.Now()
+		defer func() {
+			elapsed := time.Since(startedAt).Milliseconds()
+			if elapsed < 1 {
+				elapsed = 1
+			}
+			a.prefetchTaskMS.Store(elapsed)
+		}()
 		if result := a.semantix.InjectDetailed(warmCtx, input); result.Text != "" {
 			a.storePrefetch(&prefetchedInjectResult{Text: result.Text, Targets: result.Targets, Turn: a.semantixTurn.Load()})
 		}

--- a/harness/agent/execute_batch.go
+++ b/harness/agent/execute_batch.go
@@ -104,6 +104,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 	// replaces the static partitionToolCalls grouping below; when no
 	// scheduler is wired (nil), the static grouping is used unchanged.
 	plan := a.decideRound(ctx, turn, calls)
+	a.armPrefetch(plan.PrefetchReason)
 	suspended := suspendedToolSet(plan.SuspendTools)
 	// U41 C3 hard_stop (kernel path): a plan-issued hard_stop blocks every
 	// call in this round before any tool runs. Outcomes stay paired with the
@@ -608,6 +609,10 @@ func (a *Agent) decideRound(ctx context.Context, turn *turnRuntime, calls []prov
 		ToolCalls:      info,
 		SuspendedTools: suspended,
 		Budget:         sched.BudgetState{LimitUSD: budget.LimitUSD, SpentUSD: budget.SpentUSD, Window: budget.Window},
+		PrefetchLoad: sched.PrefetchLoadHint{
+			WaitWindowMS:   a.prefetchWaitMS.Load(),
+			TaskEstimateMS: a.prefetchTaskMS.Load(),
+		},
 	})
 	if err != nil {
 		if a.resources != nil {

--- a/harness/agent/prefetch_feedback.go
+++ b/harness/agent/prefetch_feedback.go
@@ -1,9 +1,42 @@
 package agent
 
+type prefetchGateDecision struct {
+	Turn   int64
+	Allow  bool
+	Reason string
+}
+
 type prefetchedInjectResult struct {
 	Text    string
 	Targets []string
 	Turn    int64
+}
+
+func (a *Agent) armPrefetch(reason string) {
+	if a == nil || reason == "" {
+		if a != nil {
+			a.prefetchGate.Store(nil)
+		}
+		return
+	}
+	allow := true
+	switch reason {
+	case "load_saturated", "window_too_short", "budget:halt_prefetch", "budget:hard_stop":
+		allow = false
+	}
+	a.prefetchGate.Store(&prefetchGateDecision{
+		Turn:   a.semantixTurn.Load(),
+		Allow:  allow,
+		Reason: reason,
+	})
+}
+
+func (a *Agent) prefetchAllowed() bool {
+	if a == nil {
+		return false
+	}
+	decision := a.prefetchGate.Load()
+	return decision == nil || decision.Turn != a.semantixTurn.Load() || decision.Allow
 }
 
 func (a *Agent) storePrefetch(next *prefetchedInjectResult) {

--- a/harness/agent/prefetch_feedback_test.go
+++ b/harness/agent/prefetch_feedback_test.go
@@ -54,3 +54,42 @@ func TestPrefetchReplacementAndExpirySettleAsWaste(t *testing.T) {
 		t.Fatalf("hits=%d wastes=%d", hits, wastes)
 	}
 }
+
+func TestPrefetchGateControlsWarmWithoutCreatingFeedback(t *testing.T) {
+	b := semantix.NewBridge(semantix.Config{Enabled: true})
+	defer b.Close()
+	var hits, wastes int
+	b.Events().Subscribe(func(e kernelevent.Event) {
+		switch e.Kind {
+		case kernelevent.PrefetchHit:
+			hits++
+		case kernelevent.PrefetchWaste:
+			wastes++
+		}
+	})
+	a := &Agent{semantix: b}
+	a.semantixTurn.Store(3)
+
+	if !a.prefetchAllowed() {
+		t.Fatal("cold start must preserve legacy allow behavior")
+	}
+	a.armPrefetch("load_saturated")
+	if a.prefetchAllowed() {
+		t.Fatal("load skip must block the warm")
+	}
+	if hits != 0 || wastes != 0 {
+		t.Fatalf("a skipped warm is not feedback: hits=%d wastes=%d", hits, wastes)
+	}
+	a.armPrefetch("candidate")
+	if !a.prefetchAllowed() {
+		t.Fatal("candidate plan must allow the warm")
+	}
+	a.armPrefetch("no_candidate")
+	if !a.prefetchAllowed() {
+		t.Fatal("no-candidate plan must preserve legacy fail-open warm")
+	}
+	a.semantixTurn.Add(1)
+	if !a.prefetchAllowed() {
+		t.Fatal("a stale prior-turn gate must not block a new turn")
+	}
+}

--- a/harness/agent/run_loop.go
+++ b/harness/agent/run_loop.go
@@ -113,6 +113,7 @@ func (s *deferredStreamSink) Discard() {
 func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string, state *turnRuntime) {
 	a.wastePrefetch()
 	a.semantixTurn.Add(1)
+	a.prefetchGate.Store(nil)
 	rawInput = RawUserInput(ctx, input)
 	providerInput := input
 	// A fresh user turn starts from zeroed per-turn host state; the new turn's

--- a/harness/agent/scheduler_integration_test.go
+++ b/harness/agent/scheduler_integration_test.go
@@ -61,6 +61,8 @@ func TestSchedulerReceivesFrozenTurnIntent(t *testing.T) {
 	reg.Add(&testTool{name: "read_file"})
 	d := &sequenceDecider{}
 	a := New(nil, reg, NewSession(""), Options{Decider: d}, event.Discard)
+	a.prefetchWaitMS.Store(120)
+	a.prefetchTaskMS.Store(40)
 	turn := &turnRuntime{}
 	turn.policy.Intent = taskintent.Mutation
 	turn.policySet = true
@@ -71,6 +73,9 @@ func TestSchedulerReceivesFrozenTurnIntent(t *testing.T) {
 	defer d.mu.Unlock()
 	if len(d.inputs) != 1 || d.inputs[0].Intent != "mutation" {
 		t.Fatalf("scheduler input intent = %+v, want mutation", d.inputs)
+	}
+	if got := d.inputs[0].PrefetchLoad; got.WaitWindowMS != 120 || got.TaskEstimateMS != 40 {
+		t.Fatalf("scheduler prefetch load = %+v", got)
 	}
 }
 

--- a/kernel/prefetch/load_test.go
+++ b/kernel/prefetch/load_test.go
@@ -1,0 +1,64 @@
+package prefetch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvaluateLoad(t *testing.T) {
+	tests := []struct {
+		name string
+		hint LoadHint
+		want PlanReason
+	}{
+		{name: "cold start", hint: LoadHint{}, want: ""},
+		{name: "below saturation", hint: LoadHint{ConcurrencyUsed: 7, ConcurrencyLimit: 10}, want: ""},
+		{name: "at saturation", hint: LoadHint{ConcurrencyUsed: 8, ConcurrencyLimit: 10}, want: ReasonLoadSaturated},
+		{name: "short window", hint: LoadHint{WaitWindow: 40 * time.Millisecond, TaskEstimate: 50 * time.Millisecond}, want: ReasonWindowTooShort},
+		{name: "long window", hint: LoadHint{WaitWindow: 50 * time.Millisecond, TaskEstimate: 40 * time.Millisecond}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EvaluateLoad(tt.hint, DefaultMaxLoad); got != tt.want {
+				t.Fatalf("EvaluateLoad() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatrixPlanWithLoadSkipsAndCounts(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	m.Observe("search", "read_file", true)
+
+	decision, err := m.PlanWithLoad([]string{"search"}, LoadHint{ConcurrencyUsed: 4, ConcurrencyLimit: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decision.Tasks) != 0 || decision.Reason != ReasonLoadSaturated {
+		t.Fatalf("saturated decision = %+v", decision)
+	}
+	decision, err = m.PlanWithLoad([]string{"search"}, LoadHint{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decision.Tasks) != 1 || decision.Reason != ReasonCandidate {
+		t.Fatalf("cold-start decision = %+v", decision)
+	}
+	if got := m.GateStats(); got.LoadSkipped != 1 || got.Candidates != 1 {
+		t.Fatalf("gate stats = %+v", got)
+	}
+}
+
+func TestPlannerPlanWithLoadKeepsFrozenPlanBehavior(t *testing.T) {
+	p := &Planner{}
+	decision, err := p.PlanWithLoad([]string{"search"}, LoadHint{WaitWindow: time.Millisecond, TaskEstimate: 2 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Reason != ReasonWindowTooShort || len(decision.Tasks) != 0 {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if tasks, err := p.Plan([]string{"search"}); err != nil || tasks != nil {
+		t.Fatalf("frozen Plan changed: tasks=%v err=%v", tasks, err)
+	}
+}

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -95,6 +95,9 @@ type Config struct {
 	// (Issue #254). Applicable only when there is any learned transition; an
 	// empty transition table still yields an empty plan.
 	Epsilon float64
+	// MaxLoad is the slot-occupancy ratio at which speculative work yields
+	// to normal execution (default 0.8).
+	MaxLoad float64
 }
 
 // Defaults returns the built-in configuration.
@@ -107,6 +110,7 @@ func Defaults() Config {
 		WasteHitLimit: 3.0,
 		Decay:         0.2,
 		Epsilon:       0, // disabled by default; enabled by evolve wiring
+		MaxLoad:       DefaultMaxLoad,
 	}
 }
 
@@ -120,6 +124,7 @@ type MatrixPrefetcher struct {
 	readOnly map[string]bool           // next -> observed read-only (safe to prefetch)
 	hit      map[string]float64        // key -> EWMA hit rate
 	waste    map[string]float64        // key -> EWMA waste rate
+	gate     gateCounter
 }
 
 // NewMatrixPrefetcher builds a MatrixPrefetcher with cfg (zero → Defaults).
@@ -145,6 +150,9 @@ func NewMatrixPrefetcher(cfg Config) *MatrixPrefetcher {
 	}
 	if cfg.Epsilon < 0 || cfg.Epsilon > 1 {
 		cfg.Epsilon = def.Epsilon
+	}
+	if cfg.MaxLoad <= 0 || cfg.MaxLoad > 1 {
+		cfg.MaxLoad = def.MaxLoad
 	}
 	return &MatrixPrefetcher{
 		cfg:      cfg,
@@ -252,6 +260,33 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 	}
 	return tasks, nil
 }
+
+// PlanWithLoad implements LoadAwarePrefetcher without changing Plan's frozen
+// behavior. Load is checked before transition lookup so a skip performs no
+// speculative ranking work.
+func (m *MatrixPrefetcher) PlanWithLoad(lastToolNames []string, hint LoadHint) (PlanDecision, error) {
+	m.mu.Lock()
+	maxLoad := m.cfg.MaxLoad
+	m.mu.Unlock()
+	if reason := EvaluateLoad(hint, maxLoad); reason != "" {
+		m.gate.observe(reason)
+		return PlanDecision{Reason: reason}, nil
+	}
+	tasks, err := m.Plan(lastToolNames)
+	if err != nil {
+		return PlanDecision{}, err
+	}
+	reason := ReasonNoCandidate
+	if len(tasks) > 0 {
+		reason = ReasonCandidate
+	}
+	m.gate.observe(reason)
+	return PlanDecision{Tasks: tasks, Reason: reason}, nil
+}
+
+// GateStats returns load-aware outcome counters. Calls through the frozen Plan
+// method are intentionally excluded because they carry no load decision.
+func (m *MatrixPrefetcher) GateStats() GateStats { return m.gate.snapshot() }
 
 // ObserveHit marks a planned prefetch as useful (the predicted tool was
 // actually called).

--- a/kernel/prefetch/planfunc.go
+++ b/kernel/prefetch/planfunc.go
@@ -1,5 +1,11 @@
 package prefetch
 
+import (
+	"time"
+
+	"semantix/kernel/sched"
+)
+
 // AsPlanFunc adapts any Prefetcher to the scheduler's prefetch-plan shape
 // (func(lastToolNames []string) []string) so sched.RuleDecider can hold a
 // prefetcher without importing this package — the dependency direction stays
@@ -19,5 +25,45 @@ func AsPlanFunc(p Prefetcher) func(lastToolNames []string) []string {
 			keys = append(keys, t.Key)
 		}
 		return keys
+	}
+}
+
+// AsLoadAwarePlanFunc adapts a Prefetcher to the scheduler's additive
+// load-aware callback. Old implementations still work through Plan; those
+// implementing LoadAwarePrefetcher receive the full hint.
+func AsLoadAwarePlanFunc(p Prefetcher) sched.LoadAwarePrefetchPlanFunc {
+	return func(lastToolNames []string, hint sched.PrefetchLoadHint) sched.PrefetchPlanResult {
+		if p == nil {
+			return sched.PrefetchPlanResult{Reason: string(ReasonNoCandidate)}
+		}
+		var (
+			decision PlanDecision
+			err      error
+		)
+		if aware, ok := p.(LoadAwarePrefetcher); ok {
+			decision, err = aware.PlanWithLoad(lastToolNames, LoadHint{
+				ConcurrencyUsed:  hint.ConcurrencyUsed,
+				ConcurrencyLimit: hint.ConcurrencyLimit,
+				WaitWindow:       time.Duration(hint.WaitWindowMS) * time.Millisecond,
+				TaskEstimate:     time.Duration(hint.TaskEstimateMS) * time.Millisecond,
+			})
+		} else {
+			decision.Tasks, err = p.Plan(lastToolNames)
+			decision.Reason = ReasonNoCandidate
+			if len(decision.Tasks) > 0 {
+				decision.Reason = ReasonCandidate
+			}
+		}
+		if err != nil {
+			return sched.PrefetchPlanResult{Reason: string(ReasonPlanError)}
+		}
+		var ids []string
+		if len(decision.Tasks) > 0 {
+			ids = make([]string, 0, len(decision.Tasks))
+		}
+		for _, task := range decision.Tasks {
+			ids = append(ids, task.Key)
+		}
+		return sched.PrefetchPlanResult{IDs: ids, Reason: string(decision.Reason)}
 	}
 }

--- a/kernel/prefetch/planfunc_test.go
+++ b/kernel/prefetch/planfunc_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"semantix/kernel/sched"
 )
 
 // fakePrefetcher is a scripted Prefetcher for adapter tests.
@@ -11,6 +13,23 @@ type fakePrefetcher struct {
 	tasks []PrefetchTask
 	err   error
 	last  []string // records the last Plan input
+}
+
+func TestAsLoadAwarePlanFuncFallsBackToFrozenPlan(t *testing.T) {
+	f := &fakePrefetcher{tasks: []PrefetchTask{{Key: "read_file"}}}
+	got := AsLoadAwarePlanFunc(f)([]string{"search"}, sched.PrefetchLoadHint{ConcurrencyUsed: 8, ConcurrencyLimit: 8})
+	if !reflect.DeepEqual(got.IDs, []string{"read_file"}) || got.Reason != string(ReasonCandidate) {
+		t.Fatalf("result = %+v", got)
+	}
+}
+
+func TestAsLoadAwarePlanFuncUsesMatrixGate(t *testing.T) {
+	m := NewMatrixPrefetcher(Config{})
+	m.Observe("search", "read_file", true)
+	got := AsLoadAwarePlanFunc(m)([]string{"search"}, sched.PrefetchLoadHint{ConcurrencyUsed: 8, ConcurrencyLimit: 8})
+	if got.IDs != nil || got.Reason != string(ReasonLoadSaturated) {
+		t.Fatalf("result = %+v", got)
+	}
 }
 
 func (f *fakePrefetcher) Plan(last []string) ([]PrefetchTask, error) {

--- a/kernel/prefetch/planner.go
+++ b/kernel/prefetch/planner.go
@@ -32,9 +32,13 @@ type Planner struct {
 	Budget int
 	// MaxTasks caps tasks per round; <=0 uses DefaultMaxTasks.
 	MaxTasks int
+	// MaxLoad is the slot-occupancy ratio at which speculative work yields;
+	// <=0 uses DefaultMaxLoad.
+	MaxLoad float64
 
 	mu     sync.RWMutex
 	matrix *transitionMatrix // set by Learn; nil until then
+	gate   gateCounter
 }
 
 // Defaults for the MVP budget control.
@@ -111,6 +115,32 @@ func (p *Planner) Plan(lastToolNames []string) ([]PrefetchTask, error) {
 	}
 	return tasks, nil
 }
+
+// PlanWithLoad implements the optional load-aware extension while preserving
+// the frozen Plan method for existing callers.
+func (p *Planner) PlanWithLoad(lastToolNames []string, hint LoadHint) (PlanDecision, error) {
+	maxLoad := p.MaxLoad
+	if maxLoad <= 0 || maxLoad > 1 {
+		maxLoad = DefaultMaxLoad
+	}
+	if reason := EvaluateLoad(hint, maxLoad); reason != "" {
+		p.gate.observe(reason)
+		return PlanDecision{Reason: reason}, nil
+	}
+	tasks, err := p.Plan(lastToolNames)
+	if err != nil {
+		return PlanDecision{}, err
+	}
+	reason := ReasonNoCandidate
+	if len(tasks) > 0 {
+		reason = ReasonCandidate
+	}
+	p.gate.observe(reason)
+	return PlanDecision{Tasks: tasks, Reason: reason}, nil
+}
+
+// GateStats returns load-aware outcome counters.
+func (p *Planner) GateStats() GateStats { return p.gate.snapshot() }
 
 func (p *Planner) budget() int {
 	if p.Budget <= 0 {

--- a/kernel/prefetch/prefetch.go
+++ b/kernel/prefetch/prefetch.go
@@ -1,5 +1,10 @@
 package prefetch
 
+import (
+	"sync"
+	"time"
+)
+
 // PrefetchTask is one speculative read-only prefetch unit.
 type PrefetchTask struct {
 	Kind string // "slice-assembly" | "embedding" | "file" (low priority)
@@ -12,4 +17,90 @@ type Prefetcher interface {
 	// Plan returns prefetch tasks given the last tool names (transition
 	// matrix + path patterns). Must only propose read-only work.
 	Plan(lastToolNames []string) ([]PrefetchTask, error)
+}
+
+// LoadHint is the caller's best-effort view of the resources available to
+// speculative work. Zero fields mean unknown and never block a cold start.
+type LoadHint struct {
+	ConcurrencyUsed  int
+	ConcurrencyLimit int
+	WaitWindow       time.Duration
+	TaskEstimate     time.Duration
+}
+
+// PlanReason is the stable explanation for a load-aware planning result.
+type PlanReason string
+
+const (
+	ReasonCandidate      PlanReason = "candidate"
+	ReasonNoCandidate    PlanReason = "no_candidate"
+	ReasonLoadSaturated  PlanReason = "load_saturated"
+	ReasonWindowTooShort PlanReason = "window_too_short"
+	ReasonPlanError      PlanReason = "plan_error"
+)
+
+// PlanDecision pairs planned work with the reason the gate produced.
+type PlanDecision struct {
+	Tasks  []PrefetchTask
+	Reason PlanReason
+}
+
+// LoadAwarePrefetcher is an optional extension. Prefetcher.Plan stays frozen;
+// adapters use this interface when present and otherwise call Plan.
+type LoadAwarePrefetcher interface {
+	PlanWithLoad(lastToolNames []string, hint LoadHint) (PlanDecision, error)
+}
+
+// DefaultMaxLoad is the slot-occupancy threshold above which speculative work
+// yields to normal execution.
+const DefaultMaxLoad = 0.8
+
+// EvaluateLoad returns a skip reason, or the empty string when prefetch may
+// proceed. Unknown inputs fail open to preserve cold-start behavior.
+func EvaluateLoad(hint LoadHint, maxLoad float64) PlanReason {
+	if maxLoad <= 0 || maxLoad > 1 {
+		maxLoad = DefaultMaxLoad
+	}
+	if hint.ConcurrencyUsed >= 0 && hint.ConcurrencyLimit > 0 &&
+		float64(hint.ConcurrencyUsed)/float64(hint.ConcurrencyLimit) >= maxLoad {
+		return ReasonLoadSaturated
+	}
+	if hint.WaitWindow > 0 && hint.TaskEstimate > 0 && hint.WaitWindow < hint.TaskEstimate {
+		return ReasonWindowTooShort
+	}
+	return ""
+}
+
+// GateStats is a snapshot of load-aware planning outcomes.
+type GateStats struct {
+	Candidates    uint64
+	NoCandidate   uint64
+	LoadSkipped   uint64
+	WindowSkipped uint64
+}
+
+type gateCounter struct {
+	mu    sync.Mutex
+	stats GateStats
+}
+
+func (c *gateCounter) observe(reason PlanReason) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch reason {
+	case ReasonCandidate:
+		c.stats.Candidates++
+	case ReasonNoCandidate:
+		c.stats.NoCandidate++
+	case ReasonLoadSaturated:
+		c.stats.LoadSkipped++
+	case ReasonWindowTooShort:
+		c.stats.WindowSkipped++
+	}
+}
+
+func (c *gateCounter) snapshot() GateStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.stats
 }

--- a/kernel/sched/rule_decider.go
+++ b/kernel/sched/rule_decider.go
@@ -66,6 +66,17 @@ var SerialToolNames = map[string]struct{}{
 // prefetch (keeps the dependency direction sched → nothing).
 type PrefetchPlanFunc func(lastToolNames []string) []string
 
+// PrefetchPlanResult is the load-aware callback's candidate list and stable
+// explanation. IDs are still reduced to tool-name keys by the adapter.
+type PrefetchPlanResult struct {
+	IDs    []string
+	Reason string
+}
+
+// LoadAwarePrefetchPlanFunc is an additive callback seam; PrefetchPlanFunc is
+// retained for existing integrations.
+type LoadAwarePrefetchPlanFunc func(lastToolNames []string, hint PrefetchLoadHint) PrefetchPlanResult
+
 // Config carries operator knobs; zero values select documented defaults.
 type Config struct {
 	// MaxParallel caps how many read-only tools may run in one parallel
@@ -126,10 +137,11 @@ func (t *toolStat) successRate() float64 {
 // lock. It is a plain struct (no interface split) so the harness can hold
 // it directly; it satisfies the frozen Decider interface.
 type RuleDecider struct {
-	mu         sync.Mutex
-	cfg        Config
-	stats      map[string]*toolStat
-	prefetchFn PrefetchPlanFunc
+	mu             sync.Mutex
+	cfg            Config
+	stats          map[string]*toolStat
+	prefetchFn     PrefetchPlanFunc
+	loadPrefetchFn LoadAwarePrefetchPlanFunc
 }
 
 // NewRuleDecider builds a RuleDecider with cfg (zero values → Defaults).
@@ -169,6 +181,14 @@ func (d *RuleDecider) SetPrefetchPlanFunc(fn PrefetchPlanFunc) {
 	d.prefetchFn = fn
 }
 
+// SetLoadAwarePrefetchPlanFunc installs the preferred load-aware planner.
+// When set, it takes precedence over the legacy PrefetchPlanFunc.
+func (d *RuleDecider) SetLoadAwarePrefetchPlanFunc(fn LoadAwarePrefetchPlanFunc) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.loadPrefetchFn = fn
+}
+
 // DecideRound implements the frozen Decider interface.
 func (d *RuleDecider) DecideRound(ctx context.Context, in RoundInput) (RoundPlan, error) {
 	d.mu.Lock()
@@ -178,8 +198,9 @@ func (d *RuleDecider) DecideRound(ctx context.Context, in RoundInput) (RoundPlan
 	active := withoutSuspended(in.ToolCalls, suspended)
 	action := decideBudgetAction(in.Budget)
 	tier, tierReason := decideTier(in.Intent, active, d.cfg)
+	groups := d.partition(active)
 	plan := RoundPlan{
-		ParallelGroups: d.partition(active),
+		ParallelGroups: groups,
 		Tier:           tier,
 		TierReason:     tierReason,
 		InjectIDs:      canonicalInjectIDs(in.SliceHits, d.cfg.InjectMax),
@@ -187,17 +208,40 @@ func (d *RuleDecider) DecideRound(ctx context.Context, in RoundInput) (RoundPlan
 		MaxParallel:    d.cfg.MaxParallel,
 		BudgetAction:   action,
 	}
-	if d.prefetchFn != nil {
+	if d.loadPrefetchFn != nil {
+		hint := normalizedPrefetchLoad(in.PrefetchLoad, groups, d.cfg.MaxParallel)
+		result := d.loadPrefetchFn(toolNames(active), hint)
+		plan.PrefetchIDs = result.IDs
+		plan.PrefetchReason = result.Reason
+	} else if d.prefetchFn != nil {
 		plan.PrefetchIDs = d.prefetchFn(toolNames(active))
 	}
 	if action == BudgetActionHaltPrefetch || action == BudgetActionHardStop {
 		plan.PrefetchIDs = nil
+		plan.PrefetchReason = "budget:" + action
 	}
 	if action == BudgetActionDegradeTier {
 		plan.Tier = d.cfg.DefaultTier
 		plan.TierReason = "budget:" + BudgetActionDegradeTier
 	}
 	return plan, nil
+}
+
+func normalizedPrefetchLoad(hint PrefetchLoadHint, groups [][]string, maxParallel int) PrefetchLoadHint {
+	if hint.ConcurrencyLimit <= 0 {
+		hint.ConcurrencyLimit = maxParallel
+	}
+	if hint.ConcurrencyUsed <= 0 {
+		for _, group := range groups {
+			if len(group) > hint.ConcurrencyUsed {
+				hint.ConcurrencyUsed = len(group)
+			}
+		}
+	}
+	if hint.ConcurrencyUsed > hint.ConcurrencyLimit && hint.ConcurrencyLimit > 0 {
+		hint.ConcurrencyUsed = hint.ConcurrencyLimit
+	}
+	return hint
 }
 
 func canonicalNames(names []string) []string {

--- a/kernel/sched/rule_decider_test.go
+++ b/kernel/sched/rule_decider_test.go
@@ -314,7 +314,7 @@ func TestRoundPlanJSONKeepsLegacyNamesAndOmitsZeroExtensions(t *testing.T) {
 	if !strings.Contains(text, `"ParallelGroups"`) || !strings.Contains(text, `"Tier"`) {
 		t.Fatalf("legacy field names changed: %s", text)
 	}
-	for _, field := range []string{"tierReason", "suspendTools", "maxParallel", "budgetAction"} {
+	for _, field := range []string{"tierReason", "prefetchReason", "suspendTools", "maxParallel", "budgetAction"} {
 		if strings.Contains(text, field) {
 			t.Fatalf("zero extension %q was not omitted: %s", field, text)
 		}
@@ -378,6 +378,49 @@ func TestPrefetchPlanFuncNil(t *testing.T) {
 	}})
 	if plan.PrefetchIDs != nil {
 		t.Fatalf("want nil prefetch, got %v", plan.PrefetchIDs)
+	}
+}
+
+func TestLoadAwarePrefetchReceivesNormalizedLoad(t *testing.T) {
+	d := NewRuleDecider(Config{MaxParallel: 5})
+	var got PrefetchLoadHint
+	d.SetLoadAwarePrefetchPlanFunc(func(_ []string, hint PrefetchLoadHint) PrefetchPlanResult {
+		got = hint
+		return PrefetchPlanResult{Reason: "load_saturated"}
+	})
+	calls := []ToolCallInfo{
+		call("a", "read_a", true), call("b", "read_b", true),
+		call("c", "read_c", true), call("d", "read_d", true),
+	}
+	plan, err := d.DecideRound(context.Background(), RoundInput{
+		ToolCalls:    calls,
+		PrefetchLoad: PrefetchLoadHint{WaitWindowMS: 100, TaskEstimateMS: 20},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ConcurrencyUsed != 4 || got.ConcurrencyLimit != 5 || got.WaitWindowMS != 100 {
+		t.Fatalf("normalized hint = %+v", got)
+	}
+	if plan.PrefetchReason != "load_saturated" || plan.PrefetchIDs != nil {
+		t.Fatalf("plan = %+v", plan)
+	}
+}
+
+func TestBudgetPrefetchReasonOverridesCandidate(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	d.SetLoadAwarePrefetchPlanFunc(func(_ []string, _ PrefetchLoadHint) PrefetchPlanResult {
+		return PrefetchPlanResult{IDs: []string{"read_file"}, Reason: "candidate"}
+	})
+	plan, err := d.DecideRound(context.Background(), RoundInput{
+		ToolCalls: []ToolCallInfo{call("a", "read_a", true)},
+		Budget:    BudgetState{LimitUSD: 1, SpentUSD: 0.7},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.PrefetchIDs != nil || plan.PrefetchReason != "budget:halt_prefetch" {
+		t.Fatalf("plan = %+v", plan)
 	}
 }
 

--- a/kernel/sched/sched.go
+++ b/kernel/sched/sched.go
@@ -15,6 +15,16 @@ type RoundInput struct {
 	Concurrency    int // available slots
 	SuspendedTools []string
 	Budget         BudgetState
+	PrefetchLoad   PrefetchLoadHint
+}
+
+// PrefetchLoadHint is the scheduler-facing, dependency-neutral load snapshot.
+// Millisecond fields are zero when the harness has no history yet.
+type PrefetchLoadHint struct {
+	ConcurrencyUsed  int
+	ConcurrencyLimit int
+	WaitWindowMS     int64
+	TaskEstimateMS   int64
 }
 
 // BudgetState is the scheduler's read-only view of the resource catalog.
@@ -41,6 +51,7 @@ type RoundPlan struct {
 	TierReason     string     `json:"tierReason,omitempty"` // stable explanation; does not affect execution
 	InjectIDs      []string   // L2 slice IDs in canonical order
 	PrefetchIDs    []string   // prefetch targets (may be empty)
+	PrefetchReason string     `json:"prefetchReason,omitempty"`
 	SuspendTools   []string   `json:"suspendTools,omitempty"`
 	MaxParallel    int        `json:"maxParallel,omitempty"`  // 0 = harness default; >0 = forced cap
 	BudgetAction   string     `json:"budgetAction,omitempty"` // one of BudgetAction* below


### PR DESCRIPTION
## Summary

- preserve the frozen Prefetcher.Plan interface and add an optional load-aware extension
- skip speculative planning at 80% slot saturation or when the known wait window is shorter than the known warm cost
- carry stable prefetch reasons through RoundPlan and retain legacy callbacks
- measure provider wait and real injection-warm duration in the harness
- block real warm-up only for explicit load/window/budget skip reasons; cold start, no-candidate, planner errors, and legacy deciders remain fail-open
- count load-aware outcomes without emitting false PrefetchWaste events

## Data flow

1. harness records the preceding stream duration and warm duration
2. sched derives slot occupancy from the current parallel groups and configured cap
3. prefetch evaluates the optional LoadHint before candidate ranking
4. RoundPlan carries PrefetchIDs plus PrefetchReason
5. the following stream honors only explicit skip reasons

## Commits

1. docs(spec): define load-aware prefetch gate (#271)
2. feat(prefetch): add optional load-aware planning (#271)
3. feat(sched): carry prefetch load and decision reason (#271)
4. feat(harness): gate real warm-up on load decisions (#271)

## Verification

- go test -race ./kernel/prefetch ./kernel/sched
- go test ./harness/agent
- focused scheduler/load-gate/turn-boundary regressions
- go vet ./kernel/prefetch ./kernel/sched ./harness/agent
- full diff review; removed unrelated gofmt drift and restored fail-open behavior for normal no-candidate rounds

## Non-goals

- provider-fleet-wide load prediction
- learned routing
- cancellation of an already-running warm
- dynamic tuning of the 80% default
- recording skips as hit/waste feedback

Closes #271