### PR TITLE
feat: compress extracted slices deterministically (#276)

### DIFF
--- a/cmd/semantix/extract.go
+++ b/cmd/semantix/extract.go
@@ -132,8 +132,31 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 		stored++
 	}
 
-	fmt.Fprintf(stdout, "extracted=%d stored=%d scope=%s db=%s\n", len(items), stored, scopeName(scope), dbPath)
+	rawBytes, storedBytes, compressionRatio := extractionCompression(items)
+	fmt.Fprintf(stdout, "extracted=%d stored=%d scope=%s db=%s raw_bytes=%d stored_bytes=%d compression_ratio=%.4f\n",
+		len(items), stored, scopeName(scope), dbPath, rawBytes, storedBytes, compressionRatio)
 	return nil
+}
+
+func extractionCompression(items []*slice.Slice) (rawBytes, storedBytes int, ratio float64) {
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		stored := len(item.Content)
+		raw := stored
+		meta := item.Meta
+		if meta.CompressionVersion != "" && meta.OriginalBytes > 0 &&
+			meta.StoredBytes == stored && meta.OriginalBytes >= meta.StoredBytes {
+			raw = meta.OriginalBytes
+		}
+		rawBytes += raw
+		storedBytes += stored
+	}
+	if rawBytes > 0 {
+		ratio = float64(rawBytes-storedBytes) / float64(rawBytes)
+	}
+	return rawBytes, storedBytes, ratio
 }
 
 func readInput(path string) ([]byte, error) {

--- a/cmd/semantix/extract.go
+++ b/cmd/semantix/extract.go
@@ -118,6 +118,7 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 	defer closeStore(store)
 
 	stored := 0
+	storedItems := make([]*slice.Slice, 0, len(items))
 	for i, item := range items {
 		if item == nil {
 			return fmt.Errorf("extractor returned nil slice at position %d", i)
@@ -130,9 +131,10 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 			return fmt.Errorf("store slice %q: %w", item.ID, err)
 		}
 		stored++
+		storedItems = append(storedItems, item)
 	}
 
-	rawBytes, storedBytes, compressionRatio := extractionCompression(items)
+	rawBytes, storedBytes, compressionRatio := extractionCompression(storedItems)
 	fmt.Fprintf(stdout, "extracted=%d stored=%d scope=%s db=%s raw_bytes=%d stored_bytes=%d compression_ratio=%.4f\n",
 		len(items), stored, scopeName(scope), dbPath, rawBytes, storedBytes, compressionRatio)
 	return nil

--- a/cmd/semantix/extract_compression_test.go
+++ b/cmd/semantix/extract_compression_test.go
@@ -27,6 +27,16 @@ func TestExtractReportsAggregateCompression(t *testing.T) {
 			},
 		},
 		{ID: "legacy", Content: []byte("legacy")},
+		{
+			ID:      "filtered-context",
+			Type:    slice.Context,
+			Content: []byte("x"),
+			Meta: slice.SliceMeta{
+				CompressionVersion: "rules-v1",
+				OriginalBytes:      100,
+				StoredBytes:        1,
+			},
+		},
 	}}
 	store := newFakeStore()
 	deps := dependencies{
@@ -36,7 +46,7 @@ func TestExtractReportsAggregateCompression(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"extract", "--input", input, "--db", filepath.Join(t.TempDir(), "slices.db")}, &stdout, &stderr, deps)
+	code := run([]string{"extract", "--input", input, "--scope", "user", "--db", filepath.Join(t.TempDir(), "slices.db")}, &stdout, &stderr, deps)
 	if code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
@@ -44,6 +54,9 @@ func TestExtractReportsAggregateCompression(t *testing.T) {
 		if !strings.Contains(stdout.String(), field) {
 			t.Fatalf("stdout = %q, missing %q", stdout.String(), field)
 		}
+	}
+	if store.items["filtered-context"] != nil {
+		t.Fatal("filtered Context slice was unexpectedly stored")
 	}
 }
 

--- a/cmd/semantix/extract_compression_test.go
+++ b/cmd/semantix/extract_compression_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/slice"
+)
+
+func TestExtractReportsAggregateCompression(t *testing.T) {
+	input := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(input, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	extractor := &fakeExtractor{items: []*slice.Slice{
+		{
+			ID:      "compressed",
+			Content: []byte("short"),
+			Meta: slice.SliceMeta{
+				CompressionVersion: "rules-v1",
+				OriginalBytes:      10,
+				StoredBytes:        5,
+			},
+		},
+		{ID: "legacy", Content: []byte("legacy")},
+	}}
+	store := newFakeStore()
+	deps := dependencies{
+		newExtractor: func() slice.Extractor { return extractor },
+		openStore:    func(string) (slice.Store, error) { return store, nil },
+		newIndex:     func() slice.Index { return bm25.New() },
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"extract", "--input", input, "--db", filepath.Join(t.TempDir(), "slices.db")}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	for _, field := range []string{"raw_bytes=16", "stored_bytes=11", "compression_ratio=0.3125"} {
+		if !strings.Contains(stdout.String(), field) {
+			t.Fatalf("stdout = %q, missing %q", stdout.String(), field)
+		}
+	}
+}
+
+func TestExtractionCompressionRejectsInconsistentMetadata(t *testing.T) {
+	items := []*slice.Slice{{
+		Content: []byte("content"),
+		Meta: slice.SliceMeta{
+			CompressionVersion: "rules-v1",
+			OriginalBytes:      100,
+			StoredBytes:        3,
+		},
+	}}
+	raw, stored, ratio := extractionCompression(items)
+	if raw != 7 || stored != 7 || ratio != 0 {
+		t.Fatalf("stats = raw %d stored %d ratio %.4f, want 7/7/0", raw, stored, ratio)
+	}
+}

--- a/docs/specs/issue-276-extract-compression.md
+++ b/docs/specs/issue-276-extract-compression.md
@@ -46,7 +46,7 @@ compression metadata.
 ## Observability
 
 `semantix extract` reports aggregate `raw_bytes`, `stored_bytes`, and
-`compression_ratio` for the slices it extracted. `compression_ratio` is the
+`compression_ratio` for the slices it successfully stores. `compression_ratio` is the
 fraction saved, `(raw_bytes - stored_bytes) / raw_bytes`, from 0 to 1. Slices
 without compression metadata count their current content bytes as both raw and
 stored bytes.

--- a/docs/specs/issue-276-extract-compression.md
+++ b/docs/specs/issue-276-extract-compression.md
@@ -22,7 +22,8 @@ Rules run in this order before the existing Prompt/Result byte limit is applied:
 3. Collapse consecutive blank lines to one blank line.
 4. Collapse consecutive identical non-empty lines to one line.
 5. Remove lines made only from at least three Markdown decoration characters
-   (`-`, `*`, `_`, `=`, `~`, or `#`). Backtick code fences are never decoration.
+   (`-`, `*`, `_`, `=`, `~`, or `#`). Content inside backtick or tilde code
+   fences is exempt from rules 3-5 so code and log evidence remain exact.
 6. If the result still exceeds the slice byte limit, retain a UTF-8-safe head
    and tail separated by the fixed marker `\n...[content compacted]...\n`.
 

--- a/docs/specs/issue-276-extract-compression.md
+++ b/docs/specs/issue-276-extract-compression.md
@@ -45,8 +45,10 @@ compression metadata.
 ## Observability
 
 `semantix extract` reports aggregate `raw_bytes`, `stored_bytes`, and
-`compression_ratio` for the slices it extracted. Slices without compression
-metadata count their current content bytes as both raw and stored bytes.
+`compression_ratio` for the slices it extracted. `compression_ratio` is the
+fraction saved, `(raw_bytes - stored_bytes) / raw_bytes`, from 0 to 1. Slices
+without compression metadata count their current content bytes as both raw and
+stored bytes.
 
 The model-call usage log remains unchanged: extraction compression is not an
 LLM request and must not be mixed into token or billing statistics.

--- a/docs/specs/issue-276-extract-compression.md
+++ b/docs/specs/issue-276-extract-compression.md
@@ -19,12 +19,13 @@ Rules run in this order before the existing Prompt/Result byte limit is applied:
 
 1. Normalize CRLF and CR line endings to LF.
 2. Remove trailing spaces and tabs from every line.
-3. Collapse consecutive blank lines to one blank line.
-4. Collapse consecutive identical non-empty lines to one line.
-5. Remove lines made only from at least three Markdown decoration characters
+3. Detect backtick and tilde code fences.
+4. Remove lines made only from at least three Markdown decoration characters
    (`-`, `*`, `_`, `=`, `~`, or `#`). Content inside backtick or tilde code
-   fences is exempt from rules 3-5 so code and log evidence remain exact.
-6. If the result still exceeds the slice byte limit, retain a UTF-8-safe head
+   fences is exempt from rules 4-6 so code and log evidence remain exact.
+5. Collapse consecutive blank lines to one blank line.
+6. Collapse consecutive identical non-empty lines to one line.
+7. If the result still exceeds the slice byte limit, retain a UTF-8-safe head
    and tail separated by the fixed marker `\n...[content compacted]...\n`.
 
 The output is trimmed at its outer edges. The compressor is a pure function and
@@ -46,10 +47,10 @@ compression metadata.
 ## Observability
 
 `semantix extract` reports aggregate `raw_bytes`, `stored_bytes`, and
-`compression_ratio` for the slices it successfully stores. `compression_ratio` is the
-fraction saved, `(raw_bytes - stored_bytes) / raw_bytes`, from 0 to 1. Slices
-without compression metadata count their current content bytes as both raw and
-stored bytes.
+`compression_ratio` for the slices it successfully stores. `compression_ratio`
+is the fraction saved, `(raw_bytes - stored_bytes) / raw_bytes`, from 0 to 1.
+Slices without compression metadata count their current content bytes as both
+raw and stored bytes.
 
 The model-call usage log remains unchanged: extraction compression is not an
 LLM request and must not be mixed into token or billing statistics.

--- a/docs/specs/issue-276-extract-compression.md
+++ b/docs/specs/issue-276-extract-compression.md
@@ -1,0 +1,67 @@
+# Issue 276: deterministic extraction compression
+
+## Status
+
+Accepted for implementation. This spec covers rule-based compression applied
+only while new Prompt and Result slices are extracted.
+
+## Goals
+
+- Increase useful content per injection byte without an LLM rewrite.
+- Keep extraction deterministic: identical input and metadata produce identical
+  content, IDs, and compression metadata.
+- Preserve both ends of oversized content instead of always discarding the tail.
+- Make compression observable without changing model-usage accounting.
+
+## Rules (`rules-v1`)
+
+Rules run in this order before the existing Prompt/Result byte limit is applied:
+
+1. Normalize CRLF and CR line endings to LF.
+2. Remove trailing spaces and tabs from every line.
+3. Collapse consecutive blank lines to one blank line.
+4. Collapse consecutive identical non-empty lines to one line.
+5. Remove lines made only from at least three Markdown decoration characters
+   (`-`, `*`, `_`, `=`, `~`, or `#`). Backtick code fences are never decoration.
+6. If the result still exceeds the slice byte limit, retain a UTF-8-safe head
+   and tail separated by the fixed marker `\n...[content compacted]...\n`.
+
+The output is trimmed at its outer edges. The compressor is a pure function and
+does not inspect time, environment, model output, or repository state.
+
+## Persistence and compatibility
+
+For compressed source text, `SliceMeta` stores:
+
+- `compression_version`: `rules-v1`;
+- `original_bytes`: source bytes before rule application;
+- `stored_bytes`: bytes used to derive the slice ID and persisted content.
+
+Compression happens before content-hash ID generation. Existing stored slices
+are not migrated or rewritten; metadata fields are additive and absent on
+legacy slices. Generated Context and ToolPattern slices do not claim source-text
+compression metadata.
+
+## Observability
+
+`semantix extract` reports aggregate `raw_bytes`, `stored_bytes`, and
+`compression_ratio` for the slices it extracted. Slices without compression
+metadata count their current content bytes as both raw and stored bytes.
+
+The model-call usage log remains unchanged: extraction compression is not an
+LLM request and must not be mixed into token or billing statistics.
+
+## Non-goals
+
+- LLM, LLMLingua, or summary-based rewriting.
+- Semantic deduplication of non-consecutive text.
+- Retrospective migration of existing slice stores.
+- A guarantee that every transcript compresses by a fixed percentage.
+
+## Verification
+
+- Repeated extraction produces identical content, IDs, and compression fields.
+- Output remains valid UTF-8 and within the Prompt/Result byte limits.
+- A noisy transcript fixture compresses by at least 30 percent.
+- Ordinary text, Context extraction, and ToolPattern extraction retain their
+  existing behavior.

--- a/kernel/slice/compress.go
+++ b/kernel/slice/compress.go
@@ -1,0 +1,102 @@
+package slice
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	compressionVersion = "rules-v1"
+	compactionMarker   = "\n...[content compacted]...\n"
+)
+
+// compressText applies the versioned, deterministic text rules documented in
+// docs/specs/issue-276-extract-compression.md and then enforces max bytes.
+func compressText(content string, max int) []byte {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+
+	lines := strings.Split(content, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		blank := strings.TrimSpace(line) == ""
+		if isMarkdownDecoration(line) {
+			continue
+		}
+		if len(kept) > 0 {
+			previous := kept[len(kept)-1]
+			if blank && strings.TrimSpace(previous) == "" {
+				continue
+			}
+			if !blank && line == previous {
+				continue
+			}
+		}
+		kept = append(kept, line)
+	}
+
+	compacted := []byte(strings.TrimSpace(strings.Join(kept, "\n")))
+	if len(compacted) <= max {
+		return compacted
+	}
+	return retainHeadAndTail(compacted, max)
+}
+
+func isMarkdownDecoration(line string) bool {
+	line = strings.TrimSpace(line)
+	if utf8.RuneCountInString(line) < 3 {
+		return false
+	}
+	for _, r := range line {
+		if !strings.ContainsRune("-*_=~#", r) {
+			return false
+		}
+	}
+	return true
+}
+
+func retainHeadAndTail(content []byte, max int) []byte {
+	if len(content) <= max {
+		return content
+	}
+	marker := []byte(compactionMarker)
+	if max <= len(marker) {
+		return utf8Prefix(content, max)
+	}
+
+	available := max - len(marker)
+	headBudget := available / 2
+	tailBudget := available - headBudget
+	head := utf8Prefix(content, headBudget)
+	tail := utf8Suffix(content, tailBudget)
+
+	out := make([]byte, 0, max)
+	out = append(out, head...)
+	out = append(out, marker...)
+	out = append(out, tail...)
+	return out
+}
+
+func utf8Prefix(content []byte, max int) []byte {
+	if len(content) <= max {
+		return content
+	}
+	prefix := content[:max]
+	for len(prefix) > 0 && !utf8.Valid(prefix) {
+		prefix = prefix[:len(prefix)-1]
+	}
+	return prefix
+}
+
+func utf8Suffix(content []byte, max int) []byte {
+	if len(content) <= max {
+		return content
+	}
+	suffix := content[len(content)-max:]
+	for len(suffix) > 0 && !utf8.Valid(suffix) {
+		suffix = suffix[1:]
+	}
+	return bytes.Clone(suffix)
+}

--- a/kernel/slice/compress.go
+++ b/kernel/slice/compress.go
@@ -19,8 +19,22 @@ func compressText(content string, max int) []byte {
 
 	lines := strings.Split(content, "\n")
 	kept := make([]string, 0, len(lines))
+	var fence byte
 	for _, line := range lines {
 		line = strings.TrimRight(line, " \t")
+		if delimiter := markdownFenceDelimiter(line); delimiter != 0 {
+			kept = append(kept, line)
+			if fence == 0 {
+				fence = delimiter
+			} else if fence == delimiter {
+				fence = 0
+			}
+			continue
+		}
+		if fence != 0 {
+			kept = append(kept, line)
+			continue
+		}
 		blank := strings.TrimSpace(line) == ""
 		if isMarkdownDecoration(line) {
 			continue
@@ -42,6 +56,20 @@ func compressText(content string, max int) []byte {
 		return compacted
 	}
 	return retainHeadAndTail(compacted, max)
+}
+
+func markdownFenceDelimiter(line string) byte {
+	line = strings.TrimSpace(line)
+	if len(line) < 3 {
+		return 0
+	}
+	if line[0] == '`' && line[1] == '`' && line[2] == '`' {
+		return '`'
+	}
+	if line[0] == '~' && line[1] == '~' && line[2] == '~' {
+		return '~'
+	}
+	return 0
 }
 
 func isMarkdownDecoration(line string) bool {

--- a/kernel/slice/compress_text_test.go
+++ b/kernel/slice/compress_text_test.go
@@ -1,0 +1,57 @@
+package slice
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestCompressTextRulesAreDeterministic(t *testing.T) {
+	input := "title  \r\n\r\n\r\n---\r\nrepeat\r\nrepeat\r\n```\r\ncode  \r\n```\r\n"
+	want := "title\n\nrepeat\n```\ncode\n```"
+
+	first := compressText(input, maxPromptLen)
+	second := compressText(input, maxPromptLen)
+	if string(first) != want {
+		t.Fatalf("compressed = %q, want %q", first, want)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("same input produced different bytes: %q vs %q", first, second)
+	}
+}
+
+func TestCompressTextNoisyFixtureSavesAtLeastThirtyPercent(t *testing.T) {
+	input := strings.Repeat("useful result   \nuseful result   \n\n\n***\n", 40)
+	got := compressText(input, maxResultLen)
+	if len(got)*10 > len(input)*7 {
+		t.Fatalf("compressed %d bytes from %d, want at least 30%% reduction", len(got), len(input))
+	}
+	if !strings.Contains(string(got), "useful result") {
+		t.Fatalf("useful content was removed: %q", got)
+	}
+}
+
+func TestCompressTextOversizeRetainsUTF8HeadAndTail(t *testing.T) {
+	input := "开头-" + strings.Repeat("中", 100) + "-结尾"
+	got := compressText(input, 80)
+	if len(got) > 80 {
+		t.Fatalf("compressed length = %d, want <= 80", len(got))
+	}
+	if !utf8.Valid(got) {
+		t.Fatalf("compressed output is invalid UTF-8: %q", got)
+	}
+	if !strings.HasPrefix(string(got), "开头-") || !strings.HasSuffix(string(got), "-结尾") {
+		t.Fatalf("head or tail missing: %q", got)
+	}
+	if !strings.Contains(string(got), strings.TrimSpace(compactionMarker)) {
+		t.Fatalf("compaction marker missing: %q", got)
+	}
+}
+
+func TestCompressTextSmallLimitStaysValid(t *testing.T) {
+	got := compressText(strings.Repeat("界", 10), 5)
+	if len(got) > 5 || !utf8.Valid(got) {
+		t.Fatalf("small-limit output = %q (%d bytes)", got, len(got))
+	}
+}

--- a/kernel/slice/compress_text_test.go
+++ b/kernel/slice/compress_text_test.go
@@ -21,6 +21,16 @@ func TestCompressTextRulesAreDeterministic(t *testing.T) {
 	}
 }
 
+func TestCompressTextPreservesFencedContent(t *testing.T) {
+	for _, fence := range []string{"```", "~~~"} {
+		input := fence + "text\nrepeat\nrepeat\n\n\n---\n" + fence
+		got := string(compressText(input, maxPromptLen))
+		if got != input {
+			t.Fatalf("fence %q content changed:\ngot  %q\nwant %q", fence, got, input)
+		}
+	}
+}
+
 func TestCompressTextNoisyFixtureSavesAtLeastThirtyPercent(t *testing.T) {
 	input := strings.Repeat("useful result   \nuseful result   \n\n\n***\n", 40)
 	got := compressText(input, maxResultLen)

--- a/kernel/slice/compression_extractor_test.go
+++ b/kernel/slice/compression_extractor_test.go
@@ -1,0 +1,88 @@
+package slice
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestExtractCompressionMetadataAndIDAreDeterministic(t *testing.T) {
+	content := "answer   \n\n\n---\nanswer   \nanswer   \nuseful tail"
+	transcript := []byte(`{"role":"user","content":"question"}` + "\n" +
+		`{"role":"assistant","content":` + quoteJSON(content) + `}`)
+	meta := SliceMeta{SourceSession: "session-1"}
+
+	first, err := NewExtractor().Extract(transcript, meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewExtractor().Extract(transcript, meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("slice counts differ: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i].ID != second[i].ID || !reflect.DeepEqual(first[i].Content, second[i].Content) ||
+			!reflect.DeepEqual(first[i].Meta, second[i].Meta) {
+			t.Fatalf("slice %d is not deterministic:\n%+v\n%+v", i, first[i], second[i])
+		}
+	}
+
+	result := sliceOfType(first, Result)
+	if result == nil {
+		t.Fatal("result slice missing")
+	}
+	if result.Meta.CompressionVersion != compressionVersion {
+		t.Fatalf("compression version = %q", result.Meta.CompressionVersion)
+	}
+	if result.Meta.OriginalBytes != len([]byte(content)) || result.Meta.StoredBytes != len(result.Content) {
+		t.Fatalf("compression bytes = original %d stored %d; content=%d", result.Meta.OriginalBytes, result.Meta.StoredBytes, len(result.Content))
+	}
+	if string(result.Content) != "answer\n\nanswer\nuseful tail" {
+		t.Fatalf("result content = %q", result.Content)
+	}
+}
+
+func TestExtractCompressionKeepsOrdinaryTextAndLimits(t *testing.T) {
+	ordinary := []byte(`{"role":"user","content":"keep this ordinary sentence"}`)
+	items, err := NewExtractor().Extract(ordinary, SliceMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := sliceOfType(items, Prompt)
+	if prompt == nil || string(prompt.Content) != "keep this ordinary sentence" {
+		t.Fatalf("ordinary prompt changed: %+v", prompt)
+	}
+
+	long := "开头-" + strings.Repeat("文", maxResultLen) + "-结尾"
+	transcript := []byte(`{"role":"assistant","content":` + quoteJSON(long) + `}`)
+	items, err = NewExtractor().Extract(transcript, SliceMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := sliceOfType(items, Result)
+	if result == nil || len(result.Content) > maxResultLen || !utf8.Valid(result.Content) {
+		t.Fatalf("bounded result invalid: %+v", result)
+	}
+	if !strings.HasPrefix(string(result.Content), "开头-") || !strings.HasSuffix(string(result.Content), "-结尾") {
+		t.Fatalf("bounded result lost head or tail: %q", result.Content)
+	}
+}
+
+func sliceOfType(items []*Slice, typ SliceType) *Slice {
+	for _, item := range items {
+		if item.Type == typ {
+			return item
+		}
+	}
+	return nil
+}
+
+func quoteJSON(value string) string {
+	quoted, _ := json.Marshal(value)
+	return string(quoted)
+}

--- a/kernel/slice/extractor.go
+++ b/kernel/slice/extractor.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	kernelevent "semantix/kernel/event"
 )
@@ -334,11 +333,11 @@ func parseTranscript(data []byte) ([]transcriptLine, error) {
 func promptSlice(turn []transcriptLine, meta SliceMeta) *Slice {
 	for _, l := range turn {
 		if l.Role == "user" {
-			content := strings.TrimSpace(l.Content)
-			if content == "" {
+			content := compressText(l.Content, maxPromptLen)
+			if len(content) == 0 {
 				return nil
 			}
-			return newSlice(Prompt, Project, truncate([]byte(content), maxPromptLen), meta)
+			return newSlice(Prompt, Project, content, compressionMeta(meta, l.Content, content))
 		}
 	}
 	return nil
@@ -365,26 +364,21 @@ func finalResultSlice(lines []transcriptLine, meta SliceMeta) *Slice {
 	for i := len(lines) - 1; i >= 0; i-- {
 		l := lines[i]
 		if l.Role == "assistant" && len(l.ToolCalls) == 0 {
-			content := strings.TrimSpace(l.Content)
-			if content == "" {
+			content := compressText(l.Content, maxResultLen)
+			if len(content) == 0 {
 				return nil
 			}
-			return newSlice(Result, Project, truncate([]byte(content), maxResultLen), meta)
+			return newSlice(Result, Project, content, compressionMeta(meta, l.Content, content))
 		}
 	}
 	return nil
 }
 
-func truncate(b []byte, max int) []byte {
-	if len(b) <= max {
-		return b
-	}
-	b = b[:max]
-	// Avoid cutting mid-rune: back off to the last valid UTF-8 boundary.
-	for len(b) > 0 && !utf8.Valid(b) {
-		b = b[:len(b)-1]
-	}
-	return b
+func compressionMeta(meta SliceMeta, original string, stored []byte) SliceMeta {
+	meta.CompressionVersion = compressionVersion
+	meta.OriginalBytes = len([]byte(original))
+	meta.StoredBytes = len(stored)
+	return meta
 }
 
 func newSlice(t SliceType, sc Scope, content []byte, meta SliceMeta) *Slice {

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -94,6 +94,14 @@ type SliceMeta struct {
 	TaskType      string
 	Language      string
 	ProjectSlug   string
+	// CompressionVersion identifies the deterministic extraction rules applied
+	// before Content and its hash-derived ID were produced. Empty means a
+	// legacy or generated slice that did not pass through source compression.
+	CompressionVersion string `json:"compression_version,omitempty"`
+	// OriginalBytes and StoredBytes make extraction compression observable
+	// without mixing non-LLM work into the model usage ledger.
+	OriginalBytes int `json:"original_bytes,omitempty"`
+	StoredBytes   int `json:"stored_bytes,omitempty"`
 	// Deps captures the dependency fingerprint at slice time (path -> sha256,
 	// Issue #8): reuse is gated on these files not having changed.
 	Deps fingerprint.Deps `json:"deps,omitempty"`


### PR DESCRIPTION
## Summary
- add a versioned `rules-v1` extraction-compression spec
- deterministically remove whitespace, decoration, and consecutive duplicate noise while preserving fenced code/log evidence
- replace tail-only truncation with UTF-8-safe head/tail retention
- persist compression provenance and byte counts on newly extracted Prompt/Result slices
- report persisted `raw_bytes`, `stored_bytes`, and saved `compression_ratio` from `semantix extract`

## Compatibility
- compression runs only before new Prompt/Result slices are stored
- existing slice stores are not migrated or rewritten
- Context and ToolPattern slices keep their existing generation path
- model usage/billing events are unchanged
- LLM-based compression is intentionally out of scope

## Verification
- `go test -race ./kernel/slice -run '^(TestCompressText|TestExtractCompression|TestExtractOversize|TestExtractTurnSlices|TestExtractToolPattern|TestExtractDedup)' -count=1`
- `go test -race ./cmd/semantix -run '^(TestExtractReportsAggregateCompression|TestExtractionCompressionRejectsInconsistentMetadata|TestExtractStoresSlicesInSelectedScope|TestExtractDoesNotStoreProjectContextInUserScope)$' -count=1`
- `go test ./kernel/slice -skip '^TestJournalForwardCompat$' -count=1`
- `go test ./cmd/semantix -run '(Extract|ExtractionCompression)' -skip '^TestExtractWithProductionDependencies$' -count=1`
- `go vet ./kernel/slice ./cmd/semantix`

## Local environment note
A full Windows run was attempted. Unrelated existing journal tests could not rename or clean still-open `.journal` files, and the first all-package build exhausted the nearly-full C: drive. Targeted verification was rerun with Go caches and temp files on D:. GitHub Linux CI is the authoritative full-suite check.

Closes #276