### PR TITLE
docs(readme): reflect Agile 2 close-out (v0.6.0) + GLM adaptation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 **Semantic Caching · Adaptive Scheduling · Speculative Prefetch · Cross-Session Learning**
 
 [![License: FSL-1.1-MIT](https://img.shields.io/badge/License-FSL--1.1--MIT-blue.svg?style=flat-square)](./LICENSE)
-[![Status](https://img.shields.io/badge/status-v0.3.1-green?style=flat-square)](#project-status)
-[![Version](https://img.shields.io/badge/release-0.3.1-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
+[![Status](https://img.shields.io/badge/status-v0.6.0-green?style=flat-square)](#project-status)
+[![Version](https://img.shields.io/badge/release-0.6.0-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
 [![GitHub stars](https://img.shields.io/github/stars/Gnosil/semantix?style=flat-square\&logo=github)](https://github.com/Gnosil/semantix/stargazers)
 [![GitHub contributors](https://img.shields.io/github/contributors/Gnosil/semantix?style=flat-square\&logo=github)](https://github.com/Gnosil/semantix/graphs/contributors)
 [![Website](https://img.shields.io/badge/website-semantix.ensureok.ai-168b6d?style=flat-square)](https://semantix.ensureok.ai)
@@ -1004,7 +1004,7 @@ Cross-project reuse must avoid leaking project-specific secrets or paths.
 
 # Project Status
 
-> **Semantix v0.3.1 is released** (2026-08-13), and **M2 CLI v2 (U19–U27) shipped** (2026-08-14): command tree, config wiring, `--json` envelope, shell completion, doctor, install, gc/export/import. The remaining gate before scaling up is **real-data validation of the cross-session hit rate**.
+> **Semantix v0.6.0 is released** (2026-08-21, "Agile 2 complete"), bundling `semantix-agent` + `semantix` + `semantix-gateway` for four platforms. **Agile 2 (self-evolving loop) is closed**: kernel-orchestrated scheduling, speculative prefetch, and the closed evolution loop (U37–U43) shipped, plus the first batch of GLM-5.x cache adaptation (prefix hygiene + per-provider hit metering, GLM P0). The remaining gate before scaling up is **real-data validation of the cross-session hit rate** (#58, Agile 1's v1.0 gate).
 
 Architecture specification v2 is complete.
 
@@ -1019,13 +1019,15 @@ Agile 1 · First downloadable agent   🚧 M0 ✅ · M1 near-complete (gate #58)
   · Observability (P0)               ✅  kernel/event + kernel/usage
   · Semantic Slice Library (P1)      🚧  extract + BM25/hybrid shipped ✅ · local embeddings + ANN pending
   · Semantic Cache (P2)              🚧  L2 + L3 shipped ✅ · real-harness e2e pending
-  · bundle + reuse visualization     🚧  v0.3.1 shipped; CLI reuse viz (U28–U31) ✅ · H4 UI pending
+  · bundle + reuse visualization     🚧  v0.6.0 shipped; CLI reuse viz (U28–U31) ✅ · H4 UI pending
 
-Agile 2 · Self-evolving loop          🚧 kernel-side MVP landed (M1-U18b); harness side pending
+Agile 2 · Self-evolving loop          ✅ shipped & released (v0.6.0, 2026-08-21) — U37–U43
   · Adaptive Scheduler (P3)           ✅  kernel/sched.RuleDecider (MVP)
   · Speculative Prefetch (P4)         ✅  Planner + MatrixPrefetcher + Runner (MVP)
-  · Evolution Loop (P5)               ✅  kernel/evolve (MVP); closed-loop wiring pending
-  · H2 ResourceLayer / H3 orchestration ⏳ blueprint only
+  · Evolution Loop (P5)               ✅  kernel/evolve; closed-loop wired (U43, causal curve)
+  · H2 ResourceLayer / H3 orchestration ✅ shipped (U37–U43)
+
+GLM adaptation · GLM-5.x provider     🚧 first-class provider, switchable w/ DeepSeek via `setup` · cache P0 shipped (v0.6.0) · P1/P2 planned
 
 Agile 3 · Multi-harness ecosystem     ⏳  paths documented (agent-skill/); no adapter shipped
 ```
@@ -1034,7 +1036,7 @@ Agile 3 · Multi-harness ecosystem     ⏳  paths documented (agent-skill/); no 
 
 **Gate**: M0-Gate passed conditionally (2026-08-09) — technical feasibility and cost savings (79.8% on synthetic replay, `docs/reports/m0-cost-comparison.md`) are verified; **real-data cross-session hit rate ≥ 70%** (`semantix verify`) is the remaining gate, per `docs/reports/m0-gate.md`.
 
-**Agile roadmap**: Agile 1 (first downloadable, brandable agent) is in progress — M0 shipped, M1 nearly complete, with #58 (real-data hit rate) as the remaining gate; Agile 2 (self-evolving loop) and Agile 3 (multi-harness ecosystem) are defined in [`docs/Agile路线图.md`](./docs/Agile路线图.md).
+**Agile roadmap**: Agile 1 (first downloadable, brandable agent) is in progress — M0 shipped, M1 nearly complete, with #58 (real-data hit rate) as the remaining gate. Agile 2 (self-evolving loop) shipped and released as **v0.6.0** (2026-08-21); Agile 3 (multi-harness ecosystem) is defined in [`docs/Agile路线图.md`](./docs/Agile路线图.md).
 
 ---
 
@@ -1045,7 +1047,7 @@ Execution is organized in **Agile cycles** — one downloadable milestone per Ag
 | Agile | Milestone                                               | Technical scope                              | Status                                                                 |
 | ----- | ------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------- |
 | **1** | First downloadable, brandable agent (v1.0)              | P0–P2 + bundle + reuse visualization (H4)     | 🚧 M0 ✅ · M1 near-complete · gate #58 · CLI v2 (U19–U27) ✅             |
-| **2** | Self-evolving loop — kernel orchestrates the harness    | P3–P5 + H2 ResourceLayer + H3 orchestration  | 🚧 kernel-side MVP landed (M1-U18b); harness side pending               |
+| **2** | Self-evolving loop — kernel orchestrates the harness    | P3–P5 + H2 ResourceLayer + H3 orchestration  | ✅ shipped & released (v0.6.0, 2026-08-21) — U37–U43                     |
 | **3** | Multi-harness ecosystem                                 | CLI install / serve / adapter contribution    | ⏳ paths documented; not started                                        |
 
 ### Technical phases (P0–P5) detail
@@ -1057,7 +1059,7 @@ Execution is organized in **Agile cycles** — one downloadable milestone per Ag
 | **P2** | Semantic cache — stable L2 injection, verified L3 reuse, pollution detection    | 🚧 L2 + L3 shipped ✅; real-harness e2e pending                      | 1        |
 | **P3** | Adaptive scheduler — intent classification, concurrency learning, model tier    | ✅ `kernel/sched.RuleDecider` MVP (M1-U18b); learning overlay pending | 2        |
 | **P4** | Speculative prefetch — T-Slice prediction, path patterns, budget control        | ✅ Planner + MatrixPrefetcher + Runner MVP (M1-U18b)                 | 2        |
-| **P5** | Evolution loop — online adaptation, offline optimization, ablation              | ✅ `kernel/evolve` MVP; closed-loop wiring + ablation pending        | 2        |
+| **P5** | Evolution loop — online adaptation, offline optimization, ablation              | ✅ `kernel/evolve`; closed-loop wired (U43, causal curve); ablation pending | 2        |
 
 Each stage should remain independently measurable.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,8 +7,8 @@
 **语义缓存 · 自适应调度 · 投机预取 · 跨会话学习**
 
 [![License: FSL-1.1-MIT](https://img.shields.io/badge/License-FSL--1.1--MIT-blue.svg?style=flat-square)](./LICENSE)
-[![Status](https://img.shields.io/badge/status-v0.3.1-green?style=flat-square)](#项目状态)
-[![Version](https://img.shields.io/badge/release-0.3.1-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
+[![Status](https://img.shields.io/badge/status-v0.6.0-green?style=flat-square)](#项目状态)
+[![Version](https://img.shields.io/badge/release-0.6.0-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
 [![GitHub stars](https://img.shields.io/github/stars/Gnosil/semantix?style=flat-square\&logo=github)](https://github.com/Gnosil/semantix/stargazers)
 [![Website](https://img.shields.io/badge/website-semantix.ensureok.ai-168b6d?style=flat-square)](https://semantix.ensureok.ai)
 
@@ -246,15 +246,15 @@ semantix install --target reasonix      # Reasonix fork 已内置集成
 
 ## 项目状态
 
-> **v0.3.1 已发布**，M2 CLI v2（命令树 / config / `--json` 信封 / completion / doctor / install / gc）已交付。规模化之前剩余的门槛是**真实数据的跨会话命中率验证**。
+> **v0.6.0 已发布**（2026-08-21，「Agile 2 完整落地」）：打包 `semantix-agent` + `semantix` + `semantix-gateway`，覆盖四平台。**Agile 2（自进化闭环）已收尾**——内核编排调度、投机预取、进化闭环接线（U37–U43）全部落地，并带上 GLM-5.x 缓存适配首批（前缀卫生 + per-provider 命中计量，GLM P0）。规模化之前剩余的门槛是**真实数据的跨会话命中率验证**（#58，Agile 1 的 v1.0 门禁）。
 
 | Agile | 里程碑 | 状态 |
 |---|---|---|
 | **1** | 首个可下载、可品牌化的 agent（v1.0） | 🚧 M0 ✅ · M1 接近完成（门禁 [#58](https://github.com/Gnosil/semantix/issues/58)）· CLI v2 ✅ · 复用可视化 CLI 侧 ✅ |
-| **2** | 自进化闭环——内核反向调配助手的并发 / 预算 / 模型档位 | 🚧 内核侧 MVP 已落地（sched/prefetch/evolve）；助手侧待接 |
+| **2** | 自进化闭环——内核反向调配助手的并发 / 预算 / 模型档位 | ✅ 完成并发布（v0.6.0，2026-08-21）：H2/H3 编排 + 进化闭环接线（U37–U43） |
 | **3** | 多助手生态——任意编程助手都能接入 | ⏳ 路径已文档化，未开始 |
 
-技术阶段 P0（可观测）✅ · P1（切片库）🚧 · P2（语义缓存）🚧 · P3（调度）✅ MVP · P4（预取）✅ MVP · P5（进化）✅ MVP。完整路线图见 [docs/Agile路线图.md](./docs/Agile路线图.md)。
+技术阶段 P0（可观测）✅ · P1（切片库）🚧 · P2（语义缓存）🚧 · P3（调度）✅ MVP · P4（预取）✅ MVP · P5（进化）✅ 闭环已接线（U43）。GLM-5.x 已作为一等 provider 接入（可与 DeepSeek 通过 `semantix setup` 切换），缓存适配 P0 已随 v0.6.0 落地，P1/P2 规划中。完整路线图见 [docs/Agile路线图.md](./docs/Agile路线图.md)。
 
 ### 参与验证（社区第一入口 👋）
 


### PR DESCRIPTION
## 背景
Song 确认 **Agile 2 已收尾**。核对权威路线图 `docs/Agile路线图.md`(§Agile 2 收尾 / §5 总览表):Agile 2(自进化闭环)DoD 三项全绿,**已随 v0.6.0「Agile 2 完整落地」发布(2026-08-21)**,仅剩 #245 挂账。

但两份 README 的状态区仍停留在 v0.3.1,把 Agile 2 描述为「内核侧 MVP;助手侧待接」,已过时。

## 改动
- **徽章**:status / release `0.3.1 → 0.6.0`(README.md + README.zh-CN.md)
- **Project Status / 项目状态**:改写为 v0.6.0 发布 + Agile 2 收尾(U37–U43)+ GLM-5.x 缓存适配首批(GLM P0);保留 #58 作为 Agile 1 的 v1.0 命中率门禁
- **状态 ascii 块 + 路线图表**:Agile 2 → ✅ shipped & released;H2/H3 编排 → ✅ shipped;P5 → 闭环已接线(U43)
- **新增 GLM 适配行**:GLM-5.x 已是一等 provider,可与 DeepSeek 通过 `semantix setup` 切换;缓存适配 P0 已落地,P1/P2 规划中
- 历史性「since v0.3.0 / shipped v0.3.1」标注保持不动(准确,指首发版本)

## 核对来源
- `docs/Agile路线图.md:17-18,98-100,156,163` — Agile 2 关账 + v0.6.0 发布
- GLM P0 issues #289–293 全部 CLOSED;`harness/provider/openai/openai.go` 确认 GLM 端到端接入

## 注意
未改动默认 provider(当前仍为 DeepSeek)。「下载默认 GLM」是另一件事,需改 `config.Default()`,不在本 PR 范围。