### PR TITLE
fix(kernel/judge): count judge call failures separately (Issue #245) [rebased #336]

### DIFF
--- a/cmd/semantix/calibrate.go
+++ b/cmd/semantix/calibrate.go
@@ -123,9 +123,13 @@ func runCalibrate(args []string, stdout io.Writer) int {
 	}
 	if runtime != nil {
 		fmt.Fprintln(stdout, "# runtime (usage log): gateway L3 decisions")
-		fmt.Fprintln(stdout, "l3_reuses\tl3_grey\tjudge_reject\tjudge_approved\trules_reject\tfingerprint_reject\tisolated_reject\tfalse_hits\tfalse_hit_rate_pct")
-		fmt.Fprintf(stdout, "%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
-			runtime.L3Reuses, runtime.L3GreyCandidates, runtime.L3JudgeReject,
+		// judge_error is a separate column from judge_reject on purpose: a judge
+		// that could not be reached is unavailability, not a verdict (Issue #245).
+		// Header, format string and argument list are three hand-maintained
+		// parallel lists with no compiler check — keep the positions aligned.
+		fmt.Fprintln(stdout, "l3_reuses\tl3_grey\tjudge_reject\tjudge_error\tjudge_approved\trules_reject\tfingerprint_reject\tisolated_reject\tfalse_hits\tfalse_hit_rate_pct")
+		fmt.Fprintf(stdout, "%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			runtime.L3Reuses, runtime.L3GreyCandidates, runtime.L3JudgeReject, runtime.L3JudgeError,
 			runtime.L3JudgeApproved, runtime.L3RulesReject, runtime.L3FingerprintReject,
 			runtime.L3IsolatedReject, runtime.L3FalseHits, runtime.rateText())
 	}
@@ -255,6 +259,7 @@ func runCalibrateRuntime(path string) (*calibrateRuntime, error) {
 		L3Reuses:            s.L3Reuses,
 		L3GreyCandidates:    s.L3GreyCandidates,
 		L3JudgeReject:       s.L3JudgeReject,
+		L3JudgeError:        s.L3JudgeError,
 		L3JudgeApproved:     s.L3JudgeApproved,
 		L3RulesReject:       s.L3RulesReject,
 		L3FingerprintReject: s.L3FingerprintReject,
@@ -310,6 +315,7 @@ type calibrateRuntime struct {
 	L3Reuses            int      `json:"l3_reuses"`
 	L3GreyCandidates    int      `json:"l3_grey_candidates"`
 	L3JudgeReject       int      `json:"l3_judge_reject"`
+	L3JudgeError        int      `json:"l3_judge_error"`
 	L3JudgeApproved     int      `json:"l3_judge_approved"`
 	L3RulesReject       int      `json:"l3_rules_reject"`
 	L3FingerprintReject int      `json:"l3_fingerprint_reject"`

--- a/cmd/semantix/calibrate_test.go
+++ b/cmd/semantix/calibrate_test.go
@@ -83,8 +83,14 @@ func TestCalibrateRuntimeOnly(t *testing.T) {
 	if !strings.Contains(o, "# runtime (usage log)") {
 		t.Errorf("runtime block header missing:\n%s", o)
 	}
-	// l3_reuses=1, false_hits=1 → rate 100.0 (1/1).
-	if !strings.Contains(o, "1\t0\t0\t0\t0\t0\t0\t1\t100.0") {
+	// The header and the data row are hand-maintained parallel lists with no
+	// compiler check, so pin both: a header edit that forgets the row (or vice
+	// versa) ships a silently misaligned report (Issue #245 added judge_error).
+	if !strings.Contains(o, "judge_reject\tjudge_error\tjudge_approved") {
+		t.Errorf("runtime header missing judge_error column:\n%s", o)
+	}
+	// l3_reuses=1, false_hits=1 → rate 100.0 (1/1). 10 columns since #245.
+	if !strings.Contains(o, "1\t0\t0\t0\t0\t0\t0\t0\t1\t100.0") {
 		t.Errorf("runtime row missing/wrong:\n%s", o)
 	}
 }

--- a/cmd/semantix/judge_error_test.go
+++ b/cmd/semantix/judge_error_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/judge"
+	"semantix/kernel/usage"
+)
+
+// Issue #245: a judge that could not be reached is unavailability, not a rule
+// rejection and not a decline. These tests pin the three CLI surfaces that
+// publish the counter, none of which had any judge assertion before.
+
+func writeJudgeErrorLog(t *testing.T) string {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "usage.jsonl")
+	r, err := usage.NewRecorder(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev := usage.Event{
+		SessionID: "s1", Turn: 1, TokensIn: 100,
+		L3GreyCandidates: 3, L3JudgeReject: 1, L3JudgeError: 2, L3RulesReject: 4,
+	}
+	if err := r.Append(ev); err != nil {
+		t.Fatal(err)
+	}
+	return logPath
+}
+
+func TestRunUsagePrintsJudgeError(t *testing.T) {
+	logPath := writeJudgeErrorLog(t)
+	var out bytes.Buffer
+	if code := runUsage([]string{"--db", logPath}, &out, productionDependencies()); code != 0 {
+		t.Fatalf("usage exit code = %d, want 0", code)
+	}
+	o := out.String()
+	if !strings.Contains(o, "l3_judge_error\t2") {
+		t.Errorf("l3_judge_error not printed:\n%s", o)
+	}
+	// The regression guard for the conflation: judge errors must not be folded
+	// back into the rule-rejection counter on the way out.
+	if !strings.Contains(o, "l3_rules_reject\t4") {
+		t.Errorf("l3_rules_reject must stay 4, judge errors are counted separately:\n%s", o)
+	}
+	if !strings.Contains(o, "l3_judge_reject\t1") {
+		t.Errorf("l3_judge_reject must stay 1:\n%s", o)
+	}
+}
+
+func TestRunUsageJSONCarriesJudgeError(t *testing.T) {
+	logPath := writeJudgeErrorLog(t)
+	var out bytes.Buffer
+	if code := runUsage([]string{"--db", logPath, "--json"}, &out, productionDependencies()); code != 0 {
+		t.Fatalf("usage --json exit code = %d, want 0", code)
+	}
+	var env struct {
+		Data struct {
+			L3JudgeError  int `json:"l3_judge_error"`
+			L3JudgeReject int `json:"l3_judge_reject"`
+			L3RulesReject int `json:"l3_rules_reject"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("--json output not parseable: %v\n%s", err, out.String())
+	}
+	if env.Data.L3JudgeError != 2 || env.Data.L3JudgeReject != 1 || env.Data.L3RulesReject != 4 {
+		t.Fatalf("data = %+v, want judge_error=2 judge_reject=1 rules_reject=4", env.Data)
+	}
+}
+
+func TestCalibrateRuntimeCarriesJudgeError(t *testing.T) {
+	logPath := writeJudgeErrorLog(t)
+	var out bytes.Buffer
+	if code := runCalibrate([]string{"--usage", logPath, "--json"}, &out); code != 0 {
+		t.Fatalf("calibrate --json exit code = %d, want 0", code)
+	}
+	var env struct {
+		Data struct {
+			Runtime struct {
+				L3JudgeError  int `json:"l3_judge_error"`
+				L3RulesReject int `json:"l3_rules_reject"`
+			} `json:"runtime"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("--json output not parseable: %v\n%s", err, out.String())
+	}
+	if env.Data.Runtime.L3JudgeError != 2 {
+		t.Fatalf("runtime.l3_judge_error = %d, want 2", env.Data.Runtime.L3JudgeError)
+	}
+	if env.Data.Runtime.L3RulesReject != 4 {
+		t.Fatalf("runtime.l3_rules_reject = %d, want 4 (unchanged by the split)", env.Data.Runtime.L3RulesReject)
+	}
+}
+
+// TestVerifyJudgeJSONKeysAreSnakeCase pins the verify --json judge block key
+// set for the first time. judge.Stats has no json tags, so marshaling it
+// directly leaked PascalCase keys into an otherwise snake_case envelope;
+// verifyJudgeJSON is the CLI-local DTO that fixes it.
+func TestVerifyJudgeJSONKeysAreSnakeCase(t *testing.T) {
+	b, err := json.Marshal(newVerifyJudgeJSON(judgeStatsFixture()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"confirmed", "rules_reject", "fingerprint",
+		"judge_reject", "judge_error", "judge_approved", "need_judge",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("judge block keys = %v, want exactly %v", keysOf(got), want)
+	}
+	for _, k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing key %q in judge block: %v", k, keysOf(got))
+		}
+	}
+	if got["judge_error"] != float64(7) {
+		t.Errorf("judge_error = %v, want 7", got["judge_error"])
+	}
+}
+
+func judgeStatsFixture() judge.Stats {
+	return judge.Stats{Confirmed: 1, RulesReject: 2, Fingerprint: 3, JudgeReject: 5, JudgeError: 7, JudgeApproved: 11, NeedJudge: 13}
+}
+
+func keysOf(m map[string]any) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/cmd/semantix/usage.go
+++ b/cmd/semantix/usage.go
@@ -34,6 +34,7 @@ type usageJSON struct {
 	// aggregates from the usage log.
 	L3GreyCandidates    int                 `json:"l3_grey_candidates"`
 	L3JudgeReject       int                 `json:"l3_judge_reject"`
+	L3JudgeError        int                 `json:"l3_judge_error"`
 	L3JudgeApproved     int                 `json:"l3_judge_approved"`
 	L3RulesReject       int                 `json:"l3_rules_reject"`
 	L3FingerprintReject int                 `json:"l3_fingerprint_reject"`
@@ -120,6 +121,7 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 			CostPaidUSD: s.CostPaidUSD, CostNoCacheUSD: s.CostNoCacheUSD,
 			SavingsUSD: s.SavingsUSD, SavingsRate: s.SavingsRate,
 			L3GreyCandidates: s.L3GreyCandidates, L3JudgeReject: s.L3JudgeReject,
+			L3JudgeError: s.L3JudgeError,
 			L3JudgeApproved: s.L3JudgeApproved, L3RulesReject: s.L3RulesReject,
 			L3FingerprintReject: s.L3FingerprintReject, L3IsolatedReject: s.L3IsolatedReject,
 			L3FalseHits: s.L3FalseHits,
@@ -157,6 +159,7 @@ func runUsage(args []string, stdout io.Writer, deps dependencies) int {
 	// cache must be distinguishable from a missing log via the events row.
 	fmt.Fprintf(stdout, "l3_grey_candidates\t%d\n", s.L3GreyCandidates)
 	fmt.Fprintf(stdout, "l3_judge_reject\t%d\n", s.L3JudgeReject)
+	fmt.Fprintf(stdout, "l3_judge_error\t%d\n", s.L3JudgeError)
 	fmt.Fprintf(stdout, "l3_judge_approved\t%d\n", s.L3JudgeApproved)
 	fmt.Fprintf(stdout, "l3_rules_reject\t%d\n", s.L3RulesReject)
 	fmt.Fprintf(stdout, "l3_fingerprint_reject\t%d\n", s.L3FingerprintReject)

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -48,9 +48,37 @@ type verifySummary struct {
 	RelevancePct   float64            `json:"relevance_pct"`
 	Icon           string             `json:"icon"`
 	WarnGrey       bool               `json:"warn_grey"`
-	Judge          *judge.Stats       `json:"judge,omitempty"`
+	Judge          *verifyJudgeJSON   `json:"judge,omitempty"`
 	Calibration    *verifyCalibration `json:"calibration,omitempty"`
 	Rows           []verifyRow        `json:"rows"`
+}
+
+// verifyJudgeJSON is the CLI-side wire shape for judge.Stats. The kernel type
+// carries no json tags, so marshaling it directly published PascalCase keys
+// ("NeedJudge", and — once Issue #245 landed — "JudgeError") into an envelope
+// that is snake_case everywhere else. Keeping the mapping here follows the
+// house rule already stated in search.go: the CLI owns its wire format and the
+// kernel type stays policy-free.
+type verifyJudgeJSON struct {
+	Confirmed     int `json:"confirmed"`
+	RulesReject   int `json:"rules_reject"`
+	Fingerprint   int `json:"fingerprint"`
+	JudgeReject   int `json:"judge_reject"`
+	JudgeError    int `json:"judge_error"`
+	JudgeApproved int `json:"judge_approved"`
+	NeedJudge     int `json:"need_judge"`
+}
+
+func newVerifyJudgeJSON(s judge.Stats) *verifyJudgeJSON {
+	return &verifyJudgeJSON{
+		Confirmed:     s.Confirmed,
+		RulesReject:   s.RulesReject,
+		Fingerprint:   s.Fingerprint,
+		JudgeReject:   s.JudgeReject,
+		JudgeError:    s.JudgeError,
+		JudgeApproved: s.JudgeApproved,
+		NeedJudge:     s.NeedJudge,
+	}
 }
 
 // verifyCalibration is the Issue #262 calibration report: the replay stream
@@ -640,7 +668,7 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 			summary.Calibration = cal
 		}
 		if *judgeProtocol != "" {
-			summary.Judge = &jstats
+			summary.Judge = newVerifyJudgeJSON(jstats)
 		}
 		if err := writeJSON(stdout, okEnvelope("verify", summary)); err != nil {
 			fmt.Fprintf(stdout, "verify: %v\n", err)
@@ -667,9 +695,12 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 		fmt.Fprintf(stdout, "# ⚠ WARN grey_ratio=%.1f%% exceeds target %.1f%%\n", greyRatio, *greyTarget)
 	}
 	if *judgeProtocol != "" {
-		fmt.Fprintf(stdout, "# judge: confirmed=%d rules_reject=%d fingerprint=%d judge_reject=%d judge_approved=%d waste=%d\n",
-			jstats.Confirmed, jstats.RulesReject, jstats.Fingerprint, jstats.JudgeReject, jstats.JudgeApproved,
-			jstats.JudgeReject+jstats.Fingerprint+jstats.RulesReject)
+		// waste keeps its pre-#245 meaning. Judge errors used to arrive inside
+		// RulesReject, so JudgeError must be added back into the total or this
+		// published number would silently shrink as a side effect of the split.
+		fmt.Fprintf(stdout, "# judge: confirmed=%d rules_reject=%d fingerprint=%d judge_reject=%d judge_error=%d judge_approved=%d waste=%d\n",
+			jstats.Confirmed, jstats.RulesReject, jstats.Fingerprint, jstats.JudgeReject, jstats.JudgeError, jstats.JudgeApproved,
+			jstats.JudgeReject+jstats.Fingerprint+jstats.RulesReject+jstats.JudgeError)
 	}
 	printVerifyCalibration(stdout, cal)
 	if *greyTarget > 0 && greyRatio > *greyTarget {

--- a/docs/reports/issue-262-acceptance.md
+++ b/docs/reports/issue-262-acceptance.md
@@ -20,7 +20,7 @@
 | 文件 | 变更 |
 |---|---|
 | `docs/specs/issue-262-l3-negative-observability.md` | 新增 spec v1:负向观测语义(拒绝四分类 + 误命中双口径)、usage.Event additive 契约、calibrate 契约、verify 分桶校准 §3.4、evolve 负向信号 §3.5、c1-c8 |
-| `kernel/cache/l3.go` | `Obs`(纯值快照)+ `ObsAccum`(线程安全累计)+ `OnDecide`(per-call 回调);`DecideL3` 全路径计数;Candidates/Grey/RulesReject/FingerprintReject/IsolatedReject/JudgeReject/JudgeApproved/Reused;`judgeGrey` 挂局部 `judge.Stats` 合并 |
+| `kernel/cache/l3.go` | `Obs`(纯值快照)+ `ObsAccum`(线程安全累计)+ `OnDecide`(per-call 回调);`DecideL3` 全路径计数;Candidates/Grey/RulesReject/FingerprintReject/IsolatedReject/JudgeReject/JudgeError/JudgeApproved/Reused;`judgeGrey` 挂局部 `judge.Stats` 合并 |
 | `kernel/usage/usage.go` | `Event` 新增 7 个 additive 字段(L3GreyCandidates/L3JudgeReject/L3JudgeApproved/L3RulesReject/L3FingerprintReject/L3IsolatedReject/L3FalseHit);`Summary` 对应聚合 |
 | `gateway/config.go` | `[cache] false_hit_sim`(默认 0.6,-1 关闭,validate 校验 NaN/Inf/越界) |
 | `gateway/gateway.go` | `l3Reuses map` + `reuseMu`(有界 1024 LRU);`New()` 初始化 |

--- a/docs/reports/verify-rubric.md
+++ b/docs/reports/verify-rubric.md
@@ -33,7 +33,7 @@
 
 - `kernel/judge` 已落地：RuleGate 三段路由 + Judge 接口 + NoopJudge（无模型时 grey 保守 Reject）。
 - **依赖指纹已接入**（`kernel/fingerprint`）：`extract --fingerprint <paths>` 采集 sha256 存入 `SliceMeta.Deps`；`RuleGate.Chain` 对带 Deps 的候选先跑指纹闸（变化 → 硬 Reject，零 LLM 成本）。
-- **waste++ 观测已接入**：`judge.Stats`（Confirmed/RulesReject/Fingerprint/JudgeReject/JudgeApproved），`verify --judge-*` 输出统计行。
+- **waste++ 观测已接入**：`judge.Stats`（Confirmed/RulesReject/Fingerprint/JudgeReject/JudgeError/JudgeApproved），`verify --judge-*` 输出统计行。
 - **LLM judge 已实现**（`kernel/judge/llm.go`，双协议）：用户自选 `openai`（chat completions）或 `anthropic`（Messages API），`--judge-base-url` + `--judge-model` 指向自己的端点/模型，API key 从环境变量 `SEMANTIX_JUDGE_API_KEY` 读取（绝不入库/入参）。
 
 ## 模型 judge 配置（用户操作）

--- a/docs/specs/issue-245-judge-error-counter.md
+++ b/docs/specs/issue-245-judge-error-counter.md
@@ -1,0 +1,221 @@
+# Spec v1 — judge 调用失败独立计数：JudgeError（Issue #245）
+
+> 判级：Spec-Required。本 spec 修复 `kernel/judge` 把「judge 调用出错」记入 `RulesReject`
+> 的口径污染，新增 `JudgeError` 计数并沿 #262 已铺好的观测链一路接到 CLI。基线为
+> `feat/issue-272-markov-metrics` @ `35c46ec`（#262 已合入，commit `80b76bc`）。
+> 不改任何判决行为——fail-closed 语义逐字保持，只改计数归属。
+
+## 0. 一句话
+
+judge 打不通和 judge 说「不」是两回事，现在它们记在同一个桶里；本期把前者拆成
+`JudgeError`，让观测方能区分「judge 拒绝」与「judge 不可用」。
+
+## 1. 现状与证据
+
+### 1.1 缺陷本体
+
+`kernel/judge` 的 `RuleGate.Chain` 在 `Judge.Confirm` 返回 error 时计入 `RulesReject`：
+
+```go
+ok, err := g.Judge.Confirm(ctx, c)
+if err != nil {
+    g.count(Stats{RulesReject: 1})            // ← 网络错误/超时/解析失败记成「规则拒」
+    return Reject, "judge error: conservative reject", err
+}
+```
+
+而 `RulesReject` 的字段注释是 `miss / grey-without-judge`。结果是 `JudgeReject`
+低估、`RulesReject` 高估，且这条污染会穿透整条 #262 观测链一路到 CLI。
+
+### 1.2 真源审计（2026-08-21，当前工作树）
+
+| 事实 | 锚点符号 | 证据 |
+|---|---|---|
+| judge error 记入 RulesReject | `kernel/judge/judge.go` `RuleGate.Chain` | 上方代码块 |
+| `Chain` 内 `if g.Judge == nil` 分支是死代码 | `kernel/judge/judge.go` `RuleGate.Chain` | `go test -covermode=count ./kernel/judge/` 输出块 `judge.go:131.20,136.3 2 0`（块体执行 0 次），其守卫 `judge.go:131.2,131.20 1 3` 求值 3 次 |
+| 死代码成因 | `RuleGate.Check` | `Check` 只在 `default:`（grey）分支且 `g.Judge != nil` 时返回 `NeedJudge`；`Chain` 的 `if v != NeedJudge { return }` 之后必然 `g.Judge != nil`。`Check`/`Chain` 均为值接收者，两次读的是同一份不可变副本；typed-nil 接口在两处对称，不构成例外 |
+| `kernel/judge` 自己的测试从不传 `Stats` | `RuleGate.count` | 覆盖率块 `judge.go:151.20,153.3 1 0`——`g.Stats.add(s)` 从未执行；`judge_test.go` 里 `Stats` 零匹配。计数语义目前只在三层之外的 `kernel/cache` 被间接验证 |
+| 污染跨包传播点 | `kernel/cache/l3.go` `L3Decider.judgeGrey` | 折叠块 `o.RulesReject += gs.RulesReject` 把 judge 故障并入 L3 的规则拒 |
+| `judgeGrey` 有两个调用臂 | `kernel/cache/l3.go` `DecideL3` | `zone.Grey` 分支，以及 Issue #260 的词法支持降级（`zone.Hit` 但 lexical support < `LexicalFloor`）也会走 judge。`JudgeError` 因此不是「grey 专属」计数 |
+| `Stats` 无 json tag，却已在 CLI 出网 | `cmd/semantix/verify.go` `verifySummary.Judge` | `Judge *judge.Stats \`json:"judge,omitempty"\`` —— 字段名以 PascalCase 直接进 `verify --json`；`NeedJudge` 今天就在泄漏，尽管无人读它 |
+| `waste` 总数今天**包含** judge 故障 | `cmd/semantix/verify.go` `runVerify` | 表达式为 `JudgeReject+Fingerprint+RulesReject`，judge 故障当前藏在 `RulesReject` 里 |
+| calibrate 运行时行是 9 列硬断言 | `cmd/semantix/calibrate_test.go` `TestCalibrateRuntimeOnly` | 字面量 `"1\t0\t0\t0\t0\t0\t0\t1\t100.0"` |
+| 基线在本机不是绿的 | — | `go test ./cmd/semantix/...` 现有 17 个失败，全部为 `TempDir RemoveAll cleanup: unlinkat ...lib.db.journal: The process cannot access the file`（Windows 文件锁），非逻辑失败。见 §6.3 |
+
+### 1.3 非目标
+
+- **不修**指纹门的同类缺陷。`Chain` 的 `fingerprint.Verify` 出错与「指纹已变更」同样都记
+  `Stats{Fingerprint: 1}`，结构上与本 issue 完全同型，但拆它会牵动 `Obs.FingerprintReject`
+  与 `l3_fingerprint_reject` 线格式。**单独开 issue**，本期只在代码注释里留指针。
+- 不改 judge 后端、不改重试策略、不改任何 fail-closed 行为。
+- 不新增事件总线 Kind（沿用 #262 的 usage 日志通道）。
+
+## 2. 语义定义（单一真源）
+
+`JudgeError` = **judge 调用本身失败**（传输错误、超时、响应解析失败），即 judge 不可用。
+它既不是 `JudgeReject`（judge 明确 approve=false），也不是 `RulesReject`（规则判定拒绝）。
+
+拒绝分类在 #262 §2.1 表格上新增一行，五类**按原因互斥、不可合并**。
+
+> 注意层级：下表是 `cache.Obs` 层的完整口径。`judge.Stats` 层只有其中四类
+> （无 `IsolatedReject`——隔离判定发生在 `DecideL3`，不经 `RuleGate`；且
+> `Obs.FingerprintReject` 在 `Stats` 里叫 `Fingerprint`）。两层的总数因此不同，
+> `verify` 打印的 waste 是 `judge.Stats` 层的四类之和。
+
+| 计数 | 语义 | 判定点 |
+|---|---|---|
+| `RulesReject` | clear miss，或 grey 无 judge 的保守拒绝 | `RuleGate.Check`；`DecideL3` 的 `zone.Miss` 臂 |
+| `FingerprintReject` | 指纹门错误 / mtime\|sha256 变更 / `L3Safe=false` | `RuleGate.Chain` 指纹门 + `L3Decider.verified` |
+| `IsolatedReject` | 上下文/model 隔离不匹配（#133） | `DecideL3` |
+| `JudgeReject` | judge 判定拒绝（approve=false） | `RuleGate.Chain` judge 分支 |
+| **`JudgeError`** | **judge 调用失败——不可用，不是判决** | **`RuleGate.Chain` judge 错误分支** |
+
+新口径：**总拒绝数 = RulesReject + FingerprintReject + IsolatedReject + JudgeReject + JudgeError**。
+
+### 2.1 三处已知重复计数（必须写进注释，禁止相加）
+
+同一次 judge 故障会同时出现在三条互不独立的通道上：
+
+1. `usage.Summary.JudgeFailClosed`（#242，经 `JudgeDecisions[].Verdict=="fail_closed"`）；
+2. 本期的 `usage.Summary.L3JudgeError`（聚合计数）；
+3. `Summary.JudgeSkipped` 与 `Obs.FingerprintReject` 之间存在同型影子关系
+   （`judgeGrey` 的 `case !timed.called: obs.Verdict = JudgeSkipped` 恰在 `Chain`
+   于指纹门短路时触发）。
+
+这是 #262 有意的双通道设计（日志流 vs 计数账本），但两个字段的注释都必须写明
+**指向同一物理事件、永不相加**。另注：`JudgeFailClosed` 仅在 `OnJudge` 接线时（gateway）
+才有值，而 `L3JudgeError` 在 CLI 与 gateway 两条路径都有值。
+
+## 3. 改动清单（按依赖序，锚定符号；行号一律不作数）
+
+> 并行风险：`cmd/semantix/usage.go`、`cmd/semantix/verify.go`、`kernel/cache/l3.go`、
+> `gateway/pipeline.go` 当前有另一路 worker 的未提交改动。**每一步开动前重读该符号**。
+
+### 3.1 kernel/judge
+
+1. **`Stats`** — 在 `JudgeReject` 后新增 `JudgeError int // judge call failed/timed out — unavailable, not a verdict`。同时补上 `JudgeApproved` 缺失的注释。
+2. **`Stats.add`** — 新增 `s.JudgeError += o.JudgeError`。**这是唯一写入路径**，漏了则计数永远为零且无编译错误。
+3. **`RuleGate.Chain`（judge 错误分支）** — `g.count(Stats{RulesReject: 1})` → `g.count(Stats{JudgeError: 1})`。**verdict、reason 字符串、返回的 err 全部逐字不动。**
+4. **`RuleGate.Chain`（死代码）** — 删除 `if v != NeedJudge { return }` 与 `g.Judge.Confirm` 之间的整个 `if g.Judge == nil { ... }` 块，把解释性注释上移为一行不变式：
+   `// v == NeedJudge implies g.Judge != nil (Check's only NeedJudge arm is guarded by it).`
+5. **注释** — 在指纹门两处 `Stats{Fingerprint: 1}` 上方留一行指针，说明同型缺陷已单列 issue（§1.3）。
+
+**测试**：`judge_test.go` 目前对 `Stats` 零断言。
+- 改 `TestChainJudgeErrorConservative`：保留 Reject+err 断言，挂 `Stats` 并断言 `JudgeError==1` **且 `RulesReject==0`**（口径回归守卫）。
+- `TestChainGreyNoJudgeRejects` 应**保持通过且不改**（它走的是 `Check` 产出的那条路，不是被删的块）；在断言处加注释点明是哪条路径产出该 reason。
+- 新增至少一条直接断言 `Chain` 每个分支计数归属的表驱动测试——把语义钉在源头，而不是三层之外。
+
+### 3.2 kernel/cache
+
+6. **`Obs`** — 在 `JudgeReject` 后新增 `JudgeError int`。
+7. **`ObsAccum.add`** — 新增 `a.n.JudgeError += o.JudgeError`。**强制**：`gateway/pipeline.go` 的 `withL3Obs` 只经 `ObsAccum.Snapshot` 读数，漏这一步会让整条 gateway→usage→CLI 链全零，而用 `OnDecide` 的 kernel 测试仍然绿——这是全链路最高风险的静默失败点。
+8. **`L3Decider.judgeGrey`** — 在四行折叠块中 `o.JudgeReject += gs.JudgeReject` 之后加 `o.JudgeError += gs.JudgeError`。不动 `ok := err == nil && v == judge.Confirm`，不动 `OnJudge` 观测 switch（#242 是独立通道）。扩写 `judgeGrey` 文档注释，记录被**有意丢弃**的两个字段（`Confirmed` 与 `o.Reused` 冗余、`NeedJudge` 与 `o.Grey` 冗余），免得下一个人当 bug 修。
+
+**测试**：`l3_test.go` 的 `wantObs` 用整结构 `got != want` 比较——新字段默认零值意味着**现有测试全绿也证明不了接对了**，必须新增显式断言。
+- 新增 `TestL3DeciderObsCounters` 子测试「judge error counts judge error not rules reject」：`mockJudge{err: context.DeadlineExceeded}` → `Obs{Candidates:1, Grey:1, JudgeError:1}`（整结构比较顺带免费断言 `RulesReject==0`）。
+- **新增第二条走词法门那条臂**：`zone.Hit` 但 lexical support 为 0 的候选 + 出错的 judge，同样断言 `Obs{JudgeError:1, Grey:1}`。两条臂都喂这个计数，spec 的语义才成立。
+- 改 `TestDecideL3GreyZoneJudgeErrorFailsClosed`：挂 `ObsAccum` 并断言同样的计数，把 fail-closed 行为与计数钉在一处。
+- 改 `TestL3ObsAccumSnapshotIsThreadSafe`：并发 `Obs` 与期望总数都加上 `JudgeError`。
+
+### 3.3 kernel/usage
+
+9. **`Event`** — 在 `L3JudgeReject` 后新增 `L3JudgeError int \`json:"l3_judge_error,omitempty"\``（保持 `omitempty`，与同组字段一致；additive，旧日志读作零）。注释写明与 #242 `fail_closed` 是同一事件的不同通道。
+10. **`Summary`** — 新增 `L3JudgeError int`，注释交叉引用 `JudgeFailClosed` 并写明**禁止相加**。
+11. **`Summarize`** — 新增 `s.L3JudgeError += e.L3JudgeError`。
+
+**测试**：改 `TestSummarizeL3NegativeObservability`——加 `L3JudgeError:2` 并断言，**同时断言 `L3RulesReject` 保持原值**，这样把错误重新路由回 rules_reject 的实现会失败。
+
+### 3.4 gateway
+
+12. **`Gateway.withL3Obs`** — 在 `L3JudgeReject` 赋值后加 `e.L3JudgeError = o.JudgeError`。无签名变化。
+    注意 `withL3Obs` 有**四个调用点**，其中包含 L3 命中那一条——所以一次 turn 可以同时带
+    `l3_reuse=true` 与 `l3_judge_error>0`（候选①的 judge 出错、候选②被复用）。
+
+**测试**：改 `gateway/false_hit_test.go` `TestWithL3Obs`。新增 `gateway/judge_observability_test.go` 用例，断言一次出错的 judge 调用**同时**产出 `l3_judge_error=1` 和一条 `Verdict=="fail_closed"` 的 `JudgeDecision`——把 §2.1 那个有意的双通道冗余钉住。
+
+### 3.5 cmd/semantix
+
+13. **`usageJSON`** — 新增 `L3JudgeError int \`json:"l3_judge_error"\``，**不带 omitempty**（该 envelope 有意始终输出零值，以区分「缓存安静」与「日志缺失」）。
+14. **`runUsage`** — (a) JSON 装配体加 `L3JudgeError: s.L3JudgeError`；(b) 人读/TSV 块在 `l3_judge_reject` 行后插 `fmt.Fprintf(stdout, "l3_judge_error\t%d\n", s.L3JudgeError)`，保持 reject → error → approved 的分组。
+15. **`feedEvolve`——本期无改动，但记录一条约束。**
+    实测（`fac8e4c` 树）：`feedEvolve` 只发 `cache_hit` 一种信号，**不存在污染分子**；
+    `inject_pollution` 由 harness 侧的 SliceReject 事件发出（见 `cmd/semantix/reject.go` 注释），
+    不经这里。故 #245 在此无事可做。
+    **给后续加污染信号的人的约束**：`L3JudgeError` **只可进分母，绝不可进 `inject_pollution` 分子**。
+    judge 不可用不是「缓存被污染」的证据；若计入分子，上游 judge 故障会被读成污染从而收紧
+    `TauL2`，在 judge 挂掉的时候反而缩小缓存——用第三方故障惩罚用户。
+16. **`calibrateRuntime` / `runCalibrateRuntime`** — 新增 `L3JudgeError int \`json:"l3_judge_error"\``（无 omitempty，与同组一致）并在装配体赋值。
+17. **`runCalibrate`** — 运行时 TSV 从 9 列扩到 10 列：header 在 `judge_reject` 后插 `judge_error`，格式串同位置加一个 `%d`，参数列表同位置加 `runtime.L3JudgeError`。**这是三条手工维护的平行列表，编译器不检查，列位必须对齐。**
+18. **`runVerify`** — `# judge:` 行在 `judge_reject=%d` 后加 `judge_error=%d`；**并且**把 waste 表达式改成
+    `jstats.JudgeReject+jstats.Fingerprint+jstats.RulesReject+jstats.JudgeError`。
+    不加这一项，一个今天已被计入的公开数字会在「重构」的名义下悄悄变小。
+19. **`verifySummary`（线格式决策）** — 不得让 PascalCase 的 `"JudgeError"` 键静默进入 `verify --json`。
+    **采用方案 (b)**：在 `cmd/semantix` 内建一个本地 DTO `verifyJudgeJSON`，带 snake_case tag，从 `judge.Stats` 映射；`kernel/judge` 保持无 tag。
+    依据是仓库自己的先例——`cmd/semantix/search.go` 写着 `json:"-" keeps search --json output byte-identical (backward compat)`，同类问题同类解法。顺带把今天已在泄漏的 `NeedJudge` 一并收进 DTO 决定（建议不导出，它无人读）。
+
+**测试**：
+- 改 `TestRunUsageJSON`（扩 Data 结构并断言 round-trip）、`TestRunUsageSummary`（`want` 加 `"l3_judge_error\t"`）。
+- `feedEvolve` 本期无改动，故无新增测试；`TestFeedEvolveAdjustsTauAfterHistory` 须保持通过不变。
+- 改 `TestCalibrateRuntimeOnly`：9 列字面量 → 10 列 `"1\t0\t0\t0\t0\t0\t0\t0\t1\t100.0"`，**并新增 header 含 `judge_error` 的断言**，防 header/row 漂移。改 `TestCalibrateJSONEnvelope`。
+- 新增 `TestVerifyJudgeStatsLineIncludesJudgeError`：`verify_test.go` 今天对 judge 零断言（`grep -i judge` 无匹配），该行与 waste 总数完全无覆盖。
+- 新增 `TestVerifyJSONJudgeBlockKeys`：反序列化为 `map[string]any` 比对精确键集，第一次把该 envelope 形状钉住。
+
+### 3.6 文档同步
+
+20. `docs/specs/issue-262-l3-negative-observability.md`：§2.1 拒绝分类表**新增 `JudgeError` 行**（该表自称「按原因不可合并」，这正是 #245 的全部论据）；`Event` 字段清单加 `l3_judge_error`；运行时 TSV 由 9 列改 10 列。
+21. `docs/reports/verify-rubric.md`：waste++ 条目内联列举了 `judge.Stats` 字段，需补。
+22. `docs/reports/issue-262-acceptance.md`：枚举 `Obs` 八字段与 `Event` 七字段的两行需补。
+
+## 4. 不变式（实现必须保持）
+
+1. **判决行为零变化**：judge 出错仍然 `Reject`，仍然返回原 err，reason 字符串逐字不变。
+2. **零配置字节等价**：本期不引入任何配置键；除新增的一列/一键外，所有既有输出保持不变。
+3. **计数互斥**：任何一次拒绝只增加五类计数中的**恰好一个**。
+4. **waste 语义不变**：`verify` 打印的 waste 总数在改动前后对同一输入产出**同一个数**。
+
+## 5. 分支与落地
+
+`kernel/judge/judge.go` 与 `kernel/usage/usage.go` 目前干净；`cmd/semantix/usage.go`、
+`cmd/semantix/verify.go`、`kernel/cache/l3.go`、`gateway/pipeline.go` 有并行 worker 的
+未提交改动。建议顺序：先落 §3.1（kernel/judge，无争用），再落 §3.3，最后在 rebase
+之后动 §3.2/3.4/3.5 那四个争用文件。
+
+`gofmt` 说明：`gofmt -l kernel/ cmd/ gateway/` 会报 147 个文件，成因是 CRLF
+（`core.autocrlf=true` 且无 `.gitattributes`，`git ls-files --eol` 显示工作区混合）。
+`Stats` 结构体确实未对齐（在 LF 规范化副本上验证）。CI 无格式门禁，提交时会规范化，
+所以**只重排这一个结构体是安全的；绝不要对全树跑 `gofmt -w`**。
+
+## 6. 验收
+
+### 6.1 复用现有门禁（不发明新的）
+
+```bash
+go vet ./...
+go test ./... -race                      # CI 的字面 job，注意 -race
+go test ./kernel/judge/ ./kernel/cache/ ./kernel/usage/ ./gateway/ -count=1
+go test ./cmd/semantix/ -run "Calibrate|Eval|Usage|Verify" -count=1
+```
+
+后两条正是 `docs/reports/issue-262-acceptance.md` 为这条链固定下来的命令。
+
+### 6.2 专项证据
+
+1. **死代码已消失**：`go test -covermode=count ./kernel/judge/` 的覆盖率输出中不再有
+   `judge.go:131.20,136.3` 这个零执行块。
+2. **口径拆分生效**：构造一次 judge 超时，`semantix usage` 输出中
+   `l3_judge_error=1` 且 `l3_rules_reject=0`。
+3. **waste 不变**：同一输入下 `semantix verify` 打印的 waste 总数与改动前逐字相同。
+4. **calibrate 列对齐**：`semantix calibrate --usage <log>` 的 header 与数据行列数一致（10 列）。
+
+### 6.3 验收环境说明
+
+Windows 上 `cmd/semantix` 的测试会**间歇性**出现
+`TempDir RemoveAll cleanup: unlinkat ...db.journal: The process cannot access the file`
+——slice store journal 的文件锁，在**并发跑多个 go test 进程**时出现，测试体本身通过、
+失败发生在 `t.TempDir()` 的清理阶段。
+
+实测口径（改动落地后，单进程串行）：`go test ./...` **退出码 0，零 FAIL**。
+所以这不是恒定的基线失败，不能拿来当「已知红」搪塞。
+
+规则：验收必须**单进程**跑；若出现上述 cleanup 失败，先确认没有其他 go test 进程在跑，
+再复跑一次；仍然失败才算真失败。有条件时以 Linux/CI 结果为准。

--- a/docs/specs/issue-262-l3-negative-observability.md
+++ b/docs/specs/issue-262-l3-negative-observability.md
@@ -43,6 +43,7 @@ L3 运行时决策(DecideL3)
 | `FingerprintReject` | 依赖失效:指纹门错误、mtime/sha256 变更、`L3Safe=false` 无 deps 拒绝 | `RuleGate.Chain` 指纹门 + `L3Decider.verified` |
 | `IsolatedReject` | 上下文/model 隔离拒绝(Issue #133):带 stamp 查询与条目 stamp 不匹配 | `DecideL3` ContextHash/Model 校验 |
 | `JudgeReject` | judge 判定拒绝(approve=false) | `RuleGate.Chain` judge 分支 |
+| `JudgeError` | judge 调用失败:不可用,不是判决(Issue #245) | `RuleGate.Chain` judge 错误分支 |
 | `JudgeApproved` | judge 判定批准 | 同上 |
 | `Reused` | 最终复用(全部 gate 通过) | `DecideL3` 返回处 |
 
@@ -66,6 +67,7 @@ type Obs struct {
     FingerprintReject int // 指纹门错误 / mtime/sha256 变更 / L3Safe=false
     IsolatedReject    int // 上下文/model 隔离拒绝
     JudgeReject       int // judge 判定拒绝
+    JudgeError        int // judge 调用失败(Issue #245)
     JudgeApproved     int // judge 判定批准(后续 gate 仍可能兜底拒绝)
     Reused            int // 最终复用
 }
@@ -81,7 +83,7 @@ type Obs struct {
 计数规则:
 
 1. `judgeGrey` 内改为 `gate := judge.RuleGate{Judge: d.Judge, Stats: &gs}`(局部
-   `judge.Stats`),Chain 返回后把 `gs` 的 RulesReject/Fingerprint/JudgeReject/
+   `judge.Stats`),Chain 返回后把 `gs` 的 RulesReject/Fingerprint/JudgeReject/JudgeError/
    JudgeApproved 合并进 `d.Obs`,并 `Obs.Grey++`;
 2. `DecideL3` 检索循环内:`s.Type == Result` 时 `Candidates++`;zone.Miss 时
    `RulesReject++`;ContextHash/Model 不匹配时 `IsolatedReject++`;
@@ -96,6 +98,7 @@ type Obs struct {
 ```go
 L3GreyCandidates    int  `json:"l3_grey_candidates,omitempty"`
 L3JudgeReject       int  `json:"l3_judge_reject,omitempty"`
+L3JudgeError        int  `json:"l3_judge_error,omitempty"`   // Issue #245
 L3JudgeApproved     int  `json:"l3_judge_approved,omitempty"`
 L3RulesReject       int  `json:"l3_rules_reject,omitempty"`
 L3FingerprintReject int  `json:"l3_fingerprint_reject,omitempty"`
@@ -208,7 +211,7 @@ consistency_pct  false_approve_pct  false_reject_pct  precision  recall  f1  del
 **运行时汇总块**(usage 日志,仅 `--usage`):
 
 ```
-l3_reuses  l3_grey  judge_reject  judge_approved  rules_reject  fingerprint_reject  isolated_reject  false_hits  false_hit_rate_pct
+l3_reuses  l3_grey  judge_reject  judge_error  judge_approved  rules_reject  fingerprint_reject  isolated_reject  false_hits  false_hit_rate_pct
 12         5        2             3               40            1                    2                1           8.3
 ```
 
@@ -234,7 +237,7 @@ JSON 输出 `runtime.na=true`,不退出 1(运行时观测失败开放,网关新�
 ## 5. 验收标准
 
 - [ ] **c1 运行时负向统计可查询**:`semantix usage --json` 输出含
-  `l3_grey_candidates/judge_reject/judge_approved/rules_reject/fingerprint_reject/isolated_reject/false_hits`
+  `l3_grey_candidates/judge_reject/judge_error/judge_approved/rules_reject/fingerprint_reject/isolated_reject/false_hits`
   聚合(usage 日志为空时输出零值,不报错);
 - [ ] **c2 拒绝分原因可见**:gateway 端到端(或单测)验证 L3Decider 各拒绝路径
   分别计数,规则/指纹/隔离/judge 四类拒绝互不混淆;

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -590,6 +590,7 @@ func (g *Gateway) recordL3Reuse(sessionID, query, sliceID string) {
 func (g *Gateway) withL3Obs(e usage.Event, o cache.Obs, falseHit bool) usage.Event {
 	e.L3GreyCandidates = o.Grey
 	e.L3JudgeReject = o.JudgeReject
+	e.L3JudgeError = o.JudgeError
 	e.L3JudgeApproved = o.JudgeApproved
 	e.L3RulesReject = o.RulesReject
 	e.L3FingerprintReject = o.FingerprintReject

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -69,6 +69,7 @@ type Obs struct {
 	FingerprintReject int // fingerprint gate error / mtime|sha256 changed / L3Safe=false
 	IsolatedReject    int // context/model isolation mismatch (Issue #133)
 	JudgeReject       int // judge declined
+	JudgeError        int // judge call failed/timed out — unavailable, not a verdict (Issue #245)
 	JudgeApproved     int // judge approved (later gates may still reject)
 	Reused            int // finally reused (all gates passed)
 }
@@ -97,6 +98,7 @@ func (a *ObsAccum) add(o Obs) {
 	a.n.FingerprintReject += o.FingerprintReject
 	a.n.IsolatedReject += o.IsolatedReject
 	a.n.JudgeReject += o.JudgeReject
+	a.n.JudgeError += o.JudgeError
 	a.n.JudgeApproved += o.JudgeApproved
 	a.n.Reused += o.Reused
 	a.mu.Unlock()
@@ -321,15 +323,17 @@ func (d *L3Decider) zones() zone.Zones {
 // (fingerprint gate → rules → judge). The L3Decider already re-verifies
 // dependency fingerprints after this (verified), so a judge "yes" still
 // cannot surface stale data. A nil judge, a judge error, or a judge "no"
-// all reject conservatively (fail-closed).
-//
-// rel is the score/top1 ratio that classified the candidate as grey; it is
-// reported through OnJudge so a rejection can later be explained without
-// re-running retrieval (Issue #242 gap 1). No observation is emitted when
-// no judge is wired: that path is deterministic and costs nothing, so
-// recording it would only add noise to the host's usage log.
 // all reject conservatively (fail-closed). The per-call observer o is
 // folded with the rule-gate counters (Issue #262).
+//
+// Two of judge.Stats' six counters are deliberately NOT folded, because the
+// caller already accounts for them: Confirmed is redundant with o.Reused
+// (set on the DecideL3 success path) and NeedJudge is redundant with o.Grey
+// (incremented at the top of this function). The omission is intentional.
+//
+// Callers: both the zone.Grey arm and the Issue #260 lexical-support
+// downgrade inside the zone.Hit arm reach this, so JudgeError is not a
+// grey-verdict-only counter (Issue #245).
 //
 // rel is the score/top1 ratio that classified the candidate as grey; it is
 // reported through OnJudge so a rejection can later be explained without
@@ -358,6 +362,7 @@ func (d *L3Decider) judgeGrey(ctx context.Context, q Query, s *slice.Slice, rel 
 	o.RulesReject += gs.RulesReject
 	o.FingerprintReject += gs.Fingerprint
 	o.JudgeReject += gs.JudgeReject
+	o.JudgeError += gs.JudgeError
 	o.JudgeApproved += gs.JudgeApproved
 	ok := err == nil && v == judge.Confirm
 	if d.OnJudge != nil {

--- a/kernel/cache/l3_test.go
+++ b/kernel/cache/l3_test.go
@@ -652,6 +652,33 @@ func TestL3DeciderObsCounters(t *testing.T) {
 		}
 		wantObs(t, d.Obs.Snapshot(), Obs{Candidates: 1, Grey: 1, JudgeApproved: 1, Reused: 1}, "judge approved")
 	})
+
+	// Issue #245: a judge that cannot be reached is unavailability, not a
+	// rule rejection and not a decline. wantObs compares the whole struct,
+	// so these also assert RulesReject == 0 and JudgeReject == 0 for free.
+	t.Run("judge error counts judge error not rules reject", func(t *testing.T) {
+		root, idx, _, _ := buildTestLib(t)
+		mj := &mockJudge{confirm: true, err: context.DeadlineExceeded}
+		d := &L3Decider{Index: idx, Root: root, Zones: greyZones(), Judge: mj, Obs: &ObsAccum{}}
+		if res, _ := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project}); res != nil {
+			t.Fatal("judge error must fail closed")
+		}
+		wantObs(t, d.Obs.Snapshot(), Obs{Candidates: 1, Grey: 1, JudgeError: 1}, "grey-arm judge error")
+	})
+
+	// The second arm that reaches judgeGrey: an Issue #260 lexical-support
+	// downgrade of a zone.Hit. JudgeError is therefore not a grey-verdict-only
+	// counter, and the spec's definition depends on both arms feeding it.
+	t.Run("lexical-gate judge error counts judge error", func(t *testing.T) {
+		root, sl := l3Fixture(t)
+		idx := &fakeIndex{hits: []slice.Hit{{Slice: sl, Score: 0.9, Lexical: 0, LexicalValid: true}}}
+		mj := &mockJudge{confirm: true, err: context.DeadlineExceeded}
+		d := &L3Decider{Index: idx, Root: root, Judge: mj, Obs: &ObsAccum{}}
+		if res, _ := d.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project}); res != nil {
+			t.Fatal("lexical-downgraded hit with an erroring judge must fail closed")
+		}
+		wantObs(t, d.Obs.Snapshot(), Obs{Candidates: 1, Grey: 1, JudgeError: 1}, "lexical-arm judge error")
+	})
 }
 
 func TestL3DeciderOnDecidePerCallDelta(t *testing.T) {
@@ -685,14 +712,14 @@ func TestL3ObsAccumSnapshotIsThreadSafe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				acc.add(Obs{Candidates: 1, JudgeReject: 1})
+				acc.add(Obs{Candidates: 1, JudgeReject: 1, JudgeError: 1})
 				_ = acc.Snapshot()
 			}
 		}()
 	}
 	wg.Wait()
 	got := acc.Snapshot()
-	want := Obs{Candidates: 800, JudgeReject: 800}
+	want := Obs{Candidates: 800, JudgeReject: 800, JudgeError: 800}
 	if got != want {
 		t.Fatalf("accumulated = %+v, want %+v", got, want)
 	}

--- a/kernel/judge/judge.go
+++ b/kernel/judge/judge.go
@@ -59,12 +59,13 @@ func (NoopJudge) Confirm(context.Context, Candidate) (bool, error) { return fals
 // Stats accumulates verification observability (waste++ tracking, Issue #8):
 // every rejection is a wasted reuse opportunity to be monitored.
 type Stats struct {
-	Confirmed    int // clear hits + judge-approved
-	RulesReject  int // miss / grey-without-judge
-	Fingerprint  int // dependency fingerprint changed (stage ① gate)
-	JudgeReject  int // judge declined
-	JudgeApproved int
-	NeedJudge    int // routed to judge
+	Confirmed     int // clear hits + judge-approved
+	RulesReject   int // miss / grey-without-judge
+	Fingerprint   int // dependency fingerprint changed (stage ① gate)
+	JudgeReject   int // judge declined
+	JudgeError    int // judge call failed/timed out — unavailable, not a verdict (Issue #245)
+	JudgeApproved int // judge approved
+	NeedJudge     int // routed to judge
 }
 
 func (s *Stats) add(o Stats) {
@@ -72,6 +73,7 @@ func (s *Stats) add(o Stats) {
 	s.RulesReject += o.RulesReject
 	s.Fingerprint += o.Fingerprint
 	s.JudgeReject += o.JudgeReject
+	s.JudgeError += o.JudgeError
 	s.JudgeApproved += o.JudgeApproved
 	s.NeedJudge += o.NeedJudge
 }
@@ -128,15 +130,15 @@ func (g RuleGate) Chain(ctx context.Context, c Candidate) (Verdict, string, erro
 	if v != NeedJudge {
 		return v, reason, nil
 	}
-	if g.Judge == nil {
-		// Keep the Check contract: grey without a judge is a conservative
-		// reject, never an ambiguous NeedJudge.
-		g.count(Stats{RulesReject: 1})
-		return Reject, "grey zone: no judge wired, conservative reject", nil
-	}
+	// v == NeedJudge implies g.Judge != nil (Check's only NeedJudge arm is
+	// guarded by it, and RuleGate's value receiver forbids mutation between
+	// the two reads). Grey without a judge already returned above, via Check.
 	ok, err := g.Judge.Confirm(ctx, c)
 	if err != nil {
-		g.count(Stats{RulesReject: 1})
+		// A judge that is unreachable is not a rule rejection and not a
+		// decline — it is unavailability, counted on its own (Issue #245).
+		// The verdict stays fail-closed and the reason string is unchanged.
+		g.count(Stats{JudgeError: 1})
 		return Reject, "judge error: conservative reject", err
 	}
 	if ok {

--- a/kernel/judge/judge_test.go
+++ b/kernel/judge/judge_test.go
@@ -43,6 +43,9 @@ func TestChainGreyNoJudgeRejects(t *testing.T) {
 	if err != nil || v != Reject {
 		t.Fatalf("chain = %v %q %v, want Reject (conservative, never NeedJudge)", v, reason, err)
 	}
+	// This reason comes from Check's grey-without-judge arm (Chain returns it
+	// via the `v != NeedJudge` early return); Chain itself has no nil-judge
+	// branch — Check never emits NeedJudge without a judge. See Issue #245.
 	if reason != "grey zone: no judge wired, conservative reject" {
 		t.Errorf("reason = %q", reason)
 	}
@@ -65,10 +68,60 @@ func TestChainGreyJudgeDeclines(t *testing.T) {
 }
 
 func TestChainJudgeErrorConservative(t *testing.T) {
-	g := RuleGate{Judge: errJudge{}}
-	v, _, err := g.Chain(context.Background(), cand(zone.Grey))
+	var st Stats
+	g := RuleGate{Judge: errJudge{}, Stats: &st}
+	v, reason, err := g.Chain(context.Background(), cand(zone.Grey))
 	if err == nil || v != Reject {
 		t.Fatalf("chain = %v %v, want Reject with error", v, err)
+	}
+	// Fail-closed behavior is unchanged; only the accounting moves (Issue #245).
+	if reason != "judge error: conservative reject" {
+		t.Errorf("reason = %q, want the unchanged fail-closed reason", reason)
+	}
+	if st.JudgeError != 1 {
+		t.Errorf("JudgeError = %d, want 1 (a judge call failure is not a verdict)", st.JudgeError)
+	}
+	// The regression guard for the #245 conflation: a judge outage must never
+	// inflate the rule-rejection counter, nor be read as "judge declined".
+	if st.RulesReject != 0 {
+		t.Errorf("RulesReject = %d, want 0 (judge error is not a rule rejection)", st.RulesReject)
+	}
+	if st.JudgeReject != 0 {
+		t.Errorf("JudgeReject = %d, want 0 (judge error is not a judge decline)", st.JudgeReject)
+	}
+}
+
+// TestChainCounterAttribution pins which counter each Chain branch increments.
+// Before Issue #245 nothing in this package asserted on Stats at all (RuleGate.count's
+// body had zero test coverage), so the counter semantics the whole observability
+// chain depends on were only verified indirectly, three layers away in kernel/cache.
+func TestChainCounterAttribution(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		gate  RuleGate
+		zone  zone.Zone
+		want  Stats
+		wantV Verdict
+	}{
+		{"clear hit", RuleGate{Judge: stubJudge{ok: true}}, zone.Hit, Stats{Confirmed: 1}, Confirm},
+		{"clear miss", RuleGate{Judge: stubJudge{ok: true}}, zone.Miss, Stats{RulesReject: 1}, Reject},
+		{"grey no judge", RuleGate{}, zone.Grey, Stats{RulesReject: 1}, Reject},
+		{"grey judge approves", RuleGate{Judge: stubJudge{ok: true}}, zone.Grey, Stats{NeedJudge: 1, Confirmed: 1, JudgeApproved: 1}, Confirm},
+		{"grey judge declines", RuleGate{Judge: stubJudge{ok: false}}, zone.Grey, Stats{NeedJudge: 1, JudgeReject: 1}, Reject},
+		{"grey judge errors", RuleGate{Judge: errJudge{}}, zone.Grey, Stats{NeedJudge: 1, JudgeError: 1}, Reject},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var st Stats
+			g := tc.gate
+			g.Stats = &st
+			v, _, _ := g.Chain(context.Background(), cand(tc.zone))
+			if v != tc.wantV {
+				t.Errorf("verdict = %v, want %v", v, tc.wantV)
+			}
+			if st != tc.want {
+				t.Errorf("stats = %+v, want %+v", st, tc.want)
+			}
+		})
 	}
 }
 

--- a/kernel/usage/usage.go
+++ b/kernel/usage/usage.go
@@ -63,6 +63,11 @@ type Event struct {
 	// All fields are additive — older logs without them read as zero.
 	L3GreyCandidates    int  `json:"l3_grey_candidates,omitempty"`
 	L3JudgeReject       int  `json:"l3_judge_reject,omitempty"`
+	// L3JudgeError counts judge calls that FAILED (transport/timeout/parse) —
+	// the judge was unavailable, which is not a verdict (Issue #245). The same
+	// physical incident is also recorded on the Issue #242 channel as a
+	// JudgeDecision with Verdict=="fail_closed"; the two must never be summed.
+	L3JudgeError        int  `json:"l3_judge_error,omitempty"`
 	L3JudgeApproved     int  `json:"l3_judge_approved,omitempty"`
 	L3RulesReject       int  `json:"l3_rules_reject,omitempty"`
 	L3FingerprintReject int  `json:"l3_fingerprint_reject,omitempty"`
@@ -176,6 +181,10 @@ type Summary struct {
 	// L3 negative observability (Issue #262): sums of the per-turn fields.
 	L3GreyCandidates    int
 	L3JudgeReject       int
+	// L3JudgeError counts judge unavailability (Issue #245). NOTE: this and
+	// JudgeFailClosed (Issue #242) count the same events through different
+	// channels — report them separately, never add them together.
+	L3JudgeError        int
 	L3JudgeApproved     int
 	L3RulesReject       int
 	L3FingerprintReject int
@@ -303,6 +312,7 @@ func Summarize(path string, costMiss, costHit float64) (*Summary, error) {
 		// older logs read as zero via the additive fields.
 		s.L3GreyCandidates += e.L3GreyCandidates
 		s.L3JudgeReject += e.L3JudgeReject
+		s.L3JudgeError += e.L3JudgeError
 		s.L3JudgeApproved += e.L3JudgeApproved
 		s.L3RulesReject += e.L3RulesReject
 		s.L3FingerprintReject += e.L3FingerprintReject


### PR DESCRIPTION
Rebased/conflict-resolved landing of **#336** (author @Allenllii, Issue #245).

#336's fork branch could not be updated in place (conflict with #262/#323 after that PR merged), so its single commit was rebased onto current `main` here with the overlap resolved. Original authorship preserved.

## Conflict resolution (verify.go + issue-262-acceptance.md)
#245 and #262/#323 both reshaped `verifySummary`. Union taken:
- `Judge *verifyJudgeJSON` — #245's snake_case CLI wire type (exposes `judge_error`), used at the construction site `summary.Judge = newVerifyJudgeJSON(jstats)`
- `Calibration *verifyCalibration` — #262's calibration report, used at `printVerifyCalibration(stdout, cal)`
- both type/function sets kept; acceptance-doc counter row unions in `JudgeError`

## Verification
- `go build ./...` clean
- `go test ./cmd/semantix/... ./kernel/judge/... ./kernel/cache/...` green

Supersedes #336 (will be closed referencing this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QjhNhD7s8FE1cCnSp1a69