### PR TITLE
feat(config): default to GLM + env-aware provider selection (B1)

### DIFF
--- a/harness/config/default_provider.go
+++ b/harness/config/default_provider.go
@@ -1,0 +1,95 @@
+package config
+
+import "os"
+
+// Issue B1 (GLM adaptation): a fresh install defaults to GLM, stays switchable
+// to DeepSeek, and never strands a user who only holds one vendor's key.
+//
+// The shipped config template (reasonix.example.toml) already defaults to GLM,
+// so packaged installs get GLM out of the box. This file covers the *no-config*
+// path — a source build or a bare run with no reasonix.toml — where the choice
+// must be inferred from which API-key env var is present instead of guessing a
+// vendor the user cannot authenticate against.
+
+// defaultProviderName is the built-in provider selected when no config file
+// pins default_model. GLM is the out-of-the-box default; a single-vendor
+// environment resolves to that vendor so an existing key is never stranded.
+const (
+	defaultProviderGLM      = "glm"
+	defaultProviderZAI      = "zai"
+	defaultProviderDeepSeek = "deepseek-flash"
+)
+
+// regularFileExists reports whether path exists and is a regular file. Used to
+// detect a truly config-less install (no project reasonix.toml on disk).
+func regularFileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// selectDefaultModel picks the built-in default provider name from the API-key
+// env vars visible to getenv, in precedence order:
+//
+//	GLM_API_KEY      → glm            (Zhipu GLM, bigmodel.cn)
+//	ZAI_API_KEY      → zai            (Z.AI global GLM)
+//	DEEPSEEK_API_KEY → deepseek-flash (respect an existing DeepSeek-only setup)
+//	(none)           → glm            (GLM is the shipped default)
+//
+// getenv is injected so the choice is deterministic and unit-testable; callers
+// pass a lookup that layers a project .env over the process environment.
+func selectDefaultModel(getenv func(string) string) string {
+	switch {
+	case getenv("GLM_API_KEY") != "":
+		return defaultProviderGLM
+	case getenv("ZAI_API_KEY") != "":
+		return defaultProviderZAI
+	case getenv("DEEPSEEK_API_KEY") != "":
+		return defaultProviderDeepSeek
+	default:
+		return defaultProviderGLM
+	}
+}
+
+// builtinGLMProvider returns the built-in GLM (Zhipu, bigmodel.cn) entry, mirroring
+// the glm-cn curated preset. The openai kind auto-detects GLM by host and gates
+// thinking via thinking.type, so no extra reasoning knobs are needed here.
+func builtinGLMProvider() ProviderEntry {
+	return ProviderEntry{
+		Name: defaultProviderGLM, Kind: "openai",
+		BaseURL: "https://open.bigmodel.cn/api/paas/v4",
+		Models:  []string{"glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo"},
+		Default: "glm-5.2", APIKeyEnv: "GLM_API_KEY",
+		ContextWindow: 1_000_000,
+	}
+}
+
+// builtinZAIProvider returns the built-in Z.AI (global GLM) entry.
+func builtinZAIProvider() ProviderEntry {
+	p := builtinGLMProvider()
+	p.Name = defaultProviderZAI
+	p.BaseURL = "https://api.z.ai/api/paas/v4"
+	p.APIKeyEnv = "ZAI_API_KEY"
+	return p
+}
+
+// applyEnvDefaultProvider is the no-config fallback: when neither a user nor a
+// project config was loaded and default_model was not pinned, it selects the
+// default provider from env keys and makes sure that provider exists in the
+// in-memory config so the choice resolves. It never mutates a config the user
+// or project already configured — callers must gate it on "no toml source".
+func applyEnvDefaultProvider(cfg *Config, getenv func(string) string) {
+	if cfg == nil || getenv == nil {
+		return
+	}
+	name := selectDefaultModel(getenv)
+	cfg.DefaultModel = name
+	if _, ok := cfg.Provider(name); ok {
+		return
+	}
+	switch name {
+	case defaultProviderGLM:
+		cfg.Providers = append(cfg.Providers, builtinGLMProvider())
+	case defaultProviderZAI:
+		cfg.Providers = append(cfg.Providers, builtinZAIProvider())
+	}
+}

--- a/harness/config/default_provider_test.go
+++ b/harness/config/default_provider_test.go
@@ -1,0 +1,63 @@
+package config
+
+import "testing"
+
+func envFrom(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestSelectDefaultModel(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{"glm key wins", map[string]string{"GLM_API_KEY": "x"}, defaultProviderGLM},
+		{"glm beats deepseek", map[string]string{"GLM_API_KEY": "x", "DEEPSEEK_API_KEY": "y"}, defaultProviderGLM},
+		{"glm beats zai", map[string]string{"GLM_API_KEY": "x", "ZAI_API_KEY": "y"}, defaultProviderGLM},
+		{"zai when no glm", map[string]string{"ZAI_API_KEY": "y"}, defaultProviderZAI},
+		{"deepseek only is respected", map[string]string{"DEEPSEEK_API_KEY": "y"}, defaultProviderDeepSeek},
+		{"no keys defaults to glm", map[string]string{}, defaultProviderGLM},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := selectDefaultModel(envFrom(tc.env)); got != tc.want {
+				t.Fatalf("selectDefaultModel(%v) = %q, want %q", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyEnvDefaultProviderInjectsGLM(t *testing.T) {
+	cfg := Default() // ships DeepSeek providers only
+	if _, ok := cfg.Provider(defaultProviderGLM); ok {
+		t.Fatal("precondition: Default() must not already contain a glm provider")
+	}
+	applyEnvDefaultProvider(cfg, envFrom(map[string]string{"GLM_API_KEY": "x"}))
+
+	if cfg.DefaultModel != defaultProviderGLM {
+		t.Fatalf("DefaultModel = %q, want %q", cfg.DefaultModel, defaultProviderGLM)
+	}
+	p, ok := cfg.Provider(defaultProviderGLM)
+	if !ok {
+		t.Fatalf("glm provider not injected: %+v", cfg.Providers)
+	}
+	if p.APIKeyEnv != "GLM_API_KEY" || p.Default != "glm-5.2" {
+		t.Fatalf("glm provider = %+v, want GLM_API_KEY / glm-5.2", p)
+	}
+	// DeepSeek must remain so the user can switch back.
+	if _, ok := cfg.Provider("deepseek-flash"); !ok {
+		t.Fatal("deepseek-flash must remain available for switching")
+	}
+}
+
+func TestApplyEnvDefaultProviderDeepSeekOnlyNotStranded(t *testing.T) {
+	cfg := Default()
+	applyEnvDefaultProvider(cfg, envFrom(map[string]string{"DEEPSEEK_API_KEY": "y"}))
+	if cfg.DefaultModel != defaultProviderDeepSeek {
+		t.Fatalf("DefaultModel = %q, want %q (existing DeepSeek key respected)", cfg.DefaultModel, defaultProviderDeepSeek)
+	}
+	if _, ok := cfg.Provider(defaultProviderDeepSeek); !ok {
+		t.Fatalf("deepseek-flash provider must resolve: %+v", cfg.Providers)
+	}
+}

--- a/harness/config/example_config_test.go
+++ b/harness/config/example_config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExampleConfigDefaultsToGLM pins the shipped package behavior (B1): the
+// config template a fresh download installs defaults to GLM and keeps DeepSeek
+// available so the user can switch. It loads the real reasonix.example.toml so
+// the file and the loader can never drift apart silently.
+func TestExampleConfigDefaultsToGLM(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "reasonix.example.toml"))
+	if err != nil {
+		t.Fatalf("read example config: %v", err)
+	}
+
+	project := t.TempDir()
+	home := t.TempDir()
+	launch := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(launch)
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	cfg, err := LoadForRoot(project)
+	if err != nil {
+		t.Fatalf("load example config: %v", err)
+	}
+
+	if cfg.DefaultModel != "glm" {
+		t.Fatalf("default_model = %q, want glm", cfg.DefaultModel)
+	}
+	if _, ok := cfg.ResolveModel(cfg.DefaultModel); !ok {
+		t.Fatalf("default_model %q does not resolve to any provider/model", cfg.DefaultModel)
+	}
+	glm, ok := cfg.Provider("glm")
+	if !ok {
+		t.Fatalf("glm provider missing: %+v", cfg.Providers)
+	}
+	if glm.APIKeyEnv != "GLM_API_KEY" || glm.Kind != "openai" {
+		t.Fatalf("glm provider = %+v, want openai / GLM_API_KEY", glm)
+	}
+	// DeepSeek must remain so the user can switch by editing default_model.
+	if _, ok := cfg.Provider("deepseek"); !ok {
+		t.Fatalf("deepseek provider must remain available to switch to: %+v", cfg.Providers)
+	}
+}

--- a/harness/config/load.go
+++ b/harness/config/load.go
@@ -150,6 +150,9 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	} else if projectMeta.IsDefined("agent", "system_prompt_file") {
 		cfg.systemPromptFileSource = promptFileSourceProject
 	}
+	// Whether any config source pinned default_model. When none did and no
+	// config file exists at all, B1 infers the default provider from env keys.
+	projectDefaultModelExplicit := err == nil && projectMeta.IsDefined("default_model")
 	// The native CLI update channel controls the one user-installed binary.
 	// A repository-local reasonix.toml must never switch that global choice.
 	cfg.CLI = globalCLI
@@ -235,6 +238,21 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	backfillDeepSeekOfficialPrices(cfg)
 	normalizeEffortConfig(cfg)
 	backfillDeepSeekPro(cfg)
+	// B1 (GLM adaptation): a brand-new install with no config file at all infers
+	// its default provider from env keys — GLM out of the box — instead of the
+	// DeepSeek seed, and injects that provider so the choice resolves. A
+	// DeepSeek-only key is respected so an existing key is never stranded. Any
+	// existing config (user or project) that pins default_model or ships its own
+	// providers is untouched: this only fires when neither config file exists.
+	if !userDefaultModelExplicit && !projectDefaultModelExplicit &&
+		userConfigLoadPath() == "" && !regularFileExists(projectTOML) {
+		applyEnvDefaultProvider(cfg, func(k string) string {
+			if v := expansionEnv[k]; v != "" {
+				return v
+			}
+			return os.Getenv(k)
+		})
+	}
 	if userDefaultModelExplicit {
 		restoreUnresolvableProjectDefaultModel(cfg, userDefaultModel)
 	}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -4,7 +4,7 @@
 # Provider entries name secrets via api_key_env; saved key values live in
 # Reasonix's global <Reasonix home>/.env. Never put API key values here.
 
-default_model = "deepseek"   # a provider name (→ its default model) or "provider/model"
+default_model = "glm"   # 默认 GLM(智谱)。切 DeepSeek:改成 "deepseek";切海外 GLM:改成 "zai"。也可写 "provider/model"
 # language      = "zh"   # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
 
 [ui]
@@ -56,6 +56,29 @@ compact_force_ratio = 0.9   # force compacting at this high-water mark
 # GLM/Z.AI CN/Global API and coding-plan routes, OpenCode Go/Zen, Qwen/DashScope
 # CN/Global API and coding-plan routes, Token Rhythm (基元律动), StepFun,
 # NovitaAI, GMI, Vercel AI Gateway, HuggingFace, NVIDIA, KiloCode, and Ollama Cloud.
+# ── 默认 provider:GLM(智谱 GLM-5.x,国内 bigmodel.cn 端点)──
+# 需要环境变量 GLM_API_KEY。GLM openai 端点按 host 自动识别,思考常开、thinking.type 门控。
+# 海外用户改用下方 zai(Z.AI)块并把 default_model 设为 "zai"。
+[[providers]]
+name        = "glm"
+kind        = "openai"
+base_url    = "https://open.bigmodel.cn/api/paas/v4"
+models      = ["glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo"]
+default     = "glm-5.2"   # optional; defaults to the first of `models`
+api_key_env = "GLM_API_KEY"
+context_window = 1000000
+
+# 海外 GLM(Z.AI 国际端点)。用它就把上面的 default_model 改成 "zai"。需要 ZAI_API_KEY。
+# [[providers]]
+# name        = "zai"
+# kind        = "openai"
+# base_url    = "https://api.z.ai/api/paas/v4"
+# models      = ["glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo"]
+# default     = "glm-5.2"
+# api_key_env = "ZAI_API_KEY"
+# context_window = 1000000
+
+# ── 备选 provider:DeepSeek(把 default_model 改成 "deepseek" 即启用)──
 [[providers]]
 name        = "deepseek"
 kind        = "openai"
@@ -85,13 +108,19 @@ effort      = "high"
 # "none" to disable that or "openai" to force ordinary reasoning_effort.
 # Other OpenAI-compatible providers don't expose /effort unless you opt in here.
 #
+# ── BYOK:任何模型都能用 ──────────────────────────────────────────────
+# 即使某模型没有做专门适配,只要它兼容 OpenAI 或 Anthropic 协议,填上
+# base_url + api_key_env 就能用上基础功能(对话/工具/复用层)。把下面任一块
+# 取消注释、改成你的地址和 key,再把顶部 default_model 指向它的 name 即可。
+#
+# OpenAI 协议兼容端点(kind = "openai"):
 # [[providers]]
 # name           = "openai-compatible-custom"
 # kind           = "openai"
-# base_url       = "https://api.example.com/v1"
-# model          = "example-reasoning-model"
-# api_key_env    = "EXAMPLE_API_KEY"
-# reasoning_protocol = "openai"   # auto|deepseek|openai|none
+# base_url       = "https://api.example.com/v1"   # 你的目标地址
+# model          = "example-reasoning-model"       # 或用 models = [...]
+# api_key_env    = "EXAMPLE_API_KEY"               # key 值放全局 .env,勿写在此
+# reasoning_protocol = "openai"   # auto|deepseek|openai|none;没适配就用 openai 或 none
 # supported_efforts = ["low", "medium", "high"]
 # default_effort    = "high"
 


### PR DESCRIPTION
**B1 of the GLM-first package (Agile 3).** A fresh download defaults to GLM and stays switchable to DeepSeek; a config-less run infers the default from whichever API key is present.

## What changed
- **`reasonix.example.toml`** (shipped template): `default_model = "glm"` + a GLM provider block (bigmodel.cn / `GLM_API_KEY`); DeepSeek kept as switch-to; Z.AI global shown commented. **BYOK note** clarifies any OpenAI/Anthropic-compatible endpoint works by filling `base_url` + `api_key_env`, even for non-adapted models.
- **`selectDefaultModel(getenv)`**: `GLM_API_KEY`→glm, `ZAI_API_KEY`→zai, `DEEPSEEK_API_KEY`→deepseek-flash, none→glm.
- **`applyEnvDefaultProvider`**: wired into `loadForRoot` **only when no config file exists and default_model is unpinned**; injects the selected built-in provider so it resolves. Existing user/project configs untouched (tight gate: `userConfigLoadPath()==""` && no project `reasonix.toml`).

## Tests
- env precedence table, provider injection, DeepSeek-only-not-stranded
- `TestExampleConfigDefaultsToGLM` loads the **real shipped template** and asserts GLM default resolves + DeepSeek switchable
- `./harness/config/... ./cmd/semantix/... -race` green

## Not in this PR
- C1 (reasonix+GLM integration hardening) and A-track (GLM cache P1/P2) — separate.
- A local test build `v0.7.0-alpha.1` was produced for C1 manual testing; **not a published release**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QjhNhD7s8FE1cCnSp1a69