### PR TITLE
fix(gateway/billing): failed wallet probe short backoff, not full TTL (Issue B, #318 follow-up)

### DIFF
--- a/gateway/quota.go
+++ b/gateway/quota.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,6 +35,14 @@ const (
 
 // quotaStateVersion is the persisted counter schema.
 const quotaStateVersion = 1
+
+// balanceErrorBackoff bounds how long a *failed* wallet probe suppresses the
+// next probe. A successful verdict is cached for balance_cache_seconds, but an
+// error must be retried quickly (not held for the full success TTL): otherwise
+// a flaky wallet endpoint — especially right after a restart, when no prior
+// verdict exists to fall back on — would 402 a paying customer for the whole
+// TTL. Short backoff keeps stale-while-error self-healing in seconds.
+const balanceErrorBackoff = 5 * time.Second
 
 // quotaState is the durable token counter. It survives gateway restarts via
 // an atomic tmp+rename write next to the slice store.
@@ -72,7 +81,8 @@ type quotaEngine struct {
 	// out a paying customer, and the free-tier gate itself never depends on
 	// the probe.
 	paidOK      bool
-	paidChecked time.Time
+	paidChecked time.Time // last *successful* probe; cached for balance_cache_seconds
+	probeErrAt  time.Time // last *failed* probe; suppresses re-probe for balanceErrorBackoff only
 }
 
 // newQuotaEngine loads (or initializes) the persisted counter. A corrupt or
@@ -170,7 +180,16 @@ func (q *quotaEngine) balanceActive(ctx context.Context) bool {
 	}
 	q.mu.Lock()
 	ttl := time.Duration(q.cfg.BalanceCacheSeconds) * time.Second
+	// Reuse a cached *successful* verdict for the full TTL.
 	if !q.paidChecked.IsZero() && q.now().Sub(q.paidChecked) < ttl {
+		ok := q.paidOK
+		q.mu.Unlock()
+		return ok
+	}
+	// After a *failed* probe, suppress re-probing only for the short backoff —
+	// never the full success TTL — so a transient wallet error self-heals fast
+	// and cannot lock out a paid customer (Issue B).
+	if !q.probeErrAt.IsZero() && q.now().Sub(q.probeErrAt) < balanceErrorBackoff {
 		ok := q.paidOK
 		q.mu.Unlock()
 		return ok
@@ -184,12 +203,16 @@ func (q *quotaEngine) balanceActive(ctx context.Context) bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if err != nil {
-		// stale-while-error: keep the previous verdict, retry after ttl
-		q.paidChecked = q.now()
+		// stale-while-error: keep the previous verdict and retry after a short
+		// backoff (not the full TTL). Logged so a misconfigured/expired
+		// balance_key that would silently 402 paid customers is diagnosable.
+		q.probeErrAt = q.now()
+		log.Printf("gateway: wallet balance probe failed (%v); keeping previous paid=%v, retrying in %s", err, q.paidOK, balanceErrorBackoff)
 		return q.paidOK
 	}
 	q.paidOK = b != nil && b.Available
 	q.paidChecked = q.now()
+	q.probeErrAt = time.Time{} // clear the error backoff on any successful probe
 	return q.paidOK
 }
 

--- a/gateway/quota_test.go
+++ b/gateway/quota_test.go
@@ -357,3 +357,66 @@ func TestBillingConfigValidation(t *testing.T) {
 		t.Fatalf("disabled billing: %v", err)
 	}
 }
+
+// TestQuotaBalanceProbeErrorRetriesQuickly is the Issue B regression: a failed
+// wallet probe must suppress re-probing only for balanceErrorBackoff, never the
+// full balance_cache_seconds TTL. Otherwise a transient wallet error right
+// after a restart (no prior verdict) would 402 a paying customer for the whole
+// TTL. Drives quotaEngine directly with an injected clock so no real sleeping.
+func TestQuotaBalanceProbeErrorRetriesQuickly(t *testing.T) {
+	var probes atomic.Int64
+	var failing atomic.Bool
+	failing.Store(true)
+	wallet := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probes.Add(1)
+		if failing.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = io.WriteString(w, `{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"50.00"}]}`)
+	}))
+	defer wallet.Close()
+
+	nowT := time.Now()
+	nowFn := func() time.Time { return nowT }
+	dir := t.TempDir()
+	q, err := newQuotaEngine(BillingConfig{
+		Enabled: true, FreeTokens: 10, RechargeURL: "u",
+		BalanceURL: wallet.URL, BalanceKey: "k", BalanceCacheSeconds: 300,
+	}, filepath.Join(dir, "quota-state.json"), &http.Client{}, nowFn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Consume(20); err != nil { // exhaust the free tier
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// 1) cold start, probe fails → blocked (no verdict to fall back on), 1 probe.
+	if got := q.Status(ctx).Mode; got != quotaModeBlocked {
+		t.Fatalf("failed probe: mode=%q, want blocked", got)
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("probes=%d, want 1", got)
+	}
+
+	// 2) within the short backoff → cached, no re-probe.
+	nowT = nowT.Add(2 * time.Second)
+	if got := q.Status(ctx).Mode; got != quotaModeBlocked {
+		t.Fatalf("during backoff: mode=%q, want blocked", got)
+	}
+	if got := probes.Load(); got != 1 {
+		t.Fatalf("re-probed during backoff: probes=%d, want 1", got)
+	}
+
+	// 3) after the backoff (well before the 300s success TTL), wallet recovers →
+	//    re-probe → paid. This is the fix: the error was NOT cached for 300s.
+	failing.Store(false)
+	nowT = nowT.Add(balanceErrorBackoff + time.Second)
+	if got := q.Status(ctx).Mode; got != quotaModePaid {
+		t.Fatalf("after backoff: mode=%q, want paid (should have re-probed)", got)
+	}
+	if got := probes.Load(); got != 2 {
+		t.Fatalf("probes=%d, want 2 (retry after short backoff)", got)
+	}
+}


### PR DESCRIPTION
Post-merge hardening of **#318**'s free-tier gate (0.8.0 managed path). From the #318 review, the one finding that could **wrongly 402 a paying customer**.

## The bug (Issue B)
A failed wallet balance probe set `paidChecked = now`, so the full `balance_cache_seconds` TTL (default **300s**) also gated re-probing. On a cold start (gateway restart) there is no prior verdict to fall back on — so a single transient wallet error 402s a paid customer for up to 300s. This contradicts #318's stated "never lock a paid customer on a flaky wallet" guarantee (stale-while-error only works once a verdict is cached).

## Fix
- Split the probe cache: `paidChecked` caches only **successful** verdicts (full TTL); a **failed** probe records `probeErrAt` and suppresses re-probe for `balanceErrorBackoff` (**5s**) only → self-heals in seconds.
- **Log** the probe failure (was silent) so a misconfigured/expired `balance_key` silently 402-ing paid customers is diagnosable (B-补).
- Regression test drives `quotaEngine` with an injected clock: failed probe → blocked; within backoff → cached (no re-probe); after backoff (well before the 300s success TTL) → re-probes → paid. **Fails against old code.**

## Verification
`go vet ./gateway/`, `go build ./...`, `go test ./gateway/ -race` all green.

## Not in this PR (tracked, must-fix-before-enabling-billing)
From the #318 review, lower-severity / customer-favorable items: A (non-atomic admission → free over-grant under concurrency, no overcharge), D (runtime persist-write fail is fail-open), H (state validation only rejects unparseable, not zeroed), and build-protected.sh gaps (cross-compiled artifacts not smoke-tested; garble seed not captured). None wrongly charge a customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QjhNhD7s8FE1cCnSp1a69