### PR TITLE
fix(cli): reset mouse tracking on TUI shutdown

### DIFF
--- a/docs/issues/issue-348-tui-mouse-tracking-leak.md
+++ b/docs/issues/issue-348-tui-mouse-tracking-leak.md
@@ -1,0 +1,24 @@
+# Issue #348 — Windows 长时间闲置后 TUI 鼠标协议泄漏到父 Shell
+
+## 现象
+
+Windows Terminal/ConPTY 中启动 `semantix-agent`，长时间闲置、休眠或切走窗口后返回，父 PowerShell 提示符可能已经出现。此后点击或滚轮会向提示符写入类似 `ESC[<64;121;14M` 的文本。这是 SGR 鼠标报告，不是字符编码损坏。
+
+## 根因
+
+TUI 使用 `tea.MouseModeCellMotion`，并在 focus、resize 和 turn settle 时重发 `1002 + 1006` 鼠标模式。终端恢复依赖 Bubble Tea renderer 正常 shutdown；应用层只在 Ctrl+Z 前显式发送完整 `resetMouseTracking`。当 `Program.Run` 异常返回、panic 展开，或 shutdown 与延迟 `mouseReenableMsg` 竞争时，父 Shell 可能恢复输入而终端仍保持鼠标上报。
+
+诊断日志还会在 idle 状态每秒写 heartbeat，约数小时耗尽 4 MiB 上限，导致真正退出阶段没有证据。
+
+## 验收条件
+
+- [ ] `Program.Run` 的正常返回、错误返回和 panic 路径均最终写入完整鼠标 reset。
+- [ ] TUI 收到 shutdown 后不再发送 mouse enable 序列。
+- [ ] idle watchdog 仍不升级动作，但 heartbeat 至多每分钟写一次。
+- [ ] 回归测试覆盖上述行为，且 `go test ./harness/cli` 通过。
+
+## 非目标
+
+- 不改变鼠标选择、滚轮或滚动条行为。
+- 不处理操作系统强制终止后无法执行用户态清理的情况。
+

--- a/docs/specs/issue-348-tui-mouse-lifecycle.md
+++ b/docs/specs/issue-348-tui-mouse-lifecycle.md
@@ -1,0 +1,25 @@
+# Spec — Issue #348 TUI 鼠标生命周期闭环
+
+## 1. 状态模型
+
+`chatTUI` 新增不可逆的 `shuttingDown bool`。`tuiShutdownMsg` 首先置位并清除 pending timer 状态；`maybeReenableMouse` 在该状态下返回 nil。已排队的 focus、resize、settle 和 `mouseReenableMsg` 因此不再开启鼠标模式。
+
+## 2. 退出兜底
+
+用窄接口 `tuiProgramRunner { Run() (tea.Model, error) }` 包装 `p.Run()`。`runTUIProgram` 在调用前 defer 写入 `resetMouseTracking`，覆盖正常返回、错误返回和 panic 展开。DEC private-mode reset 幂等，和 Bubble Tea 自身清理重复发送兼容。
+
+## 3. 诊断日志
+
+watchdog 检查频率保持一秒；idle heartbeat 首次立即记录，之后至少间隔一分钟。状态转换和 running/booting 检测不采样。
+
+## 4. 测试
+
+1. fake runner 正常、错误和 panic 路径均输出 reset。
+2. shutdown 后 `maybeReenableMouse` 返回 nil 并清除 pending。
+3. `tuiShutdownMsg` 将模型标记为 shutting down。
+4. idle 连续 tick 只按一分钟间隔记录且从不升级。
+
+## 5. 兼容性
+
+不新增配置、CLI flag 或依赖；不承诺覆盖 `TerminateProcess`、断电等无法运行 defer 的强制终止。
+

--- a/harness/cli/chat_tui.go
+++ b/harness/cli/chat_tui.go
@@ -76,6 +76,10 @@ type chatTUI struct {
 	// drag-select, the transcript scrollbar, and wheel-scroll while it's on,
 	// since the terminal no longer forwards those events to Reasonix.
 	mouseCaptureOff bool
+	// shuttingDown is irreversible once tuiShutdownMsg is received. It prevents
+	// focus/resize/settle events and already-armed timers from re-enabling mouse
+	// tracking while Bubble Tea restores the parent shell.
+	shuttingDown bool
 
 	input       textarea.Model
 	composerSel composerSelection
@@ -1950,6 +1954,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tuiShutdownMsg:
+		m.shuttingDown = true
+		m.mouseReenablePending = false
+		m.mouseReenableTimerArmed = false
 		if m.ctrl != nil {
 			_ = m.ctrl.Snapshot()
 			m.followSessionLease()

--- a/harness/cli/chat_tui_test.go
+++ b/harness/cli/chat_tui_test.go
@@ -2359,6 +2359,28 @@ func TestEchoLocalCommandAddsTranscriptMarker(t *testing.T) {
 	}
 }
 
+func TestMouseReenableIsSuppressedAfterShutdownStarts(t *testing.T) {
+	m := newTestChatTUI()
+	m.shuttingDown, m.mouseReenablePending, m.mouseReenableTimerArmed = true, true, true
+	if cmd := m.maybeReenableMouse(); cmd != nil {
+		t.Fatal("shutdown must suppress mouse re-enable")
+	}
+	if m.mouseReenablePending || m.mouseReenableTimerArmed {
+		t.Fatal("shutdown must clear delayed mouse state")
+	}
+}
+
+func TestShutdownMessageMakesMouseLifecycleIrreversible(t *testing.T) {
+	m := newTestChatTUI()
+	next, cmd := m.Update(tuiShutdownMsg{})
+	if !next.(chatTUI).shuttingDown {
+		t.Fatal("shutdown must mark TUI")
+	}
+	if cmd == nil {
+		t.Fatal("shutdown must request quit")
+	}
+}
+
 func isolateUserConfig(t *testing.T) {
 	t.Helper()
 	root := t.TempDir()

--- a/harness/cli/cli.go
+++ b/harness/cli/cli.go
@@ -1301,7 +1301,7 @@ func chatREPL(args []string, version string) int {
 			p.Send(tuiShutdownMsg{})
 		}
 	}()
-	final, runErr := p.Run()
+	final, runErr := runTUIProgram(p, os.Stdout)
 	signal.Stop(hangup)
 	diagnostics.Milestone("terminal_released")
 	// Close the active controller plus any retired ones from /model switches.
@@ -1353,6 +1353,25 @@ func chatREPL(args []string, version string) int {
 		return runWebCommand(webHandoffArgs(launchWebPath, launchWebSessionID, launchWebModelRef, launchWebProfile))
 	}
 	return 0
+}
+
+// tuiProgramRunner is the lifecycle surface runTUIProgram needs. Keeping it
+// narrow makes the terminal reset invariant testable without a real TTY.
+type tuiProgramRunner interface {
+	Run() (tea.Model, error)
+}
+
+// runTUIProgram adds an application-owned final mouse reset around Bubble
+// Tea's renderer cleanup. DEC private-mode resets are idempotent, so this is a
+// harmless duplicate on ordinary exits and a necessary fallback on Run errors
+// and panic unwinding.
+func runTUIProgram(p tuiProgramRunner, out io.Writer) (tea.Model, error) {
+	defer func() {
+		if out != nil {
+			_, _ = io.WriteString(out, resetMouseTracking)
+		}
+	}()
+	return p.Run()
 }
 
 // adoptCarriedHistoryPreservingProfileAndGrants resumes c on the carried

--- a/harness/cli/cli_test.go
+++ b/harness/cli/cli_test.go
@@ -15,6 +15,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"semantix/harness/agent"
 	"semantix/harness/boot"
 	"semantix/harness/config"
@@ -25,6 +27,45 @@ import (
 	"semantix/harness/provider"
 	"semantix/harness/telemetry"
 )
+
+type fakeTUIProgramRunner struct {
+	err        error
+	panicValue any
+}
+
+func (f fakeTUIProgramRunner) Run() (tea.Model, error) {
+	if f.panicValue != nil {
+		panic(f.panicValue)
+	}
+	return nil, f.err
+}
+
+func TestRunTUIProgramAlwaysResetsMouseTracking(t *testing.T) {
+	wantErr := errors.New("input loop failed")
+	for _, err := range []error{nil, wantErr} {
+		var out bytes.Buffer
+		_, gotErr := runTUIProgram(fakeTUIProgramRunner{err: err}, &out)
+		if !errors.Is(gotErr, err) {
+			t.Fatalf("error = %v, want %v", gotErr, err)
+		}
+		if got := out.String(); got != resetMouseTracking {
+			t.Fatalf("reset = %q, want %q", got, resetMouseTracking)
+		}
+	}
+}
+
+func TestRunTUIProgramResetsMouseTrackingDuringPanic(t *testing.T) {
+	var out bytes.Buffer
+	defer func() {
+		if got := recover(); got != "boom" {
+			t.Fatalf("panic = %v, want boom", got)
+		}
+		if got := out.String(); got != resetMouseTracking {
+			t.Fatalf("reset = %q, want %q", got, resetMouseTracking)
+		}
+	}()
+	_, _ = runTUIProgram(fakeTUIProgramRunner{panicValue: "boom"}, &out)
+}
 
 func TestChdirTo(t *testing.T) {
 	orig, err := os.Getwd()

--- a/harness/cli/mouse_reenable.go
+++ b/harness/cli/mouse_reenable.go
@@ -33,8 +33,9 @@ type mouseReenableMsg struct{}
 // No-op for Termux native scrollback (mouse is intentionally off so the soft
 // keyboard can focus) and when the user has toggled capture off via /mouse.
 func (m *chatTUI) maybeReenableMouse() tea.Cmd {
-	if m.nativeScrollback || m.mouseCaptureOff {
+	if m.shuttingDown || m.nativeScrollback || m.mouseCaptureOff {
 		m.mouseReenablePending = false
+		m.mouseReenableTimerArmed = false
 		return nil
 	}
 	now := m.mouseNow()

--- a/harness/cli/tui_diagnostics.go
+++ b/harness/cli/tui_diagnostics.go
@@ -72,6 +72,7 @@ type tuiDiagnostics struct {
 	generation          uint64 // increments on each idle→running transition
 	lastHeartbeat       time.Time
 	lastHeartbeatSource string
+	lastIdleLog         time.Time // idle checks stay 1 Hz; diagnostic lines are sampled
 	// escalatedGeneration is the generation currently inside dump/cancel/grace
 	// (0 means none). Cleared when a heartbeat aborts the grace window so a
 	// later stall can re-enter escalation for hard-kill only.
@@ -341,6 +342,13 @@ func (d *tuiDiagnostics) onTick(now time.Time) {
 	hardKilledGen := d.hardKilledGen
 	statusFn := d.statusFn
 	cancelFn := d.cancelFn
+	if phase == watchdogIdle && !d.lastIdleLog.IsZero() && now.Sub(d.lastIdleLog) < time.Minute {
+		d.mu.Unlock()
+		return
+	}
+	if phase == watchdogIdle {
+		d.lastIdleLog = now
+	}
 	d.logfLocked("heartbeat t=%s phase=%s gen=%d last_progress_age=%s last_source=%s cancel_requested=%v hard_kill_phase=%v",
 		now.UTC().Format(time.RFC3339Nano),
 		phase,

--- a/harness/cli/tui_diagnostics_test.go
+++ b/harness/cli/tui_diagnostics_test.go
@@ -237,6 +237,23 @@ func TestWatchdogBootStallDumpsAndKills(t *testing.T) {
 	}
 }
 
+func TestWatchdogSamplesIdleHeartbeatOncePerMinute(t *testing.T) {
+	clock := &fakeWatchClock{now: time.Unix(1_700_000_000, 0)}
+	d := newWatchdogForTest(t, clock)
+	var logs atomic.Int32
+	d.logFn = func(string, ...any) { logs.Add(1) }
+	d.NoteBooted()
+	logs.Store(0)
+	d.onTick(clock.now)
+	clock.now = clock.now.Add(30 * time.Second)
+	d.onTick(clock.now)
+	clock.now = clock.now.Add(30 * time.Second)
+	d.onTick(clock.now)
+	if got := logs.Load(); got != 2 {
+		t.Fatalf("idle logs = %d, want 2", got)
+	}
+}
+
 func TestWatchdogRunningElapsedHeartbeatPreventsKill(t *testing.T) {
 	clock := &fakeWatchClock{now: time.Unix(1_700_000_000, 0)}
 	d := newWatchdogForTest(t, clock)


### PR DESCRIPTION
## Summary

Close the Semantix TUI mouse lifecycle so Windows Terminal/ConPTY cannot leave SGR mouse reports flowing into the parent PowerShell after a normal, error, or panic exit.

The change also makes shutdown irreversible for queued mouse re-enable timers and samples idle watchdog logs once per minute so the 4 MiB diagnostic log retains the eventual failure boundary.

## Scope

- `harness/cli`: TUI shutdown state, terminal reset wrapper, mouse re-enable guard, watchdog idle-log sampling
- focused regression tests for normal/error/panic cleanup and queued timer suppression
- Issue and implementation spec documentation

## Validation

- [x] `go vet ./harness/cli`
- [ ] `go test ./... -race` — not run; repository-wide suite is outside this focused PR
- [x] `git diff --check`
- [x] `go test ./harness/cli -run 'TestRunTUIProgram|TestMouseReenableIsSuppressed|TestShutdownMessageMakesMouse|TestWatchdogSamplesIdle|TestViewMouseModeFollowsCapture|TestCtrlZResetsMouseTrackingBeforeSuspend|TestWatchdogIdleNeverEscalates' -count=1`
- [ ] `go test ./harness/cli -count=1` — upstream baseline and this branch both fail `TestModelSwitchRefreshesCustomStatusline` at `statusline_test.go:97`; unrelated to the changed paths

## Compatibility and data impact

No configuration, wire contract, or stored-data changes. DEC private-mode reset sequences are idempotent. Mouse selection, wheel, scrollbar, and Termux behavior remain unchanged.

## Security and privacy

None. No new external requests or persisted sensitive data.

## Evidence

Observed leaked input has the SGR form `ESC[<button;x;yM`, which is emitted when the parent shell regains input while terminal mouse reporting remains enabled.

Independent code review found no Critical, Important, or Minor findings. Focused tests passed.

## Related issues

Closes #348

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md` (not applicable; no wire changes).
