### PR TITLE
fix(release): 打包排除 macOS 元数据，并在发布前自检资产完整性

### DIFF
--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -1,0 +1,79 @@
+# v0.7.1 — 品牌统一版
+
+> 发版日期：2026-08-22 · tag：`v0.7.1` · 范围：v0.7.0 之后合入 main 的 47 个提交、10 个 PR
+
+## ⚠️ 破坏性变更（升级前必读）
+
+**本版按 patch 号发布，但包含破坏性变更。** PR #315 完成了全仓品牌替换，落盘契约随之变更：
+
+| 项 | 旧 | 新 | 影响 |
+|---|---|---|---|
+| 用户目录 | `~/.reasonix/` | `~/.semantix/` | 旧数据不整体自动迁移；会话有既有迁移机制兜底 |
+| 项目配置 | `reasonix.toml` | `semantix-agent.toml` | 需手动改名（不能叫 `semantix.toml`，与 kernel 配置撞名） |
+| 环境变量 | `REASONIX_*` | `SEMANTIX_*` | 114 个，含 `REASONIX_HOME`、`REASONIX_STATE_HOME` 等 |
+| keyring 服务名 | `reasonix` | `semantix` | **provider 密钥需重新输入一次** |
+| 项目记忆文件 | `REASONIX.md` | `SEMANTIX.md` | |
+
+兼容性保留：插件清单 `semantix-plugin.json` 回退读取旧名 `reasonix-plugin.json`；插件 `apiVersion` 旧值 `reasonix.io/plugin/v2` 仍接受；主题扩展名 `.reasonix-theme` 保留兼容；`~/.reasonix/config.json` 与 `~/.reasonix/sessions/` 仍作为 legacy 源被迁移机制读取。
+
+### 升级步骤
+
+```bash
+mv ~/.reasonix ~/.semantix                          # 或让迁移机制处理会话
+mv reasonix.toml semantix-agent.toml                # 项目根目录
+sed -i 's/REASONIX_/SEMANTIX_/g' <你的 shell rc>    # 环境变量
+# 首次启动后重新输入 provider 密钥（keyring 服务名已变）
+```
+
+## 修复发布链（本版新增）
+
+v0.7.0 的实物包核对暴露两类打包缺陷，本版一并修复。
+
+### macOS 元数据混入所有产物
+
+v0.7.0 的每个 tar 里，真实文件旁边都躺着一份 AppleDouble 影子文件：
+
+```
+semantix-agent-v0.7.0-linux-arm64/._semantix-agent
+semantix-agent-v0.7.0-linux-arm64/semantix-agent
+```
+
+成因是在 Mac 上用 bsdtar 打包时扩展属性被写成了归档成员。打包脚本现在 `export COPYFILE_DISABLE=1`，并对 `.DS_Store` 显式排除。
+
+### 自更新与 curl 安装器此前不可用
+
+v0.7.0 只发了 4 个 bundle + `SHA256SUMS.txt`，而：
+
+- `semantix-agent upgrade` 找的是 `semantix-agent-<os>-<arch>.tar.gz` 和 `SHA256SUMS`（不带 `.txt`）→ 双双 404
+- agent-skill 的 `install.sh` 要下裸 kernel 资产 `semantix-<version>-<os>-<arch>` → 不存在
+
+资产产出侧随 #315 落地，本版补上**发布前自检**：打完包就地校验每平台三件资产、`SHA256SUMS` 条目、AppleDouble 残留、双份校验文件名，不过就 `exit 1`。
+
+## 其他改动
+
+| PR | 内容 |
+|---|---|
+| #350 | V16 精简 prompt + 条件式语义 review |
+| #349 | TUI 退出时重置鼠标追踪（终端不再残留鼠标模式） |
+| #345 | gateway/billing：钱包探测失败走短退避而非整个 TTL（#318 后续） |
+| #344 | 检索 hybrid 融合——`kernel/fuse` 单一真源 + RRF/可配权重（#274） |
+| #343 | 类型化片段确定性上下文淘汰 + Compact 事件联动（#277） |
+| #301 | prefetch：probation 探针释放被降级的候选（#282） |
+| #314 | 修 `TestSemantixLookupSubprocess` 全量并行下的偶发超时 |
+
+## 资产
+
+每平台三件，共四平台（`darwin-arm64` / `darwin-amd64` / `linux-amd64` / `linux-arm64`）：
+
+- `semantix-agent-v0.7.1-<platform>.tar.gz` — 完整包（`semantix-agent` + `semantix` + `semantix-gateway` + 两个 example.toml + `semantix-install.sh` + README）
+- `semantix-agent-<platform>.tar.gz` — 扁平单二进制，`semantix-agent upgrade` 用
+- `semantix-v0.7.1-<platform>` — 裸 kernel 二进制，agent-skill 的 curl 安装器用
+
+外加 `SHA256SUMS` 与 `SHA256SUMS.txt`（同一份校验、两个名字：自更新器读前者，`install.sh` 读后者）。
+
+## 验证
+
+- `scripts/release/build-full.sh --version v0.7.1` 四平台实跑，12 项资产 + 双份校验文件全部产出，自检全绿
+- 8 个 tar 的 AppleDouble / `.DS_Store` 计数均为 0
+- ldflags 变量名与 `cmd/semantix-agent/main.go:26-28`、`cmd/semantix/version.go:14-16` 逐个对齐；二进制内确认含 `v0.7.1` 与 commit 戳
+- 更新器扁平包内只有裸 `semantix-agent`，符合 `harness/releaseasset/cli.go` 预期

--- a/scripts/release/build-full.sh
+++ b/scripts/release/build-full.sh
@@ -56,6 +56,14 @@ OUT="$ROOT/dist"
 rm -rf "$OUT"
 mkdir -p "$OUT"
 
+# macOS bsdtar archives extended attributes as AppleDouble "._name" members and
+# would also sweep in .DS_Store, so a release packed on a Mac ships a shadow
+# file next to every real one (v0.7.0 did). These make the tarball wrong for
+# every consumer, not just Linux. COPYFILE_DISABLE is the documented bsdtar
+# opt-out; the older name is kept for pre-10.5 tars. Both are inert on GNU tar.
+export COPYFILE_DISABLE=1
+export COPY_EXTENDED_ATTRIBUTES_DISABLE=1
+
 COMMIT="$(git -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
 BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -126,11 +134,11 @@ for plat in ${PLATFORMS//,/ }; do
 EOF
   chmod +x "$D/semantix-agent" "$D/semantix" "$D/semantix-gateway" "$D/semantix-install.sh"
 
-  (cd "$OUT" && tar -czf "$PKG.tar.gz" "$PKG")
+  (cd "$OUT" && tar --exclude='.DS_Store' -czf "$PKG.tar.gz" "$PKG")
 
   # Flat single-binary archive for `semantix-agent upgrade`: the updater
   # expects semantix-agent-<os>-<arch>.tar.gz with the binary at the root.
-  (cd "$D" && tar -czf "$OUT/semantix-agent-$plat.tar.gz" semantix-agent)
+  (cd "$D" && tar --exclude='.DS_Store' -czf "$OUT/semantix-agent-$plat.tar.gz" semantix-agent)
   # Raw kernel binary for agent-skill/scripts/install.sh (curl flow).
   cp "$D/semantix" "$OUT/semantix-$VERSION-$plat"
   rm -rf "$D"
@@ -141,5 +149,43 @@ done
 # self-updater downloads the asset literally named SHA256SUMS, while the
 # agent-skill install.sh fetches SHA256SUMS.txt.
 (cd "$OUT" && shasum -a 256 semantix-agent-*.tar.gz semantix-"$VERSION"-* > SHA256SUMS && cp SHA256SUMS SHA256SUMS.txt)
+
+# Self-check. v0.7.0 shipped with the updater asset missing, the kernel asset
+# missing, SHA256SUMS absent under the name the updater reads, and AppleDouble
+# junk inside every tarball — none of it caught before publishing. Fail the
+# build here instead of finding out from a user's broken `upgrade`.
+echo "--- verifying assets"
+verify_fail=0
+note() { echo "  FAIL: $*" >&2; verify_fail=1; }
+# shasum writes "<hash>  name" in text mode but "<hash> *name" in binary mode
+# (the Git-Bash default), so compare on the name field with the marker stripped
+# rather than pattern-matching the whole line. Both consumers already tolerate
+# the marker: releaseasset/cli.go TrimPrefixes it and install.sh pipes through
+# `shasum -c`.
+sums_have() { awk '{sub(/^\*/, "", $2); print $2}' "$OUT/SHA256SUMS" | grep -Fxq "$1"; }
+for plat in ${PLATFORMS//,/ }; do
+  [ -f "$OUT/semantix-agent-$VERSION-$plat.tar.gz" ] || note "missing bundle for $plat"
+  [ -f "$OUT/semantix-agent-$plat.tar.gz" ]          || note "missing updater asset for $plat"
+  [ -f "$OUT/semantix-$VERSION-$plat" ]              || note "missing raw kernel asset for $plat"
+  # The updater resolves its asset through SHA256SUMS; a name mismatch there is
+  # exactly how v0.7.0's `upgrade` 404'd.
+  sums_have "semantix-agent-$plat.tar.gz" \
+    || note "SHA256SUMS has no entry for semantix-agent-$plat.tar.gz"
+  sums_have "semantix-$VERSION-$plat" \
+    || note "SHA256SUMS has no entry for semantix-$VERSION-$plat"
+done
+for t in "$OUT"/*.tar.gz; do
+  if tar -tzf "$t" 2>/dev/null | grep -qE '(^|/)(\._|\.DS_Store)'; then
+    note "$(basename "$t") contains AppleDouble/.DS_Store junk"
+  fi
+done
+[ -f "$OUT/SHA256SUMS" ]     || note "SHA256SUMS missing (self-updater reads this exact name)"
+[ -f "$OUT/SHA256SUMS.txt" ] || note "SHA256SUMS.txt missing (agent-skill install.sh reads this)"
+if [ "$verify_fail" -ne 0 ]; then
+  echo "release assets are incomplete — not publishable" >&2
+  exit 1
+fi
+echo "  all asset checks passed"
+
 echo "---"
 ls -lh "$OUT" | awk '{print $5, $9}'


### PR DESCRIPTION
## 背景

核对 v0.7.0 实物包发现两类打包缺陷，都不是代码问题而是发布链缺环。

## ① macOS 元数据混入所有产物

`gh release download v0.7.0` 解开后，每个真实文件旁边都躺着一份 AppleDouble 影子文件：

```
semantix-agent-v0.7.0-linux-arm64/._semantix-agent
semantix-agent-v0.7.0-linux-arm64/semantix-agent
semantix-agent-v0.7.0-linux-arm64/._reasonix.example.toml
semantix-agent-v0.7.0-linux-arm64/reasonix.example.toml
```

tar 同时报 `LIBARCHIVE.xattr.com.apple.provenance`。成因是在 Mac 上用 bsdtar 打包时扩展属性被写成了归档成员。这对所有消费者都是错的产物。

修复：脚本顶层 `export COPYFILE_DISABLE=1`（bsdtar 官方退出开关）与 `COPY_EXTENDED_ATTRIBUTES_DISABLE=1`（10.5 前旧名），两者在 GNU tar 上惰性、不影响 Linux/CI 打包；两处 tar 调用加 `--exclude='.DS_Store'`（真实文件，前者管不到）。

## ② 发布前完全不验资产

v0.7.0 实际只发了 4 个 bundle + `SHA256SUMS.txt`，导致：

- **`semantix-agent upgrade` 404** — `harness/releaseasset/cli.go:54,57` 找 `semantix-agent-<os>-<arch>.tar.gz` 和 `SHA256SUMS`（不带 .txt），两者都没发
- **agent-skill 的 curl 安装器失败** — `install.sh:43` 要下裸 kernel 资产 `semantix-$VERSION-$OS-$ARCH`，没发；`SHA256SUMS.txt` 里也没有对应条目，`grep` 取空后校验失败

这四项没有一项在发布前被发现，因为脚本压根不验。本 PR 让打包脚本打完就地自检，不过就 `exit 1`：

- 每平台三件资产（bundle / 更新器扁平包 / 裸 kernel）存在性
- `SHA256SUMS` 里必须有更新器资产与裸 kernel 的条目
- 每个 tar 扫 AppleDouble 与 `.DS_Store` 残留
- `SHA256SUMS` 与 `SHA256SUMS.txt` 双名都在

> 资产名的产出侧（扁平包、裸 kernel、双份校验文件）已随 #315 落地，本 PR 只补验证侧。

### 自检的一个细节

条目比对按字段取名再比，不整行匹配：`shasum` 文本模式输出 `<hash>  name`，二进制模式（Git Bash 默认）输出 `<hash> *name`。两端消费者本来就都容忍星号——`releaseasset/cli.go:113` 会 `TrimPrefix`，`install.sh` 走 `shasum -c`——所以自检也必须容忍，否则误报。（第一版就是整行匹配，实跑时误报了 8 条。）

## 验证

`scripts/release/build-full.sh --version v0.7.1` 实跑四平台：

- 12 项资产 + 双份校验文件全部产出，自检全绿
- 8 个 tar 的 AppleDouble/`.DS_Store` 计数均为 0
- bundle 内含 `semantix-agent` / `semantix` / `semantix-gateway` / 两个 example.toml / `semantix-install.sh`
- 更新器扁平包内只有裸 `semantix-agent`，符合 updater 预期
- ldflags 变量名与 `cmd/semantix-agent/main.go:26-28`、`cmd/semantix/version.go:14-16` 逐个对齐；二进制内确认含 `v0.7.1` 与 commit 戳

Refs #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KywiuAhs2m17Sf4CiAvWKM