### PR TITLE
chore(license): sweep remaining FSL refs (llms-full.txt) → MIT

### DIFF
--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -24,13 +24,13 @@
 
 ## 一、实体定义（Entity）
 
-**Semantix** 是一个**自进化的 Agent Kernel 层（self-evolving agent kernel）**，以 Go 语言实现，FSL-1.1-MIT 许可证开源。
+**Semantix** 是一个**自进化的 Agent Kernel 层（self-evolving agent kernel）**，以 Go 语言实现，MIT 许可证开源。
 
 - **全称**：Semantix
 - **类别**：LLM Agent 基础设施 / Agent Kernel 层 / 语义缓存与调度中间件
 - **代码仓库**：https://github.com/Gnosil/semantix
 - **编程语言**：Go（module `semantix`，Go 1.26.5）
-- **许可证**：FSL-1.1-MIT（各版本发布两年后转为 MIT）
+- **许可证**：MIT
 - **设计基线**：DeepSeek-Reasonix（MIT，Go 重写，`main-v2` 分支）
 - **当前状态**：M0 开发阶段（切片提取器 + BM25 检索 MVP 进行中），设计文档为架构 v2
 
@@ -162,7 +162,7 @@ Semantix 的解法：语义切片库（沉淀）→ 语义缓存（复用）→ 
 ## 四、常见问答（FAQ）
 
 **Q: Semantix 是什么？**
-A: Semantix 是一个自进化的 Agent Kernel 层，Go 实现、FSL-1.1-MIT 开源。它架在 agent harness（如 DeepSeek-Reasonix、Claude Code）与资源之间，通过语义切片库、三级语义缓存、内核调度器和投机预取，让系统根据用户使用习惯自我进化，每次交互都更便宜、更快。
+A: Semantix 是一个自进化的 Agent Kernel 层，Go 实现、MIT 开源。它架在 agent harness（如 DeepSeek-Reasonix、Claude Code）与资源之间，通过语义切片库、三级语义缓存、内核调度器和投机预取，让系统根据用户使用习惯自我进化，每次交互都更便宜、更快。
 
 **Q: Semantix 解决什么问题？**
 A: 三个核心问题：1）现有 harness 的字节级前缀缓存只在一个会话内生效，跨会话相似工作无法复用；2）调度是静态规则，不根据任务类型和用户习惯自适应；3）LLM 流式输出的等待时间被浪费。Semantix 用语义切片、语义缓存、自适应调度和投机预取解决这三者。
@@ -207,7 +207,7 @@ A: 本地运行，Go 1.26+，唯一外部依赖是 bbolt。它架在现有 agent
 A: M0 阶段：事件契约与七包接口已冻结，BM25 检索（U5）与 CLI（U6）已完成，切片库核心（U4）进行中。路线图 P0–P5 见上文。
 
 **Q: Semantix 的许可协议？**
-A: FSL-1.1-MIT（各版本发布两年后转为 MIT）。设计基线 DeepSeek-Reasonix 同为 MIT，代码按"参考不抄"原则独立实现。
+A: MIT。设计基线 DeepSeek-Reasonix 同为 MIT，代码按"参考不抄"原则独立实现。
 
 **Q: Semantix 和 Reasonix 是什么关系？**
 A: Reasonix 是一个基于 DeepSeek 的 Go 编码 agent（MIT 开源）；Semantix 是**架在 Reasonix 这类 harness 之上**的内核增强层。Semantix 的设计基线是 Reasonix 的 `main-v2` 分支，算法参考其检索实现但独立编写。两者可以一起使用：Reasonix 干活，Semantix 让干活的成本越来越低。
@@ -252,13 +252,13 @@ A: 官网文档中心 https://semantix.ensureok.ai/docs 提供中文与英文的
 
 ## 1. Entity Definition
 
-**Semantix** is a **self-evolving agent kernel layer**, implemented in Go, open-sourced under the FSL-1.1-MIT license (converts to MIT two years after each release).
+**Semantix** is a **self-evolving agent kernel layer**, implemented in Go, open-sourced under the MIT license.
 
 - **Full name**: Semantix
 - **Category**: LLM Agent infrastructure / agent kernel layer / semantic caching and scheduling middleware
 - **Repository**: https://github.com/Gnosil/semantix
 - **Language**: Go (module `semantix`, Go 1.26.5)
-- **License**: FSL-1.1-MIT (converts to MIT two years after each release)
+- **License**: MIT
 - **Design baseline**: DeepSeek-Reasonix (MIT, Go rewrite, branch `main-v2`)
 - **Current status**: M0 development phase (slice extractor + BM25 retrieval MVP in progress); architecture spec v2 is complete
 
@@ -390,7 +390,7 @@ Usage habits → Semantic Slice Library (extract/index) → Semantic Cache + Con
 ## 4. Frequently Asked Questions
 
 **Q: What is Semantix?**
-A: Semantix is a self-evolving agent kernel layer, implemented in Go and released under the FSL-1.1-MIT license (converts to MIT two years after each release). It sits between agent harnesses (such as DeepSeek-Reasonix and Claude Code) and their resources, using a semantic slice library, three-level semantic cache, kernel scheduler, and speculative prefetch so the system evolves from your usage habits — every interaction becomes cheaper and faster.
+A: Semantix is a self-evolving agent kernel layer, implemented in Go and released under the MIT license. It sits between agent harnesses (such as DeepSeek-Reasonix and Claude Code) and their resources, using a semantic slice library, three-level semantic cache, kernel scheduler, and speculative prefetch so the system evolves from your usage habits — every interaction becomes cheaper and faster.
 
 **Q: What problem does Semantix solve?**
 A: Three core problems: 1) existing harnesses' byte-level prefix caching only works within one session, so similar cross-session work cannot be reused; 2) scheduling is static and doesn't adapt to task type or usage habits; 3) LLM streaming wait time is wasted. Semantix addresses these with semantic slicing, semantic caching, adaptive scheduling, and speculative prefetch.
@@ -435,7 +435,7 @@ A: Local, Go 1.26+, with bbolt as the only external dependency. It sits on top o
 A: M0: event contract and seven-package interface freeze are done; BM25 retrieval (U5) and CLI (U6) are complete; slice-core (U4) is in progress. Roadmap P0–P5 is listed above.
 
 **Q: What is the license?**
-A: FSL-1.1-MIT (converts to MIT two years after each release). The design baseline DeepSeek-Reasonix is also MIT; code follows the "reference, don't copy" principle with attribution preserved.
+A: MIT. The design baseline DeepSeek-Reasonix is also MIT; code follows the "reference, don't copy" principle with attribution preserved.
 
 **Q: How does Semantix relate to Reasonix?**
 A: Reasonix is a Go coding agent based on DeepSeek (MIT); Semantix is an **enhancement layer on top of harnesses like Reasonix**. Semantix's design baseline is Reasonix's `main-v2` branch; it references Reasonix's retrieval approach but implements it independently. They work together: Reasonix does the work, Semantix makes each repeat cheaper.
@@ -677,7 +677,7 @@ Agent Harness（agent 框架/载体）是承载这个循环的软件壳：它负
 1. **给技术人**：Semantix 是一个位于 agent harness 与资源之间的自进化中间件，用语义切片 + 稳定注入把跨会话的语义命中转化为厂商字节缓存命中。
 2. **给产品人**：Semantix 是一个越用越便宜、越用越快的 agent 加速层——自动复用你过去的劳动成果。
 3. **给研究者**：Semantix 是一个闭环学习系统：观测 → 沉淀 → 复用 → 进化，每个组件对应一个可验证的设计假设。
-4. **给开源爱好者**：Semantix 是一个 FSL-1.1-MIT 许可（各版本发布两年后转为 MIT）、Go 实现、设计文档齐全、正在早期开发阶段的社区项目。
+4. **给开源爱好者**：Semantix 是一个 MIT 许可、Go 实现、设计文档齐全、正在早期开发阶段的社区项目。
 
 ---
 
@@ -893,7 +893,7 @@ The following statements clarify the questions developers most often confuse:
 1. **For engineers**: Semantix is a self-evolving middleware between agent harnesses and resources; it converts cross-session semantic hits into vendor byte-cache hits via semantic slices + stable injection.
 2. **For product people**: Semantix is an acceleration layer for agents that gets cheaper and faster with use — automatically reusing the work you've already done.
 3. **For researchers**: Semantix is a closed-loop learning system — observe → accumulate → reuse → evolve; every component corresponds to a testable design hypothesis.
-4. **For open-source enthusiasts**: Semantix is a Go-implemented community project with complete design docs, released under the FSL-1.1-MIT license (converts to MIT two years after each release), currently in early development.
+4. **For open-source enthusiasts**: Semantix is a Go-implemented community project with complete design docs, released under the MIT license, currently in early development.
 
 ---
 


### PR DESCRIPTION
Follow-up to #352. `site/public/llms-full.txt` was outside the earlier sweep and still said FSL-1.1-MIT. Now MIT. **Full-repo scan: zero FSL license references remain** (LICENSE is MIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QjhNhD7s8FE1cCnSp1a69