### PR TITLE
chore(patrol): brand cleanup + bug-hunt fixes (2026-08-22)

### DIFF
--- a/harness/cli/chat_tui_test.go
+++ b/harness/cli/chat_tui_test.go
@@ -3309,6 +3309,42 @@ func TestChooserFreeTextWideInputChangeRequestsClearScreen(t *testing.T) {
 	}
 }
 
+// TestChooserMultiSelectNumberKeyTogglesInsteadOfSubmitting guards against a
+// regression where a number-key press on a multi-select ask() question
+// bypassed the toggle and submitted the question with no selection (#360).
+func TestChooserMultiSelectNumberKeyTogglesInsteadOfSubmitting(t *testing.T) {
+	m := newTestChatTUI()
+	m.chooser = newChooser(event.Ask{
+		ID: "ask-1",
+		Questions: []event.AskQuestion{{
+			ID:     "q1",
+			Prompt: "Pick any",
+			Multi:  true,
+			Options: []event.AskOption{
+				{Label: "Option A"},
+				{Label: "Option B"},
+			},
+		}},
+	})
+
+	next, _ := m.update(tea.KeyPressMsg{Code: '2'})
+	got := next.(chatTUI)
+
+	if got.chooser == nil {
+		t.Fatal("number key on a multi-select question must not submit/dismiss the chooser")
+	}
+	if !got.chooser.sel[0][1] {
+		t.Fatal("number key on a multi-select question should toggle the picked option, like space does")
+	}
+
+	// Pressing the same key again toggles it back off, exactly like space.
+	next, _ = got.update(tea.KeyPressMsg{Code: '2'})
+	got = next.(chatTUI)
+	if got.chooser.sel[0][1] {
+		t.Fatal("a second number-key press should toggle the option back off")
+	}
+}
+
 func TestReplayActiveBranchClearsPlanModeAndMarksSessionSwitch(t *testing.T) {
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{})

--- a/harness/cli/chooser.go
+++ b/harness/cli/chooser.go
@@ -138,9 +138,16 @@ func (m chatTUI) handleChooserKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		return m.chooserActivate(c.cursor)
 	default:
-		// number keys 1..9 jump to / pick an option
+		// number keys 1..9 jump to (single-select: select and advance) or pick
+		// (multi-select: toggle, like space) an option.
 		if s := msg.String(); len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
 			if idx := int(s[0] - '1'); idx < len(q.Options) {
+				if q.Multi {
+					c.cursor = idx
+					c.sel[c.tab][idx] = !c.sel[c.tab][idx]
+					c.custom[c.tab] = ""
+					return m, nil
+				}
 				return m.chooserActivate(idx)
 			}
 		}
@@ -157,9 +164,9 @@ func (m chatTUI) chooserActivate(row int) (tea.Model, tea.Cmd) {
 	switch {
 	case row < len(q.Options):
 		if q.Multi {
-			// Space toggles; Enter confirms current selections and advances.
-			// (Toggling is handled in handleChooserKey; we only arrive here
-			// via Enter or number keys, both of which should commit.)
+			// Space and number keys toggle (handled in handleChooserKey);
+			// Enter is the only path that reaches here for a multi-select
+			// question, and it confirms the current selections and advances.
 			return m.chooserAdvance()
 		}
 		c.sel[c.tab] = map[int]bool{row: true}

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -1,5 +1,5 @@
-// Package config loads Reasonix's runtime configuration from TOML. Resolution order:
-// flag > project ./reasonix.toml > user config.toml (in the OS user-config dir) > built-in defaults.
+// Package config loads Semantix's runtime configuration from TOML. Resolution order:
+// flag > project ./semantix-agent.toml > user config.toml (in the OS user-config dir) > built-in defaults.
 // Secrets come from the environment via api_key_env and are never stored in
 // config files.
 package config
@@ -40,11 +40,11 @@ func SkillNameKey(name string) string {
 	return name
 }
 
-// Config is Reasonix's runtime configuration.
+// Config is Semantix's runtime configuration.
 type Config struct {
 	ConfigVersion    int                 `toml:"config_version"`
 	DefaultModel     string              `toml:"default_model"`
-	Language         string              `toml:"language"` // ui/model language tag (e.g. "zh"); empty = auto-detect from $LANG / $REASONIX_LANG
+	Language         string              `toml:"language"` // ui/model language tag (e.g. "zh"); empty = auto-detect from $LANG / $SEMANTIX_LANG
 	CredentialsStore string              `toml:"credentials_store"`
 	UI               UIConfig            `toml:"ui"`
 	CLI              CLIConfig           `toml:"cli"`
@@ -149,7 +149,7 @@ func IsMissingSystemPromptFile(err error) bool {
 }
 
 // TelemetryConfig controls content-free CLI usage metrics. It is user-global:
-// project reasonix.toml values are ignored so a cloned repository cannot opt a
+// project semantix-agent.toml values are ignored so a cloned repository cannot opt a
 // user into reporting.
 type TelemetryConfig struct {
 	CLIMetrics string `toml:"cli_metrics"` // auto|on|off; empty means consent has not been requested
@@ -220,7 +220,7 @@ func (c *Config) IgnoredLegacyAgentStepLimits() bool {
 	return c != nil && c.ignoredLegacyStepLimits
 }
 
-// IgnoredProjectDefaultModel returns the project reasonix.toml default_model
+// IgnoredProjectDefaultModel returns the project semantix-agent.toml default_model
 // that LoadForRoot ignored because no configured provider serves it (see
 // restoreUnresolvableProjectDefaultModel), or "" when none was ignored.
 func (c *Config) IgnoredProjectDefaultModel() string {
@@ -231,7 +231,7 @@ func (c *Config) IgnoredProjectDefaultModel() string {
 }
 
 // SecretsConfig controls the credential protection layers. It is a user-global
-// setting: project reasonix.toml values are ignored (see LoadForRoot), so a
+// setting: project semantix-agent.toml values are ignored (see LoadForRoot), so a
 // cloned repository cannot silently opt the user into workflow-breaking
 // protections.
 type SecretsConfig struct {
@@ -938,7 +938,7 @@ type ServeConfig struct {
 	// cryptographically random token is generated at startup and printed.
 	Token string `toml:"token"`
 	// PasswordHash is a bcrypt hash of the password for auth_mode = "password".
-	// Generate one with: reasonix serve --hash-password --password '...'
+	// Generate one with: semantix-agent serve --hash-password --password '...'
 	PasswordHash string `toml:"password_hash"`
 	// BehindProxy indicates the server sits behind a trusted reverse proxy
 	// (nginx, Caddy, Cloudflare, etc.) that sets X-Forwarded-For and
@@ -1057,7 +1057,7 @@ func (c *Config) NetworkProxyMode() string {
 
 // SkillsConfig configures skill discovery. Paths adds extra "custom"-scope skill
 // roots — each a directory of SKILL.md / <name>.md playbooks — scanned between
-// the project roots (.reasonix/.agents/.agent/.claude under the workspace) and
+// the project roots (.semantix/.agents/.agent/.claude under the workspace) and
 // the global roots. ExcludedPaths hides matching discovery roots without deleting
 // folders. ~, relative paths, and ${VAR} expansion are supported. DisabledSkills
 // hides named skills from the agent prompt, slash invocation, and skill tools
@@ -1325,7 +1325,7 @@ type AgentConfig struct {
 	MaxParallelWriters int `toml:"max_parallel_writers"`
 	// OutputStyle selects a persona/tone block folded into the system prompt at
 	// startup (a built-in like "explanatory"/"learning"/"concise", or a custom
-	// .reasonix/output-styles/<name>.md). Empty = the unmodified prompt.
+	// .semantix/output-styles/<name>.md). Empty = the unmodified prompt.
 	OutputStyle string `toml:"output_style"`
 	// Deprecated compatibility field. Automatic plan mode was retired in config
 	// version 5; old TOML remains readable, but loading normalizes it to "off"
@@ -1888,8 +1888,8 @@ func Default() *Config {
 			MaxSubagentConcurrency: 6,
 			MaxParallelWriters:     3,
 		},
-		// Mode "ask" with no rules keeps `reasonix run` autonomous (no TTY → ask
-		// resolves to allow) while `reasonix` prompts before writers. Users add
+		// Mode "ask" with no rules keeps `semantix-agent run` autonomous (no TTY → ask
+		// resolves to allow) while `semantix-agent` prompts before writers. Users add
 		// deny/allow rules to harden or quiet specific tools.
 		Permissions: PermissionsConfig{Mode: "ask"},
 		// Sandbox uses platform defaults: macOS/Linux jail bash by default;
@@ -2145,7 +2145,7 @@ func (e *ProviderEntry) APIKey() string {
 
 // ResolveAPIKeyFromProcessEnvForProbe pins a setup-time, user-entered key onto
 // this entry for an immediate connectivity probe. Normal runtime resolution does
-// not call this; loaded provider entries still resolve only from Reasonix's
+// not call this; loaded provider entries still resolve only from Semantix's
 // global .env.
 func (e *ProviderEntry) ResolveAPIKeyFromProcessEnvForProbe() {
 	if e == nil {
@@ -2228,7 +2228,7 @@ func (c *Config) ResolveSystemPrompt() (string, error) {
 // ResolveSystemPromptForRoot is like ResolveSystemPrompt but resolves a relative
 // system_prompt_file against root. Desktop tabs pass their workspace root here so
 // prompt files are project-scoped even when the process cwd is elsewhere. A path
-// inherited from user config may fall back to Reasonix home, while a path chosen
+// inherited from user config may fall back to Semantix home, while a path chosen
 // by project config is confined to the workspace and never probes user files.
 func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
 	path := c.Agent.SystemPromptFile

--- a/harness/control/extensions.go
+++ b/harness/control/extensions.go
@@ -161,8 +161,10 @@ func (s *frontendEventSink) Emit(ev event.Event) {
 			payload = before
 		}
 	}
-	// Observers see exactly what the frontend is about to receive.
-	s.d.Event(extension.PointFrontendEvent, payload)
+	// Observers see exactly what the frontend is about to receive. Use the
+	// dispatcher captured under warnMu above, not s.d directly: setDispatcher
+	// can swap s.d concurrently from a hot-reload goroutine (#357).
+	d.Event(extension.PointFrontendEvent, payload)
 	ev.Text, ev.Detail = payload.Text, payload.Detail
 	s.inner.Emit(ev)
 }

--- a/kernel/usage/usage.go
+++ b/kernel/usage/usage.go
@@ -250,6 +250,7 @@ func Summarize(path string, costMiss, costHit float64) (*Summary, error) {
 	s := &Summary{ByProvider: map[string]*ProviderStats{}}
 	var l3In, l3Out int64 // tokens of L3-reused turns (not billed)
 	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // tolerate entries up to 8 MiB
 	for sc.Scan() {
 		line := sc.Bytes()
 		if len(line) == 0 {


### PR DESCRIPTION
## Summary

Automated nightly patrol run (brand consistency + bug scan), 2026-08-22.

### Brand cleanup (reasonix → semantix)

Full-repo scan found the vast majority of the codebase already rebranded (a prior effort — see `docs/specs/semantix-full-rebrand.md` and issue #347 — already converted the ~7000+ historical occurrences). Remaining `reasonix` hits were audited file-by-file; almost all are legitimate and were left untouched:

- Legal attribution (`harness/LICENSE.reasonix.md`, `ATTRIBUTION.md`)
- Real upstream repo/site references (`Gnosil/DeepSeek-Reasonix`, `reasonix.io`)
- Runtime legacy-compat literals protected by design: `REASONIX_*` env vars, `~/.reasonix/` migration source paths, `reasonix-plugin.json` / `reasonix.io/plugin/v2` legacy manifest fallbacks, `enabled_reasonix`/`apps.reasonix` third-party (CC Switch) contract keys
- Historical spec/acceptance reports and vendored fork patches (accurate as history, not live brand)

The one genuine stray was in `harness/config/config.go`: several doc comments still said `reasonix.toml` / `REASONIX_LANG` / `.reasonix/` / bare `reasonix` CLI invocations, even though the actual functional names are already `semantix-agent.toml`, `SEMANTIX_LANG`, `.semantix/`, and the `semantix-agent` CLI. Fixed those 13 comment-only mentions. No env var, config filename, wire-protocol string, or serialization tag was touched.

### Bug patrol

Four parallel static-review passes (kernel/gateway, harness control/tool/hook, harness config/migration/boot, harness cli) surfaced 6 candidate bugs; after manually re-verifying each against source, 5 were confirmed as real and filed as issues (deduped against existing open issues/PRs first). Per the run's 3-fix-commit cap, the 3 lowest-risk, most-confidently-fixable ones were fixed here; the other 2 are issue-only for a human to pick up.

**Fixed in this PR:**
- #357 — `harness/control/extensions.go`: `frontendEventSink.Emit` read the raw `s.d` field instead of the dispatcher already captured under `warnMu`, racing `setDispatcher` during a live extension hot-reload. Fixed the unsynchronized read (one-line). *(Issue also covers a second, harder unguarded race on `inboxEventSink.inner` — left open, needs its own mutex + dedicated test.)*
- #359 — `kernel/usage/usage.go`: `Summarize`'s `bufio.Scanner` had no buffer bound (unlike every sibling JSONL reader in the codebase), so one oversized line aborted the whole scan with "token too long" instead of just being skipped — silently zeroing out all cost/savings data. Added the same buffer bound used elsewhere.
- #360 — `harness/cli/chooser.go`: a number-key press on a multi-select `ask()` question skipped the toggle-selection step and submitted immediately with an empty selection (no way to correct it once submitted). Number keys now toggle for multi-select questions, matching space; Enter's confirm-and-advance behavior is unchanged. Added regression test coverage (chooser.go had none).

**Issue-only (not fixed here):**
- #356 — `harness/config/migrate.go`: legacy directory migration (`migrateSupportData`/`copyDir`) overwrites existing user session/skill files instead of skipping them like the flat-file path does — silent data loss, contradicts the documented "never overwrite" guarantee. Needs a recursion-safe existence check; deferred given the commit cap and the risk of a rushed fix in a data-migration path.
- #358 — `kernel/judge/sanitize.go`: a validly UTF-8-encoded C1 control character is mis-dispatched (wrong terminator search on the wrong byte offset), silently deleting arbitrary legitimate content between it and an unrelated later BEL/ST byte — part of the judge's prompt-injection sanitization pipeline. Deferred: fix needs care to get the byte-offset logic exactly right plus new test coverage, better done as a focused follow-up than squeezed into this run's cap.

## Scope

- `harness/config/config.go` (comments only)
- `harness/control/extensions.go`
- `kernel/usage/usage.go`
- `harness/cli/chooser.go`, `harness/cli/chat_tui_test.go`

## Validation

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./harness/config/... -race`, `go test ./harness/control/... -race`, `go test ./kernel/usage/... -race`, `go test ./harness/cli/... -race` — all green, including the new regression test for #360. (One pre-existing test, `TestSaveToUnwritableUserSymlinkTargetPreservesLink`, fails identically on unmodified `main` when run as root — a test-harness/root-environment artifact unrelated to this PR's changes.)

## Compatibility and data impact

None for the brand/comment changes. The three code fixes are all behavior corrections with no config/wire/schema impact:
- extensions.go: synchronization fix only, no observable behavior change in the non-racing case.
- usage.go: previously-fatal oversized lines are now tolerated (up to 8 MiB), matching the documented "never fatal" contract.
- chooser.go: number-key behavior on multi-select `ask()` questions changes from "submit immediately with nothing selected" to "toggle the option, like space" — a bug fix, not a behavior most users would have relied on (a workflow relying on the old broken behavior isn't a real workflow).

## Security and privacy

None. (#358, left as issue-only, is the only finding with security relevance — it's part of the judge's prompt-injection-defense sanitization path — but the fix wasn't rushed into this run.)

## Related issues

Closes (this PR): #357 (partially — see note above), #359, #360
Filed, not fixed here: #356, #358
Related: #347 (brand cleanup tracking issue — already largely resolved on `main`; this PR fixes the last stray comments)

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior (new regression test added for #360; #357/#359 are covered by existing `-race` suites).
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md` (N/A — no wire changes).
