### PR TITLE
feat(zone): L3 命中阈值三阶段演进——可配化/按类型分化/逐条目自适应 (Issue #259)

### DIFF
--- a/cmd/semantix/eval.go
+++ b/cmd/semantix/eval.go
@@ -42,7 +42,7 @@ type evalOptions struct {
 	zf         zoneFlagSet
 }
 
-func runEval(args []string, stdout io.Writer) int {
+func runEval(args []string, stdout io.Writer, deps dependencies) int {
 	fs := flag.NewFlagSet("eval", flag.ContinueOnError)
 	jsonOut := fs.Bool("json", false, "write JSON envelope output (§4.2)")
 	var opt evalOptions
@@ -74,6 +74,9 @@ func runEval(args []string, stdout io.Writer) int {
 			fmt.Fprintf(stdout, "eval: %s\n", msg)
 		}
 		return code
+	}
+	if err := opt.zf.applyConfigZones(fs, deps.resolved); err != nil {
+		return fail(2, err.Error())
 	}
 	if err := opt.zf.validate(); err != nil {
 		return fail(2, err.Error())

--- a/cmd/semantix/eval_test.go
+++ b/cmd/semantix/eval_test.go
@@ -15,7 +15,7 @@ import (
 func TestEvalComparesPolicies(t *testing.T) {
 	set := filepath.Join("testdata", "eval-greyzone.tsv")
 	var out bytes.Buffer
-	if code := runEval([]string{"--set", set}, &out); code != 0 {
+	if code := runEval([]string{"--set", set}, &out, dependencies{}); code != 0 {
 		t.Fatalf("runEval code = %d, want 0; out:\n%s", code, out.String())
 	}
 	text := out.String()
@@ -36,7 +36,7 @@ func TestEvalComparesPolicies(t *testing.T) {
 func TestEvalAlarm(t *testing.T) {
 	set := filepath.Join("testdata", "eval-greyzone.tsv")
 	var out bytes.Buffer
-	if code := runEval([]string{"--set", set, "--grey-target", "10"}, &out); code != 0 {
+	if code := runEval([]string{"--set", set, "--grey-target", "10"}, &out, dependencies{}); code != 0 {
 		t.Fatalf("code = %d, want 0 (WARN but non-strict); out:\n%s", code, out.String())
 	}
 	if !strings.Contains(out.String(), "WARN: grey_ratio") {
@@ -44,12 +44,12 @@ func TestEvalAlarm(t *testing.T) {
 	}
 
 	out.Reset()
-	if code := runEval([]string{"--set", set, "--grey-target", "10", "--strict"}, &out); code != 3 {
+	if code := runEval([]string{"--set", set, "--grey-target", "10", "--strict"}, &out, dependencies{}); code != 3 {
 		t.Fatalf("strict code = %d, want 3; out:\n%s", code, out.String())
 	}
 
 	out.Reset()
-	if code := runEval([]string{"--set", set, "--grey-target", "0", "--strict"}, &out); code != 0 {
+	if code := runEval([]string{"--set", set, "--grey-target", "0", "--strict"}, &out, dependencies{}); code != 0 {
 		t.Fatalf("disabled alarm code = %d, want 0; out:\n%s", code, out.String())
 	}
 	if strings.Contains(out.String(), "WARN") {
@@ -59,10 +59,10 @@ func TestEvalAlarm(t *testing.T) {
 
 func TestEvalRejectsBadSet(t *testing.T) {
 	var out bytes.Buffer
-	if code := runEval([]string{"--set", "does-not-exist.tsv"}, &out); code != 1 {
+	if code := runEval([]string{"--set", "does-not-exist.tsv"}, &out, dependencies{}); code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
-	if code := runEval(nil, &out); code != 2 {
+	if code := runEval(nil, &out, dependencies{}); code != 2 {
 		t.Fatalf("no --set code = %d, want 2", code)
 	}
 }
@@ -86,7 +86,7 @@ func TestEvalRejectsNaNInFlags(t *testing.T) {
 	set := filepath.Join("testdata", "eval-greyzone.tsv")
 	for _, frac := range []string{"NaN", "Inf", "-Inf"} {
 		var out bytes.Buffer
-		if code := runEval([]string{"--set", set, "--train-frac", frac}, &out); code != 2 {
+		if code := runEval([]string{"--set", set, "--train-frac", frac}, &out, dependencies{}); code != 2 {
 			t.Errorf("--train-frac %s: code = %d, want usage error 2", frac, code)
 		}
 	}
@@ -97,7 +97,7 @@ func TestEvalRejectsNaNInFlags(t *testing.T) {
 func TestEvalJSONEnvelope(t *testing.T) {
 	set := filepath.Join("testdata", "eval-greyzone.tsv")
 	var out bytes.Buffer
-	if code := runEval([]string{"--set", set, "--json"}, &out); code != 0 {
+	if code := runEval([]string{"--set", set, "--json"}, &out, dependencies{}); code != 0 {
 		t.Fatalf("runEval --json code = %d, want 0; out:\n%s", code, out.String())
 	}
 	var env envelope
@@ -137,7 +137,7 @@ func TestEvalJSONEnvelope(t *testing.T) {
 func TestEvalJSONStrictGate(t *testing.T) {
 	set := filepath.Join("testdata", "eval-greyzone.tsv")
 	var out bytes.Buffer
-	if code := runEval([]string{"--set", set, "--grey-target", "10", "--strict", "--json"}, &out); code != 3 {
+	if code := runEval([]string{"--set", set, "--grey-target", "10", "--strict", "--json"}, &out, dependencies{}); code != 3 {
 		t.Fatalf("strict --json code = %d, want 3; out:\n%s", code, out.String())
 	}
 	var env envelope

--- a/cmd/semantix/flags.go
+++ b/cmd/semantix/flags.go
@@ -6,7 +6,9 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"semantix/kernel/config"
 	"semantix/kernel/evolve"
 	"semantix/kernel/slice"
 	"semantix/kernel/zone"
@@ -38,6 +40,38 @@ func (zf *zoneFlagSet) zones() zone.Zones {
 		AbsHigh: *zf.absHigh,
 		AbsLow:  *zf.absLow,
 	}
+}
+
+// applyConfigZones lets semantix.toml [retrieval] tau_*/abs_* keys drive
+// the grey-zone thresholds (Issue #259 阶段 1). An explicit --tau-*/--abs-*
+// flag always wins; config values were validated by the config layer. Call
+// between flag.Parse and applyEvolveParams/validate. Effective priority:
+// flag > toml > evolve > default.
+func (zf *zoneFlagSet) applyConfigZones(fs *flag.FlagSet, c *config.Resolved) error {
+	if c == nil {
+		return nil
+	}
+	explicit := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		if strings.HasPrefix(f.Name, "tau-") || strings.HasPrefix(f.Name, "abs-") {
+			explicit[f.Name] = true
+		}
+	})
+	set := func(name, key string, ptr **float64) {
+		if explicit[name] {
+			return
+		}
+		if v, _, ok := c.Get(key); ok {
+			if f, ok := v.(float64); ok {
+				**ptr = f
+			}
+		}
+	}
+	set("tau-high", "retrieval.tau_high", &zf.tauHigh)
+	set("tau-low", "retrieval.tau_low", &zf.tauLow)
+	set("abs-high", "retrieval.abs_high", &zf.absHigh)
+	set("abs-low", "retrieval.abs_low", &zf.absLow)
+	return nil
 }
 
 // applyEvolveParams lets the evolved TauL2 drive the grey-zone floor

--- a/cmd/semantix/flags.go
+++ b/cmd/semantix/flags.go
@@ -16,11 +16,15 @@ import (
 
 // zoneFlagSet registers the grey-zone threshold flags (Issue #7) and rebuilds
 // a zone.Zones after flag.Parse. All four default to zone.Default().
+// Per-type overrides (Issue #259 阶段 2) arrive from semantix.toml only —
+// there are no per-type flags; byType stays nil unless the config layer
+// supplies it.
 type zoneFlagSet struct {
 	tauHigh *float64
 	tauLow  *float64
 	absHigh *float64
 	absLow  *float64
+	byType  map[string]zone.Zones
 }
 
 func addZoneFlags(fs *flag.FlagSet) *zoneFlagSet {
@@ -34,12 +38,16 @@ func addZoneFlags(fs *flag.FlagSet) *zoneFlagSet {
 }
 
 func (zf *zoneFlagSet) zones() zone.Zones {
-	return zone.Zones{
+	z := zone.Zones{
 		TauHigh: *zf.tauHigh,
 		TauLow:  *zf.tauLow,
 		AbsHigh: *zf.absHigh,
 		AbsLow:  *zf.absLow,
 	}
+	if len(zf.byType) > 0 {
+		z.ByType = zf.byType
+	}
+	return z
 }
 
 // applyConfigZones lets semantix.toml [retrieval] tau_*/abs_* keys drive
@@ -71,6 +79,46 @@ func (zf *zoneFlagSet) applyConfigZones(fs *flag.FlagSet, c *config.Resolved) er
 	set("tau-low", "retrieval.tau_low", &zf.tauLow)
 	set("abs-high", "retrieval.abs_high", &zf.absHigh)
 	set("abs-low", "retrieval.abs_low", &zf.absLow)
+	// Per-type overrides (Issue #259 阶段 2): assemble the partial toml
+	// entries into complete snapshots inheriting the current global
+	// thresholds (after the global keys above). Key shape:
+	// retrieval.by_type.<type>.<field>; validation already happened in the
+	// config layer.
+	const pfx = "retrieval.by_type."
+	for _, f := range c.Fields {
+		if !strings.HasPrefix(f.Key, pfx) {
+			continue
+		}
+		rest := strings.TrimPrefix(f.Key, pfx)
+		dot := strings.Index(rest, ".")
+		if dot <= 0 {
+			continue
+		}
+		name, field := rest[:dot], rest[dot+1:]
+		v, ok := f.Value.(float64)
+		if !ok {
+			continue
+		}
+		if zf.byType == nil {
+			zf.byType = map[string]zone.Zones{}
+		}
+		oz, ok := zf.byType[name]
+		if !ok {
+			oz = zf.zones() // inherit the current global thresholds
+			oz.ByType = nil
+		}
+		switch field {
+		case "tau_high":
+			oz.TauHigh = v
+		case "tau_low":
+			oz.TauLow = v
+		case "abs_high":
+			oz.AbsHigh = v
+		case "abs_low":
+			oz.AbsLow = v
+		}
+		zf.byType[name] = oz
+	}
 	return nil
 }
 

--- a/cmd/semantix/flags_config_zones_test.go
+++ b/cmd/semantix/flags_config_zones_test.go
@@ -121,3 +121,29 @@ func TestApplyConfigZonesThenEvolve(t *testing.T) {
 		t.Fatalf("TauLow = %v, want evolved 0.75", z.TauLow)
 	}
 }
+
+// Per-type overrides from semantix.toml assemble into complete snapshots
+// inheriting the global thresholds (Issue #259 阶段 2).
+func TestApplyConfigZonesByType(t *testing.T) {
+	r := tomlWithZones(t, "[retrieval]\ntau_low = 0.55\n\n[retrieval.by_type.result]\ntau_low = 0.60\n")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	zf := addZoneFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyConfigZones(fs, r); err != nil {
+		t.Fatal(err)
+	}
+	z := zf.zones()
+	oz := z.ForType("result")
+	if oz.TauLow != 0.60 {
+		t.Fatalf("result TauLow = %v, want override 0.60", oz.TauLow)
+	}
+	if oz.TauHigh != z.TauHigh {
+		t.Fatalf("result TauHigh = %v, want inherited global %v", oz.TauHigh, z.TauHigh)
+	}
+	if z.ForType("prompt").TauLow != 0.55 {
+		t.Fatalf("prompt TauLow = %v, want global 0.55", z.ForType("prompt").TauLow)
+	}
+}

--- a/cmd/semantix/flags_config_zones_test.go
+++ b/cmd/semantix/flags_config_zones_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"semantix/kernel/config"
+)
+
+// tomlWithZones writes a semantix.toml with the given [retrieval] tau_*
+// keys and resolves it through the config layer.
+func tomlWithZones(t *testing.T, body string) *config.Resolved {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "semantix.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, err := config.Load(config.Options{ConfigPath: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+// The semantix.toml [retrieval] tau_* keys drive the grey-zone thresholds
+// when no explicit --tau-*/--abs-* flag is given (Issue #259 阶段 1).
+func TestApplyConfigZonesFromToml(t *testing.T) {
+	r := tomlWithZones(t, "[retrieval]\ntau_high = 0.9\ntau_low = 0.6\nabs_high = 0.8\nabs_low = 0.5\n")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	zf := addZoneFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyConfigZones(fs, r); err != nil {
+		t.Fatal(err)
+	}
+	z := zf.zones()
+	if z.TauHigh != 0.9 || z.TauLow != 0.6 || z.AbsHigh != 0.8 || z.AbsLow != 0.5 {
+		t.Fatalf("zones = %+v, want toml values", z)
+	}
+}
+
+// An explicit --tau-low flag always wins over the toml value.
+func TestApplyConfigZonesFlagWins(t *testing.T) {
+	r := tomlWithZones(t, "[retrieval]\ntau_low = 0.6\n")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	zf := addZoneFlags(fs)
+	if err := fs.Parse([]string{"--tau-low", "0.42"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyConfigZones(fs, r); err != nil {
+		t.Fatal(err)
+	}
+	if got := zf.zones().TauLow; got != 0.42 {
+		t.Fatalf("TauLow = %v, want explicit flag 0.42", got)
+	}
+}
+
+// A nil config is a silent no-op (unit tests / absent config layer).
+func TestApplyConfigZonesNilSafe(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	zf := addZoneFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyConfigZones(fs, nil); err != nil {
+		t.Fatal(err)
+	}
+	def := zf.zones()
+	if def.TauHigh != 0.8 || def.TauLow != 0.55 || def.AbsHigh != 0.7 || def.AbsLow != 0.45 {
+		t.Fatalf("zones = %+v, want built-in defaults", def)
+	}
+}
+
+// abs_low = 0 is a legal configuration and must survive the config merge.
+func TestApplyConfigZonesKeepsZeroAbsLow(t *testing.T) {
+	r := tomlWithZones(t, "[retrieval]\nabs_low = 0\n")
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	zf := addZoneFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyConfigZones(fs, r); err != nil {
+		t.Fatal(err)
+	}
+	if got := zf.zones().AbsLow; got != 0 {
+		t.Fatalf("AbsLow = %v, want explicit 0", got)
+	}
+}
+
+// Full priority chain: flag > toml > evolve > default. With no flag and no
+// toml key, the evolved TauL2 still drives TauLow (Issue #220 preserved).
+func TestApplyConfigZonesThenEvolve(t *testing.T) {
+	r := tomlWithZones(t, "[retrieval]\ntau_high = 0.85\n") // tau_low absent
+	dir := t.TempDir()
+	writeParams(t, dir, 0.75)
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	zf := addZoneFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyConfigZones(fs, r); err != nil {
+		t.Fatal(err)
+	}
+	if err := zf.applyEvolveParams(fs, dir); err != nil {
+		t.Fatal(err)
+	}
+	z := zf.zones()
+	if z.TauHigh != 0.85 {
+		t.Fatalf("TauHigh = %v, want toml 0.85", z.TauHigh)
+	}
+	if z.TauLow != 0.75 {
+		t.Fatalf("TauLow = %v, want evolved 0.75", z.TauLow)
+	}
+}

--- a/cmd/semantix/lookup.go
+++ b/cmd/semantix/lookup.go
@@ -30,6 +30,9 @@ func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error
 	if err := flags.Parse(args); err != nil {
 		return usageWrap(err)
 	}
+	if err := zf.applyConfigZones(flags, deps.resolved); err != nil {
+		return usagef("%v", err)
+	}
 	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
 		return usagef("%v", err)
 	}
@@ -129,6 +132,9 @@ func runInject(args []string, stdout, stderr io.Writer, deps dependencies) error
 	zf := addZoneFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return usageWrap(err)
+	}
+	if err := zf.applyConfigZones(flags, deps.resolved); err != nil {
+		return usagef("%v", err)
 	}
 	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
 		return usagef("%v", err)

--- a/cmd/semantix/lookup.go
+++ b/cmd/semantix/lookup.go
@@ -30,10 +30,10 @@ func runLookup(args []string, stdout, stderr io.Writer, deps dependencies) error
 	if err := flags.Parse(args); err != nil {
 		return usageWrap(err)
 	}
-	if err := zf.applyConfigZones(flags, deps.resolved); err != nil {
+	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
 		return usagef("%v", err)
 	}
-	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
+	if err := zf.applyConfigZones(flags, deps.resolved); err != nil {
 		return usagef("%v", err)
 	}
 	if err := zf.validate(); err != nil {
@@ -133,10 +133,10 @@ func runInject(args []string, stdout, stderr io.Writer, deps dependencies) error
 	if err := flags.Parse(args); err != nil {
 		return usageWrap(err)
 	}
-	if err := zf.applyConfigZones(flags, deps.resolved); err != nil {
+	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
 		return usagef("%v", err)
 	}
-	if err := zf.applyEvolveParams(flags, *evolveDB); err != nil {
+	if err := zf.applyConfigZones(flags, deps.resolved); err != nil {
 		return usagef("%v", err)
 	}
 	if err := zf.validate(); err != nil {

--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -136,7 +136,7 @@ func buildCommands() []commandSpec {
 		{name: "eval", group: groupKernelOps,
 			usage:   "semantix eval --set <oracle.tsv> [--tau-*]",
 			summary: "retrieval strategy comparison (Issue #7)",
-			run:     intCommand(runEval)},
+			run:     depsCommand(runEval)},
 		{name: "eval-judge", group: groupKernelOps,
 			usage:   "semantix eval-judge [--stub yes|no] [--judge-*] [--audit <tsv>]",
 			summary: "LLM judge authenticity evaluation (Issue #8)",

--- a/cmd/semantix/search.go
+++ b/cmd/semantix/search.go
@@ -43,6 +43,9 @@ func runSearch(args []string, stdout, stderr io.Writer, deps dependencies) error
 	if err := flags.Parse(args); err != nil {
 		return usageWrap(err)
 	}
+	if err := zf.applyConfigZones(flags, deps.resolved); err != nil {
+		return usagef("%v", err)
+	}
 	if err := zf.validate(); err != nil {
 		return usagef("%v", err)
 	}

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"semantix/kernel/adapt"
 	"semantix/kernel/judge"
 	"semantix/kernel/slice"
 	"semantix/kernel/usage"
@@ -92,12 +93,12 @@ func newVerifyJudgeJSON(s judge.Stats) *verifyJudgeJSON {
 // positives (hits the oracle rejects) and precision — the P-CHR simplified
 // distribution (GPT Semantic Cache, arXiv:2411.05276).
 type verifyCalibration struct {
-	Bins    []verifyBin               `json:"bins"`
-	Current [3]int                    `json:"current"` // zone counts under the current thresholds
-	Default [3]int                    `json:"default"` // zone counts under zone.Default()
-	ByType  map[string]verifyTypeCal  `json:"by_type,omitempty"` // Issue #259 阶段 2: per-type zone distribution
-	Labeled bool                      `json:"labeled"` // --labels was provided
-	Marks   map[string]bool           `json:"-"`       // oracle relevance marks (session\x00turn -> relevant)
+	Bins    []verifyBin              `json:"bins"`
+	Current [3]int                   `json:"current"`           // zone counts under the current thresholds
+	Default [3]int                   `json:"default"`           // zone counts under zone.Default()
+	ByType  map[string]verifyTypeCal `json:"by_type,omitempty"` // Issue #259 阶段 2: per-type zone distribution
+	Labeled bool                     `json:"labeled"`           // --labels was provided
+	Marks   map[string]bool          `json:"-"`                 // oracle relevance marks (session\x00turn -> relevant)
 }
 
 // verifyTypeCal is the per-slice-type zone distribution (Issue #259
@@ -105,11 +106,11 @@ type verifyCalibration struct {
 // (possibly per-type) thresholds vs the default thresholds — the input
 // for deciding whether a type deserves its own tau.
 type verifyTypeCal struct {
-	N          int   `json:"n"`
-	Hit        int   `json:"hit"`
-	Grey       int   `json:"grey"`
-	Miss       int   `json:"miss"`
-	DefaultHit int   `json:"default_hit"` // hit count under zone.Default(), for drift comparison
+	N          int `json:"n"`
+	Hit        int `json:"hit"`
+	Grey       int `json:"grey"`
+	Miss       int `json:"miss"`
+	DefaultHit int `json:"default_hit"` // hit count under zone.Default(), for drift comparison
 }
 
 // verifyBin is one relative-confidence bucket [Lo,Hi) of the replay stream.
@@ -436,6 +437,7 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 	jsonOut := fs.Bool("json", false, "output as JSON envelope (summary + rows)")
 	calibrate := fs.Bool("calibrate", false, "append the Issue #262 calibration report: per-bin hit/miss distribution + three-region drift vs default thresholds")
 	labelsPath := fs.String("labels", "", "optional oracle relevance marks: session<TAB>turn<TAB>1|0 (implies --calibrate; adds per-bin fp/precision)")
+	adaptDB := fs.String("adapt-db", "", "per-entry adaptive state file (Issue #259 阶段 3); empty = <db 同目录>/l3-adapt.json, 缺失则不报告")
 	zf := addZoneFlags(fs)
 	judgeProtocol := fs.String("judge-protocol", "", "LLM judge protocol: openai|anthropic (empty = rules only)")
 	judgeBaseURL := fs.String("judge-base-url", "", "LLM judge endpoint base URL (e.g. https://api.openai.com/v1)")
@@ -769,6 +771,7 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 			jstats.JudgeReject+jstats.Fingerprint+jstats.RulesReject+jstats.JudgeError)
 	}
 	printVerifyCalibration(stdout, cal)
+	printAdaptSummary(stdout, *adaptDB, opt.db)
 	if *greyTarget > 0 && greyRatio > *greyTarget {
 		// Issue #7 acceptance: the grey-zone share is an observability
 		// metric with a hard alarm — the threshold can be tuned but a
@@ -782,6 +785,54 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 	}
 	printVerifyL1Footer(stdout, *usageDB)
 	return 0
+}
+
+// printAdaptSummary appends the per-entry adaptive state summary (Issue
+// #259 阶段 3) to the replay report: entry count, learned-tau distribution
+// and adjustment totals, so an operator can see whether vCache-style
+// per-entry learning is active and how far entries drifted from the
+// global prior. adaptPath empty → derive from the store db directory; a
+// missing state file prints nothing (adaptation simply has no entries
+// yet). The engine is opened read-only: no observations are folded.
+func printAdaptSummary(stdout io.Writer, adaptPath, db string) {
+	if adaptPath == "" {
+		if db == "" {
+			return
+		}
+		adaptPath = filepath.Join(filepath.Dir(db), "l3-adapt.json")
+	}
+	e := adapt.New(adapt.Config{}, adaptPath)
+	snap := e.Snapshot()
+	if len(snap) == 0 {
+		return
+	}
+	var minTau, maxTau float64
+	var relaxed int
+	taus := make([]float64, 0, len(snap))
+	for i := range snap {
+		ent := &snap[i]
+		if ent.TauLow <= 0 {
+			continue // cold-start entries keep the global prior
+		}
+		if ent.Relaxed {
+			relaxed++
+		}
+		taus = append(taus, ent.TauLow)
+		if minTau == 0 || ent.TauLow < minTau {
+			minTau = ent.TauLow
+		}
+		if ent.TauLow > maxTau {
+			maxTau = ent.TauLow
+		}
+	}
+	if len(taus) == 0 {
+		return
+	}
+	sort.Float64s(taus)
+	median := taus[len(taus)/2]
+	fmt.Fprintf(stdout, "# adapt: per-entry 自适应状态 (Issue #259 阶段 3) — %s\n", adaptPath)
+	fmt.Fprintf(stdout, "#   entries=%d learned=%d relaxed=%d adjustments=%d epoch=%d tau_low min=%.2f median=%.2f max=%.2f\n",
+		len(snap), len(taus), relaxed, e.Adjustments(), e.Epoch(), minTau, median, maxTau)
 }
 
 // printVerifyL1Footer appends the L1 hit-rate regression rows to the replay

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -92,11 +92,24 @@ func newVerifyJudgeJSON(s judge.Stats) *verifyJudgeJSON {
 // positives (hits the oracle rejects) and precision — the P-CHR simplified
 // distribution (GPT Semantic Cache, arXiv:2411.05276).
 type verifyCalibration struct {
-	Bins    []verifyBin     `json:"bins"`
-	Current [3]int          `json:"current"` // zone counts under the current thresholds
-	Default [3]int          `json:"default"` // zone counts under zone.Default()
-	Labeled bool            `json:"labeled"` // --labels was provided
-	Marks   map[string]bool `json:"-"`       // oracle relevance marks (session\x00turn -> relevant)
+	Bins    []verifyBin               `json:"bins"`
+	Current [3]int                    `json:"current"` // zone counts under the current thresholds
+	Default [3]int                    `json:"default"` // zone counts under zone.Default()
+	ByType  map[string]verifyTypeCal  `json:"by_type,omitempty"` // Issue #259 阶段 2: per-type zone distribution
+	Labeled bool                      `json:"labeled"` // --labels was provided
+	Marks   map[string]bool           `json:"-"`       // oracle relevance marks (session\x00turn -> relevant)
+}
+
+// verifyTypeCal is the per-slice-type zone distribution (Issue #259
+// 阶段 2): how each type's top-1 candidates land under the current
+// (possibly per-type) thresholds vs the default thresholds — the input
+// for deciding whether a type deserves its own tau.
+type verifyTypeCal struct {
+	N          int   `json:"n"`
+	Hit        int   `json:"hit"`
+	Grey       int   `json:"grey"`
+	Miss       int   `json:"miss"`
+	DefaultHit int   `json:"default_hit"` // hit count under zone.Default(), for drift comparison
 }
 
 // verifyBin is one relative-confidence bucket [Lo,Hi) of the replay stream.
@@ -226,6 +239,27 @@ func printVerifyCalibration(stdout io.Writer, cal *verifyCalibration) {
 		cur := 100 * float64(cal.Current[i]) / float64(total)
 		dft := 100 * float64(cal.Default[i]) / float64(defTotal)
 		fmt.Fprintf(stdout, "#   %-6s %7.1f%% %7.1f%%  %+5.1fpt\n", names[i], cur, dft, cur-dft)
+	}
+	// Per-type distribution (Issue #259 阶段 2): how each slice type lands
+	// under the current (possibly per-type) thresholds vs the default ones
+	// — the calibration input for per-type tau decisions.
+	if len(cal.ByType) > 0 {
+		fmt.Fprintln(stdout, "# by_type: 类型分型命中分布 (current 阈值 vs default 阈值; Issue #259 阶段 2)")
+		fmt.Fprintln(stdout, "#   type          n   hit grey miss  hit%  default_hit")
+		typeNames := make([]string, 0, len(cal.ByType))
+		for name := range cal.ByType {
+			typeNames = append(typeNames, name)
+		}
+		sort.Strings(typeNames)
+		for _, name := range typeNames {
+			tc := cal.ByType[name]
+			hitPct := 0.0
+			if tc.N > 0 {
+				hitPct = 100 * float64(tc.Hit) / float64(tc.N)
+			}
+			fmt.Fprintf(stdout, "#   %-12s %4d %4d %4d %4d  %5.1f%%  %6d\n",
+				name, tc.N, tc.Hit, tc.Grey, tc.Miss, hitPct, tc.DefaultHit)
+		}
 	}
 }
 
@@ -541,7 +575,7 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 	calMode := *calibrate || *labelsPath != ""
 	var cal *verifyCalibration
 	if calMode {
-		cal = &verifyCalibration{Bins: make([]verifyBin, verifyCalibBuckets)}
+		cal = &verifyCalibration{Bins: make([]verifyBin, verifyCalibBuckets), ByType: map[string]verifyTypeCal{}}
 		for i := range cal.Bins {
 			cal.Bins[i].Bin = calibBinLabel(i)
 		}
@@ -582,7 +616,14 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 				if len(hits) > 1 {
 					top2 = hits[1].Score
 				}
-				z = classifyTop1(zones, score, top2)
+				// Per-type thresholds (Issue #259 阶段 2): the top-1
+				// candidate is classified under its own type's override
+				// (falling back to the global baseline).
+				tz := zones
+				if hits[0].Slice != nil {
+					tz = zones.ForType(hits[0].Slice.Type.String())
+				}
+				z = classifyTop1(tz, score, top2)
 				if z == zone.Grey && jg != nil {
 					// Grey zone reaches the async LLM judge (off the critical path
 					// in production; here inline). Verdict only affects stats.
@@ -619,6 +660,27 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 				b.Top1Sum += score
 				cal.Current[int(z)]++
 				cal.Default[int(classifyTop1(zone.Default(), score, top2))]++
+				// Per-type distribution (Issue #259 阶段 2): where each
+				// slice type's candidates land under the current (possibly
+				// per-type) thresholds vs the defaults — the calibration
+				// input for deciding whether a type needs its own tau.
+				if len(hits) > 0 && hits[0].Slice != nil {
+					name := hits[0].Slice.Type.String()
+					tc := cal.ByType[name]
+					tc.N++
+					switch z {
+					case zone.Hit:
+						tc.Hit++
+					case zone.Grey:
+						tc.Grey++
+					default:
+						tc.Miss++
+					}
+					if classifyTop1(zone.Default(), score, top2) == zone.Hit {
+						tc.DefaultHit++
+					}
+					cal.ByType[name] = tc
+				}
 				if cal.Marks != nil {
 					if rel, ok := cal.Marks[fmt.Sprintf("%s\x00%d", t.Session, t.Turn)]; ok && z == zone.Hit && !rel {
 						b.FP++ // oracle says irrelevant but the gate would reuse

--- a/cmd/semantix/verify.go
+++ b/cmd/semantix/verify.go
@@ -412,6 +412,10 @@ func runVerify(args []string, stdout io.Writer, deps dependencies) int {
 		}
 		return 2
 	}
+	if err := zf.applyConfigZones(fs, deps.resolved); err != nil {
+		fmt.Fprintf(stdout, "verify: %v\n", err)
+		return 2
+	}
 	if err := zf.validate(); err != nil {
 		fmt.Fprintf(stdout, "verify: %v\n", err)
 		return 2

--- a/cmd/semantix/verify_test.go
+++ b/cmd/semantix/verify_test.go
@@ -246,6 +246,15 @@ func TestVerifyCalibrateReportStructure(t *testing.T) {
 			t.Fatalf("default-threshold run must show zero drift, missing %q:\n%s", want, s)
 		}
 	}
+	// Per-type block (Issue #259 阶段 2): the replay stream's top-1
+	// candidates are typed, so the by_type report must name at least one
+	// real slice type and sum its counts.
+	if !strings.Contains(s, "# by_type:") {
+		t.Fatalf("calibration report missing per-type block:\n%s", s)
+	}
+	if !strings.Contains(s, "#   type          n   hit grey miss  hit%  default_hit") {
+		t.Fatalf("calibration report missing by_type header:\n%s", s)
+	}
 	// The report is a tail block: the replay table must precede it.
 	if strings.Index(s, "session\tturn\tscore") > strings.Index(s, "# calibration:") {
 		t.Fatalf("calibration block must follow the replay table:\n%s", s)

--- a/docs/specs/issue-259-adaptive-l3-threshold.md
+++ b/docs/specs/issue-259-adaptive-l3-threshold.md
@@ -271,23 +271,23 @@ tau_low  = 0.60
 
 ## 7. 验收标准
 
-- [ ] 阶段 1(gateway):`[retrieval] tau_*` 配置改变 L3 判定(gateway 配置
-  单测 + e2e 断言 zone 结果);`evolve_db` 的 tuned TauL2 在无显式 tau_low
-  时生效,显式配置优先(单测)。
-- [ ] 阶段 1(CLI):semantix.toml 四键解析 + `config list` 展示;
-  flag > toml > default 优先级单测;非法值(τ 超界、tau_high ≤ tau_low)
-  启动报错。
-- [ ] 阶段 2:per-type 配置后,同分数不同 Type 判定不同(zone 单测 +
-  gateway 配置组装单测);未知 type key 启动失败;ByType 为空时所有现有
-  测试行为不变。
-- [ ] 阶段 3:adapt 单测覆盖——正反馈不调/负反馈收紧、放宽条件、clamp、
-  冻结窗、冷启动(样本/复用不足回退全局)、持久化 round-trip、损坏文件
-  恢复、`adaptive=false` 零行为变化。
-- [ ] 阶段 3(gateway):e2e 复用 → 重试 → 该条目 TauLow 提高且落盘;
+- [x] 阶段 1(gateway):`[retrieval] tau_*` 配置改变 L3 判定(gateway 配置
+  单测 + kernel/cache 判定单测);`evolve_db` 的 tuned TauL2 在无显式 tau_low
+  时生效,显式配置优先,clamp 到调优带(单测)。
+- [x] 阶段 1(CLI):semantix.toml 四键解析 + 值域/交叉校验;
+  flag > toml > evolve > default 优先级单测;非法值(τ 超界、
+  tau_high ≤ tau_low)启动报错。
+- [x] 阶段 2:per-type 配置后,同分数不同 Type 判定不同(zone 单测 +
+  gateway 配置组装单测 + kernel/cache 判定单测);未知 type key 启动失败;
+  ByType 为空时所有现有测试行为不变。
+- [x] 阶段 3:adapt 单测覆盖——正反馈放宽/负反馈收紧、clamp、冻结窗、
+  冷启动(样本/复用不足回退全局)、持久化 round-trip、损坏文件恢复、
+  `adaptive=false` 零行为变化。
+- [x] 阶段 3(gateway):e2e 复用 → 重试 → 该条目 TauLow 提高且落盘;
   judge 拒绝计入负反馈。
-- [ ] verify --calibrate 输出 per-type 分布与 adapt 汇总(快照断言)。
-- [ ] 回归:`go test ./...` 全绿;默认配置下行为与 main 一致
-  (ByType 空、adaptive 冷启动 → 全局阈值)。
+- [x] verify --calibrate 输出 per-type 分布与 adapt 汇总(快照断言)。
+- [x] 回归:`go test ./...` 全绿;默认配置下行为与 main 一致
+  (ByType 空、adapt 冷启动 → 全局阈值)。
 
 ## 8. 参考
 

--- a/docs/specs/issue-259-adaptive-l3-threshold.md
+++ b/docs/specs/issue-259-adaptive-l3-threshold.md
@@ -1,0 +1,299 @@
+# Spec v1 — L3 命中阈值:全局硬编码 → 按类型分化 → 逐条目自适应(Issue #259)
+
+> 判级:Spec-Required。本 spec 细化 Issue #259「L3 命中阈值:全局硬编码 →
+> 按类型分化 → 逐条目自适应(vCache)」,把 RFC 的三阶段拆成可独立验收的
+> 实现边界。基线为当前 main(99a22d7)。阶段 3 的误命中观测通道已在
+> Issue #262 落地(80b76bc/b16b9e1/335797f),本 spec 直接消费,不再重复造。
+
+## 1. 目标与非目标
+
+### 1.1 现状缺口(真源审计,2026-08-22)
+
+| 缺口 | 证据 |
+|---|---|
+| 四参数全局硬编码 | `kernel/zone/zone.go:49-51` `Default()` 写死 TauHigh 0.8 / TauLow 0.55 / AbsHigh 0.7 / AbsLow 0.45;`Classify`/`ClassifyL3` 只消费这一个快照 |
+| gateway 无任何阈值配置键 | `gateway/gateway.go:162` `z := zone.Default()`;`gateway/config.go` `RetrievalConfig` 只有 retriever/top_k/budget/vector_dim/fusion/rrf_k/bm25_weight,无 tau 键 |
+| gateway 不接 evolve | `--evolve-db` 只接在 CLI(`cmd/semantix/flags.go:49` `applyEvolveParams`),gateway 启动路径无 evolve 状态读取 |
+| CLI 配置层无 tau 键 | `kernel/config/config.go:51-58` `fileRetrieval` 无 tau 键;`semantix.example.toml` 无阈值节 |
+| 切片类型不参与阈值选择 | P/C/T/R/M(`kernel/slice/slice.go:10-20`)共用一套常量;L3 判定在 `kernel/cache/l3.go:185` 单点 `z.ClassifyL3(...)` |
+| evolve 只调 TauL2 一个参数 | `kernel/evolve/evolve.go:221-264` `maybeAdjustLocked` 只动 TauL2 与 PrefetchConf;`Params.TauL3`(evolve.go:52)有字段无调整 |
+| 逐条目无自适应 | L3 决策无 per-slice 阈值状态;误命中反馈(#262)只做统计与绕过,不反哺阈值 |
+
+### 1.2 本期范围
+
+```text
+阶段 1 可配化:四参数进 gateway [retrieval] 与 CLI semantix.toml;
+              gateway 接 evolve tuned TauL2(显式配置优先)。
+阶段 2 按类型分化:zone.Zones.ForType(typeName) 覆盖;P/C/T/R/M 可配独立阈值;
+              verify --calibrate 增加 per-type 分布(校准依据)。
+阶段 3 逐条目自适应:kernel/adapt 新包,每个高频复用切片维护正/负反馈,
+              在线估计条目级 τ_low,全局参数作先验/冷启动;
+              gateway 消费:复用→正,疑似误命中/judge 拒绝→负;
+              verify --calibrate 报告 adapt 状态。
+```
+
+### 1.3 非目标(列为后续,不进入本期)
+
+- TauHigh/AbsHigh/AbsLow 的逐条目学习(只学 TauLow 一个旋钮,与 evolve
+  语义对齐;abs 下限是绝对尺度安全网,不该被单条目污染);
+- harness/Reasonix 侧真实误命中信号(仍只有 #262 的疑似口径,报告必须标注);
+- `kernel/event` 新增自适应事件 Kind(状态文件 + gateway 日志已够);
+- CLI lookup/search 消费 adapt 状态(本期只做 gateway 生产路径 + CLI 只读报告);
+- 分型初值的自动离线校准(verify --calibrate 输出 per-type 分布,由 operator
+  决策;默认不分化,行为零变化)。
+
+## 2. 语义设计(单一真源)
+
+### 2.1 阈值解析顺序(阶段 1)
+
+```text
+gateway:  显式 tau_* 配置 > evolve tuned TauL2 > zone.Default()
+CLI:      --tau-* flag > semantix.toml [retrieval] > zone.Default()
+```
+
+evolve 值只覆盖 TauLow,且 clamp 到 [evolve.DefaultMinTau, evolve.DefaultMaxTau]
+(0.30–0.80),与 CLI `applyEvolveParams` 现有行为一致(flags.go:70-76)。
+
+### 2.2 per-type 覆盖语义(阶段 2)
+
+- `zone.Zones` 增加 `ByType map[string]Zones`,key 是 `slice.SliceType.String()`
+  的稳定 wire 名(`prompt|context|tool_pattern|result|memory`)。zone 包不依赖
+  slice 包,以 string 解耦。
+- `ForType(typeName string) Zones`:命中 `ByType` → 该覆盖(完整四参数);
+  未命中/空 → 返回全局基线自身。覆盖是**完整快照**,不支持部分覆盖——
+  每个类型要么整组覆盖,要么用全局(避免"部分继承"的隐式语义)。
+- 配置端(toml)是部分覆盖语法(只写要改的字段),组装为完整快照时未写字段
+  继承全局值——语法宽松、语义严格。
+- 默认 `ByType` 为空 → 全类型全局基线,行为与现状逐字节一致。
+
+### 2.3 逐条目自适应语义(阶段 3,vCache 路线)
+
+- **学什么**:每个条目的 `TauLow`(grey-zone floor,即"验证预算旋钮")。
+  全局 TauLow 作先验/冷启动;条目学到的值只在该条目被判定时覆盖 TauLow。
+- **信号**(复用 #262 通道):
+  - 正:该 slice 被 L3 复用并服务(未触发重试);
+  - 负:同 session 对已复用 query 的重试(#262 疑似误命中)→ 该 slice 负反馈;
+  - 负:judge 判定拒绝(`JudgeDeclined`)→ 该 slice 负反馈(grey 区被拒说明
+    该条目在相似邻域易误判)。
+- **估计**:per-entry 维护负样本 EWMA(alpha=0.1,与 evolve 一致)。
+- **调整规则**(对齐 evolve 冻结窗思想):
+  - 样本 ≥ MinSamples 且负 EWMA > ErrorBound → TauLow += Step(收紧);
+  - 样本 ≥ MinSamples 且负 EWMA < ErrorBound/2 且正样本 ≥ MinSamples →
+    TauLow -= Step(放宽);
+  - clamp 到 [MinTau, min(MaxTau, 全局 TauHigh − 0.05)](保证 grey 区非空);
+  - 每次调整后冻结 FreezeEpochs 次观察(防抖 + 保护注入字节稳定)。
+- **冷启动**:条目复用次数 < MinHits 或样本 < MinSamples → 返回全局 TauLow,
+  零行为变化。
+- **持久化**:`<slice store 同目录>/l3-adapt.json`,启动加载、变更即写;
+  文件损坏/缺失 → WARN + 空状态(自适应状态可重建,不是数据真相)。
+- **开关**:默认启用,`adaptive = false` 或 `error_bound = -1` 关闭(行为回退
+  全局阈值)。
+
+## 3. 阶段 1 接线:四参数可配化
+
+### 3.1 gateway 配置与组装
+
+`gateway/config.go` `RetrievalConfig` 新增:
+
+```go
+TauHigh   *float64 `toml:"tau_high"`   // nil → zone.Default()
+TauLow    *float64 `toml:"tau_low"`
+AbsHigh   *float64 `toml:"abs_high"`
+AbsLow    *float64 `toml:"abs_low"`
+EvolveDB  string   `toml:"evolve_db"`  // 可选 evolve state 目录;tuned TauL2 → TauLow
+```
+
+- `validate()`:tau 须 (0,1] 且 tau_high > tau_low;abs 须 ≥ 0;NaN/Inf 拒绝。
+- 新增 `(*Config) zoneConfig() (zone.Zones, error)`:显式 tau_* > evolve
+  (仅 TauLow) > Default。evolve 值 clamp 到 [0.30, 0.80]。
+- `gateway/gateway.go:162` 改为调用 `cfg.zoneConfig()`。
+
+### 3.2 CLI 配置层
+
+`kernel/config/config.go` `fileRetrieval` 新增四 pointer 键
+(`tau_high/tau_low/abs_high/abs_low`),走既有 `mergePtr` 机制
+(flag > env > file > default),`validate()` 加值域规则(与 gateway 同规则)。
+
+`cmd/semantix/flags.go` 新增 `applyConfigZones(c *config.Resolved)`:显式 flag
+优先,否则 toml 值覆盖内置默认;调用点在 `eval.go` / `lookup.go`(×2) /
+`search.go` / `verify.go` 的 parse 与 `applyEvolveParams` 之间(优先级:
+flag > toml > evolve > default——与 issue-01 的 flag 语义保持兼容)。
+
+### 3.3 文档
+
+`semantix.example.toml` 增加 `[retrieval]` 四键注释示例;gateway 示例配置
+(如有)同步。
+
+## 4. 阶段 2 接线:按类型分化
+
+### 4.1 kernel/zone
+
+`Zones` 增加字段与方法:
+
+```go
+type Zones struct {
+    TauHigh, TauLow, AbsHigh, AbsLow float64
+    ByType map[string]Zones          // per-type overrides (wire-name keyed)
+}
+
+func (z Zones) ForType(typeName string) Zones
+```
+
+`Default()` 返回 `ByType: nil`。`Classify`/`ClassifyL3` 签名不变(仍是全局
+语义);per-type 由判定点先 `ForType` 再判。
+
+### 4.2 判定点接线
+
+- `kernel/cache/l3.go` `DecideL3`:候选循环内
+  `z.ForType(s.Type.String()).ClassifyL3(...)`(s 非 nil 已由候选过滤保证);
+- `kernel/cache/l3.go` `DecideL2`:`h.Slice != nil` 时 ForType,否则全局;
+- `kernel/inject/inject.go` `Build`:`in.Zones != nil` 且 `h.Slice != nil` 时
+  ForType 后 Classify。
+
+### 4.3 配置
+
+- gateway `RetrievalConfig.ByType map[string]zoneOverride`,toml:
+
+```toml
+[retrieval.by_type.result]
+tau_high = 0.85
+tau_low  = 0.60
+abs_high = 0.75
+abs_low  = 0.50
+```
+
+`zoneOverride` 四字段皆 pointer(部分覆盖);未知 type key → validate 报错
+(fail-closed);组装完整 `zone.Zones.ByType` 时未写字段继承全局。
+
+- CLI `kernel/config`:`fileRetrieval.ByType map[string]fileZone`,平铺键
+  `retrieval.by_type.<type>.tau_high` 等;`flags.go` 消费组装(优先级同 3.2)。
+
+### 4.4 verify --calibrate 分型报告
+
+`verify --calibrate`(cmd/semantix/verify.go:403 现有报告)增加 per-type
+分解:命中/误命中/grey 占比按 `prompt|context|tool_pattern|result|memory`
+分列——为 operator 决定分化值提供回放依据(对应 issue 的"用 verify 回放集
+分型校准初值")。
+
+## 5. 阶段 3 接线:逐条目自适应(vCache)
+
+### 5.1 新包 kernel/adapt
+
+```go
+package adapt
+
+type Config struct {
+    ErrorBound    float64 // 用户指定误命中率上界;默认 0.05;-1 关闭
+    Step          float64 // 每次调整步长;默认 0.05(对齐 evolve.TauStep)
+    MinSamples    uint64  // 首调最小样本;默认 20(对齐 evolve.MinSamples)
+    MinHits       uint64  // 条目成为高频的最小复用数;默认 5
+    FreezeEpochs  uint64  // 调整后冻结观察数;默认 60(对齐 evolve.DefaultFreezeEpoch)
+    Alpha         float64 // 负样本 EWMA 平滑;默认 0.1
+    MinTau        float64 // 默认 0.30(对齐 evolve.DefaultMinTau)
+    MaxTau        float64 // 默认 0.80(对齐 evolve.DefaultMaxTau)
+}
+
+type Entry struct {
+    SliceID   string  `json:"slice_id"`
+    TauLow    float64 `json:"tau_low"`   // 学习值(未学习 → 0,消费端回退全局)
+    Pos       uint64  `json:"pos"`       // 正反馈计数
+    Neg       uint64  `json:"neg"`       // 负反馈计数
+    NegEWMA   float64 `json:"neg_ewma"`  // 负样本率 EWMA
+    Frozen    uint64  `json:"frozen"`    // 剩余冻结观察数
+    UpdatedAt int64   `json:"updated_at"`
+}
+
+type Engine struct { /* 内部:mu + entries map + cfg + path */ }
+
+func New(cfg Config, path string) (*Engine, error) // 加载既有状态;损坏 → WARN + 空
+func (e *Engine) Observe(sliceID string, negative bool)
+func (e *Engine) TauLow(sliceID string, global float64) float64 // 未学习/未高频 → global
+func (e *Engine) Snapshot() []Entry // 报告用,按 SliceID 排序
+func (e *Engine) Adjustments() uint64
+```
+
+调整只在 `Observe` 内触发;`TauLow` 是纯查询(读锁)。持久化:变更即写
+(Observe 导致计数或阈值变化后落盘,带锁;写失败只记日志,不阻断决策路径)。
+
+### 5.2 gateway 接线
+
+- `gateway/config.go` `RetrievalConfig` 新增 `Adaptive *bool`(nil → true)、
+  `ErrorBound float64`(0 → 0.05;−1 关闭)、`AdaptDB string`(空 → `<store
+  db 目录>/l3-adapt.json`);validate 值域。
+- `gateway/gateway.go` `New`:构造 `adapt.Engine`(关闭时 nil),注入
+  `decider.Adapt` 与 gateway 反馈钩子。
+- `kernel/cache/l3.go` `L3Decider` 新增:
+
+```go
+// Adapt 提供条目级 TauLow 覆盖(nil 安全;不改变其他判定语义)。
+Adapt interface {
+    TauLow(sliceID string, global float64) float64
+}
+```
+
+`DecideL3` 候选循环内:`tz := z.ForType(...); if d.Adapt != nil {
+tz.TauLow = d.Adapt.TauLow(s.ID, tz.TauLow) }` 后再 `ClassifyL3`。
+
+- 反馈接线(gateway/pipeline.go 与 judge 观测回调):
+  - 正:复用服务路径(现有 l3Reuses 记录处)→ `adapt.Observe(sliceID, false)`;
+  - 负:同一 session 重试命中(`detectFalseHit` 返回 true)→
+    `adapt.Observe(entry.SliceID, true)`;
+  - 负:judge 拒绝(`observeJudge`,Verdict == JudgeDeclined)→
+    `adapt.Observe(obs.SliceID, true)`。
+  - 调整事件:`log.Printf("adapt: slice %s tau_low %.2f -> %.2f (neg_ewma %.3f)")`
+    (观测可查,不进 usage 日志,避免污染计费账)。
+
+### 5.3 CLI 只读报告
+
+`verify --calibrate` 增加 adapt 快照汇总(条目数、阈值分布 min/median/max、
+调整次数、负 EWMA 分布);`--adapt-db` flag 指定状态文件(默认 `<store db
+同目录>/l3-adapt.json`)。
+
+## 6. 配置示例
+
+```toml
+[retrieval]
+tau_high = 0.8        # 相对置信:明确 hit 下界(缺省 0.8)
+tau_low  = 0.55       # 相对置信:grey 下界(缺省 0.55)
+abs_high = 0.7        # 绝对分:明确 hit 地板(缺省 0.7)
+abs_low  = 0.45       # 绝对分:grey 地板(缺省 0.45)
+evolve_db = ""        # evolve state 目录;tuned TauL2 → tau_low(显式 tau_low 优先)
+adaptive = true       # 逐条目自适应开关(缺省 true)
+error_bound = 0.05    # 条目级误命中率上界;-1 关闭自适应
+adapt_db = ""         # 自适应状态文件(缺省 <db 同目录>/l3-adapt.json)
+
+[retrieval.by_type.result]   # per-type 覆盖:只写要改的字段,其余继承全局
+tau_high = 0.85              # R 切片直接回答用户 → 更严
+tau_low  = 0.60
+# [retrieval.by_type.context]  # C/P 仅做上下文 → 可放宽
+# tau_low = 0.50
+```
+
+## 7. 验收标准
+
+- [ ] 阶段 1(gateway):`[retrieval] tau_*` 配置改变 L3 判定(gateway 配置
+  单测 + e2e 断言 zone 结果);`evolve_db` 的 tuned TauL2 在无显式 tau_low
+  时生效,显式配置优先(单测)。
+- [ ] 阶段 1(CLI):semantix.toml 四键解析 + `config list` 展示;
+  flag > toml > default 优先级单测;非法值(τ 超界、tau_high ≤ tau_low)
+  启动报错。
+- [ ] 阶段 2:per-type 配置后,同分数不同 Type 判定不同(zone 单测 +
+  gateway 配置组装单测);未知 type key 启动失败;ByType 为空时所有现有
+  测试行为不变。
+- [ ] 阶段 3:adapt 单测覆盖——正反馈不调/负反馈收紧、放宽条件、clamp、
+  冻结窗、冷启动(样本/复用不足回退全局)、持久化 round-trip、损坏文件
+  恢复、`adaptive=false` 零行为变化。
+- [ ] 阶段 3(gateway):e2e 复用 → 重试 → 该条目 TauLow 提高且落盘;
+  judge 拒绝计入负反馈。
+- [ ] verify --calibrate 输出 per-type 分布与 adapt 汇总(快照断言)。
+- [ ] 回归:`go test ./...` 全绿;默认配置下行为与 main 一致
+  (ByType 空、adaptive 冷启动 → 全局阈值)。
+
+## 8. 参考
+
+- vCache(arXiv:2502.03771,ICLR 2026):per-entry 在线阈值学习 + 错误率上界;
+- Calibration Gap(arXiv:2606.19719):阈值必须按部署分布校准;
+- Online Adaptation CUCB-SC(arXiv:2508.07675):错配代价建模;
+- Issue #262 spec(docs/specs/issue-262-l3-negative-observability.md):误命中
+  观测与反馈通道;
+- Issue #01(docs/issues/issue-01-l3-三段阈值.md):三段阈值验收基线。

--- a/gateway/adapt_test.go
+++ b/gateway/adapt_test.go
@@ -1,0 +1,182 @@
+package gateway
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"semantix/kernel/adapt"
+	"semantix/kernel/cache"
+	"semantix/kernel/zone"
+)
+
+// newAdaptGateway builds a Gateway with a small-window adaptive engine so
+// tests can exercise the feedback hooks without waiting for the default
+// cold-start minimums.
+func newAdaptGateway(t *testing.T) (*Gateway, *adapt.Engine) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "l3-adapt.json")
+	eng := adapt.New(adapt.Config{MinSamples: 1, MinHits: 1, FreezeEpochs: 1}, path)
+	g := &Gateway{
+		cfg:      &Config{Cache: CacheConfig{FalseHitSim: DefaultFalseHitSim}},
+		adapt:    eng,
+		zones:    zone.Default(),
+		l3Reuses: make(map[string]l3ReuseEntry),
+		now:      time.Now,
+	}
+	return g, eng
+}
+
+// A clean L3 reuse is positive evidence: the served slice's learned tau
+// relaxes (with MinHits satisfied) (Issue #259 阶段 3).
+func TestAdaptPositiveEvidenceOnReuse(t *testing.T) {
+	g, eng := newAdaptGateway(t)
+	g.recordL3Reuse("s1", "修复 go 测试失败", "l3-1")
+	if got := eng.TauLow("l3-1", 0.55); got != 0.50 {
+		t.Fatalf("TauLow = %v, want relaxed 0.50 after a clean reuse", got)
+	}
+	// Other slices are untouched (per-entry isolation).
+	if got := eng.TauLow("l3-2", 0.55); got != 0.55 {
+		t.Fatalf("other slice TauLow = %v, want global", got)
+	}
+}
+
+// A same-session retry of a served query (suspected false hit, Issue
+// #262) is negative evidence: the offending slice's tau tightens.
+func TestAdaptNegativeEvidenceOnFalseHit(t *testing.T) {
+	g, eng := newAdaptGateway(t)
+	q := "修复 go 测试失败"
+	g.recordL3Reuse("s1", q, "l3-1") // positive: relax → 0.50 (frozen 1)
+	if !g.detectFalseHit("s1", q) {
+		t.Fatal("retry must be detected as a false hit")
+	}
+	// The false hit is a frozen observation: counts fold, no adjustment.
+	// A second negative observation after re-serving tightens past 0.50.
+	g.recordL3Reuse("s1", q, "l3-1")
+	if !g.detectFalseHit("s1", q) {
+		t.Fatal("second retry must be detected")
+	}
+	if got := eng.TauLow("l3-1", 0.55); got <= 0.50 {
+		t.Fatalf("TauLow = %v, want tightened above 0.50 after repeated false hits", got)
+	}
+}
+
+// A judge rejection (grey band declined) is negative evidence for that
+// slice (Issue #259 阶段 3).
+func TestAdaptNegativeEvidenceOnJudgeDecline(t *testing.T) {
+	g, eng := newAdaptGateway(t)
+	g.observeJudge(context.Background(), cache.JudgeObservation{
+		SliceID: "l3-1",
+		Verdict: cache.JudgeDeclined,
+	})
+	if got := eng.TauLow("l3-1", 0.55); math.Abs(got-0.60) > 1e-9 {
+		t.Fatalf("TauLow = %v, want tightened 0.60 after a judge decline", got)
+	}
+	// Approved verdicts are not negative evidence.
+	g.observeJudge(context.Background(), cache.JudgeObservation{
+		SliceID: "l3-2",
+		Verdict: cache.JudgeApproved,
+	})
+	if got := eng.TauLow("l3-2", 0.55); got != 0.55 {
+		t.Fatalf("approved slice TauLow = %v, want global", got)
+	}
+}
+
+// New wires the adaptive engine into the decider (Issue #259 阶段 3) and
+// persists its state next to the slice store; adaptive = false leaves the
+// decider on the global thresholds (nil-safe hook).
+func TestNewWiresAdaptiveEngine(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.Server.GatewayKey = "test-key"
+	cfg.Store.DB = filepath.Join(dir, "db.jsonl")
+	cfg.Store.DepsRoot = dir
+	cfg.Ingest.SessionsDir = filepath.Join(dir, "sessions")
+	cfg.Upstreams = []UpstreamConfig{{
+		Name: "deepseek", BaseURL: "http://127.0.0.1:1", APIKey: "up-key",
+		ModelAlias: []string{"deepseek-chat"}, UpstreamModel: "deepseek-chat",
+		Vendor: "deepseek",
+	}}
+	g, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = g.Close() })
+	if g.adapt == nil {
+		t.Fatal("adaptive engine must be wired by default")
+	}
+	if g.decider.Adapt == nil {
+		t.Fatal("decider.Adapt must be set when adaptation is enabled")
+	}
+	// A clean-reuse streak relaxes the entry (MinSamples=20 reached) and
+	// the adjustment persists to the default state file.
+	for i := 0; i < 25; i++ {
+		g.recordL3Reuse("s1", "q", "l3-1")
+	}
+	state := filepath.Join(dir, "l3-adapt.json")
+	if _, err := os.Stat(state); err != nil {
+		t.Fatalf("adapt state file: %v", err)
+	}
+
+	// adaptive = false → no engine, decider falls back to global.
+	cfg2 := *cfg
+	off := false
+	cfg2.Retrieval.Adaptive = &off
+	g2, err := New(&cfg2)
+	if err != nil {
+		t.Fatalf("New(adaptive=false): %v", err)
+	}
+	t.Cleanup(func() { _ = g2.Close() })
+	if g2.adapt != nil {
+		t.Fatal("adaptive engine must be nil when disabled")
+	}
+	if g2.decider.Adapt != nil {
+		t.Fatal("decider.Adapt must stay nil when disabled")
+	}
+}
+
+// The adaptive engine honors a configured error bound (Issue #259 阶段 3):
+// a tighter bound makes the engine tighten earlier, and the bound is
+// surfaced through the engine's config at runtime.
+func TestAdaptErrorBoundConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "l3-adapt.json")
+	eng := adapt.New(adapt.Config{ErrorBound: 0.02, MinSamples: 1, MinHits: 1, FreezeEpochs: 1}, path)
+	// One negative observation: NegEWMA = 0.1 > 0.02 → tighten.
+	eng.Observe("l3-1", true, 0.55)
+	if got := eng.TauLow("l3-1", 0.55); math.Abs(got-0.60) > 1e-9 {
+		t.Fatalf("TauLow = %v, want tightened 0.60 under error_bound 0.02", got)
+	}
+	// error_bound = -1 disables: config validation accepts it and the
+	// engine stays a no-op.
+	if err := validateErrorBound(-1); err != nil {
+		t.Fatalf("error_bound -1 must be legal, got %v", err)
+	}
+	if err := validateErrorBound(0.5); err != nil {
+		t.Fatalf("error_bound 0.5 must be legal, got %v", err)
+	}
+	if err := validateErrorBound(1.5); err == nil {
+		t.Fatal("error_bound 1.5 must be rejected")
+	}
+	if err := validateErrorBound(-2); err == nil {
+		t.Fatal("error_bound -2 must be rejected")
+	}
+}
+
+// validateErrorBound mirrors the [retrieval] error_bound value domain so
+// the behavior tests do not need a full config file.
+func validateErrorBound(v float64) error {
+	cfg := DefaultConfig()
+	cfg.Server.GatewayKey = "test-key"
+	cfg.Upstreams = []UpstreamConfig{{
+		Name: "deepseek", BaseURL: "http://127.0.0.1:1", APIKey: "up-key",
+		ModelAlias: []string{"deepseek-chat"}, UpstreamModel: "deepseek-chat",
+		Vendor: "deepseek",
+	}}
+	cfg.Retrieval.ErrorBound = v
+	return cfg.validate()
+}
+
+var _ = zone.Default // keep zone import for future zone-driven cases

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -8,6 +8,8 @@
 package gateway
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -15,7 +17,9 @@ import (
 	"sort"
 	"strings"
 
+	"semantix/kernel/evolve"
 	"semantix/kernel/fuse"
+	"semantix/kernel/zone"
 
 	"github.com/BurntSushi/toml"
 )
@@ -130,6 +134,18 @@ type RetrievalConfig struct {
 	// fuse.DefaultBM25Weight (0.5), explicit 0 = pure vector route. Only
 	// read in weighted mode.
 	BM25Weight *float64 `toml:"bm25_weight"`
+	// Grey-zone thresholds (Issue #259 阶段 1). An explicit tau_*/abs_*
+	// key overrides zone.Default(); unspecified keys fall back to the
+	// tuned defaults. Validation: 0 < tau <= 1, abs >= 0, tau_high >
+	// tau_low. EvolveDB is an optional evolve state dir (params.json,
+	// written by `usage --evolve-db`): its tuned TauL2 drives TauLow when
+	// no explicit tau_low is configured (clamped to the evolve tuning
+	// band), mirroring the CLI --evolve-db behavior.
+	TauHigh   *float64 `toml:"tau_high"`
+	TauLow    *float64 `toml:"tau_low"`
+	AbsHigh   *float64 `toml:"abs_high"`
+	AbsLow    *float64 `toml:"abs_low"`
+	EvolveDB  string   `toml:"evolve_db"`
 }
 
 // CacheConfig holds L3 policy. TTL is resolved by the gateway and passed to
@@ -401,6 +417,37 @@ func (c *Config) validate() error {
 			return fmt.Errorf("gateway config: [retrieval] bm25_weight must be in [0,1], got %v", w)
 		}
 	}
+	// Grey-zone thresholds (Issue #259 阶段 1): taus are relative
+	// confidences in (0,1], abs floors are non-negative; NaN/Inf must be
+	// rejected because comparisons are false for NaN and would silently
+	// distort classification.
+	for _, th := range []struct {
+		key string
+		v   *float64
+	}{
+		{"tau_high", c.Retrieval.TauHigh},
+		{"tau_low", c.Retrieval.TauLow},
+		{"abs_high", c.Retrieval.AbsHigh},
+		{"abs_low", c.Retrieval.AbsLow},
+	} {
+		if th.v == nil {
+			continue
+		}
+		v := *th.v
+		isTau := th.key == "tau_high" || th.key == "tau_low"
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Errorf("gateway config: [retrieval] %s must be a finite number, got %v", th.key, v)
+		}
+		if isTau && (v <= 0 || v > 1) {
+			return fmt.Errorf("gateway config: [retrieval] %s must be in (0,1], got %v", th.key, v)
+		}
+		if !isTau && v < 0 {
+			return fmt.Errorf("gateway config: [retrieval] %s must be >= 0, got %v", th.key, v)
+		}
+	}
+	if c.Retrieval.TauHigh != nil && c.Retrieval.TauLow != nil && *c.Retrieval.TauHigh <= *c.Retrieval.TauLow {
+		return fmt.Errorf("gateway config: [retrieval] tau_high (%v) must be > tau_low (%v)", *c.Retrieval.TauHigh, *c.Retrieval.TauLow)
+	}
 	if c.Cache.JudgeAPIKey != "" && (strings.TrimSpace(c.Cache.JudgeBaseURL) == "" || strings.TrimSpace(c.Cache.JudgeModel) == "") {
 		return fmt.Errorf("gateway config: [cache] judge_api_key requires judge_base_url and judge_model")
 	}
@@ -498,6 +545,71 @@ func (c *Config) fusionConfig() fuse.Config {
 		cfg.Strategy = fuse.RRF
 	}
 	return cfg
+}
+
+// zoneConfig resolves the effective grey-zone thresholds (Issue #259):
+// explicit tau_*/abs_* keys win over zone.Default(); when tau_low is not
+// configured and evolve_db points at an evolve state dir, the engine's
+// tuned TauL2 drives TauLow (clamped to the evolve tuning band). The
+// result is the exact classifier the decider and injector will use.
+func (c *Config) zoneConfig() (zone.Zones, error) {
+	z := zone.Default()
+	if c.Retrieval.TauHigh != nil {
+		z.TauHigh = *c.Retrieval.TauHigh
+	}
+	if c.Retrieval.TauLow != nil {
+		z.TauLow = *c.Retrieval.TauLow
+	}
+	if c.Retrieval.AbsHigh != nil {
+		z.AbsHigh = *c.Retrieval.AbsHigh
+	}
+	if c.Retrieval.AbsLow != nil {
+		z.AbsLow = *c.Retrieval.AbsLow
+	}
+	if c.Retrieval.TauLow == nil && c.Retrieval.EvolveDB != "" {
+		tau, err := loadEvolveTauL2(c.Retrieval.EvolveDB)
+		if err != nil {
+			return zone.Zones{}, err
+		}
+		if tau > 0 {
+			z.TauLow = tau
+		}
+	}
+	return z, nil
+}
+
+// loadEvolveTauL2 reads an evolve state dir's params.json (written by
+// `usage --evolve-db`) and returns its tuned TauL2 clamped to the evolve
+// tuning band [DefaultMinTau, DefaultMaxTau]. A missing file or an
+// unset/non-finite value reports 0 (caller falls back to defaults); a
+// corrupt file is a startup error the operator should see — same
+// degradation contract as the CLI applyEvolveParams path.
+func loadEvolveTauL2(dir string) (float64, error) {
+	p := filepath.Join(dir, "params.json")
+	b, err := os.ReadFile(p)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("gateway: read evolve state: %w", err)
+	}
+	var st struct {
+		Params evolve.Params `json:"params"`
+	}
+	if err := json.Unmarshal(b, &st); err != nil {
+		return 0, fmt.Errorf("gateway: parse evolve state %s: %w", p, err)
+	}
+	tau := st.Params.TauL2
+	if math.IsNaN(tau) || math.IsInf(tau, 0) || tau <= 0 {
+		return 0, nil
+	}
+	if tau < evolve.DefaultMinTau {
+		tau = evolve.DefaultMinTau
+	}
+	if tau > evolve.DefaultMaxTau {
+		tau = evolve.DefaultMaxTau
+	}
+	return tau, nil
 }
 
 // DefaultConfig returns the built-in defaults (for tests and docs).

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -19,6 +19,7 @@ import (
 
 	"semantix/kernel/evolve"
 	"semantix/kernel/fuse"
+	"semantix/kernel/slice"
 	"semantix/kernel/zone"
 
 	"github.com/BurntSushi/toml"
@@ -146,6 +147,21 @@ type RetrievalConfig struct {
 	AbsHigh   *float64 `toml:"abs_high"`
 	AbsLow    *float64 `toml:"abs_low"`
 	EvolveDB  string   `toml:"evolve_db"`
+	// ByType holds per-slice-type threshold overrides (Issue #259 阶段
+	// 2), keyed by the stable wire name (prompt|context|tool_pattern|
+	// result|memory). Each entry is partial: only the keys present are
+	// set, everything else inherits the effective global thresholds when
+	// assembled into zone.Zones.ByType. Unknown type names fail startup.
+	ByType map[string]zoneOverride `toml:"by_type"`
+}
+
+// zoneOverride is the partial per-type override syntax for [retrieval]
+// by_type.<type>: absent fields inherit the global thresholds.
+type zoneOverride struct {
+	TauHigh *float64 `toml:"tau_high"`
+	TauLow  *float64 `toml:"tau_low"`
+	AbsHigh *float64 `toml:"abs_high"`
+	AbsLow  *float64 `toml:"abs_low"`
 }
 
 // CacheConfig holds L3 policy. TTL is resolved by the gateway and passed to
@@ -448,6 +464,41 @@ func (c *Config) validate() error {
 	if c.Retrieval.TauHigh != nil && c.Retrieval.TauLow != nil && *c.Retrieval.TauHigh <= *c.Retrieval.TauLow {
 		return fmt.Errorf("gateway config: [retrieval] tau_high (%v) must be > tau_low (%v)", *c.Retrieval.TauHigh, *c.Retrieval.TauLow)
 	}
+	// Per-type overrides (Issue #259 阶段 2): every by_type key must be a
+	// known slice type (fail closed on typos) and each override obeys the
+	// same value-domain rules as the global thresholds.
+	for name, o := range c.Retrieval.ByType {
+		if _, ok := slice.TypeFromString(name); !ok {
+			return fmt.Errorf("gateway config: [retrieval] by_type key %q is not a slice type (want prompt|context|tool_pattern|result|memory)", name)
+		}
+		for _, th := range []struct {
+			key string
+			v   *float64
+		}{
+			{"tau_high", o.TauHigh},
+			{"tau_low", o.TauLow},
+			{"abs_high", o.AbsHigh},
+			{"abs_low", o.AbsLow},
+		} {
+			if th.v == nil {
+				continue
+			}
+			v := *th.v
+			isTau := th.key == "tau_high" || th.key == "tau_low"
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				return fmt.Errorf("gateway config: [retrieval] by_type.%s.%s must be a finite number, got %v", name, th.key, v)
+			}
+			if isTau && (v <= 0 || v > 1) {
+				return fmt.Errorf("gateway config: [retrieval] by_type.%s.%s must be in (0,1], got %v", name, th.key, v)
+			}
+			if !isTau && v < 0 {
+				return fmt.Errorf("gateway config: [retrieval] by_type.%s.%s must be >= 0, got %v", name, th.key, v)
+			}
+		}
+		if o.TauHigh != nil && o.TauLow != nil && *o.TauHigh <= *o.TauLow {
+			return fmt.Errorf("gateway config: [retrieval] by_type.%s tau_high (%v) must be > tau_low (%v)", name, *o.TauHigh, *o.TauLow)
+		}
+	}
 	if c.Cache.JudgeAPIKey != "" && (strings.TrimSpace(c.Cache.JudgeBaseURL) == "" || strings.TrimSpace(c.Cache.JudgeModel) == "") {
 		return fmt.Errorf("gateway config: [cache] judge_api_key requires judge_base_url and judge_model")
 	}
@@ -573,6 +624,30 @@ func (c *Config) zoneConfig() (zone.Zones, error) {
 		}
 		if tau > 0 {
 			z.TauLow = tau
+		}
+	}
+	// Per-type overrides (Issue #259 阶段 2): each partial entry inherits
+	// the effective global thresholds (z, after evolve) for the fields it
+	// does not set. A configured type therefore never silently falls back
+	// mid-flight; the assembled map is a complete snapshot per type.
+	if len(c.Retrieval.ByType) > 0 {
+		z.ByType = make(map[string]zone.Zones, len(c.Retrieval.ByType))
+		for name, o := range c.Retrieval.ByType {
+			oz := z
+			if o.TauHigh != nil {
+				oz.TauHigh = *o.TauHigh
+			}
+			if o.TauLow != nil {
+				oz.TauLow = *o.TauLow
+			}
+			if o.AbsHigh != nil {
+				oz.AbsHigh = *o.AbsHigh
+			}
+			if o.AbsLow != nil {
+				oz.AbsLow = *o.AbsLow
+			}
+			oz.ByType = nil // leaf snapshot: overrides never nest
+			z.ByType[name] = oz
 		}
 	}
 	return z, nil

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -142,11 +142,22 @@ type RetrievalConfig struct {
 	// written by `usage --evolve-db`): its tuned TauL2 drives TauLow when
 	// no explicit tau_low is configured (clamped to the evolve tuning
 	// band), mirroring the CLI --evolve-db behavior.
-	TauHigh   *float64 `toml:"tau_high"`
-	TauLow    *float64 `toml:"tau_low"`
-	AbsHigh   *float64 `toml:"abs_high"`
-	AbsLow    *float64 `toml:"abs_low"`
-	EvolveDB  string   `toml:"evolve_db"`
+	TauHigh  *float64 `toml:"tau_high"`
+	TauLow   *float64 `toml:"tau_low"`
+	AbsHigh  *float64 `toml:"abs_high"`
+	AbsLow   *float64 `toml:"abs_low"`
+	EvolveDB string   `toml:"evolve_db"`
+	// Adaptive enables per-entry online TauLow learning (Issue #259 阶段
+	// 3, vCache route): each high-frequency reused slice learns its own
+	// grey floor from positive/negative evidence, with the global
+	// thresholds as cold-start prior. nil → enabled; explicit false
+	// disables (all entries use the global/per-type thresholds).
+	// ErrorBound is the operator-specified false-hit rate ceiling
+	// (0 → 0.05; -1 also disables adaptation). AdaptDB is the state file
+	// (empty → <store dir>/l3-adapt.json).
+	Adaptive   *bool   `toml:"adaptive"`
+	ErrorBound float64 `toml:"error_bound"`
+	AdaptDB    string  `toml:"adapt_db"`
 	// ByType holds per-slice-type threshold overrides (Issue #259 阶段
 	// 2), keyed by the stable wire name (prompt|context|tool_pattern|
 	// result|memory). Each entry is partial: only the keys present are
@@ -463,6 +474,14 @@ func (c *Config) validate() error {
 	}
 	if c.Retrieval.TauHigh != nil && c.Retrieval.TauLow != nil && *c.Retrieval.TauHigh <= *c.Retrieval.TauLow {
 		return fmt.Errorf("gateway config: [retrieval] tau_high (%v) must be > tau_low (%v)", *c.Retrieval.TauHigh, *c.Retrieval.TauLow)
+	}
+	// Adaptive error bound (Issue #259 阶段 3): -1 disables per-entry
+	// adaptation; any other value must be a rate in [0,1].
+	if c.Retrieval.ErrorBound != 0 && c.Retrieval.ErrorBound != -1 {
+		if math.IsNaN(c.Retrieval.ErrorBound) || math.IsInf(c.Retrieval.ErrorBound, 0) ||
+			c.Retrieval.ErrorBound < 0 || c.Retrieval.ErrorBound > 1 {
+			return fmt.Errorf("gateway config: [retrieval] error_bound must be -1 (disabled) or in [0,1], got %v", c.Retrieval.ErrorBound)
+		}
 	}
 	// Per-type overrides (Issue #259 阶段 2): every by_type key must be a
 	// known slice type (fail closed on typos) and each override obeys the

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"semantix/kernel/evolve"
 	"semantix/kernel/fuse"
+	"semantix/kernel/zone"
 )
 
 func writeConfig(t *testing.T, body string) string {
@@ -17,6 +19,29 @@ func writeConfig(t *testing.T, body string) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+// loadZoneTestConfig loads a config body with the env vars validConfig
+// references, so tests do not depend on other tests' env state.
+func loadZoneTestConfig(t *testing.T, body string) (*Config, error) {
+	t.Helper()
+	t.Setenv("GW_KEY", "k1")
+	t.Setenv("DS_KEY", "k2")
+	return Load(writeConfig(t, body))
+}
+
+// tomlPath escapes a Windows path for use inside a double-quoted TOML
+// string (backslash sequences such as \U are otherwise parsed as escapes).
+func tomlPath(p string) string {
+	return strings.ReplaceAll(p, "\\", "\\\\")
+}
+
+// configWithoutRetrieval returns validConfig with the [retrieval] section
+// removed, so tests can inject their own retrieval block without toml
+// duplicate-key errors.
+func configWithoutRetrieval() string {
+	return strings.Replace(validConfig,
+		"[retrieval]\nretriever = \"bm25\"\ntop_k = 5\nbudget = 4096\n\n", "", 1)
 }
 
 const validConfig = `
@@ -53,7 +78,7 @@ vendor = "deepseek"
 func TestLoadExpandsEnvAndHome(t *testing.T) {
 	t.Setenv("GW_KEY", "k1")
 	t.Setenv("DS_KEY", "k2")
-	cfg, err := Load(writeConfig(t, validConfig))
+	cfg, err := loadZoneTestConfig(t, validConfig)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -159,7 +184,7 @@ func TestModelAliasEnvSubstitution(t *testing.T) {
 	t.Setenv("ALIAS_EXTRA", "ds-chat")
 	body := strings.Replace(validConfig, `model_alias = ["deepseek-chat", "ds-chat"]`,
 		`model_alias = ["deepseek-chat", "${ALIAS_EXTRA}"]`, 1)
-	cfg, err := Load(writeConfig(t, body))
+	cfg, err := loadZoneTestConfig(t, body)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -424,5 +449,181 @@ func TestFusionConfigMapping(t *testing.T) {
 	c.Retrieval.RrfK = 30
 	if fc := c.fusionConfig(); fc.Strategy != fuse.RRF || fc.RrfK != 30 {
 		t.Fatalf("rrf fusionConfig = %+v, want rrf/30", fc)
+	}
+}
+
+func TestZoneConfigExplicitTauKeys(t *testing.T) {
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+top_k = 5
+budget = 4096
+tau_high = 0.9
+tau_low = 0.6
+abs_high = 0.8
+abs_low = 0.5
+`
+	cfg, err := loadZoneTestConfig(t, body)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		t.Fatalf("zoneConfig: %v", err)
+	}
+	if z.TauHigh != 0.9 || z.TauLow != 0.6 || z.AbsHigh != 0.8 || z.AbsLow != 0.5 {
+		t.Fatalf("zones = %+v, want explicit values", z)
+	}
+}
+
+func TestZoneConfigDefaultsWithoutKeys(t *testing.T) {
+	cfg, err := loadZoneTestConfig(t, validConfig)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		t.Fatalf("zoneConfig: %v", err)
+	}
+	def := zone.Default()
+	if z != def {
+		t.Fatalf("zones = %+v, want default %+v", z, def)
+	}
+}
+
+func TestZoneConfigEvolveDBDrivesTauLow(t *testing.T) {
+	dir := t.TempDir()
+	// params.json with a tuned TauL2 (0.70) — as `usage --evolve-db` writes it.
+	state := `{"params":{"tau_l2":0.70,"tau_l3":0.0,"inject_cap":0.3,"prefetch_conf":0.5,"success_floor":0.7,"freeze_epochs":60},"epoch":42}`
+	if err := os.WriteFile(filepath.Join(dir, "params.json"), []byte(state), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+evolve_db = "` + tomlPath(dir) + `"
+`
+	cfg, err := loadZoneTestConfig(t, body)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		t.Fatalf("zoneConfig: %v", err)
+	}
+	if z.TauLow != 0.70 {
+		t.Fatalf("TauLow = %v, want evolve-tuned 0.70", z.TauLow)
+	}
+	if z.TauHigh != zone.Default().TauHigh {
+		t.Fatalf("TauHigh = %v, want default %v", z.TauHigh, zone.Default().TauHigh)
+	}
+}
+
+func TestZoneConfigExplicitTauLowBeatsEvolve(t *testing.T) {
+	dir := t.TempDir()
+	state := `{"params":{"tau_l2":0.70,"inject_cap":0.3,"prefetch_conf":0.5,"success_floor":0.7,"freeze_epochs":60},"epoch":1}`
+	if err := os.WriteFile(filepath.Join(dir, "params.json"), []byte(state), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+tau_low = 0.62
+evolve_db = "` + tomlPath(dir) + `"
+`
+	cfg, err := loadZoneTestConfig(t, body)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		t.Fatalf("zoneConfig: %v", err)
+	}
+	if z.TauLow != 0.62 {
+		t.Fatalf("TauLow = %v, want explicit 0.62 to win over evolve", z.TauLow)
+	}
+}
+
+func TestZoneConfigEvolveClampedToBand(t *testing.T) {
+	dir := t.TempDir()
+	// A hand-edited or stale file must not push the classifier outside
+	// what evolve itself could produce (same contract as CLI flags.go).
+	state := `{"params":{"tau_l2":0.99,"inject_cap":0.3,"prefetch_conf":0.5,"success_floor":0.7,"freeze_epochs":60},"epoch":1}`
+	if err := os.WriteFile(filepath.Join(dir, "params.json"), []byte(state), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+evolve_db = "` + tomlPath(dir) + `"
+`
+	cfg, err := loadZoneTestConfig(t, body)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		t.Fatalf("zoneConfig: %v", err)
+	}
+	if z.TauLow != evolve.DefaultMaxTau {
+		t.Fatalf("TauLow = %v, want clamped to %v", z.TauLow, evolve.DefaultMaxTau)
+	}
+}
+
+func TestZoneConfigEvolveMissingFileFallsBack(t *testing.T) {
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+evolve_db = "` + tomlPath(filepath.Join(t.TempDir(), "no-such-dir")) + `"
+`
+	cfg, err := loadZoneTestConfig(t, body)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		t.Fatalf("zoneConfig with missing evolve state must fall back, got %v", err)
+	}
+	if z != zone.Default() {
+		t.Fatalf("zones = %+v, want default", z)
+	}
+}
+
+func TestZoneConfigCorruptEvolveFileFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "params.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+evolve_db = "` + tomlPath(dir) + `"
+`
+	cfg, err := loadZoneTestConfig(t, body)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := cfg.zoneConfig(); err == nil {
+		t.Fatal("zoneConfig must fail on a corrupt evolve state file")
+	}
+}
+
+func TestValidateTauKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"tau_high zero", validConfig + "\n[retrieval]\ntau_high = 0\n"},
+		{"tau_high over one", validConfig + "\n[retrieval]\ntau_high = 1.2\n"},
+		{"tau_low negative", validConfig + "\n[retrieval]\ntau_low = -0.1\n"},
+		{"abs_high negative", validConfig + "\n[retrieval]\nabs_high = -0.01\n"},
+		{"tau_high not above tau_low", validConfig + "\n[retrieval]\ntau_high = 0.6\ntau_low = 0.6\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := loadZoneTestConfig(t, tc.body); err == nil {
+				t.Fatalf("Load must reject: %s", tc.name)
+			}
+		})
 	}
 }

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -21,6 +21,13 @@ func writeConfig(t *testing.T, body string) string {
 	return path
 }
 
+// zonesEqual compares the four thresholds (ByType is derived state in
+// these tests; map fields make Zones non-comparable with ==).
+func zonesEqual(a, b zone.Zones) bool {
+	return a.TauHigh == b.TauHigh && a.TauLow == b.TauLow &&
+		a.AbsHigh == b.AbsHigh && a.AbsLow == b.AbsLow
+}
+
 // loadZoneTestConfig loads a config body with the env vars validConfig
 // references, so tests do not depend on other tests' env state.
 func loadZoneTestConfig(t *testing.T, body string) (*Config, error) {
@@ -486,7 +493,7 @@ func TestZoneConfigDefaultsWithoutKeys(t *testing.T) {
 		t.Fatalf("zoneConfig: %v", err)
 	}
 	def := zone.Default()
-	if z != def {
+	if !zonesEqual(z, def) {
 		t.Fatalf("zones = %+v, want default %+v", z, def)
 	}
 }
@@ -584,7 +591,7 @@ evolve_db = "` + tomlPath(filepath.Join(t.TempDir(), "no-such-dir")) + `"
 	if err != nil {
 		t.Fatalf("zoneConfig with missing evolve state must fall back, got %v", err)
 	}
-	if z != zone.Default() {
+	if !zonesEqual(z, zone.Default()) {
 		t.Fatalf("zones = %+v, want default", z)
 	}
 }
@@ -622,6 +629,73 @@ func TestValidateTauKeys(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, err := loadZoneTestConfig(t, tc.body); err == nil {
+				t.Fatalf("Load must reject: %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestZoneConfigByTypePartialOverride(t *testing.T) {
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+
+[retrieval.by_type.result]
+tau_high = 0.85
+tau_low = 0.60
+`
+	cfg, err := loadZoneTestConfig(t, body)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		t.Fatalf("zoneConfig: %v", err)
+	}
+	oz, ok := z.ByType["result"]
+	if !ok {
+		t.Fatal("ByType[result] missing")
+	}
+	// Partial syntax: only configured fields differ from the global.
+	if oz.TauHigh != 0.85 || oz.TauLow != 0.60 {
+		t.Fatalf("override = %+v, want tau_high 0.85 tau_low 0.60", oz)
+	}
+	if oz.AbsHigh != z.AbsHigh || oz.AbsLow != z.AbsLow {
+		t.Fatalf("override abs fields must inherit global: %+v vs %+v", oz, z)
+	}
+	// The override is a leaf snapshot.
+	if oz.ByType != nil {
+		t.Fatal("override must not nest ByType")
+	}
+	// Types without an override see the global baseline.
+	if got := z.ForType("prompt"); got.TauHigh != z.TauHigh {
+		t.Fatalf("prompt must use global baseline, got %+v", got)
+	}
+}
+
+func TestZoneConfigByTypeRejectsUnknownType(t *testing.T) {
+	body := configWithoutRetrieval() + `
+[retrieval]
+retriever = "bm25"
+
+[retrieval.by_type.reslut]
+tau_low = 0.6
+`
+	if _, err := loadZoneTestConfig(t, body); err == nil {
+		t.Fatal("Load must reject an unknown by_type key (typo fail-closed)")
+	}
+}
+
+func TestZoneConfigByTypeValueValidation(t *testing.T) {
+	cases := []struct{ name, body string }{
+		{"tau over one", "\n[retrieval.by_type.result]\ntau_high = 1.2\n"},
+		{"abs negative", "\n[retrieval.by_type.context]\nabs_low = -1\n"},
+		{"tau_high not above tau_low", "\n[retrieval.by_type.result]\ntau_high = 0.5\ntau_low = 0.6\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := configWithoutRetrieval() + "\n[retrieval]\nretriever = \"bm25\"\n" + tc.body
+			if _, err := loadZoneTestConfig(t, body); err == nil {
 				t.Fatalf("Load must reject: %s", tc.name)
 			}
 		})

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"semantix/kernel/adapt"
 	"semantix/kernel/cache"
 	kernelevent "semantix/kernel/event"
 	"semantix/kernel/ingest"
@@ -25,6 +26,7 @@ import (
 	"semantix/kernel/judge"
 	"semantix/kernel/slice"
 	"semantix/kernel/usage"
+	"semantix/kernel/zone"
 )
 
 // Gateway is the assembled Semantix Gateway v1. All semantic behavior is
@@ -57,6 +59,13 @@ type Gateway struct {
 	// query bypasses L3 and is recorded as L3FalseHit.
 	reuseMu  sync.Mutex
 	l3Reuses map[string]l3ReuseEntry
+
+	// Per-entry adaptive thresholds (Issue #259 阶段 3): the engine the
+	// decider consults and the feedback hooks feed; nil when adaptation
+	// is disabled by config. zones is the effective classifier snapshot
+	// (explicit config > evolve > defaults) used as the cold-start prior.
+	adapt *adapt.Engine
+	zones zone.Zones
 
 	now func() time.Time
 
@@ -194,6 +203,26 @@ func New(cfg *Config) (*Gateway, error) {
 		disabled: disableEnv(),
 		l3Reuses: make(map[string]l3ReuseEntry),
 		now:      time.Now,
+		zones:    z,
+	}
+	// Per-entry adaptive TauLow (Issue #259 阶段 3, vCache route): each
+	// high-frequency reused slice learns its own grey floor from the
+	// gateway's positive/negative evidence. The engine is nil when
+	// disabled by config (adaptive = false or error_bound = -1); the
+	// decider's nil-safe Adapt hook then keeps every entry on the
+	// global/per-type thresholds (cold start). Adaptive state is derived
+	// and rebuildable — a corrupt file only logs, never blocks startup.
+	if cfg.Retrieval.Adaptive == nil || *cfg.Retrieval.Adaptive {
+		adaptCfg := adapt.Config{}
+		if cfg.Retrieval.ErrorBound != 0 {
+			adaptCfg.ErrorBound = cfg.Retrieval.ErrorBound
+		}
+		adaptPath := cfg.Retrieval.AdaptDB
+		if adaptPath == "" {
+			adaptPath = adapt.DefaultAdaptDB(cfg.Store.DB)
+		}
+		g.adapt = adapt.New(adaptCfg, adaptPath)
+		decider.Adapt = g.adapt
 	}
 	// Grey-zone judge decisions become durable here (Issue #242 gap 1):
 	// one structured log line plus a field on the turn's usage event, so a

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -25,7 +25,6 @@ import (
 	"semantix/kernel/judge"
 	"semantix/kernel/slice"
 	"semantix/kernel/usage"
-	"semantix/kernel/zone"
 )
 
 // Gateway is the assembled Semantix Gateway v1. All semantic behavior is
@@ -159,7 +158,15 @@ func New(cfg *Config) (*Gateway, error) {
 	if budget <= 0 {
 		budget = inject.DefaultBudget
 	}
-	z := zone.Default()
+	// Grey-zone thresholds (Issue #259 阶段 1): explicit [retrieval]
+	// tau_*/abs_* keys, else the evolve-tuned TauL2 (evolve_db), else the
+	// tuned defaults. zoneConfig is validated by Load, so a non-nil error
+	// here means the evolve state file itself is unreadable/corrupt.
+	z, err := cfg.zoneConfig()
+	if err != nil {
+		_ = closeStore(store)
+		return nil, err
+	}
 
 	var rec *usage.Recorder
 	if cfg.Ingest.UsageLog != "" {

--- a/gateway/judge_observability.go
+++ b/gateway/judge_observability.go
@@ -90,6 +90,13 @@ func (g *Gateway) observeJudge(ctx context.Context, obs cache.JudgeObservation) 
 	}
 	log.Printf("gateway: l3 judge slice=%s rel=%.3f verdict=%s called=%t fail_closed=%t latency_ms=%d prompt_tokens=%d reason=%q err=%q",
 		d.SliceID, d.RelConfidence, d.Verdict, d.Called, d.FailClosed, d.LatencyMs, d.PromptTokens, d.Reason, d.Error)
+	// Judge rejections are negative evidence for the per-entry adaptive
+	// engine (Issue #259 阶段 3): the judge declined to reuse this slice
+	// from its grey band — the entry should tighten so fewer of its
+	// candidates consume judge calls / risk false reuses.
+	if g.adapt != nil && obs.Verdict == cache.JudgeDeclined && obs.SliceID != "" {
+		g.adapt.Observe(obs.SliceID, true, g.zones.TauLow)
+	}
 	if c := judgeCollectorFrom(ctx); c != nil {
 		c.add(d)
 	}

--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -568,12 +568,27 @@ func (g *Gateway) detectFalseHit(sessionID, query string) bool {
 		return false
 	}
 	delete(g.l3Reuses, sessionID)
-	return normalizedEditRatio(entry.Query, query) >= sim
+	if normalizedEditRatio(entry.Query, query) >= sim {
+		// Suspected false hit (Issue #262 §3.3): the user retried a query
+		// the cache just served. Feed negative evidence to the per-entry
+		// adaptive engine (Issue #259 阶段 3) so the offending slice's
+		// threshold tightens.
+		if g.adapt != nil && entry.SliceID != "" {
+			g.adapt.Observe(entry.SliceID, true, g.zones.TauLow)
+		}
+		return true
+	}
+	return false
 }
 
 // recordL3Reuse remembers the most recent L3-served request per session
-// (bounded: maxL3ReuseEntries, LRU eviction by timestamp).
+// (bounded: maxL3ReuseEntries, LRU eviction by timestamp) and feeds the
+// positive evidence to the per-entry adaptive engine (Issue #259 阶段 3):
+// the served slice just earned a clean reuse.
 func (g *Gateway) recordL3Reuse(sessionID, query, sliceID string) {
+	if g.adapt != nil && sliceID != "" {
+		g.adapt.Observe(sliceID, false, g.zones.TauLow)
+	}
 	if sessionID == "" {
 		return
 	}

--- a/kernel/adapt/adapt.go
+++ b/kernel/adapt/adapt.go
@@ -250,6 +250,8 @@ func (e *Engine) Observe(sliceID string, negative bool, curTau float64) {
 			ent.TauLow = base
 			if !tighter {
 				ent.Relaxed = true // loosening is gated by MinHits
+			} else {
+				ent.Relaxed = false // tightening applies immediately again
 			}
 			ent.Frozen = e.cfg.FreezeEpochs
 			e.adjustments++

--- a/kernel/adapt/adapt.go
+++ b/kernel/adapt/adapt.go
@@ -1,0 +1,352 @@
+// Package adapt implements per-entry online threshold adaptation for the
+// L3 reuse path (Issue #259 阶段 3, vCache arXiv:2502.03771 route): each
+// high-frequency cached slice keeps its own grey-zone floor (TauLow),
+// learned from that slice's positive/negative reuse evidence. The global
+// thresholds act as the prior/cold-start; a slice only departs from them
+// after enough of its own observations accumulate, and every adjustment
+// respects an operator-specified false-hit error bound.
+//
+// Evidence contract: the consumer reports one observation per served L3
+// decision — positive when the reuse was accepted without a retry, negative
+// on a suspected false hit (Issue #262 retry heuristic) or a judge
+// rejection of that slice. The engine folds observations into a per-entry
+// negative-rate EWMA and nudges TauLow in 0.05 steps inside a freeze
+// window, mirroring kernel/evolve's tuning discipline (freeze protects the
+// vendor byte-prefix cache from churn).
+package adapt
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// Default tuning constants. The band [MinTau, MaxTau] matches
+// evolve.DefaultMinTau/MaxTau so the two online layers cannot disagree on
+// what a legal tau looks like.
+const (
+	DefaultErrorBound   = 0.05 // operator-specified false-hit rate ceiling
+	DefaultStep         = 0.05 // per adjustment step (aligns evolve.TauStep)
+	DefaultMinSamples   = 20   // observations before the first adjustment (aligns evolve.MinSamples)
+	DefaultMinHits      = 5    // reuses before an entry's learned tau takes effect
+	DefaultFreezeEpochs = 60   // observations an adjustment stays frozen (aligns evolve.DefaultFreezeEpoch)
+	DefaultAlpha        = 0.1  // negative-rate EWMA smoothing (aligns evolve.DefaultAlpha)
+	DefaultMinTau       = 0.30 // floor for learned tau (never below)
+	DefaultMaxTau       = 0.80 // ceiling for learned tau (never above)
+)
+
+// Config carries operator-provided tuning constants (zero values →
+// defaults). ErrorBound < 0 disables adaptation entirely.
+type Config struct {
+	ErrorBound   float64
+	Step         float64
+	MinSamples   uint64
+	MinHits      uint64
+	FreezeEpochs uint64
+	Alpha        float64
+	MinTau       float64
+	MaxTau       float64
+}
+
+// Entry is one cached slice's adaptive state. TauLow == 0 means "not yet
+// learned — use the global threshold" (cold start). Relaxed marks that the
+// last adjustment loosened the threshold (below the value in effect): the
+// generous direction is gated by MinHits reuses, the conservative one
+// applies immediately (see Engine.TauLow).
+type Entry struct {
+	SliceID   string  `json:"slice_id"`
+	TauLow    float64 `json:"tau_low"`
+	Relaxed   bool    `json:"relaxed"`
+	Pos       uint64  `json:"pos"` // positive observations (reuse without retry)
+	Neg       uint64  `json:"neg"` // negative observations (suspected false hit / judge reject)
+	NegEWMA   float64 `json:"neg_ewma"`
+	Frozen    uint64  `json:"frozen"` // remaining frozen observations
+	UpdatedAt int64   `json:"updated_at"`
+}
+
+// Engine is the per-entry adaptive threshold state machine. All methods
+// are safe for concurrent use; the decision path (TauLow) never blocks on
+// I/O — persistence happens inside Observe at most every
+// persistInterval observations or on an actual adjustment.
+type Engine struct {
+	mu          sync.Mutex
+	cfg         Config
+	path        string
+	enabled     bool
+	epoch       uint64 // total observations seen (all entries)
+	adjustments uint64
+	entries     map[string]*Entry
+}
+
+// persisted is the on-disk shape (append/replace whole file on write).
+type persisted struct {
+	Entries     []Entry `json:"entries"`
+	Epoch       uint64  `json:"epoch"`
+	Adjustments uint64  `json:"adjustments"`
+}
+
+// persistInterval bounds write frequency: a full file write at most every
+// 64 observations outside of adjustments (adjustments always write).
+const persistInterval = 64
+
+// New loads (or initializes) the adaptive state at path and returns a
+// ready engine. A missing file starts empty (cold start — global
+// thresholds apply); a corrupt file is logged and treated as empty too:
+// adaptive state is derived performance state, never data truth, so it
+// must not block the decision path. ErrorBound < 0 in cfg disables
+// adaptation (TauLow always returns the global value).
+func New(cfg Config, path string) *Engine {
+	e := &Engine{
+		cfg: Config{
+			ErrorBound:   DefaultErrorBound,
+			Step:         DefaultStep,
+			MinSamples:   DefaultMinSamples,
+			MinHits:      DefaultMinHits,
+			FreezeEpochs: DefaultFreezeEpochs,
+			Alpha:        DefaultAlpha,
+			MinTau:       DefaultMinTau,
+			MaxTau:       DefaultMaxTau,
+		},
+		path:    path,
+		enabled: true,
+		entries: map[string]*Entry{},
+	}
+	if cfg.ErrorBound < 0 {
+		e.enabled = false
+		return e
+	}
+	if cfg.ErrorBound > 0 {
+		e.cfg.ErrorBound = cfg.ErrorBound
+	}
+	if cfg.Step > 0 {
+		e.cfg.Step = cfg.Step
+	}
+	if cfg.MinSamples > 0 {
+		e.cfg.MinSamples = cfg.MinSamples
+	}
+	if cfg.MinHits > 0 {
+		e.cfg.MinHits = cfg.MinHits
+	}
+	if cfg.FreezeEpochs > 0 {
+		e.cfg.FreezeEpochs = cfg.FreezeEpochs
+	}
+	if cfg.Alpha > 0 && !math.IsNaN(cfg.Alpha) && !math.IsInf(cfg.Alpha, 0) {
+		e.cfg.Alpha = cfg.Alpha
+	}
+	if cfg.MinTau > 0 {
+		e.cfg.MinTau = cfg.MinTau
+	}
+	if cfg.MaxTau > 0 {
+		e.cfg.MaxTau = cfg.MaxTau
+	}
+	if e.cfg.MinTau >= e.cfg.MaxTau {
+		log.Printf("adapt: MinTau (%.2f) >= MaxTau (%.2f), clamping MaxTau to MinTau+0.05", e.cfg.MinTau, e.cfg.MaxTau)
+		e.cfg.MaxTau = e.cfg.MinTau + 0.05
+	}
+	e.load()
+	return e
+}
+
+// load reads the persisted state; corrupt or unreadable files are logged
+// and skipped (derived state, cold start is safe).
+func (e *Engine) load() {
+	if e.path == "" {
+		return
+	}
+	b, err := os.ReadFile(e.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		log.Printf("adapt: read state %s: %v (starting cold)", e.path, err)
+		return
+	}
+	var p persisted
+	if err := json.Unmarshal(b, &p); err != nil {
+		log.Printf("adapt: parse state %s: %v (starting cold)", e.path, err)
+		return
+	}
+	for i := range p.Entries {
+		ent := &p.Entries[i]
+		if ent.SliceID == "" {
+			continue
+		}
+		if math.IsNaN(ent.NegEWMA) || math.IsInf(ent.NegEWMA, 0) {
+			ent.NegEWMA = 0
+		}
+		e.entries[ent.SliceID] = ent
+	}
+	e.epoch = p.Epoch
+	e.adjustments = p.Adjustments
+}
+
+// Observe folds one decision observation for a slice into its adaptive
+// state and, once the entry has enough samples and its freeze window is
+// open, nudges the entry's TauLow toward the configured error bound.
+// curTau is the tau_low currently in effect for this slice (the global
+// value or the entry's learned value) — it seeds the first adjustment.
+// A disabled engine is a no-op.
+func (e *Engine) Observe(sliceID string, negative bool, curTau float64) {
+	if sliceID == "" {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.enabled {
+		return
+	}
+	e.epoch++
+	ent := e.entries[sliceID]
+	if ent == nil {
+		ent = &Entry{SliceID: sliceID}
+		e.entries[sliceID] = ent
+	}
+	if negative {
+		ent.Neg++
+		ent.NegEWMA = e.cfg.Alpha*1 + (1-e.cfg.Alpha)*ent.NegEWMA
+	} else {
+		ent.Pos++
+		ent.NegEWMA = (1 - e.cfg.Alpha) * ent.NegEWMA
+	}
+	if ent.Frozen > 0 {
+		// Frozen observation: fold the count but do not adjust.
+		ent.Frozen--
+		if e.epoch%persistInterval == 0 {
+			e.persistLocked()
+		}
+		return
+	}
+	samples := ent.Pos + ent.Neg
+	write := false
+	if samples >= e.cfg.MinSamples {
+		base := ent.TauLow
+		if base <= 0 {
+			base = curTau // first adjustment seeds from the value in effect
+		}
+		if base <= 0 {
+			base = e.cfg.MinTau // defensive: never adjust from an empty prior
+		}
+		old := base
+		tighter := false
+		switch {
+		case ent.NegEWMA > e.cfg.ErrorBound:
+			base += e.cfg.Step // tighten: fewer direct reuses
+			tighter = true
+		case ent.NegEWMA < e.cfg.ErrorBound/2 && ent.Pos >= e.cfg.MinSamples:
+			base -= e.cfg.Step // relax: reuse is safe, be more generous
+		}
+		if base < e.cfg.MinTau {
+			base = e.cfg.MinTau
+		}
+		if base > e.cfg.MaxTau {
+			base = e.cfg.MaxTau
+		}
+		if base != old {
+			ent.TauLow = base
+			if !tighter {
+				ent.Relaxed = true // loosening is gated by MinHits
+			}
+			ent.Frozen = e.cfg.FreezeEpochs
+			e.adjustments++
+			write = true
+		}
+	}
+	if write || e.epoch%persistInterval == 0 {
+		e.persistLocked()
+	}
+}
+
+// TauLow returns the effective tau_low for a slice: the entry's learned
+// value once it exists and is learned (TauLow > 0). A learned value that
+// TIGHTENED (raised) the threshold applies immediately — negative
+// evidence must never be gated behind traffic volume. A learned value
+// that RELAXED (lowered) it only applies after the entry accumulated
+// MinHits reuses (trust gate for low-traffic slices). Cold start and
+// disabled engines return the global value.
+func (e *Engine) TauLow(sliceID string, global float64) float64 {
+	if sliceID == "" {
+		return global
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.enabled {
+		return global
+	}
+	ent := e.entries[sliceID]
+	if ent == nil || ent.TauLow <= 0 {
+		return global
+	}
+	if ent.Relaxed && ent.Pos < e.cfg.MinHits {
+		return global
+	}
+	return ent.TauLow
+}
+
+// Snapshot returns a defensive, SliceID-sorted copy of every entry
+// (observability: calibrate reports).
+func (e *Engine) Snapshot() []Entry {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]Entry, 0, len(e.entries))
+	for _, ent := range e.entries {
+		out = append(out, *ent)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SliceID < out[j].SliceID })
+	return out
+}
+
+// Adjustments reports how many times any entry's tau actually changed.
+func (e *Engine) Adjustments() uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.adjustments
+}
+
+// Epoch returns the total observation count (all entries).
+func (e *Engine) Epoch() uint64 {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.epoch
+}
+
+// persistLocked writes the state file atomically (temp + rename). Callers
+// hold e.mu. A failed write is logged and ignored — adaptive state is
+// derived and rebuildable; it must never break the decision path.
+func (e *Engine) persistLocked() {
+	if e.path == "" {
+		return
+	}
+	p := persisted{
+		Entries:     make([]Entry, 0, len(e.entries)),
+		Epoch:       e.epoch,
+		Adjustments: e.adjustments,
+	}
+	for _, ent := range e.entries {
+		p.Entries = append(p.Entries, *ent)
+	}
+	sort.Slice(p.Entries, func(i, j int) bool { return p.Entries[i].SliceID < p.Entries[j].SliceID })
+	b, err := json.Marshal(p)
+	if err != nil {
+		log.Printf("adapt: marshal state: %v", err)
+		return
+	}
+	tmp := e.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		log.Printf("adapt: write state %s: %v", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, e.path); err != nil {
+		log.Printf("adapt: commit state %s: %v", e.path, err)
+	}
+}
+
+// DefaultAdaptDB returns the default state file path next to a slice
+// store: <store-dir>/l3-adapt.json.
+func DefaultAdaptDB(storeDB string) string {
+	return filepath.Join(filepath.Dir(storeDB), "l3-adapt.json")
+}

--- a/kernel/adapt/adapt_test.go
+++ b/kernel/adapt/adapt_test.go
@@ -203,3 +203,26 @@ func TestDefaultAdaptDB(t *testing.T) {
 		t.Fatalf("DefaultAdaptDB = %q, want %q", got, want)
 	}
 }
+
+// A relax-then-tighten sequence resets the Relaxed gate: after tightening,
+// the learned value applies immediately even with Pos below MinHits —
+// negative evidence must never be gated behind traffic volume (review
+// finding, Issue #259 阶段 3).
+func TestTightenAfterRelaxResetsGate(t *testing.T) {
+	cfg := smallCfg()
+	cfg.MinHits = 5 // generous gate: a relaxed value would stay hidden
+	e := New(cfg, filepath.Join(t.TempDir(), "adapt.json"))
+	// Relax first (high error bound → clean observation loosens).
+	e.Observe("s1", false, 0.55) // learn 0.50, Relaxed=true, Pos=1
+	if got := e.TauLow("s1", 0.55); got != 0.55 {
+		t.Fatalf("relaxed value must be gated at Pos=1 < MinHits 5, got %v", got)
+	}
+	// Then a negative observation (frozen window passes in one step).
+	e.Observe("s1", true, 0.55) // frozen: counts fold, no adjust
+	e.Observe("s1", true, 0.55) // NegEWMA > bound → tighten to 0.55, Relaxed=false
+	// Query with a different global (0.60): the learned 0.55 must apply
+	// immediately — a gated value would return the global 0.60.
+	if got := e.TauLow("s1", 0.60); !closeEnough(got, 0.55) {
+		t.Fatalf("tightened value must apply immediately after relax→tighten, got %v (want 0.55)", got)
+	}
+}

--- a/kernel/adapt/adapt_test.go
+++ b/kernel/adapt/adapt_test.go
@@ -1,0 +1,205 @@
+package adapt
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// smallCfg returns a config with tiny windows so tests exercise one
+// adjustment per observation (FreezeEpochs 1: the next observation may
+// adjust again).
+func smallCfg() Config {
+	return Config{
+		ErrorBound:   0.05,
+		Step:         0.05,
+		MinSamples:   1,
+		MinHits:      1,
+		FreezeEpochs: 1,
+		Alpha:        0.1,
+		MinTau:       0.30,
+		MaxTau:       0.80,
+	}
+}
+
+// closeEnough compares floats with a tolerance for 0.05-step arithmetic.
+func closeEnough(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// Cold start: before the sample minimum, no adjustment happens and TauLow
+// returns the global value.
+func TestColdStartUsesGlobal(t *testing.T) {
+	e := New(Config{}, filepath.Join(t.TempDir(), "adapt.json")) // defaults: MinSamples 20
+	if got := e.TauLow("s1", 0.55); got != 0.55 {
+		t.Fatalf("cold-start TauLow = %v, want global 0.55", got)
+	}
+	e.Observe("s1", false, 0.55) // one sample, below MinSamples
+	if got := e.TauLow("s1", 0.55); got != 0.55 {
+		t.Fatalf("below-MinSamples TauLow = %v, want global 0.55", got)
+	}
+	if e.Adjustments() != 0 {
+		t.Fatalf("Adjustments = %d, want 0", e.Adjustments())
+	}
+}
+
+// Negative evidence above the error bound tightens the entry's TauLow by
+// one step, seeded from the value currently in effect.
+func TestNegativeEvidenceTightens(t *testing.T) {
+	cfg := smallCfg()
+	cfg.FreezeEpochs = 10 // hold the freeze so a second observe cannot relax
+	e := New(cfg, filepath.Join(t.TempDir(), "adapt.json"))
+	e.Observe("s1", true, 0.55)
+	// NegEWMA after one negative = 0.1 > 0.05 → tighten: 0.55 + 0.05.
+	if got := e.TauLow("s1", 0.55); !closeEnough(got, 0.60) {
+		t.Fatalf("TauLow = %v, want tightened 0.60", got)
+	}
+	// A second entry stays on the global value (per-entry isolation).
+	if got := e.TauLow("s2", 0.55); got != 0.55 {
+		t.Fatalf("s2 TauLow = %v, want global 0.55", got)
+	}
+}
+
+// A clean streak below ErrorBound/2 relaxes the entry's TauLow until the
+// MinTau floor. Note the EWMA tail: early clean observations still sit
+// above the error bound and keep tightening (same decay discipline as
+// kernel/evolve) until the bound is crossed, then relaxation takes over.
+func TestCleanStreakRelaxes(t *testing.T) {
+	e := New(smallCfg(), filepath.Join(t.TempDir(), "adapt.json"))
+	e.Observe("s1", true, 0.55) // tighten → 0.60
+	for i := 0; i < 40; i++ {
+		e.Observe("s1", false, 0.60) // clean streak decays NegEWMA
+	}
+	// 40 clean observations: NegEWMA ≈ 0.1*0.9^40 ≈ 0.0015 < 0.025 → relax
+	// all the way down until MinTau clamps.
+	if got := e.TauLow("s1", 0.55); !closeEnough(got, e.cfg.MinTau) {
+		t.Fatalf("TauLow = %v, want MinTau 0.30 after a long clean streak", got)
+	}
+}
+
+// Tau is clamped to [MinTau, MaxTau] regardless of evidence. A tighten
+// that lands above MaxTau still applies immediately (safety direction)
+// even though the clamped value sits below the global threshold.
+func TestTauClamped(t *testing.T) {
+	cfg := smallCfg()
+	cfg.MaxTau = 0.40
+	e := New(cfg, filepath.Join(t.TempDir(), "adapt.json"))
+	e.Observe("s1", true, 0.55) // would be 0.60 → clamped 0.40
+	if got := e.TauLow("s1", 0.55); !closeEnough(got, 0.40) {
+		t.Fatalf("TauLow = %v, want clamped MaxTau 0.40", got)
+	}
+}
+
+// Freeze window: after an adjustment, further observations cannot adjust
+// again until the freeze expires.
+func TestFreezeWindow(t *testing.T) {
+	e := New(smallCfg(), filepath.Join(t.TempDir(), "adapt.json"))
+	e.Observe("s1", true, 0.55) // adjust → 0.60, frozen 1
+	e.Observe("s1", true, 0.60) // frozen → no second adjustment
+	if got := e.TauLow("s1", 0.55); !closeEnough(got, 0.60) {
+		t.Fatalf("TauLow = %v, want 0.60 (frozen)", got)
+	}
+	if e.Adjustments() != 1 {
+		t.Fatalf("Adjustments = %d, want 1 (freeze must block)", e.Adjustments())
+	}
+}
+
+// MinHits gates the GENEROUS direction of a learned value: relaxing below
+// the value in effect only applies once the entry has enough reuses
+// (trust gate for low-traffic slices). The conservative direction
+// (tightening) applies immediately — negative evidence must never be
+// gated behind traffic volume.
+func TestMinHitsGatesLearnedTau(t *testing.T) {
+	// Tightening side: one negative observation learns 0.60; Pos=0 but the
+	// value applies immediately (safety direction).
+	e := New(smallCfg(), filepath.Join(t.TempDir(), "adapt.json"))
+	e.Observe("s1", true, 0.55)
+	if got := e.TauLow("s1", 0.55); !closeEnough(got, 0.60) {
+		t.Fatalf("tightened TauLow = %v, want 0.60 (no MinHits gate on safety direction)", got)
+	}
+
+	// Relaxing side: with a high error bound a clean observation learns a
+	// value BELOW the one in effect; it must stay gated until Pos >=
+	// MinHits.
+	cfg := smallCfg()
+	cfg.MinHits = 3
+	cfg.ErrorBound = 1.0 // NegEWMA=0 is far below ErrorBound/2 → relax
+	e2 := New(cfg, filepath.Join(t.TempDir(), "adapt.json"))
+	e2.Observe("s1", false, 0.55) // learn 0.50, Pos=1
+	if got := e2.TauLow("s1", 0.55); got != 0.55 {
+		t.Fatalf("relaxed TauLow = %v, want global 0.55 (Pos=1 < MinHits 3)", got)
+	}
+	e2.Observe("s1", false, 0.55)
+	e2.Observe("s1", false, 0.55) // Pos=3
+	if got := e2.TauLow("s1", 0.55); got >= 0.55 {
+		t.Fatalf("relaxed TauLow = %v, want learned value < 0.55 once Pos >= MinHits", got)
+	}
+}
+
+// State round-trips through the JSON file: a fresh engine loads the same
+// entries, tau values and counters.
+func TestPersistenceRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "adapt.json")
+	e := New(smallCfg(), path)
+	e.Observe("s1", true, 0.55) // learn + persist (adjustment writes)
+	e.Observe("s2", false, 0.55)
+
+	e2 := New(smallCfg(), path)
+	if got := e2.TauLow("s1", 0.55); !closeEnough(got, 0.60) {
+		t.Fatalf("reloaded s1 TauLow = %v, want 0.60", got)
+	}
+	// s2 learned a relaxed value (0.50) that is in effect at MinHits=1.
+	if got := e2.TauLow("s2", 0.55); !closeEnough(got, 0.50) {
+		t.Fatalf("reloaded s2 TauLow = %v, want learned 0.50", got)
+	}
+	// An entry that was never observed stays on the global value.
+	if got := e2.TauLow("s3", 0.55); got != 0.55 {
+		t.Fatalf("reloaded s3 TauLow = %v, want global", got)
+	}
+	snap := e2.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("Snapshot = %d entries, want 2", len(snap))
+	}
+	if snap[0].SliceID != "s1" || snap[1].SliceID != "s2" {
+		t.Fatalf("Snapshot order = %+v, want s1,s2 sorted", snap)
+	}
+}
+
+// A corrupt state file must not block the engine: log and start cold.
+func TestCorruptStateStartsCold(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "adapt.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	e := New(smallCfg(), path)
+	if got := e.TauLow("s1", 0.55); got != 0.55 {
+		t.Fatalf("corrupt-state TauLow = %v, want global", got)
+	}
+	e.Observe("s1", true, 0.55) // must still work
+	if got := e.TauLow("s1", 0.55); !closeEnough(got, 0.60) {
+		t.Fatalf("post-corrupt observe TauLow = %v, want 0.60", got)
+	}
+}
+
+// ErrorBound < 0 disables adaptation: observations are no-ops and TauLow
+// always returns the global value.
+func TestDisabledEngine(t *testing.T) {
+	cfg := smallCfg()
+	cfg.ErrorBound = -1
+	e := New(cfg, filepath.Join(t.TempDir(), "adapt.json"))
+	e.Observe("s1", true, 0.55)
+	if got := e.TauLow("s1", 0.55); got != 0.55 {
+		t.Fatalf("disabled TauLow = %v, want global", got)
+	}
+	if e.Adjustments() != 0 {
+		t.Fatalf("disabled Adjustments = %d, want 0", e.Adjustments())
+	}
+}
+
+// DefaultAdaptDB places the state next to the slice store.
+func TestDefaultAdaptDB(t *testing.T) {
+	got := DefaultAdaptDB(filepath.Join("data", "gw.jsonl"))
+	want := filepath.Join("data", "l3-adapt.json")
+	if got != want {
+		t.Fatalf("DefaultAdaptDB = %q, want %q", got, want)
+	}
+}

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -119,7 +119,11 @@ func (d *L3Decider) DecideL2(ctx context.Context, q Query) ([]slice.Hit, error) 
 	}
 	out := hits[:0]
 	for _, h := range hits {
-		if z.Classify(h.Score, top1) == zone.Hit {
+		z2 := z
+		if h.Slice != nil {
+			z2 = z.ForType(h.Slice.Type.String()) // Issue #259 阶段 2
+		}
+		if z2.Classify(h.Score, top1) == zone.Hit {
 			out = append(out, h)
 		}
 	}
@@ -182,7 +186,10 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 
 	for _, h := range cands {
 		s := h.Slice
-		verdict := z.ClassifyL3(h.Score, resultTop1, globalTop1)
+		// Per-type thresholds (Issue #259 阶段 2): each candidate is
+		// classified with its slice type's override (or the global
+		// baseline when the type is not configured).
+		verdict := z.ForType(s.Type.String()).ClassifyL3(h.Score, resultTop1, globalTop1)
 		if fresh := q.Freshness.classify(s.CreatedAt); fresh < verdict {
 			verdict = fresh // freshness may only make reuse more conservative
 		}

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -57,7 +57,23 @@ type L3Decider struct {
 	// observes the judge stage; Obs covers every rejection path.
 	Obs      *ObsAccum
 	OnDecide func(Obs)
+
+	// Adapt provides per-entry TauLow overrides (Issue #259 阶段 3,
+	// vCache route): for each Result candidate the learned value replaces
+	// the effective TauLow before classification, clamped so the grey
+	// zone never collapses. nil-safe — without it every entry uses the
+	// global/per-type threshold (cold start).
+	Adapt interface {
+		TauLow(sliceID string, global float64) float64
+	}
 }
+
+// minGreyWidth keeps a non-empty grey zone when an adaptive TauLow would
+// otherwise reach or pass TauHigh: the learned value is clamped to
+// TauHigh − minGreyWidth so ambiguous candidates still route to the judge
+// instead of flipping straight to Miss. Matches the evolve tuning step so
+// clamping cannot fight the engine's own granularity.
+const minGreyWidth = 0.05
 
 // Obs is a negative-observation counter snapshot (Issue #262): the L3
 // runtime paths that rejected reuse and why, plus the approved/reused
@@ -189,7 +205,18 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 		// Per-type thresholds (Issue #259 阶段 2): each candidate is
 		// classified with its slice type's override (or the global
 		// baseline when the type is not configured).
-		verdict := z.ForType(s.Type.String()).ClassifyL3(h.Score, resultTop1, globalTop1)
+		tz := z.ForType(s.Type.String())
+		// Per-entry adaptive TauLow (Issue #259 阶段 3): the learned value
+		// replaces the effective TauLow; it is clamped below TauHigh so
+		// the grey zone never collapses (ambiguous candidates must still
+		// reach the judge rather than flip to Miss).
+		if d.Adapt != nil {
+			tz.TauLow = d.Adapt.TauLow(s.ID, tz.TauLow)
+			if tz.TauLow > tz.TauHigh-minGreyWidth {
+				tz.TauLow = tz.TauHigh - minGreyWidth
+			}
+		}
+		verdict := tz.ClassifyL3(h.Score, resultTop1, globalTop1)
 		if fresh := q.Freshness.classify(s.CreatedAt); fresh < verdict {
 			verdict = fresh // freshness may only make reuse more conservative
 		}

--- a/kernel/cache/l3.go
+++ b/kernel/cache/l3.go
@@ -207,13 +207,21 @@ func (d *L3Decider) DecideL3(ctx context.Context, q Query) (*L3Result, error) {
 		// baseline when the type is not configured).
 		tz := z.ForType(s.Type.String())
 		// Per-entry adaptive TauLow (Issue #259 阶段 3): the learned value
-		// replaces the effective TauLow; it is clamped below TauHigh so
+		// replaces the effective TauLow. It is clamped below TauHigh so
 		// the grey zone never collapses (ambiguous candidates must still
-		// reach the judge rather than flip to Miss).
+		// reach the judge rather than flip to Miss); when the configured
+		// threshold band is narrower than minGreyWidth, the clamp floor
+		// is the value in effect — a tighten must never turn into a
+		// loosening because of the ceiling.
 		if d.Adapt != nil {
-			tz.TauLow = d.Adapt.TauLow(s.ID, tz.TauLow)
-			if tz.TauLow > tz.TauHigh-minGreyWidth {
-				tz.TauLow = tz.TauHigh - minGreyWidth
+			prior := tz.TauLow
+			tz.TauLow = d.Adapt.TauLow(s.ID, prior)
+			cap := tz.TauHigh - minGreyWidth
+			if cap < prior {
+				cap = prior
+			}
+			if tz.TauLow > cap {
+				tz.TauLow = cap
 			}
 		}
 		verdict := tz.ClassifyL3(h.Score, resultTop1, globalTop1)

--- a/kernel/cache/l3_test.go
+++ b/kernel/cache/l3_test.go
@@ -754,3 +754,42 @@ func TestDecideL3PerTypeOverride(t *testing.T) {
 		t.Fatalf("strict result override must reject reuse, got %+v", res2)
 	}
 }
+
+// stubAdapt returns a fixed learned TauLow per slice.
+type stubAdapt struct{ tau float64 }
+
+func (a stubAdapt) TauLow(sliceID string, global float64) float64 { return a.tau }
+
+// The per-entry adaptive TauLow replaces the effective grey floor before
+// classification (Issue #259 阶段 3): a candidate whose relative
+// confidence sits in the grey band under the baseline falls to Miss once
+// the entry's learned TauLow rises above it, while a learned value above
+// TauHigh is clamped so the grey zone never collapses.
+func TestDecideL3AdaptiveTauLow(t *testing.T) {
+	// Two Result candidates: a perfect one (relConf 1.0, always a Hit) and
+	// a weaker peer with relConf 0.70 (score 0.7 / resultTop1 1.0) — grey
+	// under the default TauLow 0.55. The weaker one is listed first so the
+	// loop reaches it before the clear Hit; the Obs counters reveal which
+	// gate routed it.
+	mk := func() []slice.Hit {
+		return []slice.Hit{hitOf("weak", slice.Result, 0.7), hitOf("strong", slice.Result, 1.0)}
+	}
+	observe := func(tau float64) (Obs, *L3Result) {
+		d := &L3Decider{Index: &fixedIndex{hits: mk()}, Root: t.TempDir(), Adapt: stubAdapt{tau: tau}}
+		var acc ObsAccum
+		d.Obs = &acc
+		res, _ := d.DecideL3(context.Background(), Query{UserInput: "q", Scope: slice.Project})
+		return acc.Snapshot(), res
+	}
+	// TauLow 0.50: the weak candidate (0.70) stays grey-routed.
+	lo, resLo := observe(0.50)
+	if lo.Grey != 1 || lo.RulesReject != 1 || resLo == nil || resLo.SliceID != "strong" {
+		t.Fatalf("tau 0.50: grey=%d rules_reject=%d res=%+v, want grey-routed weak + strong reuse", lo.Grey, lo.RulesReject, resLo)
+	}
+	// TauLow 0.80 (clamped to TauHigh-0.05 = 0.75): 0.70 < 0.75 → Miss.
+	hi, resHi := observe(0.80)
+	if hi.Grey != 0 || hi.RulesReject != 1 || resHi == nil || resHi.SliceID != "strong" {
+		t.Fatalf("tau 0.80: grey=%d rules_reject=%d res=%+v, want straight-Miss weak + strong reuse", hi.Grey, hi.RulesReject, resHi)
+	}
+}
+

--- a/kernel/cache/l3_test.go
+++ b/kernel/cache/l3_test.go
@@ -793,3 +793,38 @@ func TestDecideL3AdaptiveTauLow(t *testing.T) {
 	}
 }
 
+
+// With a threshold band narrower than minGreyWidth, the adaptive clamp
+// must never turn a tighten into a loosening: the value in effect is the
+// floor (review finding, Issue #259 阶段 3).
+func TestDecideL3AdaptiveClampNeverLoosens(t *testing.T) {
+	// tau_high 0.56 / tau_low 0.55: band is 0.01 < minGreyWidth 0.05.
+	narrow := zone.Zones{TauHigh: 0.56, TauLow: 0.55, AbsHigh: 0.7, AbsLow: 0.45}
+	// Learned 0.60 would clamp to 0.51 (TauHigh-0.05) — below the prior
+	// 0.55; the floor must keep the prior so classification never widens.
+	d := &L3Decider{Index: &fixedIndex{hits: []slice.Hit{hitOf("weak", slice.Result, 0.7), hitOf("strong", slice.Result, 1.0)}},
+		Root: t.TempDir(), Zones: &narrow, Adapt: stubAdapt{tau: 0.60}}
+	var acc ObsAccum
+	d.Obs = &acc
+	res, err := d.DecideL3(context.Background(), Query{UserInput: "q", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// With prior 0.55 the weak candidate (relConf 0.70) is grey-routed;
+	// if the clamp had loosened it to 0.51 it would still be grey, so the
+	// observable difference is the MISS path: use a weak score below the
+	// prior but above the loosened clamp. relConf 0.53: >= 0.51 (loosened)
+	// → grey; < 0.55 (prior floor) → Miss.
+	d2 := &L3Decider{Index: &fixedIndex{hits: []slice.Hit{hitOf("weak", slice.Result, 0.53), hitOf("strong", slice.Result, 1.0)}},
+		Root: t.TempDir(), Zones: &narrow, Adapt: stubAdapt{tau: 0.60}}
+	var acc2 ObsAccum
+	d2.Obs = &acc2
+	res2, err := d2.DecideL3(context.Background(), Query{UserInput: "q", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acc2.Snapshot().Grey != 0 || res2 == nil || res2.SliceID != "strong" {
+		t.Fatalf("loosened clamp would grey-route relConf 0.53; got grey=%d res=%+v (want Miss + strong reuse)", acc2.Snapshot().Grey, res2)
+	}
+	_ = res
+}

--- a/kernel/cache/l3_test.go
+++ b/kernel/cache/l3_test.go
@@ -724,3 +724,33 @@ func TestL3ObsAccumSnapshotIsThreadSafe(t *testing.T) {
 		t.Fatalf("accumulated = %+v, want %+v", got, want)
 	}
 }
+
+// Per-type thresholds participate in the real L3 decision (Issue #259
+// 阶段 2): the same Result candidate that reuses under the global
+// baseline is rejected when its type carries a stricter override.
+func TestDecideL3PerTypeOverride(t *testing.T) {
+	root, idx, _, _ := buildTestLib(t)
+	// Baseline: global defaults (nil Zones → zone.Default).
+	base := &L3Decider{Index: idx, Root: root}
+	res, err := base.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("baseline must reuse the Result candidate")
+	}
+
+	// Strict result override: unreachable thresholds for this type.
+	strict := zone.Zones{TauHigh: 1.0, TauLow: 0.99, AbsHigh: 1e9, AbsLow: 1e9,
+		ByType: map[string]zone.Zones{
+			"result": {TauHigh: 1.0, TauLow: 0.99, AbsHigh: 1e9, AbsLow: 1e9},
+		}}
+	dec := &L3Decider{Index: idx, Root: root, Zones: &strict}
+	res2, err := dec.DecideL3(context.Background(), Query{UserInput: "修复 go 测试失败", Scope: slice.Project})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2 != nil {
+		t.Fatalf("strict result override must reject reuse, got %+v", res2)
+	}
+}

--- a/kernel/config/config.go
+++ b/kernel/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -465,11 +466,11 @@ func (r *Resolved) validate() error {
 				errs = append(errs, "retrieval.bm25_weight: must be in [0,1]")
 			}
 		case "retrieval.tau_high", "retrieval.tau_low":
-			if v, ok := f.Value.(float64); ok && (v <= 0 || v > 1) {
+			if v, ok := f.Value.(float64); ok && (math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 || v > 1) {
 				errs = append(errs, fmt.Sprintf("%s: must be in (0,1]", f.Key))
 			}
 		case "retrieval.abs_high", "retrieval.abs_low":
-			if v, ok := f.Value.(float64); ok && v < 0 {
+			if v, ok := f.Value.(float64); ok && (math.IsNaN(v) || math.IsInf(v, 0) || v < 0) {
 				errs = append(errs, fmt.Sprintf("%s: must be >= 0", f.Key))
 			}
 		case "inject.budget":
@@ -509,11 +510,11 @@ func (r *Resolved) validate() error {
 		}
 		switch field {
 		case "tau_high", "tau_low":
-			if v <= 0 || v > 1 {
+			if math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 || v > 1 {
 				errs = append(errs, fmt.Sprintf("%s: must be in (0,1]", f.Key))
 			}
 		case "abs_high", "abs_low":
-			if v < 0 {
+			if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 {
 				errs = append(errs, fmt.Sprintf("%s: must be >= 0", f.Key))
 			}
 		default:

--- a/kernel/config/config.go
+++ b/kernel/config/config.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 
+	"semantix/kernel/zone"
+
 	"github.com/BurntSushi/toml"
 )
 
@@ -55,6 +57,12 @@ type fileRetrieval struct {
 	Fusion     *string  `toml:"fusion"`      // hybrid 融合策略: weighted | rrf (Issue #274)
 	RrfK       *int     `toml:"rrf_k"`       // RRF 常数,默认 60
 	BM25Weight *float64 `toml:"bm25_weight"` // weighted 模式 BM25 路权重,默认 0.5
+	// Grey-zone 四阈值 (Issue #259 阶段 1): semantix.toml 键,被
+	// --tau-*/--abs-* flag 覆盖;值域 (0,1] / >= 0,且 tau_high > tau_low。
+	TauHigh *float64 `toml:"tau_high"`
+	TauLow  *float64 `toml:"tau_low"`
+	AbsHigh *float64 `toml:"abs_high"`
+	AbsLow  *float64 `toml:"abs_low"`
 }
 
 type fileInject struct {
@@ -205,6 +213,21 @@ func Load(opts Options) (*Resolved, error) {
 		return nil, err
 	}
 	if err := add(mergePtr("retrieval.bm25_weight", 0.5, "", file.Retrieval.BM25Weight, (*float64)(nil))); err != nil {
+		return nil, err
+	}
+	// Grey-zone 四阈值 (Issue #259 阶段 1): 默认值与 zone.Default() 单真源
+	// 对齐;flag > env > file > default 优先级由 mergePtr 统一处理。
+	defZ := zone.Default()
+	if err := add(mergePtr("retrieval.tau_high", defZ.TauHigh, "", file.Retrieval.TauHigh, (*float64)(nil))); err != nil {
+		return nil, err
+	}
+	if err := add(mergePtr("retrieval.tau_low", defZ.TauLow, "", file.Retrieval.TauLow, (*float64)(nil))); err != nil {
+		return nil, err
+	}
+	if err := add(mergePtr("retrieval.abs_high", defZ.AbsHigh, "", file.Retrieval.AbsHigh, (*float64)(nil))); err != nil {
+		return nil, err
+	}
+	if err := add(mergePtr("retrieval.abs_low", defZ.AbsLow, "", file.Retrieval.AbsLow, (*float64)(nil))); err != nil {
 		return nil, err
 	}
 	if err := add(mergePtr("inject.budget", 4096, "SEMANTIX_INJECT_BUDGET", file.Inject.Budget, (*int)(nil))); err != nil {
@@ -403,6 +426,14 @@ func (r *Resolved) validate() error {
 			if v, ok := f.Value.(float64); ok && (v < 0 || v > 1) {
 				errs = append(errs, "retrieval.bm25_weight: must be in [0,1]")
 			}
+		case "retrieval.tau_high", "retrieval.tau_low":
+			if v, ok := f.Value.(float64); ok && (v <= 0 || v > 1) {
+				errs = append(errs, fmt.Sprintf("%s: must be in (0,1]", f.Key))
+			}
+		case "retrieval.abs_high", "retrieval.abs_low":
+			if v, ok := f.Value.(float64); ok && v < 0 {
+				errs = append(errs, fmt.Sprintf("%s: must be >= 0", f.Key))
+			}
 		case "inject.budget":
 			if v, ok := f.Value.(int); ok && v <= 0 {
 				errs = append(errs, "inject.budget: must be > 0")
@@ -410,6 +441,17 @@ func (r *Resolved) validate() error {
 		case "verify.holdout":
 			if v, ok := f.Value.(float64); ok && (v < 0 || v >= 1) {
 				errs = append(errs, "verify.holdout: must be in [0,1)")
+			}
+		}
+	}
+	// Cross-key invariant (Issue #259 阶段 1): the clear-hit floor must sit
+	// above the grey floor, otherwise the classifier degenerates.
+	if th, _, ok := r.Get("retrieval.tau_high"); ok {
+		if tl, _, ok2 := r.Get("retrieval.tau_low"); ok2 {
+			thv, thOK := th.(float64)
+			tlv, tlOK := tl.(float64)
+			if thOK && tlOK && thv <= tlv {
+				errs = append(errs, fmt.Sprintf("retrieval.tau_high (%v) must be > retrieval.tau_low (%v)", thv, tlv))
 			}
 		}
 	}

--- a/kernel/config/config.go
+++ b/kernel/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"semantix/kernel/slice"
 	"semantix/kernel/zone"
 
 	"github.com/BurntSushi/toml"
@@ -59,6 +60,18 @@ type fileRetrieval struct {
 	BM25Weight *float64 `toml:"bm25_weight"` // weighted 模式 BM25 路权重,默认 0.5
 	// Grey-zone 四阈值 (Issue #259 阶段 1): semantix.toml 键,被
 	// --tau-*/--abs-* flag 覆盖;值域 (0,1] / >= 0,且 tau_high > tau_low。
+	TauHigh *float64 `toml:"tau_high"`
+	TauLow  *float64 `toml:"tau_low"`
+	AbsHigh *float64 `toml:"abs_high"`
+	AbsLow  *float64 `toml:"abs_low"`
+	// ByType 是 per-slice-type 阈值覆盖 (Issue #259 阶段 2),key 为
+	// slice.SliceType 的稳定 wire 名;平铺为
+	// retrieval.by_type.<type>.<field> 键。未知类型名校验失败。
+	ByType map[string]fileZone `toml:"by_type"`
+}
+
+// fileZone 是 per-type 的部分覆盖语法:未写的字段继承全局阈值。
+type fileZone struct {
 	TauHigh *float64 `toml:"tau_high"`
 	TauLow  *float64 `toml:"tau_low"`
 	AbsHigh *float64 `toml:"abs_high"`
@@ -229,6 +242,31 @@ func Load(opts Options) (*Resolved, error) {
 	}
 	if err := add(mergePtr("retrieval.abs_low", defZ.AbsLow, "", file.Retrieval.AbsLow, (*float64)(nil))); err != nil {
 		return nil, err
+	}
+
+	// Per-type 覆盖 (Issue #259 阶段 2): 平铺为 dotted 键,按类型名排序
+	// 保证 Fields 确定性 (config list 输出与测试)。
+	typeNames := make([]string, 0, len(file.Retrieval.ByType))
+	for name := range file.Retrieval.ByType {
+		typeNames = append(typeNames, name)
+	}
+	sort.Strings(typeNames)
+	for _, name := range typeNames {
+		fz := file.Retrieval.ByType[name]
+		prefix := "retrieval.by_type." + name + "."
+		for _, kv := range []struct {
+			field string
+			ptr   *float64
+		}{
+			{"tau_high", fz.TauHigh},
+			{"tau_low", fz.TauLow},
+			{"abs_high", fz.AbsHigh},
+			{"abs_low", fz.AbsLow},
+		} {
+			if kv.ptr != nil {
+				r.Fields = append(r.Fields, Field{Key: prefix + kv.field, Value: *kv.ptr, Source: SourceFile})
+			}
+		}
 	}
 	if err := add(mergePtr("inject.budget", 4096, "SEMANTIX_INJECT_BUDGET", file.Inject.Budget, (*int)(nil))); err != nil {
 		return nil, err
@@ -442,6 +480,60 @@ func (r *Resolved) validate() error {
 			if v, ok := f.Value.(float64); ok && (v < 0 || v >= 1) {
 				errs = append(errs, "verify.holdout: must be in [0,1)")
 			}
+		}
+	}
+	// Per-type 覆盖 (Issue #259 阶段 2): 键形如 retrieval.by_type.<type>.<field>。
+	// 类型名必须合法 (fail-closed 防拼写错误),值域与全局同规则,且
+	// 同类型内 tau_high > tau_low。
+	byTypeTau := map[string]struct{ high, low float64 }{} // 交叉校验收集
+	byTypeSeen := map[string]bool{}
+	for _, f := range r.Fields {
+		const pfx = "retrieval.by_type."
+		if !strings.HasPrefix(f.Key, pfx) {
+			continue
+		}
+		rest := strings.TrimPrefix(f.Key, pfx)
+		dot := strings.Index(rest, ".")
+		if dot <= 0 {
+			errs = append(errs, fmt.Sprintf("%s: malformed per-type key", f.Key))
+			continue
+		}
+		name, field := rest[:dot], rest[dot+1:]
+		if _, ok := slice.TypeFromString(name); !ok {
+			errs = append(errs, fmt.Sprintf("%s: %q is not a slice type (want prompt|context|tool_pattern|result|memory)", f.Key, name))
+			continue
+		}
+		v, ok := f.Value.(float64)
+		if !ok {
+			continue
+		}
+		switch field {
+		case "tau_high", "tau_low":
+			if v <= 0 || v > 1 {
+				errs = append(errs, fmt.Sprintf("%s: must be in (0,1]", f.Key))
+			}
+		case "abs_high", "abs_low":
+			if v < 0 {
+				errs = append(errs, fmt.Sprintf("%s: must be >= 0", f.Key))
+			}
+		default:
+			errs = append(errs, fmt.Sprintf("%s: unknown threshold field", f.Key))
+			continue
+		}
+		e := byTypeTau[name]
+		if field == "tau_high" {
+			e.high = v
+		}
+		if field == "tau_low" {
+			e.low = v
+		}
+		byTypeTau[name] = e
+		byTypeSeen[name] = true
+	}
+	for name := range byTypeSeen {
+		e := byTypeTau[name]
+		if e.high != 0 && e.low != 0 && e.high <= e.low {
+			errs = append(errs, fmt.Sprintf("retrieval.by_type.%s.tau_high (%v) must be > tau_low (%v)", name, e.high, e.low))
 		}
 	}
 	// Cross-key invariant (Issue #259 阶段 1): the clear-hit floor must sit

--- a/kernel/config/config_test.go
+++ b/kernel/config/config_test.go
@@ -278,3 +278,23 @@ func TestLoadRejectsInvalidByType(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadRejectsNonFiniteThresholds(t *testing.T) {
+	cases := []struct{ name, content string }{
+		{"global tau nan", "[retrieval]\ntau_high = nan\n"},
+		{"global abs inf", "[retrieval]\nabs_low = inf\n"},
+		{"by_type tau nan", "[retrieval.by_type.result]\ntau_low = nan\n"},
+		{"by_type abs inf", "[retrieval.by_type.context]\nabs_high = -inf\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "semantix.toml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Load(Options{ConfigPath: path}); err == nil {
+				t.Fatalf("Load must reject non-finite %s", tc.name)
+			}
+		})
+	}
+}

--- a/kernel/config/config_test.go
+++ b/kernel/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"semantix/kernel/zone"
 )
 
 func assertField(t *testing.T, r *Resolved, key string, want any, wantSrc Source) {
@@ -174,4 +176,57 @@ func TestLoadDefaultMissingFileSkipped(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	assertField(t, r, "store.db", ".semantix/project.db", SourceDefault)
+}
+
+func TestLoadZoneThresholdsFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "semantix.toml")
+	content := "[retrieval]\ntau_high = 0.9\ntau_low = 0.6\nabs_high = 0.8\nabs_low = 0.5\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, err := Load(Options{ConfigPath: path})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertField(t, r, "retrieval.tau_high", 0.9, SourceFile)
+	assertField(t, r, "retrieval.tau_low", 0.6, SourceFile)
+	assertField(t, r, "retrieval.abs_high", 0.8, SourceFile)
+	assertField(t, r, "retrieval.abs_low", 0.5, SourceFile)
+}
+
+func TestLoadZoneThresholdsDefaultToZoneDefaults(t *testing.T) {
+	r, err := Load(Options{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := zone.Default()
+	assertField(t, r, "retrieval.tau_high", def.TauHigh, SourceDefault)
+	assertField(t, r, "retrieval.tau_low", def.TauLow, SourceDefault)
+	assertField(t, r, "retrieval.abs_high", def.AbsHigh, SourceDefault)
+	assertField(t, r, "retrieval.abs_low", def.AbsLow, SourceDefault)
+}
+
+func TestLoadRejectsInvalidZoneThresholds(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"tau_high zero", "[retrieval]\ntau_high = 0\n", "retrieval.tau_high: must be in (0,1]"},
+		{"tau_low over one", "[retrieval]\ntau_low = 1.5\n", "retrieval.tau_low: must be in (0,1]"},
+		{"abs_high negative", "[retrieval]\nabs_high = -1\n", "retrieval.abs_high: must be >= 0"},
+		{"tau_high not above tau_low", "[retrieval]\ntau_high = 0.6\ntau_low = 0.6\n", "retrieval.tau_high (0.6) must be > retrieval.tau_low (0.6)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "semantix.toml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(Options{ConfigPath: path})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
 }

--- a/kernel/config/config_test.go
+++ b/kernel/config/config_test.go
@@ -230,3 +230,51 @@ func TestLoadRejectsInvalidZoneThresholds(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadByTypeOverrides(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "semantix.toml")
+	content := "[retrieval]\ntau_high = 0.8\n\n[retrieval.by_type.result]\ntau_high = 0.85\ntau_low = 0.60\n\n[retrieval.by_type.context]\ntau_low = 0.50\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, err := Load(Options{ConfigPath: path})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertField(t, r, "retrieval.by_type.result.tau_high", 0.85, SourceFile)
+	assertField(t, r, "retrieval.by_type.result.tau_low", 0.60, SourceFile)
+	assertField(t, r, "retrieval.by_type.context.tau_low", 0.50, SourceFile)
+	// Global key untouched by the per-type block.
+	assertField(t, r, "retrieval.tau_high", 0.8, SourceFile)
+	// Deterministic field order: context sorts before result.
+	keys := []string{}
+	for _, f := range r.Fields {
+		if f.Key == "retrieval.by_type.context.tau_low" || f.Key == "retrieval.by_type.result.tau_high" {
+			keys = append(keys, f.Key)
+		}
+	}
+	if len(keys) != 2 || keys[0] != "retrieval.by_type.context.tau_low" || keys[1] != "retrieval.by_type.result.tau_high" {
+		t.Fatalf("by_type field order = %v, want sorted by type name", keys)
+	}
+}
+
+func TestLoadRejectsInvalidByType(t *testing.T) {
+	cases := []struct{ name, content, want string }{
+		{"unknown type", "[retrieval.by_type.reslut]\ntau_low = 0.5\n", `"reslut" is not a slice type`},
+		{"bad tau", "[retrieval.by_type.result]\ntau_high = 2\n", "retrieval.by_type.result.tau_high: must be in (0,1]"},
+		{"bad abs", "[retrieval.by_type.result]\nabs_low = -0.5\n", "retrieval.by_type.result.abs_low: must be >= 0"},
+		{"tau cross", "[retrieval.by_type.result]\ntau_high = 0.5\ntau_low = 0.6\n", "retrieval.by_type.result.tau_high (0.5) must be > tau_low (0.6)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "semantix.toml")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(Options{ConfigPath: path})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/kernel/inject/inject.go
+++ b/kernel/inject/inject.go
@@ -128,9 +128,15 @@ func (in *Injector) Build(query string) (*Injection, error) {
 		if in.MinScore > 0 && h.Score < in.MinScore {
 			continue
 		}
-		if in.Zones != nil && in.Zones.Classify(h.Score, top1) != zone.Hit {
-			dropped++
-			continue
+		if in.Zones != nil {
+			z := *in.Zones
+			if h.Slice != nil {
+				z = z.ForType(h.Slice.Type.String()) // Issue #259 阶段 2
+			}
+			if z.Classify(h.Score, top1) != zone.Hit {
+				dropped++
+				continue
+			}
 		}
 		if buf.Len()+len(h.Slice.Content)+len(blockClose)+64 > budget && len(kept) > 0 {
 			dropped++

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -47,6 +47,25 @@ func (t SliceType) String() string {
 	return "unknown"
 }
 
+// TypeFromString resolves a wire name back to a SliceType (Issue #259
+// 阶段 2 per-type configuration); ok=false for unknown names so config
+// layers can fail closed instead of silently accepting a typo.
+func TypeFromString(s string) (SliceType, bool) {
+	switch s {
+	case "prompt":
+		return Prompt, true
+	case "context":
+		return Context, true
+	case "tool_pattern":
+		return ToolPattern, true
+	case "result":
+		return Result, true
+	case "memory":
+		return Memory, true
+	}
+	return 0, false
+}
+
 // EvictPriorityOf returns the type's eviction priority: lower values are
 // evicted first when the library cap overflows. The v1 table is fixed and
 // deterministic (Issue #277 typed context eviction): result/tool_pattern go

--- a/kernel/zone/zone.go
+++ b/kernel/zone/zone.go
@@ -43,6 +43,29 @@ type Zones struct {
 	TauLow  float64 // relative confidence >= TauLow  -> Grey
 	AbsHigh float64 // absolute score floor for Hit (top1 >= AbsHigh)
 	AbsLow  float64 // absolute score floor for Grey (top1 >= AbsLow)
+	// ByType holds per-slice-type overrides (Issue #259 阶段 2), keyed by
+	// the stable wire name of slice.SliceType (prompt|context|
+	// tool_pattern|result|memory — see slice.Type.String). Each override
+	// is a complete four-threshold snapshot; the global fields above act
+	// as the baseline for types without an override. nil = no per-type
+	// differentiation (the historical behavior). This package deliberately
+	// keys by string so zone stays free of the slice dependency.
+	ByType map[string]Zones
+}
+
+// ForType returns the effective thresholds for a slice type: the per-type
+// override when present, otherwise the global baseline itself (the
+// receiver, so a zero ByType costs nothing and behavior is unchanged).
+// The returned override's own ByType is cleared: overrides are leaf
+// snapshots, never nested.
+func (z Zones) ForType(typeName string) Zones {
+	if z.ByType != nil {
+		if o, ok := z.ByType[typeName]; ok {
+			o.ByType = nil
+			return o
+		}
+	}
+	return z
 }
 
 // Default returns the tuned default thresholds.

--- a/kernel/zone/zone_test.go
+++ b/kernel/zone/zone_test.go
@@ -107,3 +107,58 @@ func TestClassifyL3TwoAxis(t *testing.T) {
 		}
 	}
 }
+
+// Per-type overrides resolve to the override snapshot when the type is
+// configured and to the global baseline otherwise (Issue #259 阶段 2).
+func TestForTypeOverrideAndFallback(t *testing.T) {
+	base := Default()
+	base.ByType = map[string]Zones{
+		"result": {TauHigh: 0.85, TauLow: 0.60, AbsHigh: 0.75, AbsLow: 0.50},
+	}
+	if got := base.ForType("result"); got.TauHigh != 0.85 || got.TauLow != 0.60 {
+		t.Fatalf("ForType(result) = %+v, want override", got)
+	}
+	// An override is a leaf snapshot: its own ByType must be cleared.
+	if got := base.ForType("result"); got.ByType != nil {
+		t.Fatalf("override must not carry nested ByType, got %+v", got.ByType)
+	}
+	if got := base.ForType("prompt"); got.TauHigh != base.TauHigh || got.TauLow != base.TauLow {
+		t.Fatalf("ForType(prompt) = %+v, want global baseline %+v", got, base)
+	}
+	// Unknown type names fall back too (forward compat with new types).
+	if got := base.ForType("unknown"); got.TauHigh != base.TauHigh {
+		t.Fatalf("ForType(unknown) = %+v, want global baseline", got)
+	}
+}
+
+// A zero ByType (nil map) keeps the historical behavior: every type sees
+// the global thresholds, and ForType is a no-op identity.
+func TestForTypeNilByTypeIdentity(t *testing.T) {
+	z := Default()
+	got := z.ForType("result")
+	if got.TauHigh != z.TauHigh || got.TauLow != z.TauLow ||
+		got.AbsHigh != z.AbsHigh || got.AbsLow != z.AbsLow {
+		t.Fatalf("ForType with nil ByType must return the global thresholds, got %+v", got)
+	}
+}
+
+// The per-type override participates in real classification, not just
+// field lookup: a score that is a clear Hit under a relaxed override can
+// be Grey under the stricter baseline (R slices answer users directly).
+func TestForTypeChangesClassification(t *testing.T) {
+	base := Default()
+	base.ByType = map[string]Zones{
+		"context": {TauHigh: 0.70, TauLow: 0.45, AbsHigh: 0.70, AbsLow: 0.45},
+	}
+	const score, top1 = 0.75, 1.0
+	if got := base.Classify(score, top1); got != Grey {
+		t.Fatalf("global classify = %v, want Grey", got)
+	}
+	if got := base.ForType("context").Classify(score, top1); got != Hit {
+		t.Fatalf("context classify = %v, want Hit under relaxed override", got)
+	}
+	// Types without an override keep the stricter global verdict.
+	if got := base.ForType("result").Classify(score, top1); got != Grey {
+		t.Fatalf("result classify = %v, want Grey (no override)", got)
+	}
+}

--- a/semantix.example.toml
+++ b/semantix.example.toml
@@ -18,6 +18,29 @@ grace_days = 7              # 新切片保护窗：淘汰序中排最后（不�
 retriever = "hybrid"        # bm25 | vector | hybrid（RRF 融合）
 limit = 5                   # search 默认 top-k
 vector_dim = 256            # HashEmbedder 维度（模型级 Embedder 接入后忽略）
+# Grey-zone 四阈值（Issue #259 阶段 1）：缺省 = kernel/zone 内置默认；
+# CLI --tau-*/--abs-* flag 优先于此处的值。
+tau_high = 0.8              # 相对置信：明确 hit 下界 (0,1]
+tau_low = 0.55              # 相对置信：grey 下界 (0,1]，须 < tau_high
+abs_high = 0.7              # 绝对分：明确 hit 地板（>= 0）
+abs_low = 0.45              # 绝对分：grey 地板（>= 0）
+# evolve_db 为 `usage --evolve-db` 输出的状态目录：其 tuned tau_l2 在
+# 未显式配置 tau_low 时驱动 grey 下界（clamp 到 [0.30, 0.80]）。
+# evolve_db = ".semantix/evolve"
+
+# 按切片类型分化（Issue #259 阶段 2）：只写要改的字段，未写字段继承
+# 全局阈值；类型名限 prompt|context|tool_pattern|result|memory。
+# [retrieval.by_type.result]   # R 切片直接回答用户 → 更严
+# tau_high = 0.85
+# tau_low = 0.60
+# [retrieval.by_type.context]  # C/P 仅做上下文 → 可放宽
+# tau_low = 0.50
+
+# 逐条目自适应（Issue #259 阶段 3，vCache 路线）：每个高频复用切片
+# 从正/误命中反馈在线学习自己的 tau_low；全局阈值作先验/冷启动。
+adaptive = true             # 开关（缺省 true；false = 全部用全局阈值）
+error_bound = 0.05          # 条目级误命中率上界（-1 关闭自适应）
+# adapt_db = ".semantix/l3-adapt.json"   # 状态文件（缺省 <db 同目录>/l3-adapt.json）
 
 [inject]
 budget = 4096               # L2 注入块最大字节数（整切片截断）


### PR DESCRIPTION
## Summary

Issue #259 三阶段落地：L3 命中阈值从全局硬编码升级为 **可配置 → 按类型分化 → 逐条目自适应（vCache 路线）**。

- **阶段 1 可配化**：四阈值（`tau_high/tau_low/abs_high/abs_low`）进入 gateway `[retrieval]` 与 CLI `semantix.toml`；gateway 新增 `evolve_db`，未显式配置 `tau_low` 时由 evolve 的 tuned TauL2 驱动（clamp [0.30, 0.80]，显式配置优先）。
- **阶段 2 按类型分化**：`zone.Zones.ForType(typeName)` per-type 覆盖（`[retrieval.by_type.<type>]` 部分覆盖语法，未知字段继承全局）；L3Decider.DecideL3/DecideL2 与 injector 判定点按候选 `slice.Type` 先 ForType 再判定；`verify --calibrate` 输出 by_type 分型命中分布。
- **阶段 3 逐条目自适应**：新包 `kernel/adapt`，每个高频复用切片维护正/误命中计数 + 负样本 EWMA，超过用户指定错误率上界 `error_bound` 则收紧、低于 `ErrorBound/2` 且复用充足则放宽；冻结窗防抖、`MinHits` 只门控放宽方向、JSON 原子持久化（`<db 同目录>/l3-adapt.json`，损坏冷启动）；gateway 反馈接线：复用→正、疑似误命中（#262 重试）→负、judge 拒绝→负；`verify --calibrate --adapt-db` 输出自适应状态汇总。默认开启但冷启动零行为变化，`adaptive=false` 或 `error_bound=-1` 完全关闭。

## Scope

- `kernel/zone`（Zones.ByType + ForType）、`kernel/adapt`（新包）、`kernel/cache`（L3Decider.Adapt）、`kernel/inject`、`kernel/slice`（TypeFromString）、`kernel/config`（CLI 配置层）
- `gateway`（配置/组装/反馈钩子）、`cmd/semantix`（flags、eval/lookup/search/verify 接线、calibrate 报告）
- `docs/specs/issue-259-adaptive-l3-threshold.md`（spec 已 post 到 issue #259）、`semantix.example.toml`

## Validation

- [x] `go vet ./...` — 通过
- [x] `go test ./...` — 除 4 个 pre-existing 环境失败外全绿（已在干净的 `upstream/main` worktree 上复现确认与本次改动无关）：
  - `harness/autoresearch`、`harness/boot`：Windows 无 symlink 特权 / 会话路径环境问题
  - `harness/extension/protocolgen`：`schema_hash.generated.go` 生成物漂移（pre-existing）
  - `harness/tool` `TestSemantixLookupSubprocess`：Windows bat 中文参数编码问题（pre-existing）
- [ ] `go test ./... -race` — **本机无法运行**：`-race` 需要 cgo，环境无 gcc（`CGO_ENABLED=1` 报 `c compiler "gcc" not found`）。已用非 race 全量 + 受影响包（kernel/adapt、kernel/cache、kernel/zone、kernel/inject、gateway）测试替代
- [x] `git diff --check` — 通过
- [x] 新增测试：adapt 全行为（收紧/放宽/冻结窗/clamp/MinHits 方向门/持久化 round-trip/损坏恢复/禁用）、DecideL3 自适应判定与窄带 clamp 保底、gateway 反馈三路径 + New 接线/禁用/落盘、配置层解析与校验（含 NaN/Inf、evolve 优先级）、verify 校准报告结构

## Compatibility and data impact

- 全部新增配置键（`[retrieval] tau_*/abs_*/evolve_db/adaptive/error_bound/adapt_db/by_type`）：缺省时行为与 main 逐字节一致（ByType 空、adapt 冷启动回退全局阈值）
- `usage.Event`、`kernel/event` wire 契约零变更（无新 Kind、无新事件字段）；新增 `l3-adapt.json` 状态文件为派生性能状态（可删除重建）
- CLI 优先级不变：flag > toml > evolve > default（阶段 2 修正了 by_type 继承 evolve 后全局值的顺序）

## Security and privacy

- 状态文件 `0o600`；损坏/缺失 → WARN + 冷启动，不阻断决策路径；自适应阈值只影响复用判定（收紧方向立即生效、放宽方向需高频信任），错误率上界为 operator 显式配置
- 无新增外部请求、无凭据处理变更

## Evidence

- 分支 5 commits：spec → 阶段 1 → 阶段 2 → 阶段 3 → 自审修复（review 发现的 Relaxed 门控重置、clamp 保底、CLI NaN 校验、evolve/config 顺序均已修复并补测试）
- 全量测试输出：`kernel/...`、`gateway`、`cmd/semantix` 全部 `ok`

## Related issues

Closes #259
