### PR TITLE
chore(patrol): fix promote dedup + preview truncation bugs found in bug audit

### DIFF
--- a/harness/sessioninbox/ids.go
+++ b/harness/sessioninbox/ids.go
@@ -68,6 +68,9 @@ func PreviewText(text string, maxRunes int) string {
 			prevSpace = true
 			count++
 			if count >= maxRunes {
+				if i < len(text) {
+					b.WriteString("…")
+				}
 				break
 			}
 			continue

--- a/kernel/promote/file_store.go
+++ b/kernel/promote/file_store.go
@@ -44,7 +44,7 @@ func (s *fileStore) Put(e Entry) error {
 		return err
 	}
 	for _, old := range all {
-		if old.ContentVersion == e.ContentVersion && old.Query == e.Query {
+		if old.SourceSliceID == e.SourceSliceID && old.ContentVersion == e.ContentVersion && old.Query == e.Query {
 			return nil // duplicate
 		}
 	}


### PR DESCRIPTION
## Summary

Scheduled repo patrol run. Brand-unification scan (reasonix → semantix) found nothing to change — everything remaining under `reasonix`/`Reasonix`/`REASONIX` in the repo already matches the exception list in `docs/specs/semantix-full-rebrand.md` §3 (legal attribution, upstream `DeepSeek-Reasonix` references, CC Switch external contract keys, legacy migration path literals, fork patches, historical reports/design docs referencing the design baseline). No brand-related file changes are included in this PR.

Static bug audit across `kernel/` and `harness/` found two real, reachable, low-risk bugs which are fixed here, and two additional real bugs that were filed as issues but not fixed (see below).

## Scope

- `kernel/promote/file_store.go`
- `harness/sessioninbox/ids.go`

## Fixed in this PR

- #362 — `fileStore.Put` deduplicated by `(ContentVersion, Query)` only, omitting `SourceSliceID`, so a promotion for one source slice could be silently dropped if another, unrelated source slice happened to produce byte-identical content and query text. Fix adds the missing `SourceSliceID` comparison to match `MemStore.Put` and the store's own `List`/`Delete`.
- #363 — `PreviewText` appended the truncation ellipsis only when truncation landed on a non-whitespace character; truncation landing on a run of collapsed whitespace silently omitted the `"…"` marker. Fix adds the same ellipsis check to the whitespace-collapse branch.

## Filed but not fixed (left for maintainer triage)

- #364 — `harness/sessioncatalog`'s `directoryLocks` map never evicts entries; unbounded, slow memory growth over a long-running process's lifetime. Not a one-line fix (needs an eviction/TTL design), and low real-world impact, so left as an issue only.
- #365 — `harness/config`'s default `Bot.Control.TokenEnv` is still `"REASONIX_BOT_CONTROL_TOKEN"` while the config renderer's placeholder comment already suggests `"SEMANTIX_BOT_CONTROL_TOKEN"`. This changes a runtime-read env var default (compatibility-sensitive for anyone who already set the old name), so left for a human decision rather than changed unilaterally.

## Validation

- [x] `go build ./...` (full repo)
- [x] `go vet ./...` (full repo)
- [x] `go test ./kernel/promote/... -race` — pass
- [x] `go test ./harness/sessioninbox/... -race` — pass
- [ ] `go test ./... -race` — not run in full (out of scope for a two-line targeted fix per patrol run rules); only the two touched packages were race-tested
- [x] `git diff --check`

## Compatibility and data impact

None. Both fixes are behavior corrections within existing contracts: `fileStore.Put`'s dedup now matches its own doc comment and `MemStore.Put`'s existing semantics (no schema/wire change); `PreviewText`'s output gains a `"…"` marker in a previously-inconsistent truncation case (display-only, no stored data format change).

## Security and privacy

None.

## Related issues

Fixes #362, Fixes #363. Also files (not fixed): #364, #365.

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests cover the changed behavior (existing suites in both touched packages pass with `-race`).
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md` — N/A, no wire-contract change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViM3dUhAo5ncSEgDoRw2Ei)_