### PR TITLE
chore(patrol): bug-hunt fixes (2026-08-22, run 2)

### DIFF
--- a/gateway/pipeline.go
+++ b/gateway/pipeline.go
@@ -325,11 +325,13 @@ func (g *Gateway) passthrough(w http.ResponseWriter, resp *http.Response, sessio
 		if isHopByHopHeader(k) {
 			continue
 		}
-		if vendor == "anthropic" && http.CanonicalHeaderKey(k) == "Content-Length" {
-			// Only the translated hop may differ from the upstream body
-			// length; net/http recomputes Content-Length, so a copied value
-			// would truncate or stall the reply. The OpenAI passthrough path
-			// relays verbatim and keeps the upstream framing byte-identical.
+		if http.CanonicalHeaderKey(k) == "Content-Length" {
+			// net/http recomputes Content-Length from the bytes actually
+			// written. A copied upstream value can be wrong even for the
+			// verbatim passthrough path: out is read through a LimitReader
+			// (maxBodyBytes), so an oversized upstream body is silently
+			// truncated and the original Content-Length would then promise
+			// more bytes than are written, stalling or truncating the reply.
 			continue
 		}
 		for _, v := range vs {

--- a/harness/bot/feishu/feishu.go
+++ b/harness/bot/feishu/feishu.go
@@ -102,6 +102,7 @@ type adapter struct {
 	cancel   context.CancelFunc
 	client   *lark.Client
 	wsClient *larkws.Client
+	wsMu     sync.Mutex // 保护 wsClient：runWebSocket 的重连协程写，Stop() 从另一 goroutine 读
 
 	// fetchResource 覆盖消息资源下载（测试注入）；nil 时用 sdkFetchResource。
 	fetchResource func(ctx context.Context, messageID, key, typ string) ([]byte, string, error)
@@ -257,8 +258,11 @@ func (a *adapter) Stop() error {
 	if a.cancel != nil {
 		a.cancel()
 	}
-	if a.wsClient != nil {
-		a.wsClient.Close()
+	a.wsMu.Lock()
+	client := a.wsClient
+	a.wsMu.Unlock()
+	if client != nil {
+		client.Close()
 	}
 	return nil
 }
@@ -305,7 +309,9 @@ func (a *adapter) runWebSocket(ctx context.Context) {
 			opts = append(opts, larkws.WithDomain(lark.LarkBaseUrl))
 		}
 		client := larkws.NewClient(a.cfg.AppID, secret, opts...)
+		a.wsMu.Lock()
 		a.wsClient = client
+		a.wsMu.Unlock()
 		// client.Start blocks; run it off-loop so cancellation closes the client
 		// immediately rather than waiting for Start to notice ctx. RunWithRetry
 		// handles the reconnect backoff.

--- a/harness/bot/qq/gateway.go
+++ b/harness/bot/qq/gateway.go
@@ -324,7 +324,9 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 			<-heartbeatDone
 			return err
 		}
+		ws.mu.Lock()
 		ws.lastSeq = msg.S
+		ws.mu.Unlock()
 		a.seq = msg.S
 
 		switch msg.Op {

--- a/harness/extension/proxy.go
+++ b/harness/extension/proxy.go
@@ -82,9 +82,7 @@ func (p *StableProxy) Replace(ctx context.Context, next Backend, generation uint
 		c()
 	}
 	if prev != nil {
-		if err := prev.Close(ctx); err != nil {
-			return fmt.Errorf("drain previous backend: %w", err)
-		}
+		closeErr := prev.Close(ctx)
 		p.mu.Lock()
 		out := p.draining[:0]
 		for _, b := range p.draining {
@@ -94,6 +92,9 @@ func (p *StableProxy) Replace(ctx context.Context, next Backend, generation uint
 		}
 		p.draining = out
 		p.mu.Unlock()
+		if closeErr != nil {
+			return fmt.Errorf("drain previous backend: %w", closeErr)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Automated patrol run, 2026-08-22 (second run today — see #355 from the ~12:11 UTC run, still open).

### Brand cleanup (reasonix → semantix)

No changes. Delegated a scoped review of the remaining `reasonix` mentions in docs/prose (README, blog, agent-skill, docs/, harness/docs/, site/) not already covered by the prior rebrand effort (`docs/specs/semantix-full-rebrand.md`, issue #347) or the first patrol run (#355). Every hit found is either a reference to the real upstream project (`DeepSeek-Reasonix`), an external site/org credit (`reasonix.io`, SignPath org name), legal attribution text, or historical migration-changelog prose documenting old literal paths/env vars — none qualified as our own brand self-reference. No edits made.

### Bug patrol

Four parallel static-review passes (kernel+gateway; harness tool/hook/extension/acp; harness agent/checkpoint/environment/command; harness bot/billing/doctor) surfaced 6 candidate bugs. I manually re-read and confirmed 6 against source (one pass, harness agent/checkpoint/environment, found nothing it was highly confident about — `go vet` and `-race` clean there). Deduped against all 28 open issues and PR #355/#361 first — no overlap. Filed 5 (two structurally-identical bot races combined into one issue to stay under the 5-issue cap); fixed the 3 lowest-risk, most confidently-fixable ones here per the 3-commit cap.

**Fixed in this PR:**
- #368 — `gateway/pipeline.go` (`passthrough`): the upstream response body is read through `io.LimitReader(resp.Body, maxBodyBytes)`, which silently truncates oversized bodies with no error. The original `Content-Length` header was still forwarded verbatim for every non-anthropic vendor, promising more bytes than actually written and stalling/truncating the client's reply. Extended the existing anthropic-only skip to every vendor, letting `net/http` recompute `Content-Length` from the real bytes written.
- #370 — `harness/extension/proxy.go` (`StableProxy.Replace`): the previous backend was appended to `p.draining` before `Close(ctx)` was attempted, but only removed again on `Close`'s success path. A failing `Close` (e.g. a sidecar timing out its graceful-shutdown window) left it in `p.draining` forever — double-closed by every later `StableProxy.Close()`, and leaking one more entry per further failed `Replace`. Moved the removal to run unconditionally.
- #371 — `harness/bot/qq/gateway.go` + `harness/bot/feishu/feishu.go`: two structurally identical unsynchronized-field races. QQ's dispatch loop wrote `ws.lastSeq` without the lock the heartbeat goroutine reads it under. Feishu's reconnect closure assigned `a.wsClient` with no synchronization while `Stop()` read it unguarded from a different goroutine. Added the missing lock (QQ: existing `ws.mu`) / new mutex (Feishu: `wsMu`).

**Issue-only (not fixed here):**
- #367 — `kernel/slice/file_store.go` (`compactLocked`): a failed `os.Rename` to swap in the compacted base leaves the journal handle already nulled, but the old journal file (holding real un-folded records) un-removed on disk. The next `ensureJournalLocked()` call unconditionally overwrites that file with a fresh empty one, permanently discarding those records — silent data loss. Deferred: needs care to get the recovery semantics right without breaking the existing crash-recovery-on-reopen guarantee, plus a failure-injection test.
- #369 — `gateway/pipeline.go` (`replayStream`): L3 cache-hit SSE replay chunks content by raw 256-byte offset with no UTF-8 rune-boundary check, corrupting any multi-byte character (CJK, emoji) that straddles a chunk boundary into `�`. Deferred purely to stay under this run's 3-fix cap — it's an easy, low-risk fix (reuse `kernel/slice/compress.go`'s existing `utf8Prefix`/`utf8Suffix` helpers) that a human or the next patrol run can pick up.

## Scope

- `gateway/pipeline.go`
- `harness/extension/proxy.go`
- `harness/bot/qq/gateway.go`, `harness/bot/feishu/feishu.go`

## Validation

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./gateway/... -race` — ok
- [x] `go test ./harness/extension/... -race` — ok (all subpackages)
- [x] `go test ./harness/bot/... -race` — ok (all subpackages, including feishu and qq)

## Compatibility and data impact

None. All three fixes are synchronization/correctness corrections with no config/wire/schema impact and no change to the happy-path behavior:
- gateway: `Content-Length` is no longer copied for any vendor (was already skipped for anthropic); `net/http` recomputes it, which is what already happened for the anthropic path.
- extension proxy: no behavior change when `Close` succeeds; only changes cleanup on the already-broken error path.
- bot adapters: pure synchronization additions, no observable behavior change in the non-racing case.

## Security and privacy

None. (#367, left as issue-only, has no security implication — it's a local on-disk memory-store durability issue, not exposed to untrusted input.)

## Related issues

Fixed in this PR: #368, #370, #371
Filed, not fixed here: #367, #369
Related: #355 (first patrol run today, still open, no file overlap with this PR)

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior (all three fixes are covered by existing `-race` suites in the touched packages; no new test added since none of the three needed new coverage to exercise the fixed code path).
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md` (N/A — no wire changes).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Udbnthcm9s9wTbCC2zKMp9)_