### PR TITLE
feat(cli): 一行安装 + 全局 semantix 裸命令启动 agent（cwd 为工作区）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Tag a version (vX.Y.Z) to cut a release: cross-build every platform bundle,
+# checksum them, and publish to GitHub Releases so the one-line installer
+# (agent-skill/scripts/install.sh) has artifacts to download.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # create the release and upload assets
+
+jobs:
+  release:
+    name: Build & publish bundles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history for release notes
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build platform bundles
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$VERSION" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "tag $VERSION is not vX.Y.Z" >&2; exit 1 ;;
+          esac
+          OUT="$PWD/dist"; rm -rf "$OUT"; mkdir -p "$OUT"
+          # One Linux runner cross-compiles every target (CGO disabled). Each
+          # bundle carries the kernel/umbrella (semantix), the coding agent
+          # (semantix-agent), the gateway, and example configs.
+          for plat in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
+            os="${plat%-*}"; arch="${plat#*-}"
+            pkg="semantix-$VERSION-$plat"
+            d="$OUT/$pkg"; mkdir -p "$d"
+            for bin in semantix semantix-agent semantix-gateway; do
+              echo "-- $bin ($os/$arch)"
+              CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath \
+                -ldflags "-s -w -X main.version=$VERSION" -o "$d/$bin" "./cmd/$bin"
+            done
+            cp semantix.example.toml "$d/" 2>/dev/null || true
+            cp deploy/semantix-gateway.toml.example "$d/" 2>/dev/null || true
+            (cd "$OUT" && tar -czf "$pkg.tar.gz" "$pkg")
+            rm -rf "$d"
+          done
+          (cd "$OUT" && sha256sum semantix-*.tar.gz > SHA256SUMS.txt && cat SHA256SUMS.txt)
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh release create "$VERSION" \
+            --repo "${{ github.repository }}" \
+            --title "$VERSION" \
+            --generate-notes \
+            dist/semantix-*.tar.gz dist/SHA256SUMS.txt

--- a/agent-skill/scripts/install.sh
+++ b/agent-skill/scripts/install.sh
@@ -1,70 +1,109 @@
-#!/usr/bin/env bash
-# install.sh — install the semantix memory-kernel middleware into this agent's
-# environment. Downloads the release binary, verifies the sha256, installs it
-# under ~/.local/bin, initializes ~/.semantix/ and runs a smoke test.
+#!/bin/sh
+# install.sh — one-line installer for the Semantix coding agent + memory kernel.
 #
-# Usage: bash <(curl -sL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/scripts/install.sh)
-#        or: bash install.sh [version] [arch]
-set -euo pipefail
+# Installs two binaries under ~/.local/bin:
+#   semantix        the memory kernel AND the umbrella launcher — bare
+#                   `semantix` starts the coding agent in the current folder;
+#                   `semantix <subcommand>` runs a kernel command.
+#   semantix-agent  the interactive coding agent (the umbrella execs it).
+# Enables cross-session memory by default and prints the PATH step.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/scripts/install.sh | sh
+#   # pin a version / arch:
+#   curl -fsSL .../install.sh | sh -s -- v0.4.0 arm64
+#
+# POSIX sh (no bashisms) so `curl | sh` works everywhere.
+set -eu
 
-VERSION="${1:-v0.2.0}"
-# arch: auto-detect; override with the second argument (amd64|arm64)
+REPO="Gnosil/semantix"
+VERSION="${1:-latest}"
 ARCH="${2:-}"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 case "$OS" in
-  darwin|linux) ;;
+  darwin | linux) ;;
   *) echo "unsupported OS: $OS (darwin|linux)" >&2; exit 2 ;;
 esac
-if [[ -z "$ARCH" ]]; then
+if [ -z "$ARCH" ]; then
   case "$(uname -m)" in
-    x86_64|amd64) ARCH=amd64 ;;
-    arm64|aarch64) ARCH=arm64 ;;
-    *) echo "unsupported arch: $(uname -m)" >&2; exit 2 ;;
+    x86_64 | amd64) ARCH=amd64 ;;
+    arm64 | aarch64) ARCH=arm64 ;;
+    *) echo "unsupported arch: $(uname -m) (x86_64|arm64)" >&2; exit 2 ;;
   esac
 fi
 case "$ARCH" in
-  amd64|arm64) ;;
+  amd64 | arm64) ;;
   *) echo "invalid arch: $ARCH (amd64|arm64)" >&2; exit 2 ;;
 esac
+
+CURL="curl -fSL --retry 5 --retry-delay 2"
+
+# Resolve 'latest' to the newest published release tag via the GitHub API.
+if [ "$VERSION" = "latest" ]; then
+  VERSION="$($CURL -s "https://api.github.com/repos/$REPO/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
+  [ -n "$VERSION" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
+fi
+# Anchor the tag (reject junk that would only 404 at download time).
 case "$VERSION" in
   v[0-9]*.[0-9]*.[0-9]*) ;;
-  *) echo "invalid version: $VERSION (want vX.Y.Z)" >&2; exit 2 ;;
+  *) echo "invalid version: $VERSION (want vX.Y.Z or 'latest')" >&2; exit 2 ;;
 esac
-# Anchor the version (bash 3.2-safe [[ =~ ]]): reject empty segments and
-# trailing junk that would only 404 at download time.
-if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "invalid version: $VERSION (want vX.Y.Z, no suffix)" >&2
-  exit 2
-fi
 
 BIN_DIR="${SEMANTIX_BIN_DIR:-$HOME/.local/bin}"
-DATA_DIR="${SEMANTIX_DATA_DIR:-$HOME/.semantix}"
-BASE="https://github.com/Gnosil/semantix/releases/download/$VERSION"
-EXE="semantix-$VERSION-$OS-$ARCH"
+HOME_DIR="${SEMANTIX_HOME:-$HOME/.semantix}"
+BASE="https://github.com/$REPO/releases/download/$VERSION"
+PKG="semantix-$VERSION-$OS-$ARCH.tar.gz"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-echo "== semantix $VERSION ($OS/$ARCH) install =="
-mkdir -p "$BIN_DIR" "$DATA_DIR"
+echo "== semantix $VERSION ($OS/$ARCH) =="
+mkdir -p "$BIN_DIR" "$HOME_DIR"
 
-# 1. download binary + checksums (HTTP/1.1 + retry-all: some networks
-#    break on HTTP2 framing; resume-safe via --retry)
-CURL="curl -fSL --http1.1 --retry 5 --retry-all-errors --retry-delay 2"
-$CURL -o "$TMP/$EXE" "$BASE/$EXE"
+# 1. download bundle + checksums.
+$CURL -o "$TMP/$PKG" "$BASE/$PKG"
 $CURL -o "$TMP/SHA256SUMS.txt" "$BASE/SHA256SUMS.txt"
-# 2. verify checksum (shasum on macOS; sha256sum on most Linux)
-if command -v shasum >/dev/null 2>&1; then
-  (cd "$TMP" && grep "$EXE" SHA256SUMS.txt | shasum -a 256 -c -)
-else
-  (cd "$TMP" && grep "$EXE" SHA256SUMS.txt | sha256sum -c -)
-fi
-# 3. install
-chmod +x "$TMP/$EXE"
-mv "$TMP/$EXE" "$BIN_DIR/semantix"
 
-# 4. smoke test
-"$BIN_DIR/semantix" search --help >/dev/null 2>&1 \
+# 2. verify the checksum (shasum on macOS, sha256sum on most Linux).
+if command -v shasum >/dev/null 2>&1; then
+  (cd "$TMP" && grep " $PKG\$" SHA256SUMS.txt | shasum -a 256 -c -)
+else
+  (cd "$TMP" && grep " $PKG\$" SHA256SUMS.txt | sha256sum -c -)
+fi
+
+# 3. extract + install both binaries. Bundle layout:
+#    semantix-<version>-<os>-<arch>/{semantix, semantix-agent, ...}
+tar -xzf "$TMP/$PKG" -C "$TMP"
+SRC="$TMP/semantix-$VERSION-$OS-$ARCH"
+install -m 0755 "$SRC/semantix" "$BIN_DIR/semantix"
+install -m 0755 "$SRC/semantix-agent" "$BIN_DIR/semantix-agent"
+
+# 4. enable cross-session memory by default — only on a fresh install; never
+#    clobber an existing user config.
+CFG="$HOME_DIR/config.toml"
+if [ ! -f "$CFG" ]; then
+  cat > "$CFG" <<'TOML'
+# Semantix agent user config. Cross-session memory is on: the agent mirrors
+# sessions to the kernel and injects reusable context on similar tasks. Delete
+# the [semantix] block to disable. Provider and model are set on first run —
+# the agent guides you through it.
+[semantix]
+enabled = true
+binary  = "semantix"
+inject  = true
+budget  = 4096
+TOML
+  echo "== memory enabled: $CFG =="
+fi
+
+# 5. smoke test the kernel binary.
+"$BIN_DIR/semantix" version >/dev/null 2>&1 \
   || { echo "install: smoke test failed" >&2; exit 1; }
-echo "== installed: $BIN_DIR/semantix =="
-echo "== data dir:  $DATA_DIR (user memory library) =="
-echo "== next: add $BIN_DIR to PATH; see agent-skill/SKILL.md for usage =="
+echo "== installed: $BIN_DIR/semantix + $BIN_DIR/semantix-agent =="
+
+# 6. PATH hint (only when BIN_DIR is not already reachable).
+case ":$PATH:" in
+  *":$BIN_DIR:"*) : ;;
+  *) echo "== add to PATH: export PATH=\"$BIN_DIR:\$PATH\"  (append to ~/.bashrc or ~/.zshrc) ==" ;;
+esac
+echo "== done. run 'semantix' inside any project to start the agent (that folder is the workspace). =="

--- a/cmd/semantix/agentexec_unix.go
+++ b/cmd/semantix/agentexec_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// execAgent replaces the current process with the agent (syscall.Exec), so the
+// interactive TUI owns the terminal and signals directly — no lingering
+// umbrella parent. It only returns on failure to exec.
+func execAgent(path string) int {
+	err := syscall.Exec(path, []string{path}, os.Environ())
+	// Exec only returns on error (bad binary, permissions, ENOEXEC).
+	fmt.Fprintf(os.Stderr, "semantix: launch agent %s: %v\n", path, err)
+	return 1
+}

--- a/cmd/semantix/agentexec_windows.go
+++ b/cmd/semantix/agentexec_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// execAgent runs the agent as a child process with inherited stdio (Windows
+// has no exec-replace), propagating its exit code.
+func execAgent(path string) int {
+	cmd := exec.Command(path)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "semantix: launch agent %s: %v\n", path, err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/semantix/agentlaunch.go
+++ b/cmd/semantix/agentlaunch.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// This file makes a bare `semantix` (no subcommand) launch the co-located
+// coding agent in the current directory, so the one global `semantix` command
+// is both the interactive agent (bare) and the memory kernel (subcommands).
+// The agent already shells back out to `semantix <subcommand>` for L2/L3
+// memory (harness SemantixConfig.Binary defaults to "semantix" on PATH), so a
+// single installed binary closes the loop with no recursion — reasonix only
+// ever calls `semantix` WITH a subcommand, which routes to the kernel path.
+
+// agentBinaryNames are the coding-agent executables the umbrella launches,
+// in preference order. The downloadable bundle installs the agent as
+// `reasonix`; `semantix-agent` is the in-repo cmd name.
+var agentBinaryNames = []string{"reasonix", "semantix-agent"}
+
+// exeSuffix is ".exe" on Windows, "" elsewhere.
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}
+
+// findAgentBinary locates the coding-agent binary: first next to this
+// executable (the bundle installs kernel + agent side by side), then on PATH.
+// Returns "" when no agent is installed — the caller then falls back to help,
+// so a kernel-only install keeps its old bare-command behavior. Overridable
+// in tests.
+var findAgentBinary = func() string {
+	var selfDir string
+	if exe, err := os.Executable(); err == nil {
+		if resolved, rerr := filepath.EvalSymlinks(exe); rerr == nil {
+			selfDir = filepath.Dir(resolved)
+		} else {
+			selfDir = filepath.Dir(exe)
+		}
+	}
+	for _, name := range agentBinaryNames {
+		if selfDir != "" {
+			cand := filepath.Join(selfDir, name+exeSuffix())
+			if isExecutableFile(cand) {
+				return cand
+			}
+		}
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// isExecutableFile reports whether path is a regular file the OS will run.
+// On Windows the executable bit does not exist, so presence + regular-file is
+// enough; on unix it must have an owner/group/other execute bit.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() || !info.Mode().IsRegular() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+// launchAgent runs the agent at path with the current directory as its
+// workspace (the harness derives the workspace from cwd). It forwards no args
+// — a bare `semantix` becomes a bare agent invocation, which is what plays the
+// intro and enters the interactive TUI. On unix it replaces this process
+// (execAgent → syscall.Exec) so signals and the TTY go straight to the agent;
+// on other platforms it runs the agent as a child and returns its exit code.
+// Overridable in tests.
+var launchAgent = func(path string) int {
+	return execAgent(path)
+}

--- a/cmd/semantix/agentlaunch_test.go
+++ b/cmd/semantix/agentlaunch_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// bare `semantix` with no agent installed falls back to help (exit 2) — the
+// kernel-only install keeps its old behavior.
+func TestBareCommandFallsBackToHelpWhenNoAgent(t *testing.T) {
+	orig := findAgentBinary
+	t.Cleanup(func() { findAgentBinary = orig })
+	findAgentBinary = func() string { return "" }
+
+	var stdout, stderr bytes.Buffer
+	code := run(nil, &stdout, &stderr, productionDependencies())
+	if code != 2 {
+		t.Fatalf("bare semantix (no agent) code = %d, want 2", code)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Usage:")) {
+		t.Fatalf("expected help on stderr, got %q", stderr.String())
+	}
+}
+
+// bare `semantix` with an agent present launches it and returns its exit code,
+// without ever loading kernel config or printing help.
+func TestBareCommandLaunchesAgentWhenPresent(t *testing.T) {
+	origFind, origLaunch := findAgentBinary, launchAgent
+	t.Cleanup(func() { findAgentBinary, launchAgent = origFind, origLaunch })
+
+	findAgentBinary = func() string { return "/opt/bundle/reasonix" }
+	var launched string
+	launchAgent = func(path string) int {
+		launched = path
+		return 0
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run(nil, &stdout, &stderr, productionDependencies())
+	if code != 0 {
+		t.Fatalf("bare semantix (agent present) code = %d, want 0", code)
+	}
+	if launched != "/opt/bundle/reasonix" {
+		t.Fatalf("launched %q, want /opt/bundle/reasonix", launched)
+	}
+	if stderr.Len() != 0 || stdout.Len() != 0 {
+		t.Fatalf("launch path must not print help; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+// A subcommand invocation must never launch the agent — it routes to the
+// kernel path (this is exactly what reasonix calls back as `semantix <cmd>`).
+func TestSubcommandNeverLaunchesAgent(t *testing.T) {
+	origFind, origLaunch := findAgentBinary, launchAgent
+	t.Cleanup(func() { findAgentBinary, launchAgent = origFind, origLaunch })
+	findAgentBinary = func() string { t.Fatal("findAgentBinary must not be consulted for a subcommand"); return "" }
+	launchAgent = func(string) int { t.Fatal("launchAgent must not run for a subcommand"); return 0 }
+
+	var stdout, stderr bytes.Buffer
+	// `help` is a subcommand-like arg; it must reach runHelp, not the launcher.
+	if code := run([]string{"help"}, &stdout, &stderr, productionDependencies()); code != 0 {
+		t.Fatalf("semantix help code = %d, want 0", code)
+	}
+}
+
+// findAgentBinary discovers an agent on PATH when none sits beside the
+// executable (the PATH branch of the real discovery).
+func TestFindAgentBinaryOnPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix executable-bit discovery")
+	}
+	dir := t.TempDir()
+	agent := filepath.Join(dir, "reasonix")
+	if err := os.WriteFile(agent, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	got := findAgentBinary()
+	// EvalSymlinks may canonicalize /var → /private/var on macOS; compare basenames + existence.
+	if filepath.Base(got) != "reasonix" {
+		t.Fatalf("findAgentBinary() = %q, want a reasonix path under %q", got, dir)
+	}
+	if !isExecutableFile(got) {
+		t.Fatalf("discovered agent %q is not executable", got)
+	}
+}

--- a/cmd/semantix/main.go
+++ b/cmd/semantix/main.go
@@ -188,6 +188,13 @@ func buildCommands() []commandSpec {
 
 func run(args []string, stdout, stderr io.Writer, deps dependencies) int {
 	if len(args) == 0 {
+		// Bare `semantix` (no subcommand): launch the co-located coding agent
+		// with the current directory as its workspace. When no agent binary is
+		// installed (kernel-only install), fall back to the command help so the
+		// old behavior is preserved.
+		if agent := findAgentBinary(); agent != "" {
+			return launchAgent(agent)
+		}
 		printHelp(stderr)
 		return 2
 	}

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,38 +6,42 @@
 
 ## 安装
 
-### 方式一：GitHub Release（推荐）
-
-**完整产品（v0.3.0+）**：`semantix-agent-v0.3.0-<platform>.tar.gz`——semantix-agent（coding-agent harness）+ semantix（记忆内核）+ 示例配置 + 安装脚本：
+### 一行安装（推荐）
 
 ```bash
-tar -xzf semantix-agent-v0.3.0-darwin-arm64.tar.gz
-cd semantix-agent-v0.3.0-darwin-arm64
-./semantix-install.sh v0.3.0   # 安装两个二进制 + 配置
-semantix-agent --config semantix-agent.toml   # 启动完整 agent
+curl -fsSL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/scripts/install.sh | sh
 ```
 
-**仅内核**：从 [Releases](https://github.com/Gnosil/semantix/releases) 下载对应平台二进制：
+自动检测平台、拉取最新 release、把两个二进制装到 `~/.local/bin`、开启跨会话记忆，并提示把该目录加进 `PATH`。装的是：
 
-| 平台 | 文件 |
-|---|---|
-| macOS Intel | `semantix-v0.3.0-darwin-amd64` |
-| macOS Apple Silicon | `semantix-v0.3.0-darwin-arm64` |
-| Linux amd64/arm64 | `semantix-v0.3.0-linux-{amd64,arm64}` |
-| Windows amd64/arm64 | `semantix-v0.3.0-windows-{amd64,arm64}.exe` |
+- **`semantix`** —— 记忆内核 **兼** umbrella 启动器；
+- **`semantix-agent`** —— 交互式 coding agent（umbrella 会 exec 它）。
+
+固定版本 / 架构：`... install.sh | sh -s -- v0.4.0 arm64`。校验用 `SHA256SUMS.txt`。
+
+### 全局 `semantix` 怎么用
+
+装好后，`semantix` 是**一个全局命令、两种入口**：
 
 ```bash
-chmod +x semantix-v0.3.0-darwin-arm64
-sudo mv semantix-v0.3.0-darwin-arm64 /usr/local/bin/semantix
+cd ~/你的项目
+semantix                 # 裸命令 → 在【当前文件夹】启动 coding agent（cwd = 工作区）
+                         #   首次运行 agent 会引导你配置模型/API key（像 claude 那样）
+semantix search "..."    # 带子命令 → 走记忆内核（检索/extract/inject/verify/usage）
+semantix help            # 全部内核命令
 ```
 
-校验：`shasum -a 256 -c SHA256SUMS.txt`
+裸 `semantix` 会 exec 同目录（或 PATH 上）的 `semantix-agent`，以当前目录为工作区；agent 运行时又会回调 `semantix <子命令>` 做 L2/L3 记忆——一个二进制闭环，无需你手动串联。安装脚本已在 `~/.semantix/config.toml` 开启 `[semantix]` 记忆，开箱即用。
 
-### 方式二：源码构建
+> 若只装了内核（没有 `semantix-agent`），裸 `semantix` 回退为打印命令帮助，行为不变。
+
+### 源码构建（开发者）
 
 ```bash
 git clone https://github.com/Gnosil/semantix.git && cd semantix
-go build -o semantix ./cmd/semantix   # 需要 Go 1.26+
+go build -o semantix       ./cmd/semantix         # 内核 + umbrella，需要 Go 1.26+
+go build -o semantix-agent ./cmd/semantix-agent   # coding agent
+# 把两者放进同一个 PATH 目录，裸 semantix 即可启动 agent
 ```
 
 ## 30 秒体验


### PR DESCRIPTION
## Summary

让 semantix 像 Claude Code 一样上手：**一行 `curl|sh` 装好，全局 `semantix` 命令随时用，在任意目录裸敲 `semantix` 即以当前文件夹为工作区进入 coding agent**。

一个全局 `semantix` = 两种入口：
- **裸 `semantix`**（无子命令）→ 在当前目录启动交互式 coding agent（cwd = workspace）；
- **`semantix <子命令>`** → 记忆内核（search/extract/inject/verify/usage…）——正是 harness 运行时回调 `semantix <cmd>` 的路径，一个二进制闭环、无递归。

## Scope

- **umbrella 启动器**：`cmd/semantix/agentlaunch.go` + `agentexec_unix.go`（`syscall.Exec` 进程替换，TTY/信号直达 agent）+ `agentexec_windows.go`（子进程）。裸 `semantix` 发现同目录/PATH 的 agent 二进制（`reasonix` / `semantix-agent`）并 exec；找不到则回退命令帮助（内核-only 安装向后兼容）。`cmd/semantix/main.go` 接线 zero-arg 分支。`agentlaunch_test.go` 4 个单测。
- **`agent-skill/scripts/install.sh`** 重写为 POSIX sh（`curl|sh` 通用）：默认拉最新 release、下载全平台 bundle、装 `semantix` + `semantix-agent` 到 `~/.local/bin`、在 `~/.semantix/config.toml` 开启 `[semantix]` 记忆（仅新装、不覆盖既有）、PATH 提示。
- **`.github/workflows/release.yml`**（新增）：push tag `v*` → 单 runner 交叉编译 darwin/linux×amd64/arm64 三二进制 → 打 bundle `semantix-<ver>-<plat>.tar.gz` + `SHA256SUMS.txt` → `gh` 发布到 Releases，给 install.sh 提供下载产物。
- **`docs/QUICKSTART.md`** 安装章节重写为一行安装 + 全局 semantix 两种入口。

## Validation

- [x] `go vet ./cmd/...` — 通过
- [x] `go test ./cmd/semantix/ -race` — 通过（含 4 个 umbrella 单测：无 agent 回退 help / 有 agent 启动并返回其退出码 / 子命令永不启动 agent / PATH 发现）
- [x] `git diff --check` — 无空白错误
- [x] `sh -n install.sh` 通过；`release.yml` YAML 合法
- [x] **真实 bundle 端到端**：本地按 release.yml 逻辑打 `semantix-<ver>-linux-amd64.tar.gz`，解包布局 = install.sh 期望的 `semantix-<ver>-<plat>/{semantix,semantix-agent,semantix-gateway,…}`；解包目录内裸 `semantix` 成功 exec `semantix-agent`（打印 agent banner）、`semantix search` 仍走内核、`-X main.version` 注入正确。

## Compatibility and data impact

- **裸 `semantix` 行为变更**：从"打印帮助 + exit 2"改为"启动 agent（若 agent 二进制存在）"。**内核-only 安装向后兼容**——无 agent 时仍打印帮助。
- `semantix <子命令>` / `semantix help` 行为不变；harness 子进程集成（回调 `semantix extract/lookup/inject`）不受影响。
- 首次 `curl|sh` 在 `~/.semantix/config.toml` 写入 `[semantix]` 默认配置（仅当文件不存在）。
- 新增 release workflow 只在 push `v*` tag 时触发，不影响现有 CI。

## Security and privacy

- install.sh 走 HTTPS + `SHA256SUMS.txt` 校验；latest 版本经 GitHub API 解析后仍做 `vX.Y.Z` 锚定校验，防止 404/注入。
- release.yml 用内置 `GITHUB_TOKEN`（`permissions: contents: write`），无第三方 action、无额外密钥。
- umbrella exec 仅查同目录与 PATH 的固定二进制名，不执行任意路径。

## Related issues

无（产品 onboarding 体验需求）。后续可加 Windows kernel 包、`semantix upgrade` 自更新。

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed（QUICKSTART）。
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized（无 wire 契约变更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYV5u8eLCRH9dhZXcUcuoy)_