### PR TITLE
fix(release): 发布链收口，install.sh / release.yml 对齐 build-full.sh 契约

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Release
 
-# Tag a version (vX.Y.Z) to cut a release: cross-build every platform bundle,
-# checksum them, and publish to GitHub Releases so the one-line installer
-# (agent-skill/scripts/install.sh) has artifacts to download.
+# Tag a version (vX.Y.Z) to cut a release: run the proven full-bundle builder
+# (scripts/release/build-full.sh — cross-builds every platform, stamps
+# version/commit/build-time, and self-verifies the asset set before it can
+# publish), then upload every asset to GitHub Releases. Both downstream
+# consumers get exactly the names they hardcode: `semantix-agent upgrade`
+# reads semantix-agent-<plat>.tar.gz + SHA256SUMS, and the one-line installer
+# (agent-skill/scripts/install.sh) reads semantix-agent-<ver>-<plat>.tar.gz +
+# SHA256SUMS.txt.
 on:
   push:
     tags:
@@ -19,7 +24,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # full history for release notes
+          fetch-depth: 0 # full history for release notes + commit stamping
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -32,29 +37,12 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          case "$VERSION" in
-            v[0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "tag $VERSION is not vX.Y.Z" >&2; exit 1 ;;
-          esac
-          OUT="$PWD/dist"; rm -rf "$OUT"; mkdir -p "$OUT"
-          # One Linux runner cross-compiles every target (CGO disabled). Each
-          # bundle carries the kernel/umbrella (semantix), the coding agent
-          # (semantix-agent), the gateway, and example configs.
-          for plat in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
-            os="${plat%-*}"; arch="${plat#*-}"
-            pkg="semantix-$VERSION-$plat"
-            d="$OUT/$pkg"; mkdir -p "$d"
-            for bin in semantix semantix-agent semantix-gateway; do
-              echo "-- $bin ($os/$arch)"
-              CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build -trimpath \
-                -ldflags "-s -w -X main.version=$VERSION" -o "$d/$bin" "./cmd/$bin"
-            done
-            cp semantix.example.toml "$d/" 2>/dev/null || true
-            cp deploy/semantix-gateway.toml.example "$d/" 2>/dev/null || true
-            (cd "$OUT" && tar -czf "$pkg.tar.gz" "$pkg")
-            rm -rf "$d"
-          done
-          (cd "$OUT" && sha256sum semantix-*.tar.gz > SHA256SUMS.txt && cat SHA256SUMS.txt)
+          # build-full.sh validates the version, cross-builds darwin/linux ×
+          # amd64/arm64, and exits non-zero if any expected asset or checksum
+          # entry is missing — so a broken release fails here, not on a user's
+          # `upgrade`.
+          bash scripts/release/build-full.sh --version "$VERSION"
+          echo "-- dist assets:"; ls -1 dist
 
       - name: Publish GitHub Release
         env:
@@ -62,8 +50,11 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          # dist/ holds only publishable files (build-full.sh removes the
+          # per-platform staging dirs): full bundles, flat updater bundles, raw
+          # kernel binaries, and both checksum files.
           gh release create "$VERSION" \
             --repo "${{ github.repository }}" \
             --title "$VERSION" \
             --generate-notes \
-            dist/semantix-*.tar.gz dist/SHA256SUMS.txt
+            dist/*

--- a/agent-skill/scripts/install.sh
+++ b/agent-skill/scripts/install.sh
@@ -1,17 +1,25 @@
 #!/bin/sh
 # install.sh — one-line installer for the Semantix coding agent + memory kernel.
 #
-# Installs two binaries under ~/.local/bin:
+# Installs two binaries under ~/.local/bin (both come out of the release's
+# full bundle, `semantix-agent-<version>-<os>-<arch>.tar.gz`):
 #   semantix        the memory kernel AND the umbrella launcher — bare
 #                   `semantix` starts the coding agent in the current folder;
 #                   `semantix <subcommand>` runs a kernel command.
 #   semantix-agent  the interactive coding agent (the umbrella execs it).
 # Enables cross-session memory by default and prints the PATH step.
 #
+# Want ONLY the kernel dropped into another agent's environment (Claude Code,
+# etc.)? Don't use this — install the agent, then run
+# `semantix install --target claude-code` (or `--target custom --dir ...`).
+#
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/scripts/install.sh | sh
 #   # pin a version / arch:
-#   curl -fsSL .../install.sh | sh -s -- v0.4.0 arm64
+#   curl -fsSL .../install.sh | sh -s -- v0.7.2 arm64
+#
+# Env overrides: SEMANTIX_BIN_DIR, SEMANTIX_HOME, SEMANTIX_RELEASE_BASE
+# (point the last at a mirror or a local server to test without GitHub).
 #
 # POSIX sh (no bashisms) so `curl | sh` works everywhere.
 set -eu
@@ -52,8 +60,12 @@ esac
 
 BIN_DIR="${SEMANTIX_BIN_DIR:-$HOME/.local/bin}"
 HOME_DIR="${SEMANTIX_HOME:-$HOME/.semantix}"
-BASE="https://github.com/$REPO/releases/download/$VERSION"
-PKG="semantix-$VERSION-$OS-$ARCH.tar.gz"
+BASE="${SEMANTIX_RELEASE_BASE:-https://github.com/$REPO/releases/download/$VERSION}"
+# The release's full bundle carries semantix-agent + semantix + gateway + config
+# templates. We install the two binaries the umbrella needs; the rest stays in
+# the tarball. Asset + inner directory share this name (build-full.sh).
+PKG="semantix-agent-$VERSION-$OS-$ARCH.tar.gz"
+DIR="semantix-agent-$VERSION-$OS-$ARCH"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -64,19 +76,25 @@ mkdir -p "$BIN_DIR" "$HOME_DIR"
 $CURL -o "$TMP/$PKG" "$BASE/$PKG"
 $CURL -o "$TMP/SHA256SUMS.txt" "$BASE/SHA256SUMS.txt"
 
-# 2. verify the checksum (shasum on macOS, sha256sum on most Linux).
+# 2. verify the checksum. SHA256SUMS.txt lists every platform's assets, so pull
+#    the one line whose filename is exactly ours (tolerating the "*" binary-mode
+#    marker some shasum builds emit) and feed only that to the checker — passing
+#    the whole file would fail on the other platforms' absent files.
+SUM_LINE="$(awk -v f="$PKG" '{n=$2; sub(/^\*/,"",n); if (n==f) print}' "$TMP/SHA256SUMS.txt")"
+[ -n "$SUM_LINE" ] || { echo "install: no checksum entry for $PKG" >&2; exit 1; }
 if command -v shasum >/dev/null 2>&1; then
-  (cd "$TMP" && grep " $PKG\$" SHA256SUMS.txt | shasum -a 256 -c -)
+  printf '%s\n' "$SUM_LINE" | (cd "$TMP" && shasum -a 256 -c -)
 else
-  (cd "$TMP" && grep " $PKG\$" SHA256SUMS.txt | sha256sum -c -)
+  printf '%s\n' "$SUM_LINE" | (cd "$TMP" && sha256sum -c -)
 fi
 
-# 3. extract + install both binaries. Bundle layout:
-#    semantix-<version>-<os>-<arch>/{semantix, semantix-agent, ...}
+# 3. extract + install both binaries out of the bundle directory.
 tar -xzf "$TMP/$PKG" -C "$TMP"
-SRC="$TMP/semantix-$VERSION-$OS-$ARCH"
-install -m 0755 "$SRC/semantix" "$BIN_DIR/semantix"
-install -m 0755 "$SRC/semantix-agent" "$BIN_DIR/semantix-agent"
+SRC="$TMP/$DIR"
+for b in semantix semantix-agent; do
+  [ -f "$SRC/$b" ] || { echo "install: $b missing from $PKG" >&2; exit 1; }
+  install -m 0755 "$SRC/$b" "$BIN_DIR/$b"
+done
 
 # 4. enable cross-session memory by default — only on a fresh install; never
 #    clobber an existing user config.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -17,7 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/sc
 - **`semantix`** —— 记忆内核 **兼** umbrella 启动器；
 - **`semantix-agent`** —— 交互式 coding agent（umbrella 会 exec 它）。
 
-固定版本 / 架构：`... install.sh | sh -s -- v0.4.0 arm64`。校验用 `SHA256SUMS.txt`。
+固定版本 / 架构：`... install.sh | sh -s -- v0.7.2 arm64`。校验用 `SHA256SUMS.txt`。
 
 ### 全局 `semantix` 怎么用
 

--- a/scripts/release/build-full.sh
+++ b/scripts/release/build-full.sh
@@ -116,8 +116,9 @@ for plat in ${PLATFORMS//,/ }; do
   把 base_url 指过来即可）
 - \`semantix-agent.example.toml\` — agent 配置模板（provider + [semantix] 段）
 - \`semantix.example.toml\` — kernel 配置模板
-- \`semantix-install.sh\` — 独立 curl 安装器，只把 semantix memory kernel
-  装进别的 agent 环境
+- \`semantix-install.sh\` — 独立 curl 安装器，装 semantix + semantix-agent
+  两个二进制到 ~/.local/bin（裸 \`semantix\` 即 umbrella 启动 agent）；只想把
+  memory kernel 注入别的 agent 用 \`semantix install --target\`
 
 ## 快速开始
 1. cp semantix-agent.example.toml ~/.semantix/semantix-agent.toml，填 provider key，


### PR DESCRIPTION
## Summary

#374 引入的 `install.sh` + `release.yml` 用了一套谁都不用的新资产命名 `semantix-<ver>-<plat>.tar.gz`，与生产中的 `scripts/release/build-full.sh` 契约冲突。若不修就打 tag，会发出一个**坏 Release**：

- `release.yml` 不产出 `semantix-agent-<plat>.tar.gz` + `SHA256SUMS`，会让**已随 v0.7.x 发出去的二进制里写死**的 `semantix-agent upgrade` 自更新 404（正是 v0.7.1「发前自证」专门修掉的坑，见 `harness/releaseasset/cli.go:54-57`）。
- `install.sh` 下载的 `semantix-<ver>-<plat>.tar.gz` 在任何 Release 里都不存在（真实资产是裸内核 `semantix-<ver>-<plat>` + 完整包 `semantix-agent-<ver>-<plat>.tar.gz`）。

本 PR 把两者收口到既有、已在生产、带发前自检门禁的 `build-full.sh` 契约上，四条下游链（自更新 / curl 一行装 / 完整包 / 裸内核）命名全部一致，tag 一推即自动发版。

## Scope

- `agent-skill/scripts/install.sh` — 改下载完整包 `semantix-agent-<ver>-<plat>.tar.gz`，装出 `semantix` + `semantix-agent` 两个二进制（裸 `semantix` 即 umbrella 启动 agent）；走 `SHA256SUMS.txt` 校验（awk 精确取本平台条目，容忍 shasum 二进制标记）；新增 `SEMANTIX_RELEASE_BASE` 覆盖便于镜像 / 本地测试。只想把 memory kernel 注入别的 agent 的场景改由 `semantix install --target` 承担。
- `.github/workflows/release.yml` — 改为直接调 `scripts/release/build-full.sh --version $TAG` + `gh release create dist/*`，复用带自检门禁的成熟构建，替换我 #374 那套残缺的平行实现。
- `scripts/release/build-full.sh` — 包内 README 对 `semantix-install.sh` 的描述同步为「装两个二进制、umbrella」。
- `docs/QUICKSTART.md` — 固定版本示例 `v0.4.0` → `v0.7.2`。

## Validation

- [x] `git diff --check` — clean
- [x] `sh -n install.sh` / `bash -n build-full.sh` — 语法 OK
- [x] `build-full.sh --version v0.7.2 --platforms linux-amd64` — 发前自检门禁全过，产出 5 件资产
- [x] **端到端**：本地 http 服务端托管 dist/ → `install.sh v0.7.2 amd64` 下载完整包 → `semantix-agent-v0.7.2-linux-amd64.tar.gz: OK`（校验通过）→ 装出 `semantix`(7M) + `semantix-agent`(40M) → `semantix version`=v0.7.2 / commit / build_time，`semantix-agent --version`=v0.7.2，config 落盘 `[semantix] enabled`
- [ ] `go vet ./...` / `go test ./... -race` — 不适用（本 PR 零 Go 改动，只动 shell / workflow / docs）

## Compatibility and data impact

- **修复而非引入**不兼容：让 `semantix-agent upgrade`（v0.7.x 已发二进制的自更新路径）在下个 Release 继续可用，避免 404 回归。
- `install.sh` 默认行为从「只装 kernel」变为「装 kernel + agent」（umbrella），承接 #374 的产品意图；kernel-only 注入迁到 `semantix install --target`。
- 资产命名回到 `build-full.sh` 既有约定，与所有历史 Release 一致。

## Security and privacy

- 无新增信任边界。`install.sh` 仍对下载资产做 SHA256 校验；`SEMANTIX_RELEASE_BASE` 仅供指向镜像 / 本地测试，默认仍是官方 GitHub Releases。
- `release.yml` 仅用 `secrets.GITHUB_TOKEN`（`contents: write`）建 Release，无外发。

## Evidence

端到端本地验证输出（节选）：

```
== semantix v0.7.2 (linux/amd64) ==
semantix-agent-v0.7.2-linux-amd64.tar.gz: OK
== installed: .../bin/semantix + .../bin/semantix-agent ==
$ semantix version        → version v0.7.2 / commit e8df90adada4 / build_time 2026-...Z
$ semantix-agent --version → semantix-agent v0.7.2
```

## Related issues

延续 #374（该 PR 已合并；本 PR 修其发布链资产命名与自更新兼容性）。

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md`（无 wire 契约改动）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYV5u8eLCRH9dhZXcUcuoy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYV5u8eLCRH9dhZXcUcuoy)_