### PR TITLE
docs(readme): remove Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,24 +299,6 @@ Semantix 还很早期——欢迎贡献、质疑、实验和架构讨论：语�
 
 ---
 
-## Star History
-
-<div align="center">
-
-<a href="https://star-history.com/#Gnosil/semantix&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Gnosil/semantix&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Gnosil/semantix&type=Date" />
-    <img alt="Star History Chart for Gnosil/semantix" src="https://api.star-history.com/svg?repos=Gnosil/semantix&type=Date" width="640" />
-  </picture>
-</a>
-
-<sub>If Semantix saves you tokens, a <a href="https://github.com/Gnosil/semantix/stargazers">star</a> helps other agent builders find it.<br/>如果 Semantix 帮你省下了 token，点个 <a href="https://github.com/Gnosil/semantix/stargazers">star</a> 能让更多人找到它。</sub>
-
-</div>
-
----
-
 <div align="center">
 
 ### Semantix


### PR DESCRIPTION
Reverts the README section added in #377.

## Why

GitHub [restricted the stargazers API][changelog] on **2026-06-30** to a repository's own admins and collaborators. star-history.com requests the data as a third party, so it no longer gets a curve — the embed renders this instead:

> **GitHub restricted access to star data**
> GitHub team is looking into it
> Meanwhile, repo owners can restore it temporarily with a workaround

That placeholder is live on the front page of the README right now. Removing it beats leaving a broken image there.

Worth noting for anyone verifying similar embeds: the failure returns `200 OK` with a valid 60 KB `image/svg+xml` body. Status and content-type checks pass; only the rendered text reveals it.

## Scope

`README.md` is restored **byte-for-byte** to its state at `09a85aa`, immediately before #377 merged:

```
$ diff <(git show 09a85aa:README.md) README.md
$ git diff --stat upstream/main HEAD
 README.md | 18 ------------------
```

The **star count badge** at the top of the README is unaffected — shields.io reads the count from the repository endpoint, which is not restricted, so it keeps working.

## If a curve is wanted later

The chart can be self-hosted: a scheduled workflow fetching stargazers with the repository's own token (which *is* accepted) and committing the rendered SVG. That keeps the data reachable regardless of what third-party services can see. Out of scope here — this PR only removes what is broken.

[changelog]: https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgyxBqHhLZWpGDd6JK9aC2
