### PR TITLE
docs(release): v0.7.2 发版记录 + README 版本徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Semantic Caching · Adaptive Scheduling · Speculative Prefetch · Cross-Session Learning**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](./LICENSE)
-[![Version](https://img.shields.io/badge/release-0.7.1-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
+[![Version](https://img.shields.io/badge/release-0.7.2-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
 [![GitHub stars](https://img.shields.io/github/stars/Gnosil/semantix?style=flat-square&logo=github)](https://github.com/Gnosil/semantix/stargazers)
 [![GitHub contributors](https://img.shields.io/github/contributors/Gnosil/semantix?style=flat-square&logo=github)](https://github.com/Gnosil/semantix/graphs/contributors)
 [![Website](https://img.shields.io/badge/website-semantix.ensureok.ai-168b6d?style=flat-square)](https://semantix.ensureok.ai)

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,0 +1,94 @@
+# v0.7.2 — 自适应 L3 阈值
+
+> 发版日期：2026-08-23 · tag：`v0.7.2` · 范围：v0.7.1 之后合入 main 的 40 个提交、10 个 PR
+
+## 升级须知
+
+**本版无破坏性变更。** 与 v0.7.1 不同，落盘契约（用户目录、配置文件名、环境变量前缀、keyring 服务名）一律未动，从 v0.7.1 升级不需要任何手工操作。
+
+本版按 patch 号发布但含新功能（Issue #259 三阶段）。新增配置键**全部可选**：不写任何一项，检索行为与 v0.7.1 完全一致。
+
+## L3 命中阈值三阶段演进（Issue #259）
+
+v0.7.1 的 L3 判定用的是一套写死的全局阈值：所有切片类型共用同一个门槛，且不随使用变化。本版分三个阶段把它打开。
+
+### 阶段 1 — 四阈值可配化
+
+判定所用的四个量从常量变为配置项，gateway `[retrieval]` 段与 kernel `semantix.toml` 同键：
+
+| 键 | 缺省 | 含义 |
+|---|---|---|
+| `tau_high` | `0.8` | 相对置信：明确 hit 下界，区间 (0,1] |
+| `tau_low` | `0.55` | 相对置信：grey 区下界，(0,1]，须 < `tau_high` |
+| `abs_high` | `0.7` | 绝对分：明确 hit 地板，≥ 0 |
+| `abs_low` | `0.45` | 绝对分：grey 区地板，≥ 0 |
+| `evolve_db` | 未设 | `usage --evolve-db` 的状态目录；其 tuned `tau_l2` 在未显式配置 `tau_low` 时驱动 grey 下界，clamp 到 `[0.30, 0.80]` |
+
+### 阶段 2 — 按切片类型分化
+
+阈值可按切片类型覆盖（`ByType`），判定与校准报告都按类型走。result 类切片和 prompt 类项目知识本来就该用不同的门槛，此前被迫共用一个。
+
+### 阶段 3 — 逐条目自适应
+
+走 vCache 路线：每个条目从自己的正命中／误命中反馈**在线学习**各自的 `tau_low`，全局阈值退居先验与冷启动角色。用得越多，单个条目的门槛越贴合它自己的实际表现。
+
+配套自审修复一并合入：Relaxed 门控重置、clamp 保底、CLI NaN 校验、`evolve`/`config` 初始化顺序。
+
+完整设计见 [`docs/specs/issue-259-adaptive-l3-threshold.md`](../specs/issue-259-adaptive-l3-threshold.md)。
+
+## 授权口径统一为 MIT
+
+**这不是重新授权。** `LICENSE` 文件在 v0.7.1 时就已经是 MIT，本版修的是仓库里残留的旧描述——README 徽章、`docs/GEO*.md`、superpowers 规格的 JSON-LD、`site/package.json`、站点内容与源码里仍写着 `FSL-1.1-MIT`（附带「发布两年后转 MIT」的措辞）。现在全仓口径一致为 MIT，`LICENSE` 本身未改动。
+
+无代码行为变更。
+
+## 安装与启动
+
+一行安装落地，并支持全局 `semantix` 裸命令直接拉起 agent，工作区取当前目录（`cwd`）。
+
+## 发布链收口
+
+v0.7.1 修的是资产**产出**侧，本版收口**消费**侧：`agent-skill/scripts/install.sh` 改为消费既有资产而非另起一套命名，`release.yml` 统一走 `scripts/release/build-full.sh`。至此产出与消费两侧共用同一份资产清单。
+
+## 文档
+
+- 新增任务导向的文档中心（按「我要做什么」组织，而非按模块罗列）
+- README 精简为**双语单文件**，深度内容迁至 `docs/TECHNICAL-OVERVIEW.md` 及其中文版
+- 清理 `harness/config` 中残留的 reasonix 注释
+
+## 修复
+
+| Issue | 内容 |
+|---|---|
+| #358 | `kernel/judge`：不再删除 UTF-8 编码 C1 字节周围的正文；同版另有一次订正，改为对**已解码值**分发 |
+| #368 | `gateway`：不再透传上游 `Content-Length`，并检测响应体截断 |
+| #369 | `gateway`：L3 重放按 UTF-8 **码点边界**切块，不再切碎多字节字符 |
+| #356 | `harness/config`：legacy 目录迁移不得覆盖已存在的文件 |
+| #362 | `kernel/promote`：`fileStore.Put` 去重纳入 `SourceSliceID` |
+| #367 | `kernel/slice`：压缩阶段 base-rename 失败时恢复 journal |
+| #370 | `harness/extension`：`Close` 出错时移除已排空的 backend |
+| #371 | `harness/bot`：同步 QQ `lastSeq` 与飞书 `wsClient` |
+| #365 | `harness/config`：bot control 的 `TokenEnv` 缺省改为 `SEMANTIX_` 前缀 |
+| #363 | `harness/sessioninbox`：在空格处截断时补省略号 |
+| #364 | `harness/sessioncatalog`：`directoryLocks` 按引用计数淘汰，不再无界增长 |
+| — | `cli`：多选 `ask()` 上按数字键改为**切换**选项而非直接提交 |
+| — | `usage`：`Summarize` 限制 JSONL scanner 缓冲区上限 |
+| — | `control`：`frontendEventSink.Emit` 使用加锁时捕获的 dispatcher |
+
+## 资产
+
+每平台三件，共四平台（`darwin-arm64` / `darwin-amd64` / `linux-amd64` / `linux-arm64`）：
+
+- `semantix-agent-v0.7.2-<platform>.tar.gz` — 完整包（`semantix-agent` + `semantix` + `semantix-gateway` + 两个 example.toml + `semantix-install.sh` + README）
+- `semantix-agent-<platform>.tar.gz` — 扁平单二进制，`semantix-agent upgrade` 用
+- `semantix-v0.7.2-<platform>` — 裸 kernel 二进制，agent-skill 的 curl 安装器用
+
+外加 `SHA256SUMS` 与 `SHA256SUMS.txt`（同一份校验、两个名字：自更新器读前者，`install.sh` 读后者）。
+
+## 验证
+
+- `main` 分支 CI 全绿（Go checks / Website checks），tag 从该提交切出
+- `scripts/release/build-full.sh --version v0.7.2` **发版前本地实跑**，四平台（`darwin-amd64` / `darwin-arm64` / `linux-amd64` / `linux-arm64`）12 件资产 + 双份校验文件全部产出，脚本自检 `all asset checks passed`
+- 版本串已烙入二进制：`semantix-v0.7.2-linux-amd64` 内含 `v0.7.2`
+- `SHA256SUMS` 12 条目，与 `SHA256SUMS.txt` 逐字节一致
+- 8 个 tar 的 AppleDouble / `.DS_Store` 计数均为 0


### PR DESCRIPTION
发布 v0.7.2 的准备工作。合并后打 tag `v0.7.2`，`release.yml` 会自动构建并发布。

## 改动

- `docs/releases/v0.7.2.md` — 发版记录（照 v0.7.1 的格式）
- `README.md` — 版本徽章 `0.7.1` → `0.7.2`（第 10 行，仅此一处；`README.zh-CN.md` 重构后已无版本徽章）

## 本版范围

v0.7.1 之后 **40 个提交、10 个 PR**：

- **Issue #259 三阶段** — L3 命中阈值可配化 → 按切片类型分化 → 逐条目在线自适应（vCache 路线）
- **MIT 口径统一** — 清理仓库里残留的 `FSL-1.1-MIT` 描述
- **安装与发布链** — 一行安装 + 全局 `semantix` 裸命令；`install.sh` 与 `release.yml` 共用同一份资产清单
- **文档重构** — 任务导向文档中心；README 精简为双语单文件，深度内容迁至 `docs/TECHNICAL-OVERVIEW.md`
- **14 项修复** — 多个 UTF-8 正确性问题（C1 字节、码点边界切块）、资源泄漏（`directoryLocks` 无界增长、未移除的 drained backend）、配置迁移覆盖、gateway 响应体截断检测

## 两处写作上的纠正

写发版记录时核对出两个容易写错的点，已按事实纠正：

1. **MIT 这条不是「重新授权」。** `git show v0.7.1:LICENSE` 显示 v0.7.1 时 `LICENSE` 就已经是 MIT；本版改的是 README 徽章、`docs/GEO*.md`、`site/` 内容里仍写着 `FSL-1.1-MIT`（含「发布两年后转 MIT」措辞）的描述。`LICENSE` 文件本身未动。
2. **按 patch 号发布但含新功能。** 已在发版记录顶部标注，并说明新增配置键全部可选——不写任何一项时检索行为与 v0.7.1 完全一致，故无破坏性变更。

## 验证

发版前**本地实跑**了打包脚本，不是靠 CI 事后发现：

```
$ bash scripts/release/build-full.sh --version v0.7.2
--- verifying assets
  all asset checks passed
```

| 检查项 | 结果 |
|---|---|
| 四平台 12 件资产 + 双份校验文件 | 全部产出 |
| 版本串烙入二进制 | `semantix-v0.7.2-linux-amd64` 含 `v0.7.2` |
| `SHA256SUMS` 条目 | 12 条，与 `SHA256SUMS.txt` 逐字节一致 |
| 8 个 tar 的 AppleDouble / `.DS_Store` | 均为 0 |

也就是说这个 tag 推上去，流水线不会在打包环节炸。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgyxBqHhLZWpGDd6JK9aC2
