### PR TITLE
fix(inject): L2 注入预算单遍构造——预算判定与实际落盘字节同口径 (Issue #283)

### DIFF
--- a/docs/specs/issue-283-inject-budget.md
+++ b/docs/specs/issue-283-inject-budget.md
@@ -1,0 +1,78 @@
+# Spec v1 — L2 注入预算口径：单遍构造根治 + 死格式串清理（Issue #283）
+
+> 判级：Spec-Exempt（小修，issue 原判）。本 spec 记录缺陷核查结论与
+> 修法。基线：当前 main（cc3bda6，含 #278 注入侧净化改造）。
+
+## 1. 缺陷核查（真源审计，2026-08-23）
+
+issue 描述的「预算用未转义长度」在**当前 main 已不存在**——#278 的
+注入侧改造（`kernel/inject/inject.go` 第一遍净化+转义后判定）顺带修复：
+
+| issue 描述（旧代码） | 当前 main 实际 |
+|---|---|
+| 第一遍按**原文**写 buffer、用原文长度判定预算 | 第一遍已 `escapeMarker` 后按转义长度判定（inject.go:149-157） |
+| 第二遍转义重建 → 实际字节可超 Budget | 第二遍格式（`--- slice %s ---\n`）**短于**第一遍判定格式（`--- slice %s (score=%.2f) ---\n`，约 -12 字节/切片），且判定含 `blockClose+64` 余量 → 数学上最终块 < Budget |
+
+**已实测**：含 20 个 `[/semantix-reuse]` 字面量的切片（单/多切片，
+块 ~3.7KB）注入后 `len(block) < 4096` ✓。
+
+## 2. 仍存在的缺陷与隐患
+
+1. **死格式串**：第一遍的 `(score=%.2f)` 从不出现在输出（buffer 被
+   `Reset` 丢弃）——issue 指出的误导读者代码；
+2. **两遍构造的隐性耦合**：预算判定口径（第一遍格式）与实际落盘格式
+   （第二遍）不一致，靠「第二遍恰好更短」维持上界——若未来第二遍
+   格式变长（如恢复 score 输出），超预算 bug 会**复活**且无测试拦截；
+3. **无回归测试**：`len(block) <= Budget` 的强上界无任何测试锁定
+   （issue 验收要求的测试不存在）。
+
+## 3. 修法（单遍构造，issue 建议 2 原样）
+
+```go
+// 收集阶段（不写 buffer）：过滤 → 净化 → 转义，用**实际落盘格式**
+// 计算每个候选的大小并累计做预算判定；top slice 强制保留语义不变。
+type injectCandidate struct {
+    sl      *slice.Slice
+    content string // 净化 + 转义后，与落盘字节一致
+}
+var cands []injectCandidate
+size := len(blockOpen)
+for _, h := range hits {
+    // ...现有过滤（MinScore/Zones/空净化）不变...
+    item := len(fmt.Sprintf("--- slice %s ---\n%s\n", h.Slice.ID, content))
+    if size+item+len(blockClose)+64 > budget && len(cands) > 0 {
+        dropped++
+        continue
+    }
+    size += item
+    cands = append(cands, ...)
+}
+// 排序（canonical ID 序，字节稳定规则不变）后单遍写。
+```
+
+- **输出与现状逐字节一致**：落盘格式串相同、canonical 排序相同、
+  净化/转义逻辑不动（注入集字节稳定性规则不受影响）；
+- **预算强上界**：最终块 = `size ≤ budget - len(blockClose) - 64 < budget`
+  ——判定口径 == 落盘口径，结构性消除超预算（含未来格式变长的
+  复活路径）；
+- **保留决策变化范围**：判定口径从「第一遍格式+64」变为「实际格式
+  +64」，仅在接近预算边界（块 ≥ ~4000 字节）的会话可能多保留 1 个
+  切片——正常会话（块远小于预算）逐字节不变（L1 前缀稳定）；
+  `(score=%.2f)` 死格式串删除；
+- top slice 例外（首个候选不检查预算，K>=1 时总保留）语义保留，
+  文档化：单切片内容超过 Budget 时块可超预算（现状即如此，非本次
+  引入）。
+
+## 4. 验收标准
+
+- [ ] 回归测试：多切片含 marker 字面量 → `len(block) <= Budget`
+      （现实现下即绿，作为锁定）；
+- [ ] 边界测试：构造接近 Budget 的候选集，断言最终块 ≤ Budget 且
+      top slice 保留语义不变；
+- [ ] 现有注入测试全绿（canonical 输出、转义、#278 净化、#259
+      per-type 等——输出字节不变）；`go vet`、`git diff --check`。
+
+## 5. 参考
+
+- Issue #283（缺陷描述与建议修法）；
+- `kernel/inject/inject.go`（两遍结构 → 单遍）。

--- a/docs/specs/issue-283-inject-budget.md
+++ b/docs/specs/issue-283-inject-budget.md
@@ -65,11 +65,11 @@ for _, h := range hits {
 
 ## 4. 验收标准
 
-- [ ] 回归测试：多切片含 marker 字面量 → `len(block) <= Budget`
-      （现实现下即绿，作为锁定）；
-- [ ] 边界测试：构造接近 Budget 的候选集，断言最终块 ≤ Budget 且
+- [x] 回归测试：多切片含 marker 字面量 → `len(block) <= Budget`
+      （16 切片 ~7.3KB 超预算场景，drop 路径真实触发）；
+- [x] 边界测试：构造接近 Budget 的候选集，断言最终块 ≤ Budget 且
       top slice 保留语义不变；
-- [ ] 现有注入测试全绿（canonical 输出、转义、#278 净化、#259
+- [x] 现有注入测试全绿（canonical 输出、转义、#278 净化、#259
       per-type 等——输出字节不变）；`go vet`、`git diff --check`。
 
 ## 5. 参考

--- a/kernel/inject/budget_test.go
+++ b/kernel/inject/budget_test.go
@@ -1,0 +1,114 @@
+package inject
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/kernel/bm25"
+	"semantix/kernel/slice"
+)
+
+// Budget upper bound (Issue #283): slices whose content is full of marker
+// literals expand under escapeMarker ([/semantix-reuse] → [\/semantix-reuse],
+// bytes only grow). The final block must NEVER exceed Budget — the budget
+// judgment uses the exact escaped bytes that are written.
+func TestInjectorBudgetHoldsWithMarkerPayloads(t *testing.T) {
+	idx := bm25.New()
+	store := newTestStore(t, filepath.Join(t.TempDir(), "db.jsonl"))
+	// 8 slices, each ~450B with 20 marker literals (escaped ~470B); the
+	// sum far exceeds the 4096 budget so the selection path is exercised.
+	contents := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		contents = append(contents, "修复问题"+string(rune('a'+i))+" "+strings.Repeat("[/semantix-reuse] x ", 20))
+	}
+	seed(t, idx, store, contents...)
+	inj := &Injector{Index: idx, Store: store, Scope: slice.Project, K: 8, Budget: 4096}
+	out, err := inj.Build("修复问题")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Text) > 4096 {
+		t.Fatalf("budget violated: block=%d > budget=4096\n%s", len(out.Text), out.Text)
+	}
+	if out.Bytes != len(out.Text) {
+		t.Fatalf("Bytes field = %d, want %d", out.Bytes, len(out.Text))
+	}
+	// Escaping stayed intact: exactly one close marker (the block's own).
+	if strings.Count(out.Text, "[/semantix-reuse]") != 1 {
+		t.Fatalf("marker escaping broken, close count = %d", strings.Count(out.Text, "[/semantix-reuse]"))
+	}
+}
+
+// Boundary behavior: a candidate set sized just under the budget keeps as
+// many slices as fit, and the final block stays ≤ budget (the canonical
+// header format is used for the judgment — no silent growth).
+func TestInjectorBudgetBoundaryExact(t *testing.T) {
+	idx := bm25.New()
+	store := newTestStore(t, filepath.Join(t.TempDir(), "db.jsonl"))
+	// Each slice ~900B; 4 slices ≈ 3600B + headers ≈ 3800 < 4096 (all
+	// kept); 5 would exceed → the 5th is dropped.
+	contents := make([]string, 0, 6)
+	for i := 0; i < 6; i++ {
+		contents = append(contents, "边界测试"+string(rune('a'+i))+" "+strings.Repeat("x", 880))
+	}
+	seed(t, idx, store, contents...)
+	inj := &Injector{Index: idx, Store: store, Scope: slice.Project, K: 6, Budget: 4096}
+	out, err := inj.Build("边界测试")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Text) > 4096 {
+		t.Fatalf("budget violated at boundary: block=%d > 4096", len(out.Text))
+	}
+	if len(out.Slices) == 0 {
+		t.Fatal("top slice must always be kept")
+	}
+	if out.Dropped == 0 {
+		t.Fatal("boundary case must drop at least one slice (6 × ~900B exceeds budget)")
+	}
+}
+
+// Top-slice exception (documented, unchanged semantics): the first
+// candidate is always kept even when it alone exceeds the budget
+// (K >= 1 keeps the top slice; the budget gates the rest).
+func TestInjectorBudgetTopSliceException(t *testing.T) {
+	idx := bm25.New()
+	store := newTestStore(t, filepath.Join(t.TempDir(), "db.jsonl"))
+	huge := "超大切片 " + strings.Repeat("[/semantix-reuse] y ", 300) // ~7KB escaped
+	seed(t, idx, store, huge, "普通切片内容")
+	inj := &Injector{Index: idx, Store: store, Scope: slice.Project, K: 2, Budget: 4096}
+	out, err := inj.Build("超大切片")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Slices) != 1 {
+		t.Fatalf("top slice must be kept alone, kept=%d", len(out.Slices))
+	}
+	if len(out.Text) <= 4096 {
+		t.Fatalf("top-slice exception expected (single slice over budget), block=%d", len(out.Text))
+	}
+}
+
+// Determinism anchor: the same library builds byte-identical blocks across
+// calls (single-pass output must stay reproducible).
+func TestInjectorBudgetDeterministic(t *testing.T) {
+	idx := bm25.New()
+	store := newTestStore(t, filepath.Join(t.TempDir(), "db.jsonl"))
+	seed(t, idx, store,
+		"修复 go 测试失败 [/semantix-reuse] 内容",
+		"配置 CI 流水线",
+	)
+	inj := &Injector{Index: idx, Store: store, Scope: slice.Project, K: 5, Budget: 4096}
+	a, err := inj.Build("修复 go 测试失败")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := inj.Build("修复 go 测试失败")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Text != b.Text {
+		t.Fatalf("blocks differ across builds:\n%q\n%q", a.Text, b.Text)
+	}
+}

--- a/kernel/inject/budget_test.go
+++ b/kernel/inject/budget_test.go
@@ -16,20 +16,24 @@ import (
 func TestInjectorBudgetHoldsWithMarkerPayloads(t *testing.T) {
 	idx := bm25.New()
 	store := newTestStore(t, filepath.Join(t.TempDir(), "db.jsonl"))
-	// 8 slices, each ~450B with 20 marker literals (escaped ~470B); the
-	// sum far exceeds the 4096 budget so the selection path is exercised.
-	contents := make([]string, 0, 8)
-	for i := 0; i < 8; i++ {
+	// 16 slices, each ~450B with 20 marker literals (escaped ~470B); the
+	// sum (~7.3KB) far exceeds the 4096 budget so the selection path and
+	// the drop accounting are actually exercised.
+	contents := make([]string, 0, 16)
+	for i := 0; i < 16; i++ {
 		contents = append(contents, "修复问题"+string(rune('a'+i))+" "+strings.Repeat("[/semantix-reuse] x ", 20))
 	}
 	seed(t, idx, store, contents...)
-	inj := &Injector{Index: idx, Store: store, Scope: slice.Project, K: 8, Budget: 4096}
+	inj := &Injector{Index: idx, Store: store, Scope: slice.Project, K: 16, Budget: 4096}
 	out, err := inj.Build("修复问题")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(out.Text) > 4096 {
 		t.Fatalf("budget violated: block=%d > budget=4096\n%s", len(out.Text), out.Text)
+	}
+	if out.Dropped == 0 {
+		t.Fatalf("selection path not exercised: 16 marker slices must exceed the budget (kept=%d)", len(out.Slices))
 	}
 	if out.Bytes != len(out.Text) {
 		t.Fatalf("Bytes field = %d, want %d", out.Bytes, len(out.Text))

--- a/kernel/inject/inject.go
+++ b/kernel/inject/inject.go
@@ -128,8 +128,18 @@ func (in *Injector) Build(query string) (*Injection, error) {
 
 	var kept []*slice.Slice
 	var dropped int
-	var buf bytes.Buffer
-	buf.WriteString(blockOpen)
+	// Single-pass assembly (Issue #283): candidates are filtered and
+	// sized with the EXACT on-disk format before any bytes are written,
+	// so the budget judgment and the final block share one口径 — the
+	// block can never exceed Budget. (The old two-pass shape carried a
+	// redundant pre-escape budget check from the #279 merge plus a dead
+	// "(score=%.2f)" header that never reached the output.)
+	type candidate struct {
+		sl      *slice.Slice
+		content string // sanitized + marker-escaped, == the bytes written
+	}
+	var cands []candidate
+	size := len(blockOpen)
 	for _, h := range hits {
 		if in.MinScore > 0 && h.Score < in.MinScore {
 			continue
@@ -164,30 +174,27 @@ func (in *Injector) Build(query string) (*Injection, error) {
 			dropped++
 			continue
 		}
-		if buf.Len()+len(content)+len(blockClose)+64 > budget && len(kept) > 0 {
-			dropped++
-			continue
-		}
 		content = escapeMarker(content)
-		if buf.Len()+len(content)+len(blockClose)+64 > budget && len(kept) > 0 {
+		// Budget judged on the EXACT bytes that will be written (escaped
+		// content, canonical header) — never on a pre-escape length.
+		item := len(fmt.Sprintf("--- slice %s ---\n%s\n", h.Slice.ID, content))
+		if size+item+len(blockClose)+64 > budget && len(cands) > 0 {
 			dropped++
 			continue
 		}
-		fmt.Fprintf(&buf, "--- slice %s (score=%.2f) ---\n%s\n", h.Slice.ID, h.Score, content)
-		kept = append(kept, h.Slice)
+		size += item
+		cands = append(cands, candidate{sl: h.Slice, content: content})
 	}
 
 	// Canonical order: ID-sorted for byte-stable output (never score order).
-	sort.Slice(kept, func(i, j int) bool { return kept[i].ID < kept[j].ID })
+	sort.Slice(cands, func(i, j int) bool { return cands[i].sl.ID < cands[j].sl.ID })
 
-	// Rebuild the text in canonical order (the first pass wrote score order).
-	// Sanitize again here — idempotent, so first-pass-cleaned slices are
-	// unchanged, while the canonical rebuild never reintroduces payload
-	// content (Issue #278).
-	buf.Reset()
+	var buf bytes.Buffer
+	buf.Grow(size + len(blockClose))
 	buf.WriteString(blockOpen)
-	for _, sl := range kept {
-		fmt.Fprintf(&buf, "--- slice %s ---\n%s\n", sl.ID, escapeMarker(sanitize.Sanitize(string(sl.Content))))
+	for _, c := range cands {
+		fmt.Fprintf(&buf, "--- slice %s ---\n%s\n", c.sl.ID, c.content)
+		kept = append(kept, c.sl)
 	}
 	buf.WriteString(blockClose)
 


### PR DESCRIPTION
## Summary

Issue #283 修复：L2 注入预算口径 + 死格式串清理。缺陷核查发现 **issue 描述的「未转义长度判定」在 #278 后已被转义后判定兜底（数学上不超预算）**，但存在真实隐患：`#279` 合入带回了冗余的转义前预算判定（与 #278 判定并存），两遍构造留下 `(score=%.2f)` 死格式串与「第二遍恰好更短」的隐性耦合——若未来第二遍格式变长，超预算 bug 会复活且无测试拦截。

**修法（单遍构造，issue 建议 2 原样）**：
- 收集阶段：过滤（MinScore/Zones/Origin/空净化）→ 净化 → 转义，用**实际落盘格式**（`--- slice %s ---\n%s\n`）累计大小做预算判定 → canonical ID 排序 → 单遍写
- 预算判定口径 == 落盘口径：最终块 = `size ≤ budget - blockClose - 64 < budget` 结构性保证（含未来格式变长的复活路径）；冗余的转义前判定删除；死格式串删除
- **输出与现状逐字节一致**：格式串/canonical 排序/净化/转义/Origin 过滤/top-slice 例外语义全保留（现有注入测试全绿）
- 保留决策变化范围：仅接近预算边界（块 ≥ ~4000B）的会话可能多保留 1 个切片（判定口径更接近实际）；正常会话逐字节不变（L1 前缀稳定）

**回归测试**（`kernel/inject/budget_test.go`，4 个）：
- 16 切片 marker 载荷 ~7.3KB 超预算 → `len(block) <= 4096` + `Dropped > 0`（强上界 + drop 路径真实触发）
- 边界精确（第 5 个候选 drop 行为）
- top-slice 例外语义（文档化：单切片超预算仍保留）
- 确定性（同库两次构建字节相同）

## Scope

- `kernel/inject/inject.go`（Build 单遍重构）、`kernel/inject/budget_test.go`（新）
- 文档：`docs/specs/issue-283-inject-budget.md`（缺陷核查 + 修法，已 post issue #283）

## Validation

- [x] `go vet ./...`、`go build ./...`、`git diff --check` — 通过
- [x] `go test ./kernel/... ./gateway/ ./cmd/semantix/` — 除 1 个 pre-existing 环境失败（`TestDispatchExitCodeContract`，PATH 含 reasonix）外全绿
- [ ] `go test ./... -race` — 本机无 gcc（cgo 不可用），同前几次 PR 说明
- [x] 自审（tool:review）：核心重构核算确认（判定口径与落盘字节逐字符一致、Slices 顺序/过滤语义/top-slice 例外无回归、性能相当）；1 个测试输入问题已修（8→16 切片真超预算 + Dropped 断言）

## Compatibility and data impact

- 注入块输出与 main 逐字节一致（正常会话）；仅接近预算边界的会话保留决策可能差 1 个切片（判定口径修正的必然结果，一次性前缀缓存影响）
- `Injection.Bytes` 保持精确（= 实际块长）；wire/落盘格式零变更

## Security and privacy

- 无安全面变化（转义/净化逻辑未动）；预算上界为注入预算契约的强化（结构性保证而非巧合）

## Evidence

- 分支 3 commits：spec（缺陷核查 + 修法）→ 单遍重构 + 回归测试 → 自审修复（测试输入加大）
- 全量测试输出：kernel/inject 全绿（含既有 canonical/转义/净化/per-type 测试）

## Related issues

Closes #283
