### PR TITLE
test(harness): close lookup subprocess timeout coverage gap

### DIFF
--- a/docs/specs/issue-296-lookup-subprocess-timeout.md
+++ b/docs/specs/issue-296-lookup-subprocess-timeout.md
@@ -1,0 +1,63 @@
+# Issue #296: deterministic `semantix_lookup` subprocess tests
+
+## Status
+
+Accepted for implementation.
+
+## Problem
+
+`TestSemantixLookupSubprocess` verifies the command-line arguments passed to a
+fake `semantix` executable. Production lookups intentionally use a three-second
+deadline and fail soft by returning an empty result. Under a repository-wide
+`go test ./... -race` run, scheduler and process-start contention can consume
+that deadline before the fake executable writes its output. The test then sees
+an empty string and reports an argv mismatch even though argv construction is
+correct.
+
+The production deadline and fail-soft behavior are user-facing resilience
+contracts and must not be relaxed to accommodate a test.
+
+## Root cause
+
+One deadline previously served two unrelated concerns:
+
+1. production availability bounds for an external kernel process; and
+2. a test that observes argv construction rather than latency.
+
+When the production deadline expires, `Execute` deliberately erases the
+subprocess error. Consequently, the argv test cannot distinguish scheduling
+contention from incorrect argv.
+
+## Requirements
+
+1. A zero-value `semantixLookup` keeps the three-second production deadline.
+2. Tests may inject a deadline on an individual `semantixLookup` value without
+   mutating package-global state.
+3. `TestSemantixLookupSubprocess` uses a one-minute deadline and continues to
+   assert the exact query and limit argv.
+4. A dedicated regression test proves that an injected expired deadline still
+   returns an empty result and no error.
+5. The test suite remains portable across Unix shell scripts and Windows batch
+   shims.
+6. No public API or production configuration is added.
+
+## Design
+
+`semantixLookup` owns an unexported `timeout time.Duration` field. `Execute`
+uses that value when positive and otherwise selects the three-second default.
+The argv test constructs a value with a one-minute timeout; production
+registration continues to use the zero value. A timeout regression test uses
+an already-expired duration and a fake executable, then checks the fail-soft
+contract directly.
+
+Instance-local injection avoids data races that a mutable package variable
+would introduce during parallel or race-enabled tests.
+
+## Acceptance criteria
+
+- `go test ./harness/tool -run 'TestSemantixLookup(Subprocess|TimeoutFailsSoft)$' -count=20` passes.
+- `go test -race ./harness/tool -run 'TestSemantixLookup(Subprocess|TimeoutFailsSoft)$' -count=20` passes on a race-capable host.
+- `go test ./...` passes.
+- Production code still defaults to a three-second subprocess timeout and
+  returns `"", nil` for process failures and deadline expiry.
+

--- a/docs/specs/issue-296-lookup-subprocess-timeout.md
+++ b/docs/specs/issue-296-lookup-subprocess-timeout.md
@@ -60,4 +60,3 @@ would introduce during parallel or race-enabled tests.
 - `go test ./...` passes.
 - Production code still defaults to a three-second subprocess timeout and
   returns `"", nil` for process failures and deadline expiry.
-

--- a/docs/superpowers/plans/2026-08-23-issue-296-lookup-subprocess-timeout.md
+++ b/docs/superpowers/plans/2026-08-23-issue-296-lookup-subprocess-timeout.md
@@ -97,4 +97,3 @@ gh pr create --repo Gnosil/semantix --base main --head Allenllii:codex/issue-296
 
 The PR body must include `Closes #296`, the root cause, the preserved
 production behavior, and exact verification commands.
-

--- a/docs/superpowers/plans/2026-08-23-issue-296-lookup-subprocess-timeout.md
+++ b/docs/superpowers/plans/2026-08-23-issue-296-lookup-subprocess-timeout.md
@@ -1,0 +1,100 @@
+# Issue #296 Lookup Subprocess Timeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the argv subprocess test independent of the production timeout while preserving and directly testing fail-soft timeout behavior.
+
+**Architecture:** Keep timeout injection instance-local on `semantixLookup`; its zero value retains the production default. Add a focused regression test that forces deadline expiry through the real subprocess boundary and observes the existing soft-degrade result.
+
+**Tech Stack:** Go, `testing`, `os/exec`, race detector
+
+**Spec:** `docs/specs/issue-296-lookup-subprocess-timeout.md`
+
+## Global Constraints
+
+- The zero-value production timeout remains exactly three seconds.
+- Timeout injection is unexported and instance-local; no mutable package global is allowed.
+- Subprocess failures and deadline expiry continue to return `"", nil`.
+- Tests support Unix and Windows command shims.
+
+---
+
+### Task 1: Timeout fail-soft regression
+
+**Files:**
+- Modify: `harness/tool/semantix_test.go`
+
+**Interfaces:**
+- Consumes: `semantixLookup{timeout time.Duration}.Execute(context.Context, json.RawMessage) (string, error)`
+- Produces: `TestSemantixLookupTimeoutFailsSoft`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a fake executable with the existing platform-specific script convention,
+execute `semantixLookup{timeout: time.Nanosecond}`, and require `out == ""` and
+`err == nil`. Before the production branch is correct, the test must fail by
+returning the fake executable's argv output.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./harness/tool -run '^TestSemantixLookupTimeoutFailsSoft$' -count=1`
+
+Expected: FAIL because the temporary red-phase assertion expects a non-empty
+result while deadline expiry produces an empty result.
+
+- [ ] **Step 3: Complete the regression assertion**
+
+Replace the temporary red-phase assertion with explicit checks that execution
+returns no error and empty output. Keep setup local to the test and use no
+mutable shared state.
+
+- [ ] **Step 4: Run focused verification**
+
+Run: `go test ./harness/tool -run 'TestSemantixLookup(Subprocess|TimeoutFailsSoft)$' -count=20`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add harness/tool/semantix_test.go
+git commit -m "test(harness): cover lookup timeout soft degradation"
+```
+
+### Task 2: Repository verification and issue linkage
+
+**Files:**
+- Modify: `docs/specs/issue-296-lookup-subprocess-timeout.md` only if observed commands require acceptance-result corrections
+
+**Interfaces:**
+- Consumes: the regression tests from Task 1
+- Produces: passing package and repository verification plus a PR that closes issue #296
+
+- [ ] **Step 1: Run race-focused repetitions**
+
+Run: `go test -race ./harness/tool -run 'TestSemantixLookup(Subprocess|TimeoutFailsSoft)$' -count=20`
+
+Expected: PASS on a race-capable host.
+
+- [ ] **Step 2: Run the repository suite**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 3: Review the branch**
+
+Run: `git diff upstream/main...HEAD --check` and `git status --short`.
+
+Expected: no whitespace errors and a clean worktree.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin codex/issue-296-lookup-subprocess-timeout
+gh pr create --repo Gnosil/semantix --base main --head Allenllii:codex/issue-296-lookup-subprocess-timeout --title "test(harness): close lookup subprocess timeout coverage gap" --body-file PR_BODY.md
+```
+
+The PR body must include `Closes #296`, the root cause, the preserved
+production behavior, and exact verification commands.
+

--- a/harness/tool/semantix_test.go
+++ b/harness/tool/semantix_test.go
@@ -83,3 +83,28 @@ func TestSemantixLookupSubprocess(t *testing.T) {
 		t.Errorf("argv mismatch:\n got %q\nwant %q", out, want+"\n")
 	}
 }
+
+// TestSemantixLookupTimeoutFailsSoft locks in the production resilience
+// contract independently of the argv test's deliberately widened budget.
+func TestSemantixLookupTimeoutFailsSoft(t *testing.T) {
+	bin := t.TempDir()
+	scriptName := "semantix"
+	scriptBody := "#!/bin/sh\necho unexpected\n"
+	if runtime.GOOS == "windows" {
+		scriptName = "semantix.bat"
+		scriptBody = "@echo off\r\necho unexpected\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(bin, scriptName), []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := (semantixLookup{timeout: time.Nanosecond}).Execute(context.Background(),
+		json.RawMessage(`{"query":"deadline"}`))
+	if err != nil {
+		t.Fatalf("timeout must fail soft, got error: %v", err)
+	}
+	if out != "" {
+		t.Fatalf("timeout must fail soft with empty output, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

- documents the root cause and accepted design for the race-enabled full-suite timeout
- adds `TestSemantixLookupTimeoutFailsSoft` so the injected deadline contract is covered separately from argv construction
- keeps the existing one-minute argv-test budget, instance-local timeout injection, zero-value three-second production default, and fail-soft behavior

The implementation-side timeout injection landed previously in #314; this PR closes the remaining specification and direct regression-coverage gap.

## Scope

- `harness/tool/semantix_test.go`
- `docs/specs/issue-296-lookup-subprocess-timeout.md`
- `docs/superpowers/plans/2026-08-23-issue-296-lookup-subprocess-timeout.md`

## Validation

- [x] `go vet ./harness/tool`
- [ ] `go test ./... -race` — local Windows Go has CGO disabled (`-race requires cgo`)
- [x] `git diff upstream/main...HEAD --check`
- [x] `go test ./harness/tool -run 'TestSemantixLookup(Subprocess|TimeoutFailsSoft)$' -count=20`
- [x] `go test ./harness/tool`

Repository-wide `go test ./...` also exposed unrelated existing failures in `cmd/semantix` (`TestDispatchExitCodeContract`) and `harness/acp` (`TestSessionParamsCarryClientIOFromInitializeCaps`); the affected package is green.

## Compatibility and data impact

None. No public API, CLI, configuration, persisted data, or production timeout changes.

## Security and privacy

None.

## Evidence

The new regression was observed failing before its nanosecond timeout input was applied (`got "unexpected\\r\\n"`) and passing afterward for 20 repetitions alongside the argv test.

## Related issues

Closes #296

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md` (not applicable; no wire changes).