### PR TITLE
fix(evolve): isolate speculative probe feedback

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -40,8 +40,8 @@
 | `SliceHit` | 5 | 语义缓存命中（L1 字节 / L2 语义注入 / L3 结果复用） | `layer`("L1"\|"L2"\|"L3"), `slice_ids`, `scores`(omitempty) | kernel 缓存层 |
 | `SliceInject` | 6 | L2 稳定切片注入（按规范序） | `slice_ids`(canonical order), `bytes` | kernel 注入器 |
 | `SliceReject` | 7 | 注入污染被拒绝（用户编辑/回滚） | `slice_id`, `reason`(omitempty) | kernel 验证层 |
-| `PrefetchHit` | 8 | 投机预取被使用 | `targets`, `lead_ms`(omitempty，消费−预热完成 ms，正=赶趟，#272) | kernel 预取器 |
-| `PrefetchWaste` | 9 | 投机预取未被使用 | `targets`, `lead_ms`(omitempty，存活时长 ms，#272) | kernel 预取器 |
+| `PrefetchHit` | 8 | 投机预取被使用 | `targets`, `lead_ms`(omitempty，消费−预热完成 ms，正=赶趟，#272), `probe_targets`(omitempty，仅探索候选，#302) | kernel 预取器 |
+| `PrefetchWaste` | 9 | 投机预取未被使用 | `targets`, `lead_ms`(omitempty，存活时长 ms，#272), `probe_targets`(omitempty，仅探索候选，#302) | kernel 预取器 |
 | `Compact` | 10 | 上下文压缩（snip/prune/summary）或库级淘汰（evict） | `trigger`("snip"\|"prune"\|"summary"\|"evict"), `before_tokens`, `after_tokens`, `evicted_by_type`(仅 evict) | harness 压缩器 / gateway 启动淘汰 |
 | `EvolutionTick` | 11 | 进化参数快照更新 | `params`(raw JSON) | kernel 进化引擎 |
 
@@ -50,6 +50,8 @@
 - `Compact` 的 `evict` trigger 由 gateway 启动淘汰发射（库级，sessionID 固定为
   `maintenance`，非会话事件）：`before_tokens`/`after_tokens` 此时携带**切片
   条目数**（字段名保持 wire 稳定），`evicted_by_type` 按类型 wire 名统计
+- `PrefetchHit` / `PrefetchWaste` 的 `probe_targets` 非空时，结果仍计入事件、
+  成本与局部命中/浪费反馈，但不驱动全局 evolve `PrefetchConf`（#302）。
   （result/tool_pattern/memory/prompt/context；Issue #277）。当前零消费者。
 - `ToolResult.latency_ns` 为纳秒（Go `time.Duration` 的 wire 编码）。
 - `SliceInject.SliceIDs` 必须保持规范序（确定性注入，见架构设计 §4.2）。

--- a/docs/events.md
+++ b/docs/events.md
@@ -50,9 +50,10 @@
 - `Compact` 的 `evict` trigger 由 gateway 启动淘汰发射（库级，sessionID 固定为
   `maintenance`，非会话事件）：`before_tokens`/`after_tokens` 此时携带**切片
   条目数**（字段名保持 wire 稳定），`evicted_by_type` 按类型 wire 名统计
-- `PrefetchHit` / `PrefetchWaste` 的 `probe_targets` 非空时，结果仍计入事件、
-  成本与局部命中/浪费反馈，但不驱动全局 evolve `PrefetchConf`（#302）。
   （result/tool_pattern/memory/prompt/context；Issue #277）。当前零消费者。
+- `PrefetchHit` / `PrefetchWaste` 的 `probe_targets` 非空时，结果仍计入事件、
+  成本与这些 probe key 的局部命中/浪费反馈，但不驱动全局 evolve
+  `PrefetchConf`（#302）。
 - `ToolResult.latency_ns` 为纳秒（Go `time.Duration` 的 wire 编码）。
 - `SliceInject.SliceIDs` 必须保持规范序（确定性注入，见架构设计 §4.2）。
 

--- a/docs/specs/issue-302-probe-evolve-isolation.md
+++ b/docs/specs/issue-302-probe-evolve-isolation.md
@@ -1,0 +1,113 @@
+# Issue #302: isolate probe cost from global evolution
+
+## Status
+
+Accepted for implementation.
+
+## Problem
+
+Epsilon escape (#254) and demotion probation (#282) deliberately execute
+low-confidence work. Their expected early outcome is therefore waste. Today a
+probe is indistinguishable from an ordinary `PrefetchTask`, and its terminal
+`PrefetchWaste` event enters the same `prefetch_waste` signal path as genuine
+prefetch exploitation. The evolution engine interprets exploration cost as
+evidence that the global prefetch confidence floor should rise, so one key's
+recovery experiment tightens every candidate's gate.
+
+Probe cost remains real usage and must remain observable. Only its influence on
+the global `PrefetchConf` control loop is incorrect.
+
+## Root cause
+
+Probe intent is lost at each boundary:
+
+1. `MatrixPrefetcher.Plan` returns an ordinary `PrefetchTask`.
+2. the prefetch-to-scheduler adapter reduces every task to an undifferentiated
+   key;
+3. the agent records a warmed result without the plan's probe identity;
+4. `PrefetchHitPayload` and `PrefetchWastePayload` expose only result targets;
+5. `EvolutionLoop.observe` always calls both per-key feedback and global
+   `RecordSignal`.
+
+The defect is exploration/exploitation accounting, not a bad evolution step
+size. Changing global evolve coefficients would merely hide the coupling.
+
+## Requirements
+
+1. `PrefetchTask` gains additive `Probe bool` metadata. Both Epsilon escape and
+   probation tasks set it; ordinary candidates leave it false.
+2. Probe keys survive the prefetch adapter, scheduler round plan, agent gate,
+   warmed-result settlement, bridge, and kernel event payload.
+3. `PrefetchHitPayload` and `PrefetchWastePayload` gain additive
+   `probe_targets,omitempty`; old payloads remain valid and retain existing
+   behavior.
+4. Probe hit/waste events continue to update the prefetcher's local per-key
+   feedback path and remain in usage/event reporting.
+5. Probe hit/waste events do not call the global evolve engine's
+   `RecordSignal`, do not change `PrefetchConf`, and do not emit an
+   `EvolutionTick` solely because of that outcome.
+6. Ordinary hit/waste events continue to drive global evolution unchanged.
+7. Budget suppression clears both planned IDs and probe IDs so stale probe
+   metadata cannot leak into a blocked warm-up.
+8. Wire changes are documented in `docs/events.md`.
+
+## Design
+
+### Planning metadata
+
+`PrefetchTask.Probe` identifies work admitted only to explore an otherwise
+excluded candidate. `AsLoadAwarePlanFunc` returns all task keys as `IDs` and
+the subset with `Probe=true` as `ProbeIDs`. `RuleDecider` copies the subset to
+`RoundPlan.PrefetchProbeIDs`.
+
+The legacy `PrefetchPlanFunc` remains unchanged: it cannot express probe
+metadata and therefore produces no probe IDs.
+
+### Agent and event propagation
+
+The agent's per-turn prefetch gate stores a defensive copy of planned probe
+keys. When a warm result is created, those keys are copied to the result and
+then to `Bridge.RecordPrefetch`. The bridge emits them as canonical,
+deduplicated `probe_targets` on the existing terminal hit/waste event. This is
+an additive payload field; event kinds and numeric IDs do not change.
+
+`probe_targets` describes which scheduler candidates made the warm speculative.
+It is intentionally separate from `targets`, which continues to describe the
+canonical injected slice identities.
+
+### Evolution accounting
+
+`EvolutionLoop.observe` always performs existing local `ObserveHit` or
+`ObserveWaste` feedback for event `targets`. When `probe_targets` is non-empty,
+it returns immediately after local feedback. Thus exploration remains capable
+of recovering/demoting local keys and remains visible as cost, but cannot
+change the global engine snapshot.
+
+An event without `probe_targets` follows the existing exploitation path,
+including `RecordSignal`, tuner application, and `EvolutionTick` emission.
+
+## Compatibility
+
+- Go struct fields are additive.
+- JSON `probe_targets` is omitted for ordinary events, so existing serialized
+  payloads are byte-shape compatible.
+- Consumers that do not know the field continue to decode payloads normally.
+- No configuration defaults, evolve coefficients, or event kind numbers
+  change.
+
+## Acceptance criteria
+
+- Epsilon and probation planner tests assert `Probe=true`; ordinary candidates
+  assert `Probe=false`.
+- Adapter and scheduler tests prove probe IDs survive and budget suppression
+  clears them.
+- Agent/bridge tests prove `probe_targets` reaches hit/waste payloads.
+- Evolution tests prove repeated probe waste leaves `PrefetchConf` unchanged,
+  emits no tick, and still invokes local waste feedback.
+- The paired ordinary-waste test proves `PrefetchConf` still rises and emits a
+  tick.
+- `go test ./kernel/prefetch ./kernel/sched ./harness/agent ./harness/semantix`
+  passes.
+- `go test ./...` and race-enabled affected-package tests pass where the host
+  toolchain supports the race detector.
+

--- a/docs/specs/issue-302-probe-evolve-isolation.md
+++ b/docs/specs/issue-302-probe-evolve-isolation.md
@@ -77,11 +77,12 @@ canonical injected slice identities.
 
 ### Evolution accounting
 
-`EvolutionLoop.observe` always performs existing local `ObserveHit` or
-`ObserveWaste` feedback for event `targets`. When `probe_targets` is non-empty,
-it returns immediately after local feedback. Thus exploration remains capable
-of recovering/demoting local keys and remains visible as cost, but cannot
-change the global engine snapshot.
+`EvolutionLoop.observe` performs local `ObserveHit` or `ObserveWaste` feedback
+for ordinary event `targets`. When `probe_targets` is non-empty, that explicit
+candidate subset becomes the local feedback input and the loop returns
+immediately afterward. Thus exploration remains capable of recovering or
+retaining demotion for the keys actually probed and remains visible as cost,
+but cannot change the global engine snapshot.
 
 An event without `probe_targets` follows the existing exploitation path,
 including `RecordSignal`, tuner application, and `EvolutionTick` emission.
@@ -110,4 +111,3 @@ including `RecordSignal`, tuner application, and `EvolutionTick` emission.
   passes.
 - `go test ./...` and race-enabled affected-package tests pass where the host
   toolchain supports the race detector.
-

--- a/docs/superpowers/plans/2026-08-23-issue-302-probe-evolve-isolation.md
+++ b/docs/superpowers/plans/2026-08-23-issue-302-probe-evolve-isolation.md
@@ -188,4 +188,3 @@ Run `git diff upstream/main...HEAD --check`, push
 `codex/issue-302-probe-evolve-isolation` to `origin`, and create a PR against
 `Gnosil/semantix:main` whose body contains `Closes #302` and exact validation
 results.
-

--- a/docs/superpowers/plans/2026-08-23-issue-302-probe-evolve-isolation.md
+++ b/docs/superpowers/plans/2026-08-23-issue-302-probe-evolve-isolation.md
@@ -1,0 +1,191 @@
+# Issue #302 Probe Evolution Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve probe cost and local learning while preventing Epsilon/probation outcomes from changing the global prefetch confidence control.
+
+**Architecture:** Carry additive probe metadata from `PrefetchTask` through scheduler and agent settlement into existing prefetch events. Split `EvolutionLoop.observe` after local feedback: probe outcomes return before global `RecordSignal`, while ordinary outcomes retain the current path.
+
+**Tech Stack:** Go, kernel event JSON contracts, synchronous event bus, Go testing/race detector
+
+**Spec:** `docs/specs/issue-302-probe-evolve-isolation.md`
+
+## Global Constraints
+
+- Existing event kind numbers and production evolve coefficients do not change.
+- `probe_targets` is additive and omitted for ordinary events.
+- Probe outcomes still update local per-key feedback and cost/event reporting.
+- Only probe outcomes bypass global `RecordSignal`.
+- Legacy prefetch planner callbacks remain source compatible.
+
+---
+
+### Task 1: Mark and transport probe plans
+
+**Files:**
+- Modify: `kernel/prefetch/prefetch.go`
+- Modify: `kernel/prefetch/matrix.go`
+- Modify: `kernel/prefetch/escape_test.go`
+- Modify: `kernel/prefetch/probation_test.go`
+- Modify: `kernel/prefetch/planfunc.go`
+- Modify: `kernel/prefetch/planfunc_test.go`
+- Modify: `kernel/sched/sched.go`
+- Modify: `kernel/sched/rule_decider.go`
+- Modify: `kernel/sched/rule_decider_test.go`
+
+**Interfaces:**
+- Produces: `PrefetchTask.Probe bool`, `sched.PrefetchPlanResult.ProbeIDs []string`, `sched.RoundPlan.PrefetchProbeIDs []string`
+- Consumes: existing `PrefetchTask.Key` and load-aware planning callbacks
+
+- [ ] **Step 1: Add failing planner and adapter assertions**
+
+Assert Epsilon/probation tasks have `Probe=true`, healthy tasks remain false,
+and `AsLoadAwarePlanFunc` returns the probe subset separately.
+
+- [ ] **Step 2: Run focused tests and confirm RED**
+
+Run: `go test ./kernel/prefetch ./kernel/sched`
+
+Expected: compile failures for missing `Probe`, `ProbeIDs`, and
+`PrefetchProbeIDs` fields.
+
+- [ ] **Step 3: Implement minimal additive metadata flow**
+
+Add the three fields, mark both probe construction sites, collect probe keys in
+the adapter, copy them in `RuleDecider`, and clear them with budget suppression.
+
+- [ ] **Step 4: Run focused tests and confirm GREEN**
+
+Run: `go test ./kernel/prefetch ./kernel/sched`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kernel/prefetch kernel/sched
+git commit -m "feat(prefetch): preserve probe identity in round plans"
+```
+
+### Task 2: Emit additive probe targets
+
+**Files:**
+- Modify: `kernel/event/event.go`
+- Modify: `harness/agent/prefetch_feedback.go`
+- Modify: `harness/agent/prefetch_feedback_test.go`
+- Modify: `harness/agent/execute_batch.go`
+- Modify: `harness/agent/agent.go`
+- Modify: `harness/semantix/bridge.go`
+- Modify: `harness/semantix/closed_loop_test.go`
+- Modify: `docs/events.md`
+
+**Interfaces:**
+- Consumes: `sched.RoundPlan.PrefetchProbeIDs`
+- Produces: `PrefetchHitPayload.ProbeTargets`, `PrefetchWastePayload.ProbeTargets`, and `Bridge.RecordPrefetch(..., probeTargets []string)`
+
+- [ ] **Step 1: Add failing event-propagation tests**
+
+Arm an agent with probe IDs, settle both hit and waste results, decode the
+events, and assert canonical `probe_targets`. Assert ordinary payload JSON omits
+the field.
+
+- [ ] **Step 2: Run focused tests and confirm RED**
+
+Run: `go test ./harness/agent ./harness/semantix`
+
+Expected: compile failures for missing payload fields and updated agent method.
+
+- [ ] **Step 3: Implement the propagation path**
+
+Store defensive probe-ID copies in the gate and warmed result, pass them to the
+bridge, canonicalize/deduplicate them, and populate the additive event fields.
+Document `probe_targets` in `docs/events.md`.
+
+- [ ] **Step 4: Run focused tests and confirm GREEN**
+
+Run: `go test ./harness/agent ./harness/semantix`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kernel/event harness/agent harness/semantix docs/events.md
+git commit -m "feat(events): carry speculative probe targets"
+```
+
+### Task 3: Split local and global feedback accounting
+
+**Files:**
+- Modify: `harness/semantix/evolution.go`
+- Modify: `harness/semantix/evolution_test.go`
+
+**Interfaces:**
+- Consumes: `PrefetchHitPayload.ProbeTargets` and `PrefetchWastePayload.ProbeTargets`
+- Produces: probe-local feedback without global evolve signal
+
+- [ ] **Step 1: Add the failing causal regression**
+
+Emit enough probe-waste events to move `PrefetchConf` under the old path. Assert
+the parameter remains at its initial value, no tuner/tick fires, and a capture
+prefetcher still receives `ObserveWaste`. Pair it with ordinary waste that must
+still move the parameter.
+
+- [ ] **Step 2: Run focused test and confirm RED**
+
+Run: `go test ./harness/semantix -run 'TestEvolutionLoop(ProbeWasteIsLocalOnly|RealWasteStillEvolves)$' -count=1`
+
+Expected: probe test FAIL because `PrefetchConf` changes or a tick is emitted.
+
+- [ ] **Step 3: Return before global signal for probes**
+
+Decode `probe_targets`, retain existing local feedback, and return immediately
+after it when the probe subset is non-empty.
+
+- [ ] **Step 4: Run affected verification**
+
+Run: `go test ./kernel/prefetch ./kernel/sched ./harness/agent ./harness/semantix`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add harness/semantix/evolution.go harness/semantix/evolution_test.go
+git commit -m "fix(evolve): keep probe outcomes out of global confidence"
+```
+
+### Task 4: Repository verification and PR
+
+**Files:**
+- No production files added.
+
+**Interfaces:**
+- Consumes: completed Tasks 1–3
+- Produces: verified branch and PR closing #302
+
+- [ ] **Step 1: Run formatting and static checks**
+
+Run: `gofmt -w <changed Go files>` and `go vet ./kernel/prefetch ./kernel/sched ./harness/agent ./harness/semantix`
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run affected and repository tests**
+
+Run: `go test ./kernel/prefetch ./kernel/sched ./harness/agent ./harness/semantix` and `go test ./...`
+
+Expected: PASS, with any unrelated baseline failures reported exactly.
+
+- [ ] **Step 3: Run race tests where supported**
+
+Run: `go test -race ./kernel/prefetch ./kernel/sched ./harness/agent ./harness/semantix`
+
+Expected: PASS on a CGO/race-capable host.
+
+- [ ] **Step 4: Review, push, and create PR**
+
+Run `git diff upstream/main...HEAD --check`, push
+`codex/issue-302-probe-evolve-isolation` to `origin`, and create a PR against
+`Gnosil/semantix:main` whose body contains `Closes #302` and exact validation
+results.
+

--- a/harness/agent/agent.go
+++ b/harness/agent/agent.go
@@ -2961,6 +2961,7 @@ func (a *Agent) startInjectWarm(ctx context.Context) {
 	if input == "" {
 		return
 	}
+	probeTargets := a.prefetchProbeTargets()
 	go func() {
 		// Detach from the stream context so cancellation of the current
 		// request does not cancel the warm-up; Inject applies its own 3s cap.
@@ -2974,7 +2975,7 @@ func (a *Agent) startInjectWarm(ctx context.Context) {
 			a.prefetchTaskMS.Store(elapsed)
 		}()
 		if result := a.semantix.InjectDetailed(warmCtx, input); result.Text != "" {
-			a.storePrefetch(&prefetchedInjectResult{Text: result.Text, Targets: result.Targets, Turn: a.semantixTurn.Load(), WarmAt: time.Now()})
+			a.storePrefetch(&prefetchedInjectResult{Text: result.Text, Targets: result.Targets, Turn: a.semantixTurn.Load(), WarmAt: time.Now(), ProbeTargets: probeTargets})
 		}
 	}()
 }

--- a/harness/agent/execute_batch.go
+++ b/harness/agent/execute_batch.go
@@ -104,7 +104,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 	// replaces the static partitionToolCalls grouping below; when no
 	// scheduler is wired (nil), the static grouping is used unchanged.
 	plan := a.decideRound(ctx, turn, calls)
-	a.armPrefetch(plan.PrefetchReason)
+	a.armPrefetch(plan.PrefetchReason, plan.PrefetchProbeIDs)
 	suspended := suspendedToolSet(plan.SuspendTools)
 	// U41 C3 hard_stop (kernel path): a plan-issued hard_stop blocks every
 	// call in this round before any tool runs. Outcomes stay paired with the

--- a/harness/agent/prefetch_feedback.go
+++ b/harness/agent/prefetch_feedback.go
@@ -3,9 +3,10 @@ package agent
 import "time"
 
 type prefetchGateDecision struct {
-	Turn   int64
-	Allow  bool
-	Reason string
+	Turn         int64
+	Allow        bool
+	Reason       string
+	ProbeTargets []string
 }
 
 type prefetchedInjectResult struct {
@@ -17,9 +18,12 @@ type prefetchedInjectResult struct {
 	// (Issue #272). Zero value means the producer did not stamp it and the
 	// lead is reported as 0.
 	WarmAt time.Time
+	// ProbeTargets carries the scheduler candidates admitted for exploration.
+	// Targets above remain the canonical injected slice identities.
+	ProbeTargets []string
 }
 
-func (a *Agent) armPrefetch(reason string) {
+func (a *Agent) armPrefetch(reason string, probeTargets []string) {
 	if a == nil || reason == "" {
 		if a != nil {
 			a.prefetchGate.Store(nil)
@@ -32,9 +36,10 @@ func (a *Agent) armPrefetch(reason string) {
 		allow = false
 	}
 	a.prefetchGate.Store(&prefetchGateDecision{
-		Turn:   a.semantixTurn.Load(),
-		Allow:  allow,
-		Reason: reason,
+		Turn:         a.semantixTurn.Load(),
+		Allow:        allow,
+		Reason:       reason,
+		ProbeTargets: append([]string(nil), probeTargets...),
 	})
 }
 
@@ -44,6 +49,17 @@ func (a *Agent) prefetchAllowed() bool {
 	}
 	decision := a.prefetchGate.Load()
 	return decision == nil || decision.Turn != a.semantixTurn.Load() || decision.Allow
+}
+
+func (a *Agent) prefetchProbeTargets() []string {
+	if a == nil {
+		return nil
+	}
+	decision := a.prefetchGate.Load()
+	if decision == nil || decision.Turn != a.semantixTurn.Load() || !decision.Allow {
+		return nil
+	}
+	return append([]string(nil), decision.ProbeTargets...)
 }
 
 func (a *Agent) storePrefetch(next *prefetchedInjectResult) {
@@ -80,6 +96,6 @@ func (a *Agent) recordPrefetch(hit bool, got *prefetchedInjectResult) {
 		if !got.WarmAt.IsZero() {
 			lead = time.Since(got.WarmAt)
 		}
-		a.semantix.RecordPrefetch(hit, got.Targets, int(got.Turn), lead)
+		a.semantix.RecordPrefetch(hit, got.Targets, got.ProbeTargets, int(got.Turn), lead)
 	}
 }

--- a/harness/agent/prefetch_feedback_test.go
+++ b/harness/agent/prefetch_feedback_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
@@ -75,18 +76,18 @@ func TestPrefetchGateControlsWarmWithoutCreatingFeedback(t *testing.T) {
 	if !a.prefetchAllowed() {
 		t.Fatal("cold start must preserve legacy allow behavior")
 	}
-	a.armPrefetch("load_saturated")
+	a.armPrefetch("load_saturated", nil)
 	if a.prefetchAllowed() {
 		t.Fatal("load skip must block the warm")
 	}
 	if hits != 0 || wastes != 0 {
 		t.Fatalf("a skipped warm is not feedback: hits=%d wastes=%d", hits, wastes)
 	}
-	a.armPrefetch("candidate")
+	a.armPrefetch("candidate", nil)
 	if !a.prefetchAllowed() {
 		t.Fatal("candidate plan must allow the warm")
 	}
-	a.armPrefetch("no_candidate")
+	a.armPrefetch("no_candidate", nil)
 	if !a.prefetchAllowed() {
 		t.Fatal("no-candidate plan must preserve legacy fail-open warm")
 	}
@@ -121,5 +122,48 @@ func TestRecordPrefetchLeadTime(t *testing.T) {
 	}
 	if leadMs < 900 || leadMs > 3000 {
 		t.Fatalf("lead_ms=%d, want ≈1000 (positive, consumed after warm-up)", leadMs)
+	}
+}
+
+func TestRecordPrefetchCarriesCanonicalProbeTargets(t *testing.T) {
+	b := semantix.NewBridge(semantix.Config{Enabled: true})
+	defer b.Close()
+	var got kernelevent.PrefetchHitPayload
+	b.Events().Subscribe(func(e kernelevent.Event) {
+		if e.Kind == kernelevent.PrefetchHit {
+			if err := json.Unmarshal(e.Data, &got); err != nil {
+				t.Errorf("decode hit: %v", err)
+			}
+		}
+	})
+	a := &Agent{semantix: b}
+	a.armPrefetch("candidate", []string{"probe-b", "probe-a", "probe-a"})
+	a.storePrefetch(&prefetchedInjectResult{
+		Text: "block", Targets: []string{"s1"}, Turn: 1,
+		ProbeTargets: a.prefetchProbeTargets(),
+	})
+	if result := a.takePrefetch(1); result == nil {
+		t.Fatal("take must consume the warmed block")
+	}
+	want := []string{"probe-a", "probe-b"}
+	if len(got.ProbeTargets) != len(want) || got.ProbeTargets[0] != want[0] || got.ProbeTargets[1] != want[1] {
+		t.Fatalf("probe_targets=%v, want %v", got.ProbeTargets, want)
+	}
+}
+
+func TestRecordPrefetchOrdinaryPayloadOmitsProbeTargets(t *testing.T) {
+	b := semantix.NewBridge(semantix.Config{Enabled: true})
+	defer b.Close()
+	var data json.RawMessage
+	b.Events().Subscribe(func(e kernelevent.Event) {
+		if e.Kind == kernelevent.PrefetchWaste {
+			data = append(data[:0], e.Data...)
+		}
+	})
+	a := &Agent{semantix: b}
+	a.storePrefetch(&prefetchedInjectResult{Text: "block", Targets: []string{"s1"}, Turn: 1})
+	a.wastePrefetch()
+	if bytes.Contains(data, []byte("probe_targets")) {
+		t.Fatalf("ordinary payload must omit probe_targets: %s", data)
 	}
 }

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -236,18 +236,19 @@ func (b *Bridge) recordInjection(ids []string, bytes int) {
 // the time between warm-up completion and the outcome decision: positive
 // for hits (completed before consumption — Markov timeliness, Issue #272);
 // for wastes it carries the survival time, not a consumption lead.
-func (b *Bridge) RecordPrefetch(hit bool, targets []string, turn int, lead time.Duration) {
+func (b *Bridge) RecordPrefetch(hit bool, targets, probeTargets []string, turn int, lead time.Duration) {
 	if b == nil || !b.Enabled() || len(targets) == 0 {
 		return
 	}
 	targets = append([]string(nil), targets...)
 	sort.Strings(targets)
+	probeTargets = canonicalPrefetchTargets(probeTargets)
 	kind := kernelevent.PrefetchWaste
 	leadMs := int64(lead / time.Millisecond)
-	var payload any = kernelevent.PrefetchWastePayload{Targets: targets, LeadMs: leadMs}
+	var payload any = kernelevent.PrefetchWastePayload{Targets: targets, ProbeTargets: probeTargets, LeadMs: leadMs}
 	if hit {
 		kind = kernelevent.PrefetchHit
-		payload = kernelevent.PrefetchHitPayload{Targets: targets, LeadMs: leadMs}
+		payload = kernelevent.PrefetchHitPayload{Targets: targets, ProbeTargets: probeTargets, LeadMs: leadMs}
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -257,6 +258,21 @@ func (b *Bridge) RecordPrefetch(hit bool, targets []string, turn int, lead time.
 	session := b.label
 	b.mu.Unlock()
 	b.events.Emit(kernelevent.Event{Kind: kind, SessionID: session, Turn: turn, At: time.Now().UTC(), Data: data})
+}
+
+func canonicalPrefetchTargets(targets []string) []string {
+	if len(targets) == 0 {
+		return nil
+	}
+	targets = append([]string(nil), targets...)
+	sort.Strings(targets)
+	out := targets[:0]
+	for _, target := range targets {
+		if target != "" && (len(out) == 0 || out[len(out)-1] != target) {
+			out = append(out, target)
+		}
+	}
+	return out
 }
 
 // Reuse gathers the per-turn reuse panel data (U33/H4a) in-process: the

--- a/harness/semantix/closed_loop_test.go
+++ b/harness/semantix/closed_loop_test.go
@@ -20,7 +20,7 @@ func TestBridgePersistsPrefetchAndEvolutionEventsInSessionJSONL(t *testing.T) {
 	b.Events().Emit(kernelevent.Event{Kind: kernelevent.SliceHit, SessionID: "session-c4", At: time.Now().UTC(), Data: hitData})
 	b.Events().Emit(kernelevent.Event{Kind: kernelevent.SliceInject, SessionID: "session-c4", At: time.Now().UTC(), Data: injectData})
 	for turn := 1; turn <= 60; turn++ {
-		b.RecordPrefetch(false, []string{"slice-a"}, turn, 0)
+		b.RecordPrefetch(false, []string{"slice-a"}, nil, turn, 0)
 	}
 	if err := b.Close(); err != nil {
 		t.Fatal(err)

--- a/harness/semantix/evolution.go
+++ b/harness/semantix/evolution.go
@@ -61,18 +61,21 @@ func (l *EvolutionLoop) Params() evolve.Params {
 func (l *EvolutionLoop) observe(e kernelevent.Event) {
 	var signal string
 	var targets []string
+	var probeTargets []string
 	switch e.Kind {
 	case kernelevent.PrefetchHit:
 		signal = "prefetch_hit"
 		var p kernelevent.PrefetchHitPayload
 		if json.Unmarshal(e.Data, &p) == nil {
 			targets = p.Targets
+			probeTargets = p.ProbeTargets
 		}
 	case kernelevent.PrefetchWaste:
 		signal = "prefetch_waste"
 		var p kernelevent.PrefetchWastePayload
 		if json.Unmarshal(e.Data, &p) == nil {
 			targets = p.Targets
+			probeTargets = p.ProbeTargets
 		}
 	case kernelevent.SliceReject:
 		// Issue #267 step 3: injection pollution is the last unproduced
@@ -88,13 +91,23 @@ func (l *EvolutionLoop) observe(e kernelevent.Event) {
 		ObserveHit(string)
 		ObserveWaste(string)
 	}); ok {
-		for _, target := range targets {
+		feedbackTargets := targets
+		if len(probeTargets) > 0 {
+			feedbackTargets = probeTargets
+		}
+		for _, target := range feedbackTargets {
 			if signal == "prefetch_hit" {
 				feedback.ObserveHit(target)
 			} else {
 				feedback.ObserveWaste(target)
 			}
 		}
+	}
+	// Probe outcomes are exploration cost: retain local per-target learning
+	// and event/usage observability, but do not treat them as evidence for
+	// tightening or relaxing the global exploitation threshold (Issue #302).
+	if len(probeTargets) > 0 {
+		return
 	}
 	before := l.engine.Params()
 	epoch := l.epoch.Add(1)

--- a/harness/semantix/evolution_test.go
+++ b/harness/semantix/evolution_test.go
@@ -16,6 +16,19 @@ func (c *captureTuner) ApplyEvolution(v float64) error {
 	return nil
 }
 
+type capturePrefetchFeedback struct {
+	captureTuner
+	hits, wastes []string
+}
+
+func (c *capturePrefetchFeedback) ObserveHit(target string) {
+	c.hits = append(c.hits, target)
+}
+
+func (c *capturePrefetchFeedback) ObserveWaste(target string) {
+	c.wastes = append(c.wastes, target)
+}
+
 func TestEvolutionLoopAppliesChangedSnapshotAndEmitsTick(t *testing.T) {
 	bus := kernelevent.NewSyncBus()
 	engine := evolve.New(evolve.Config{MinSamples: 2, FreezeEpochs: 1})
@@ -64,6 +77,58 @@ func TestEvolutionLoopDoesNotTickWithoutParameterChange(t *testing.T) {
 	}
 }
 
+func TestEvolutionLoopProbeWasteIsLocalOnly(t *testing.T) {
+	bus := kernelevent.NewSyncBus()
+	engine := evolve.New(evolve.Config{MinSamples: 2, FreezeEpochs: 1})
+	prefetcher := &capturePrefetchFeedback{}
+	loop := NewEvolutionLoop(bus, engine)
+	loop.Attach(nil, prefetcher)
+	defer loop.Close()
+	ticks := 0
+	bus.Subscribe(func(e kernelevent.Event) {
+		if e.Kind == kernelevent.EvolutionTick {
+			ticks++
+		}
+	})
+	before := engine.Params()
+	payload, _ := json.Marshal(kernelevent.PrefetchWastePayload{
+		Targets: []string{"slice-a"}, ProbeTargets: []string{"read_file"},
+	})
+	for turn := 1; turn <= 2; turn++ {
+		bus.Emit(kernelevent.Event{Kind: kernelevent.PrefetchWaste, Turn: turn, Data: payload})
+	}
+	if got := engine.Params(); got != before {
+		t.Fatalf("probe waste changed global params: before=%+v after=%+v", before, got)
+	}
+	if ticks != 0 || len(prefetcher.values) != 0 {
+		t.Fatalf("probe waste drove global evolution: ticks=%d applies=%v", ticks, prefetcher.values)
+	}
+	if len(prefetcher.wastes) != 2 || prefetcher.wastes[0] != "read_file" || prefetcher.wastes[1] != "read_file" {
+		t.Fatalf("local waste feedback=%v, want [read_file read_file]", prefetcher.wastes)
+	}
+}
+
+func TestEvolutionLoopRealWasteStillEvolves(t *testing.T) {
+	bus := kernelevent.NewSyncBus()
+	engine := evolve.New(evolve.Config{MinSamples: 2, FreezeEpochs: 1})
+	prefetcher := &capturePrefetchFeedback{}
+	loop := NewEvolutionLoop(bus, engine)
+	loop.Attach(nil, prefetcher)
+	defer loop.Close()
+	before := engine.Params()
+	payload, _ := json.Marshal(kernelevent.PrefetchWastePayload{Targets: []string{"slice-a"}})
+	for turn := 1; turn <= 2; turn++ {
+		bus.Emit(kernelevent.Event{Kind: kernelevent.PrefetchWaste, Turn: turn, Data: payload})
+	}
+	after := engine.Params()
+	if after.PrefetchConf <= before.PrefetchConf {
+		t.Fatalf("real waste did not tighten global confidence: before=%v after=%v", before.PrefetchConf, after.PrefetchConf)
+	}
+	if len(prefetcher.values) != 1 || len(prefetcher.wastes) != 2 {
+		t.Fatalf("real waste applies=%v local=%v", prefetcher.values, prefetcher.wastes)
+	}
+}
+
 // TestEvolveSchedulerReceivesSuccessFloor verifies the decoupling (PR #228,
 // Issue #254): after a parameter change the scheduler tuner is driven by the
 // engine's SuccessFloor default, not by TauL2 (injection confidence).
@@ -90,6 +155,7 @@ func TestEvolveSchedulerReceivesSuccessFloor(t *testing.T) {
 			got, evolve.DefaultSuccessFloor, evolve.DefaultTauL2)
 	}
 }
+
 // TestEvolutionLoopSliceRejectFeedsPollution (Issue #267 step 3): a
 // SliceReject event is folded into the engine as an inject_pollution
 // signal — the last empty signal source after PR #228 wired prefetch_*.

--- a/kernel/event/event.go
+++ b/kernel/event/event.go
@@ -117,7 +117,8 @@ type SliceRejectPayload struct {
 
 // PrefetchHitPayload reports a prefetch that was used.
 type PrefetchHitPayload struct {
-	Targets []string `json:"targets"`
+	Targets      []string `json:"targets"`
+	ProbeTargets []string `json:"probe_targets,omitempty"`
 	// LeadMs is consume − warm-up-completion in milliseconds; positive means
 	// the prefetch finished in time (Markov timeliness, Issue #272).
 	LeadMs int64 `json:"lead_ms,omitempty"`
@@ -125,7 +126,8 @@ type PrefetchHitPayload struct {
 
 // PrefetchWastePayload reports a prefetch that was not used.
 type PrefetchWastePayload struct {
-	Targets []string `json:"targets"`
+	Targets      []string `json:"targets"`
+	ProbeTargets []string `json:"probe_targets,omitempty"`
 	// LeadMs is the survival time (outcome decision − warm-up completion),
 	// not a consumption lead: wastes were never consumed. Consumers of the
 	// timeliness metric aggregate hits only (Issue #272).

--- a/kernel/prefetch/escape_test.go
+++ b/kernel/prefetch/escape_test.go
@@ -31,6 +31,9 @@ func TestPlanEpsilonProbeEscapesAbsorbingState(t *testing.T) {
 	if tasks[0].Cost != Defaults().BaseCost {
 		t.Fatalf("probe cost = %d, want default BaseCost %d", tasks[0].Cost, Defaults().BaseCost)
 	}
+	if !tasks[0].Probe {
+		t.Fatal("epsilon escape task must be marked as a probe")
+	}
 }
 
 // TestPlanEpsilonZeroKeepsEmptyPlan verifies backward compatibility: the

--- a/kernel/prefetch/matrix.go
+++ b/kernel/prefetch/matrix.go
@@ -357,9 +357,10 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 	}
 	if probation != nil && cost+m.cfg.BaseCost <= m.cfg.MaxCost {
 		tasks = append(tasks, PrefetchTask{
-			Kind: "slice-assembly",
-			Key:  probation.key,
-			Cost: m.cfg.BaseCost,
+			Kind:  "slice-assembly",
+			Key:   probation.key,
+			Cost:  m.cfg.BaseCost,
+			Probe: true,
 		})
 		cost += m.cfg.BaseCost
 	}
@@ -374,6 +375,7 @@ func (m *MatrixPrefetcher) Plan(lastToolNames []string) ([]PrefetchTask, error) 
 				Kind:     "slice-assembly",
 				Key:      probe.key,
 				Cost:     m.cfg.BaseCost,
+				Probe:    true,
 				Locality: LocalityLocal, // in-process slice-library read (Issue #273)
 			})
 		}

--- a/kernel/prefetch/planfunc.go
+++ b/kernel/prefetch/planfunc.go
@@ -57,13 +57,16 @@ func AsLoadAwarePlanFunc(p Prefetcher) sched.LoadAwarePrefetchPlanFunc {
 		if err != nil {
 			return sched.PrefetchPlanResult{Reason: string(ReasonPlanError)}
 		}
-		var ids []string
+		var ids, probeIDs []string
 		if len(decision.Tasks) > 0 {
 			ids = make([]string, 0, len(decision.Tasks))
 		}
 		for _, task := range decision.Tasks {
 			ids = append(ids, task.Key)
+			if task.Probe {
+				probeIDs = append(probeIDs, task.Key)
+			}
 		}
-		return sched.PrefetchPlanResult{IDs: ids, Reason: string(decision.Reason)}
+		return sched.PrefetchPlanResult{IDs: ids, ProbeIDs: probeIDs, Reason: string(decision.Reason)}
 	}
 }

--- a/kernel/prefetch/planfunc_test.go
+++ b/kernel/prefetch/planfunc_test.go
@@ -16,9 +16,10 @@ type fakePrefetcher struct {
 }
 
 func TestAsLoadAwarePlanFuncFallsBackToFrozenPlan(t *testing.T) {
-	f := &fakePrefetcher{tasks: []PrefetchTask{{Key: "read_file"}}}
+	f := &fakePrefetcher{tasks: []PrefetchTask{{Key: "read_file"}, {Key: "grep", Probe: true}}}
 	got := AsLoadAwarePlanFunc(f)([]string{"search"}, sched.PrefetchLoadHint{ConcurrencyUsed: 8, ConcurrencyLimit: 8})
-	if !reflect.DeepEqual(got.IDs, []string{"read_file"}) || got.Reason != string(ReasonCandidate) {
+	if !reflect.DeepEqual(got.IDs, []string{"read_file", "grep"}) ||
+		!reflect.DeepEqual(got.ProbeIDs, []string{"grep"}) || got.Reason != string(ReasonCandidate) {
 		t.Fatalf("result = %+v", got)
 	}
 }

--- a/kernel/prefetch/prefetch.go
+++ b/kernel/prefetch/prefetch.go
@@ -20,6 +20,10 @@ type PrefetchTask struct {
 	Kind string // "slice-assembly" | "embedding" | "file" (low priority)
 	Key  string // identifying key (e.g. slice id, file path)
 	Cost int    // estimated token/IO cost for budgeting
+	// Probe marks work admitted only to explore an otherwise excluded
+	// candidate. Its outcome updates local learning but not global evolve
+	// confidence (Issue #302).
+	Probe bool
 	// Locality declares the task execution boundary; empty is treated as
 	// LocalityEgress by the Runner (fail-closed, matching the empty-whitelist
 	// semantics).

--- a/kernel/prefetch/probation_test.go
+++ b/kernel/prefetch/probation_test.go
@@ -64,6 +64,9 @@ func TestProbationKeepsWastingCandidateOnProbeRoundsOnly(t *testing.T) {
 				plans, len(tasks) > 0, onProbeRound, tasks)
 		}
 		for _, task := range tasks {
+			if !task.Probe {
+				t.Fatalf("plans=%d: probation task must be marked as a probe: %+v", plans, task)
+			}
 			probed++
 			m.ObserveWaste(task.Key)
 		}

--- a/kernel/sched/rule_decider.go
+++ b/kernel/sched/rule_decider.go
@@ -69,8 +69,9 @@ type PrefetchPlanFunc func(lastToolNames []string) []string
 // PrefetchPlanResult is the load-aware callback's candidate list and stable
 // explanation. IDs are still reduced to tool-name keys by the adapter.
 type PrefetchPlanResult struct {
-	IDs    []string
-	Reason string
+	IDs      []string
+	ProbeIDs []string
+	Reason   string
 }
 
 // LoadAwarePrefetchPlanFunc is an additive callback seam; PrefetchPlanFunc is
@@ -212,12 +213,14 @@ func (d *RuleDecider) DecideRound(ctx context.Context, in RoundInput) (RoundPlan
 		hint := normalizedPrefetchLoad(in.PrefetchLoad, groups, d.cfg.MaxParallel)
 		result := d.loadPrefetchFn(toolNames(active), hint)
 		plan.PrefetchIDs = result.IDs
+		plan.PrefetchProbeIDs = result.ProbeIDs
 		plan.PrefetchReason = result.Reason
 	} else if d.prefetchFn != nil {
 		plan.PrefetchIDs = d.prefetchFn(toolNames(active))
 	}
 	if action == BudgetActionHaltPrefetch || action == BudgetActionHardStop {
 		plan.PrefetchIDs = nil
+		plan.PrefetchProbeIDs = nil
 		plan.PrefetchReason = "budget:" + action
 	}
 	if action == BudgetActionDegradeTier {

--- a/kernel/sched/rule_decider_test.go
+++ b/kernel/sched/rule_decider_test.go
@@ -407,10 +407,30 @@ func TestLoadAwarePrefetchReceivesNormalizedLoad(t *testing.T) {
 	}
 }
 
+func TestLoadAwarePrefetchCarriesProbeIDs(t *testing.T) {
+	d := NewRuleDecider(Config{})
+	d.SetLoadAwarePrefetchPlanFunc(func(_ []string, _ PrefetchLoadHint) PrefetchPlanResult {
+		return PrefetchPlanResult{
+			IDs:      []string{"read_file", "grep"},
+			ProbeIDs: []string{"grep"},
+			Reason:   "candidate",
+		}
+	})
+	plan, err := d.DecideRound(context.Background(), RoundInput{ToolCalls: []ToolCallInfo{
+		call("a", "read_a", true),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(plan.PrefetchProbeIDs, []string{"grep"}) {
+		t.Fatalf("probe IDs = %v, want [grep]", plan.PrefetchProbeIDs)
+	}
+}
+
 func TestBudgetPrefetchReasonOverridesCandidate(t *testing.T) {
 	d := NewRuleDecider(Config{})
 	d.SetLoadAwarePrefetchPlanFunc(func(_ []string, _ PrefetchLoadHint) PrefetchPlanResult {
-		return PrefetchPlanResult{IDs: []string{"read_file"}, Reason: "candidate"}
+		return PrefetchPlanResult{IDs: []string{"read_file"}, ProbeIDs: []string{"read_file"}, Reason: "candidate"}
 	})
 	plan, err := d.DecideRound(context.Background(), RoundInput{
 		ToolCalls: []ToolCallInfo{call("a", "read_a", true)},
@@ -419,7 +439,7 @@ func TestBudgetPrefetchReasonOverridesCandidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.PrefetchIDs != nil || plan.PrefetchReason != "budget:halt_prefetch" {
+	if plan.PrefetchIDs != nil || plan.PrefetchProbeIDs != nil || plan.PrefetchReason != "budget:halt_prefetch" {
 		t.Fatalf("plan = %+v", plan)
 	}
 }

--- a/kernel/sched/sched.go
+++ b/kernel/sched/sched.go
@@ -51,10 +51,13 @@ type RoundPlan struct {
 	TierReason     string     `json:"tierReason,omitempty"` // stable explanation; does not affect execution
 	InjectIDs      []string   // L2 slice IDs in canonical order
 	PrefetchIDs    []string   // prefetch targets (may be empty)
-	PrefetchReason string     `json:"prefetchReason,omitempty"`
-	SuspendTools   []string   `json:"suspendTools,omitempty"`
-	MaxParallel    int        `json:"maxParallel,omitempty"`  // 0 = harness default; >0 = forced cap
-	BudgetAction   string     `json:"budgetAction,omitempty"` // one of BudgetAction* below
+	// PrefetchProbeIDs is the subset admitted for exploration rather than
+	// normal exploitation (Issue #302).
+	PrefetchProbeIDs []string `json:"prefetchProbeIDs,omitempty"`
+	PrefetchReason   string   `json:"prefetchReason,omitempty"`
+	SuspendTools     []string `json:"suspendTools,omitempty"`
+	MaxParallel      int      `json:"maxParallel,omitempty"`  // 0 = harness default; >0 = forced cap
+	BudgetAction     string   `json:"budgetAction,omitempty"` // one of BudgetAction* below
 }
 
 const (


### PR DESCRIPTION
## Summary

- marks #254 Epsilon escape and #282 probation tasks as probes and preserves their identity through the scheduler and agent
- adds additive `probe_targets` metadata to existing prefetch hit/waste payloads
- routes probe outcomes to per-key feedback only, while ordinary outcomes continue to drive global `PrefetchConf`
- documents the wire contract and the exploration/exploitation accounting design

## Scope

- `kernel/prefetch`, `kernel/sched`, and `kernel/event`
- agent prefetch settlement and semantix bridge/evolution loop
- `docs/events.md` and issue #302 spec/implementation plan

## Validation

- [x] `go vet ./kernel/prefetch ./kernel/sched ./harness/agent ./harness/semantix`
- [ ] `go test ./... -race` — local Windows Go has CGO disabled (`-race requires cgo`)
- [x] `git diff upstream/main...HEAD --check`
- [x] `go test ./kernel/prefetch ./kernel/sched ./harness/semantix`
- [x] `go test ./harness/agent -run 'Test(Prefetch|RecordPrefetch)' -count=1`
- [x] `go test ./harness/semantix -run 'TestEvolutionLoop(ProbeWasteIsLocalOnly|RealWasteStillEvolves)$' -count=20`
- [x] `go test ./... -run '^$'`

The causal regression was observed RED before the split: two probe wastes moved `PrefetchConf` from `0.50` to `0.55`. After the change, 20 repetitions preserve the global value while local `read_file` waste feedback still executes. The ordinary-waste control still raises global confidence.

A full `go test ./...` run also encountered the existing unrelated `cmd/semantix.TestDispatchExitCodeContract` failure. All repository packages compile and all affected focused suites pass.

## Compatibility and data impact

Additive Go/JSON fields only. Existing event kinds and numeric IDs are unchanged; `probe_targets` is omitted on ordinary outcomes. No configuration defaults, evolve coefficients, persisted data migrations, or CLI behavior change.

## Security and privacy

None. Probe metadata contains the same local planner keys already present in `RoundPlan.PrefetchIDs`; no new external request or persistence boundary is introduced.

## Evidence

- Epsilon and probation planner regressions assert `PrefetchTask.Probe=true`.
- Scheduler regression asserts budget suppression clears both candidate and probe IDs.
- Agent regressions assert canonical/deduplicated probe targets and ordinary `omitempty` behavior.
- Evolution regression asserts local-only probe feedback and unchanged real-waste evolution.

## Related issues

Closes #302
Related: #254, #282

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md`.