### PR TITLE
fix(harness/tool): semantix_lookup 子进程测例密封化——去掉时钟/代码页/PATH 三条环境耦合 (Issue #296)

### DIFF
--- a/docs/specs/issue-296-lookup-subprocess-hermetic.md
+++ b/docs/specs/issue-296-lookup-subprocess-hermetic.md
@@ -114,12 +114,20 @@ func (s semantixLookup) budget() time.Duration {
 |---|---|
 | `TestSemantixLookupBudget` | 零值 → `3s`；注入值 → 原样返回 |
 | `TestSemantixLookupSubprocess` | 假内核 `argv` 模式，输出恰为 `lookup --query 修复 go 测试 --limit 7 --json\n`（**单一 want，跨平台**） |
-| `TestSemantixLookupFailsSoft` | 空 PATH → `("", nil)`；假内核 `fail` 模式 → `("", nil)` |
-| `TestSemantixLookupTimeoutDegrades` | 假内核 `hang` 模式 + 注入 200ms → `("", nil)`，且整体墙钟 < 3s（证明用的是注入预算而非生产预算） |
+| `TestSemantixLookupFailsSoft` | 子测例 `binary absent`（空 PATH）与 `binary exits non-zero`（假内核 `fail`）均 → `("", nil)` |
+| `TestSemantixLookupBudgetIsHonored` | 假内核 `argv` + 注入 **1ns** → `("", nil)` |
+| `TestSemantixLookupUnresponsiveKernel` | 假内核 `hang` + 注入 200ms → `("", nil)`，墙钟 ≤ 30s |
 | `TestSemantixLookupRequiresQuery` | 空 PATH；缺 query 报错、limit 越界被夹取不报错 |
 
 `TestSemantixLookupSubprocess` 注入 1 分钟预算：该测例断言 argv，不断言调度
 时延（§1.2 A）。
+
+**为何用 1ns 而不是「耗时 < 3s」来证明预算被遵守**：后者是墙钟断言，正是本
+issue 要根除的耦合——机器一饱和它自己就会 flaky。1ns 则两边都确定：没有任何
+机器的 fork+exec 能在 1ns 内完成，所以「预算被遵守」必然输出空；而假内核是
+会应答的，硬编码 3s 的实现会让它答出来。`UnresponsiveKernel` 的 30s 上限不
+测量延迟，只用来区分「deadline 触发了」与「根本没有 deadline」（假内核兜底
+睡 2 分钟），因此留了两个数量级的余量。
 
 ## 4. 非目标
 
@@ -146,8 +154,11 @@ func (s semantixLookup) budget() time.Duration {
 **T4 — 密封 PATH + 补 fail-soft 覆盖**
 1. `FailsSoft` 拆为「内核缺失」（空 PATH）与「内核损坏」（`fail` 模式）两个子测例。
 2. `RequiresQuery` 加空 PATH。
-3. 新增 `TestSemantixLookupTimeoutDegrades`（`hang` 模式 + 200ms 注入）。
-4. 跑全包 `-count=3`，预期全绿。commit。
+3. 新增 `TestSemantixLookupBudgetIsHonored`（`argv` + 1ns）与
+   `TestSemantixLookupUnresponsiveKernel`（`hang` + 200ms）。
+4. **变异检验**：临时把 `Execute` 的 `s.budget()` 改回硬编码 3s、把软降级改成
+   `return "", err`，确认对应测例翻红后回滚。守卫不经此步不算数。
+5. 跑全包 `-count=2`，预期全绿。commit。
 
 **T5 — 验收**
 1. `go vet ./...`
@@ -157,11 +168,19 @@ func (s semantixLookup) budget() time.Duration {
 
 ## 6. 验收标准
 
-- 本地 Windows：`go test ./harness/tool/ -run TestSemantixLookup -count=5` 全绿
-  （修复前 5/5 失败）。
+- 本地 Windows：`go test ./harness/tool/ -run TestSemantixLookup -count=5` 全绿。
+  修复前同一命令 `-count=3` 为 **3/3 失败**（代码页乱码，确定性）。
 - 该文件内所有测例不再读取宿主 PATH、不再依赖 `/bin/sh` 或 `cmd.exe`、
-  不再有平台分支的 `want`。
-- `semantixLookup{}.budget()` 仍为 3s，且有测例看守。
-- `go vet ./...` 与 `go build ./...` 干净。
-- 已知残余：`-race` 需要 cgo，本机无 C 编译器，`-race` 全仓验证由 CI
-  （ubuntu-latest）承担。
+  不再有平台分支的 `want`、不再需要 `\r\n` 归一化。
+- `semantixLookup{}.budget()` 仍为 3s，且有测例看守；变异检验通过。
+- `go vet ./...`、`go build ./...`、`go test ./...` 干净。
+
+### 6.1 已知残余
+
+- `-race` 需要 cgo，本机无 C 编译器（`go test -race` 直接报
+  `-race requires cgo`），因此 **issue 原始复现路径（全仓 `-race`）只能由 CI
+  ubuntu-latest 承担**。本 spec 通过变异检验替代该端到端复现：证明预算注入
+  确实被 `Execute` 使用、且超时确实走软降级，这两条正是原始失败链的全部环节。
+- 假内核每个测例复制一次测试二进制（3.2 MB / ~4 ms）。Windows 上首次执行新
+  写入的可执行文件另有 ~790 ms 的 AV 首扫开销（同一文件后续降到 40–75 ms），
+  Linux CI 无此开销。该成本落在注入的 1 分钟预算内，不影响判定。

--- a/docs/specs/issue-296-lookup-subprocess-hermetic.md
+++ b/docs/specs/issue-296-lookup-subprocess-hermetic.md
@@ -1,0 +1,167 @@
+# Spec v1 — semantix_lookup 子进程测例密封化（Issue #296）
+
+> 判级：Spec-Exempt（E 类，测试基建 + 一处等价重构，不改 kernel 行为）。
+> 生产语义零变更：`semantix_lookup` 的 3s 子进程预算与 fail-soft 契约
+> 逐字保留。基线为 upstream/main `0d3af89`（含 #281 / #279 合入）。
+
+## 1. 问题
+
+`harness/tool.TestSemantixLookupSubprocess` 断言的是 **argv 拼装**，但它的
+成败取决于三个测例并未控制的宿主环境变量：进程调度延迟、控制台代码页、
+以及 PATH 上是否存在真实 `semantix` 二进制。三条耦合链各自都能让断言翻车，
+且症状互不相同——这是它在 issue 里被记成「flaky」、在本地又表现为「确定性
+失败」的原因。
+
+### 1.1 真源审计（2026-08-23，worktree `fix/issue-296-lookup-subprocess-flaky`）
+
+| 耦合链 | 证据 | 现状 |
+|---|---|---|
+| A. 时钟 ↔ 生产预算 | issue #296 原始报告：全仓 `-race` 下 `argv mismatch: got ""`，耗时恰为 3.00s | 已由 `2a3324c` 的 `semantixLookup{timeout:}` 注入缓解 |
+| B. 控制台代码页 | 本地 `go test ./harness/tool/ -run TestSemantixLookup -count=3`：**3/3 失败**，`got "lookup --query \"\xd0\xde\xb8\xb4 go \xb2\xe2\xca\xd4\" ..."` | **活跃缺陷**，`2a3324c` 顺手加的 `.bat` shim 引入 |
+| C. 宿主 PATH | `command -v semantix` → `/c/Users/liwen/go/bin/semantix` | **活跃缺陷**，`FailsSoft` / `RequiresQuery` 正在执行开发机真实内核 |
+
+### 1.2 三条链的机理
+
+**A（时钟）**：`Execute` 超时后 fail-soft 返回 `("", nil)`（设计行为，由
+`TestSemantixLookupFailsSoft` 锚定）。测例向假内核发起的是一次**冷启动
+exec**——脚本刚写入临时目录、页缓存未命中、二进制未被 AV 扫描过。该延迟
+无界且随机器负载变化：本机实测首次执行新写入的可执行文件耗时 **790ms**，
+其后同一文件降到 **40–75ms**（Windows Defender 首扫）。全仓 `-race` 把 CPU
+打满时，这个尖峰越过 3s 预算，`Execute` 静默降级，断言拿到空串。
+
+结论：**冷启动 exec 的延迟不可预算化，所以它永远不该被拿去和生产预算比较。**
+
+**B（代码页）**：`.bat` shim 走 `cmd.exe`。Go 以 UTF-16 正确传入 argv，但
+`echo %*` 按控制台 OEM 代码页写 stdout。本机 CP936 下「修复」出栈即
+`D0 DE B8 B4`（GBK），Go 按 UTF-8 读回即乱码。同时 `%*` 会保留原始引号，
+迫使断言维护两份 `want`。两者都是 `cmd.exe` 的产物，与被测代码无关。
+
+**C（PATH）**：`TestSemantixLookupFailsSoft` 的注释写着「No semantix binary
+in this environment」，但它只是**假设**，没有**保证**。开发机上真实
+`semantix` 在 PATH 上，该测例每次都在跑真内核，仅因其恰好非零退出才通过；
+一旦本机存在可用 slice store，`out != ""`，测例确定性失败。`RequiresQuery`
+同理，且会为此付出最多 3s 墙钟。
+
+### 1.3 统一根因
+
+假内核 fixture 不是密封的：它借用宿主的 shell、代码页、PATH 与时钟，而不是
+自己提供。逐条打补丁（放宽超时、`chcp 65001`、两份 `want`）只是把耦合搬家。
+
+## 2. 设计
+
+### 2.1 自执行假内核（self-exec fake）
+
+测试二进制把**自己**复制成 `semantix`（Windows 为 `semantix.exe`）放进
+`t.TempDir()`，置于 PATH 首位；再用环境变量把子进程切到假内核模式。
+
+```
+TestMain  ── 若 SEMANTIX_TEST_FAKE_KERNEL 非空 → 按模式扮演内核并 os.Exit
+          └─ 否则 → m.Run()
+```
+
+模式取值：
+
+| 值 | 行为 | 服务的测例 |
+|---|---|---|
+| `argv` | `fmt.Println(strings.Join(os.Args[1:], " "))`，exit 0 | argv 断言 |
+| `fail` | exit 1（不写 stdout） | 「内核损坏」→ fail-soft |
+| `hang` | 阻塞直到被 kill | 「内核超时」→ fail-soft（预算注入回归） |
+
+这一步同时消掉 B 的两个症状：argv 由 Go 直接以 UTF-8 打印，不经任何 shell，
+因此**所有平台共用同一份 `want`**，且不再依赖 `/bin/sh` 存在。
+
+**为何是复制而非硬链接**：`os.Link` 在 Windows 上给正在运行的测试二进制创建
+另一个名字，该镜像文件被内核锁定，`t.TempDir()` 清理时 `unlinkat ... Access
+is denied`（已实测）。复制得到独立文件，子进程退出后可正常删除。成本实测
+3.2 MB / ~4 ms，Linux CI 无 AV 首扫开销。
+
+### 2.2 预算注入保留，并把生产 3s 钉死
+
+`2a3324c` 的 `semantixLookup{timeout:}` 注入是对的，保留。但当前没有任何测例
+锚定「零值 = 3s」，未来任何一次「顺手调一下超时」都能静默改掉 fail-soft 契约。
+
+把预算解析从 `Execute` 里提出来（等价重构，无行为变化）：
+
+```go
+// budget resolves the subprocess deadline. The 3s default is part of the
+// fail-soft contract: overrun degrades to an empty result, never an error.
+func (s semantixLookup) budget() time.Duration {
+	if s.timeout <= 0 {
+		return 3 * time.Second
+	}
+	return s.timeout
+}
+```
+
+配套测例直接断言 `semantixLookup{}.budget() == 3*time.Second`——零墙钟成本，
+且是唯一一处生产常量的看守。
+
+### 2.3 PATH 密封
+
+所有会走到 `exec` 的测例都必须自带 PATH，不得沿用宿主的：
+
+- 需要假内核的 → PATH 首位指向放着假内核的 `t.TempDir()`；
+- 需要「内核不存在」的（`FailsSoft`、`RequiresQuery`）→ PATH 设为一个**空**
+  `t.TempDir()`。`exec.LookPath` 立即失败，语义从「假设没有」变成「保证没
+  有」，且墙钟从最多 3s 降到微秒级。
+
+注：`t.Setenv` 与 `t.Parallel` 互斥。包 `harness/tool` 内无 `t.Parallel()`
+（已核），本 spec 也不引入。
+
+## 3. 断言口径
+
+| 测例 | 断言 |
+|---|---|
+| `TestSemantixLookupBudget` | 零值 → `3s`；注入值 → 原样返回 |
+| `TestSemantixLookupSubprocess` | 假内核 `argv` 模式，输出恰为 `lookup --query 修复 go 测试 --limit 7 --json\n`（**单一 want，跨平台**） |
+| `TestSemantixLookupFailsSoft` | 空 PATH → `("", nil)`；假内核 `fail` 模式 → `("", nil)` |
+| `TestSemantixLookupTimeoutDegrades` | 假内核 `hang` 模式 + 注入 200ms → `("", nil)`，且整体墙钟 < 3s（证明用的是注入预算而非生产预算） |
+| `TestSemantixLookupRequiresQuery` | 空 PATH；缺 query 报错、limit 越界被夹取不报错 |
+
+`TestSemantixLookupSubprocess` 注入 1 分钟预算：该测例断言 argv，不断言调度
+时延（§1.2 A）。
+
+## 4. 非目标
+
+- 不改 `Execute` 的 fail-soft 语义、不改 3s 生产默认值、不改 `Schema()`。
+- 不动 CI 配置（`go test ./... -race` 保持原样）。
+- 不清理仓库内其它测例的同类耦合——超出 #296 范围，如有另开 issue。
+
+## 5. 任务拆解（TDD，逐任务一次 commit）
+
+**T1 — 钉住生产预算**
+1. 写 `TestSemantixLookupBudget`，跑，预期编译失败（无 `budget`）。
+2. 提取 `budget()`，`Execute` 改调它。
+3. 跑测例，预期 PASS。commit。
+
+**T2 — 自执行假内核 fixture**
+1. 新增 `harness/tool/fakekernel_test.go`：`TestMain` + 模式分发 + `fakeKernelPATH(t, mode)` / `emptyPATH(t)` 助手。
+2. `go vet ./harness/tool/` + 跑全包，预期既有测例不受影响。commit。
+
+**T3 — argv 测例切到假内核**
+1. `TestSemantixLookupSubprocess` 改用 `fakeKernelPATH(t, "argv")`，删掉 `.bat`
+   分支与第二份 `want`。
+2. 跑 `-count=3`，预期由当前的 3/3 FAIL 变 3/3 PASS。commit。
+
+**T4 — 密封 PATH + 补 fail-soft 覆盖**
+1. `FailsSoft` 拆为「内核缺失」（空 PATH）与「内核损坏」（`fail` 模式）两个子测例。
+2. `RequiresQuery` 加空 PATH。
+3. 新增 `TestSemantixLookupTimeoutDegrades`（`hang` 模式 + 200ms 注入）。
+4. 跑全包 `-count=3`，预期全绿。commit。
+
+**T5 — 验收**
+1. `go vet ./...`
+2. `go test ./harness/tool/... -count=5`
+3. `go build ./...`
+4. spec 文档 commit（本文件），开 PR。
+
+## 6. 验收标准
+
+- 本地 Windows：`go test ./harness/tool/ -run TestSemantixLookup -count=5` 全绿
+  （修复前 5/5 失败）。
+- 该文件内所有测例不再读取宿主 PATH、不再依赖 `/bin/sh` 或 `cmd.exe`、
+  不再有平台分支的 `want`。
+- `semantixLookup{}.budget()` 仍为 3s，且有测例看守。
+- `go vet ./...` 与 `go build ./...` 干净。
+- 已知残余：`-race` 需要 cgo，本机无 C 编译器，`-race` 全仓验证由 CI
+  （ubuntu-latest）承担。

--- a/harness/tool/fakekernel_test.go
+++ b/harness/tool/fakekernel_test.go
@@ -1,0 +1,108 @@
+package tool
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The semantix_lookup tool shells out to a `semantix` binary found on PATH, so
+// testing it means supplying a fake kernel. A shell script is the obvious
+// fixture and the wrong one: it drags in whichever shell the host happens to
+// have, and on Windows `cmd.exe` writes stdout in the console OEM code page,
+// so a UTF-8 argv comes back as mojibake and the assertion needs a second
+// platform-specific `want`. Instead the test binary re-executes *itself* as
+// the fake kernel — argv crosses the process boundary as UTF-8 in both
+// directions, no shell is involved, and one assertion holds on every platform.
+const fakeKernelEnv = "SEMANTIX_TEST_FAKE_KERNEL"
+
+// Fake kernel behaviours, selected through fakeKernelEnv.
+const (
+	fakeKernelArgv = "argv" // echo argv, exit 0
+	fakeKernelFail = "fail" // exit non-zero without writing stdout
+	fakeKernelHang = "hang" // block until the caller's deadline kills us
+)
+
+// TestMain hands the process over to the fake kernel when fakeKernelEnv is
+// set. Only fakeKernelPATH sets it, and t.Setenv scopes it to one test; an
+// unrecognised value means the variable leaked in from the developer's shell,
+// which would otherwise turn every test in this package into an argv echo, so
+// it fails loudly instead.
+func TestMain(m *testing.M) {
+	mode, ok := os.LookupEnv(fakeKernelEnv)
+	if !ok {
+		os.Exit(m.Run())
+	}
+	switch mode {
+	case fakeKernelArgv:
+		fmt.Println(strings.Join(os.Args[1:], " "))
+		os.Exit(0)
+	case fakeKernelFail:
+		os.Exit(1)
+	case fakeKernelHang:
+		// exec.CommandContext kills us at the caller's deadline; the sleep is
+		// only a backstop so a missed kill cannot strand the process.
+		time.Sleep(2 * time.Minute)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "%s=%q is not a fake kernel mode\n", fakeKernelEnv, mode)
+		os.Exit(2)
+	}
+}
+
+// fakeKernelPATH points PATH at a directory holding nothing but a `semantix`
+// that behaves as mode says. PATH is replaced rather than prepended: the
+// machine running the tests may well have a real semantix installed — this is
+// its repository — and a test that reaches it is measuring the developer's
+// slice store instead of the tool.
+func fakeKernelPATH(t *testing.T, mode string) {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test binary: %v", err)
+	}
+	name := "semantix"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	dir := t.TempDir()
+	// Copy rather than hardlink: on Windows a link to the running test binary
+	// shares its locked image, and t.TempDir's cleanup then fails with
+	// "Access is denied".
+	copyFile(t, self, filepath.Join(dir, name))
+	t.Setenv(fakeKernelEnv, mode)
+	t.Setenv("PATH", dir)
+}
+
+// noKernelPATH makes the lookup binary unreachable, so the tool takes its
+// "kernel unavailable" path by construction rather than by assuming the host
+// has no semantix installed.
+func noKernelPATH(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open %s: %v", src, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create %s: %v", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		t.Fatalf("copy to %s: %v", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close %s: %v", dst, err)
+	}
+}

--- a/harness/tool/semantix.go
+++ b/harness/tool/semantix.go
@@ -43,6 +43,17 @@ func (semantixLookup) SnipHint() SnipHint {
 	return SnipHint{Head: 20, Tail: 0}
 }
 
+// budget resolves the subprocess deadline. The 3s default is part of the
+// fail-soft contract — an overrun degrades to an empty result rather than an
+// error — and only tests populate timeout, so a test needing room for its own
+// assertions never has to move the production value.
+func (s semantixLookup) budget() time.Duration {
+	if s.timeout <= 0 {
+		return 3 * time.Second
+	}
+	return s.timeout
+}
+
 func (s semantixLookup) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
 		Query string `json:"query"`
@@ -57,11 +68,7 @@ func (s semantixLookup) Execute(ctx context.Context, args json.RawMessage) (stri
 	if p.Limit <= 0 || p.Limit > 50 {
 		p.Limit = 5
 	}
-	timeout := s.timeout
-	if timeout <= 0 {
-		timeout = 3 * time.Second
-	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	ctx, cancel := context.WithTimeout(ctx, s.budget())
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "semantix",
 		"lookup", "--query", p.Query, "--limit", fmt.Sprint(p.Limit), "--json").Output()

--- a/harness/tool/semantix_test.go
+++ b/harness/tool/semantix_test.go
@@ -28,6 +28,22 @@ func TestSemantixLookupSchemaAndName(t *testing.T) {
 	}
 }
 
+// TestSemantixLookupBudget pins the production subprocess deadline. The 3s
+// default is half of the fail-soft contract — overrun degrades to an empty
+// result — so a test widening the budget for its own assertions must not be
+// able to move it. Zero value means production.
+func TestSemantixLookupBudget(t *testing.T) {
+	if got := (semantixLookup{}).budget(); got != 3*time.Second {
+		t.Errorf("production budget: got %s, want 3s", got)
+	}
+	if got := (semantixLookup{timeout: 250 * time.Millisecond}).budget(); got != 250*time.Millisecond {
+		t.Errorf("injected budget: got %s, want 250ms", got)
+	}
+	if got := (semantixLookup{timeout: -1}).budget(); got != 3*time.Second {
+		t.Errorf("negative budget must fall back to production: got %s", got)
+	}
+}
+
 func TestSemantixLookupRequiresQuery(t *testing.T) {
 	_, err := semantixLookup{}.Execute(context.Background(), json.RawMessage(`{}`))
 	if err == nil {

--- a/harness/tool/semantix_test.go
+++ b/harness/tool/semantix_test.go
@@ -3,10 +3,6 @@ package tool
 import (
 	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 	"time"
 )
@@ -69,33 +65,24 @@ func TestSemantixLookupFailsSoft(t *testing.T) {
 	}
 }
 
-// TestSemantixLookupSubprocess verifies the exact argv by putting a fake
-// `semantix` script first on PATH.
+// TestSemantixLookupSubprocess verifies the exact argv handed to the kernel
+// binary, including that a non-ASCII query survives the process boundary
+// unmangled.
 func TestSemantixLookupSubprocess(t *testing.T) {
-	bin := t.TempDir()
-	scriptName := "semantix"
-	scriptBody := "#!/bin/sh\necho \"$@\"\n"
-	if runtime.GOOS == "windows" {
-		scriptName = "semantix.bat"
-		scriptBody = "@echo off\r\necho %*\r\n"
-	}
-	script := filepath.Join(bin, scriptName)
-	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	// This test asserts argv, not the production subprocess time budget. Give
-	// fork+exec enough room when the full race-enabled suite loads the runner.
+	fakeKernelPATH(t, fakeKernelArgv)
+	// Assert argv, not the production time budget. The fixture's first exec of
+	// a freshly written binary is a cold start whose latency is unbounded — a
+	// saturated `go test ./... -race` run has pushed it past the 3s production
+	// budget, silently degrading Execute to an empty result mid-assert. Widen
+	// the budget here instead of weakening it in production; budget() keeps
+	// the 3s default honest.
 	out, err := (semantixLookup{timeout: time.Minute}).Execute(context.Background(),
 		json.RawMessage(`{"query":"修复 go 测试","limit":7}`))
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	want := "lookup --query 修复 go 测试 --limit 7 --json"
-	if runtime.GOOS == "windows" {
-		want = `lookup --query "修复 go 测试" --limit 7 --json`
-	}
-	if got := strings.ReplaceAll(out, "\r\n", "\n"); got != want+"\n" {
-		t.Errorf("argv mismatch:\n got %q\nwant %q", out, want+"\n")
+	want := "lookup --query 修复 go 测试 --limit 7 --json\n"
+	if out != want {
+		t.Errorf("argv mismatch:\n got %q\nwant %q", out, want)
 	}
 }

--- a/harness/tool/semantix_test.go
+++ b/harness/tool/semantix_test.go
@@ -25,9 +25,9 @@ func TestSemantixLookupSchemaAndName(t *testing.T) {
 }
 
 // TestSemantixLookupBudget pins the production subprocess deadline. The 3s
-// default is half of the fail-soft contract — overrun degrades to an empty
-// result — so a test widening the budget for its own assertions must not be
-// able to move it. Zero value means production.
+// default is part of the fail-soft contract — an overrun degrades to an empty
+// result — so a test that widens the budget for its own assertions must not be
+// able to move it. The zero value means production.
 func TestSemantixLookupBudget(t *testing.T) {
 	if got := (semantixLookup{}).budget(); got != 3*time.Second {
 		t.Errorf("production budget: got %s, want 3s", got)

--- a/harness/tool/semantix_test.go
+++ b/harness/tool/semantix_test.go
@@ -41,27 +41,88 @@ func TestSemantixLookupBudget(t *testing.T) {
 }
 
 func TestSemantixLookupRequiresQuery(t *testing.T) {
+	noKernelPATH(t)
 	_, err := semantixLookup{}.Execute(context.Background(), json.RawMessage(`{}`))
 	if err == nil {
 		t.Fatal("want error for missing query")
 	}
+	// The clamp path runs on to the subprocess; with no kernel reachable it
+	// degrades soft, which is the assertion — argument handling must not
+	// surface an error of its own.
 	_, err = semantixLookup{}.Execute(context.Background(), json.RawMessage(`{"query":"x","limit":999}`))
 	if err != nil {
 		t.Fatalf("limit clamped, no error expected: %v", err)
 	}
 }
 
-// TestSemantixLookupFailsSoft: a missing/breaking `semantix` binary must
-// degrade to an empty result, never an error.
+// TestSemantixLookupFailsSoft: neither an absent kernel binary nor a broken
+// one may surface an error — a kernel outage must never break the agent's
+// turn. Both branches are constructed rather than assumed: the machine
+// running these tests is a semantix checkout and may well have a working
+// kernel on PATH.
 func TestSemantixLookupFailsSoft(t *testing.T) {
-	// No semantix binary in this environment → subprocess fails → soft empty.
-	out, err := semantixLookup{}.Execute(context.Background(),
+	t.Run("binary absent", func(t *testing.T) {
+		noKernelPATH(t)
+		out, err := semantixLookup{}.Execute(context.Background(),
+			json.RawMessage(`{"query":"anything"}`))
+		if err != nil {
+			t.Fatalf("soft degrade violated: %v", err)
+		}
+		if out != "" {
+			t.Errorf("want empty output, got %q", out)
+		}
+	})
+
+	t.Run("binary exits non-zero", func(t *testing.T) {
+		fakeKernelPATH(t, fakeKernelFail)
+		out, err := semantixLookup{}.Execute(context.Background(),
+			json.RawMessage(`{"query":"anything"}`))
+		if err != nil {
+			t.Fatalf("soft degrade violated: %v", err)
+		}
+		if out != "" {
+			t.Errorf("want empty output, got %q", out)
+		}
+	})
+}
+
+// TestSemantixLookupBudgetIsHonored proves Execute deadlines the subprocess on
+// the value budget() resolved, not on a constant of its own. The kernel here
+// answers happily, so an empty result can only mean the 1ns budget expired —
+// and no fork+exec on any machine meets 1ns, which makes the assertion
+// immune to the scheduling latency that made this test file flaky to begin
+// with. Under a hardcoded 3s the fake would answer and this would fail.
+func TestSemantixLookupBudgetIsHonored(t *testing.T) {
+	fakeKernelPATH(t, fakeKernelArgv)
+	out, err := (semantixLookup{timeout: time.Nanosecond}).Execute(context.Background(),
 		json.RawMessage(`{"query":"anything"}`))
 	if err != nil {
 		t.Fatalf("soft degrade violated: %v", err)
 	}
 	if out != "" {
+		t.Errorf("budget ignored: kernel answered %q", out)
+	}
+}
+
+// TestSemantixLookupUnresponsiveKernel covers the other end of the deadline:
+// a kernel that accepts the call and never replies must be killed and
+// degraded, not waited on. The ceiling is deliberately far above any
+// plausible exec latency — it separates "a deadline fired" from "no deadline
+// at all" (the fake sleeps for two minutes) without asserting on wall clock.
+func TestSemantixLookupUnresponsiveKernel(t *testing.T) {
+	fakeKernelPATH(t, fakeKernelHang)
+	start := time.Now()
+	out, err := (semantixLookup{timeout: 200 * time.Millisecond}).Execute(context.Background(),
+		json.RawMessage(`{"query":"anything"}`))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("soft degrade violated: %v", err)
+	}
+	if out != "" {
 		t.Errorf("want empty output, got %q", out)
+	}
+	if elapsed > 30*time.Second {
+		t.Errorf("waited %s: the subprocess deadline never fired", elapsed)
 	}
 }
 


### PR DESCRIPTION
Closes #296

## TL;DR

issue 建议的修法（超时可注入）已在 main 上落过（`4e78505` 8/21、`2a3324c` 8/22），但 issue 仍开着——因为同一个测例还有两条活跃的环境耦合，其中一条是修 flaky 时顺手引入的。本 PR 把 fixture 整体密封化。

生产语义零变更：3s 预算与 fail-soft 契约逐字保留，`semantix.go` 只有一处等价重构。

## 根因：断言依赖三个测例并未控制的宿主变量

| 耦合链 | 证据 | 状态 |
|---|---|---|
| A. 时钟 ↔ 生产 3s 预算 | issue 原报告：全仓 `-race` 下 `argv mismatch: got ""`，耗时恰为 3.00s | 已由 `2a3324c` 缓解 |
| B. 控制台代码页 | 本机 `-count=3` **3/3 失败**：`got "...\"\xd0\xde\xb8\xb4 go ...\""` | **本 PR 修复** |
| C. 宿主 PATH | `command -v semantix` → `/c/Users/liwen/go/bin/semantix` | **本 PR 修复** |

**B**：`2a3324c` 加的 `.bat` shim 走 `cmd.exe`，`echo %*` 按控制台 OEM 代码页写 stdout。CP936 下「修复」出栈即 `D0 DE B8 B4`（GBK），Go 按 UTF-8 读回即乱码；`%*` 还保留原始引号，逼出第二份 Windows 专属 `want`。两者都是 `cmd.exe` 的产物，与被测代码无关。

**C**：`TestSemantixLookupFailsSoft` 的注释写着「No semantix binary in this environment」，但那是**假设**不是**保证**。开发机 PATH 上就有真内核——这是 semantix 自己的仓库——该测例一直在查开发者的真实 slice store，仅因其恰好非零退出才通过。`RequiresQuery` 同样在执行真二进制（0.09s → 密封后 0.00s）。

统一根因：**假内核 fixture 不密封**，它借用宿主的 shell、代码页、PATH 与时钟，而不是自己提供。逐条打补丁只是把耦合搬家。

## 修法：自执行假内核

测试二进制把自己复制成 `semantix` 放进 `t.TempDir()`，用 env 选行为（`argv` / `fail` / `hang`），PATH **整体替换**为该目录。

- argv 两个方向都是 UTF-8，不经任何 shell → 单一 `want` 跨平台，不再需要 `\r\n` 归一化，不再依赖 `/bin/sh` 或 `cmd.exe`；
- 复制而非硬链接：Windows 上指向运行中测试二进制的链接共享其锁定镜像，`t.TempDir` 清理会 `Access is denied`（实测）；
- 未识别的 env 值直接 `exit 2`，否则开发机上误设的同名变量会把整包测试静默变成 argv 回声。

生产侧只把 `Execute` 内联的超时解析抽成 `budget()`，让 `TestSemantixLookupBudget` 能钉死「零值 = 3s」——注入字段本是为测试放宽预算而加的，但此前没有任何测例拦住「顺手把默认值也一起调了」。

## 关于「怎么证明预算被遵守」

spec 起草时我写的是墙钟断言（耗时 < 3s），写完发现那等于把本 issue 要根除的耦合请回来：机器一饱和它自己就 flaky。

改成 **1ns 预算 + 会应答的假内核**——没有任何机器的 fork+exec 能在 1ns 内完成，所以「预算被遵守」必然输出空；而硬编码 3s 的实现会让假内核答出来。判据两边都确定，不测量任何延迟。

`UnresponsiveKernel` 的 30s 上限同理：它不测量延迟，只用来区分「deadline 触发了」与「根本没有 deadline」（假内核兜底睡 2 分钟），因此留了两个数量级余量。

## 变异检验

守卫不经此步不算数。临时改坏生产代码确认翻红后已回滚：

| 变异 | 结果 |
|---|---|
| `WithTimeout` 硬编码 3s | `BudgetIsHonored` FAIL——`kernel answered "lookup --query anything --limit 5 --json\n"` |
| 软降级改成 `return "", err` | 三条 fail-soft 分支各自 FAIL，错误互不相同：`executable file not found` / `exit status 1` / 被杀 |

## 验证

- `go test ./harness/tool/ -run TestSemantixLookup -count=5` ✅（修复前 `-count=3` 为 3/3 失败）
- `go build ./...` ✅ / `go vet ./...` ✅
- `go test ./...`：`harness/tool` 及其子包全绿。7 个包失败，**已逐一确认为既有问题**——把 `harness/tool/` 还原到 base 后同样失败：symlink 那批是 Windows 权限（`A required privilege is not held by the client`），另有 `TestDispatchExitCodeContract`、生成物漂移、`sessiontemp`。

### 已知残余

本机无 C 编译器，`go test -race` 直接报 `-race requires cgo`，因此 **issue 的原始复现路径（全仓 `-race`）只能由本 PR 触发的 CI ubuntu-latest 验证**。本地以变异检验替代：证明预算注入确实被 `Execute` 使用、且超时确实走软降级——这两条正是原始失败链的全部环节。

Spec：`docs/specs/issue-296-lookup-subprocess-hermetic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mYwDU1J1vtYzZQDrtFXfd
