### PR TITLE
feat(control): carry plan revision feedback through approval gates

### DIFF
--- a/docs/specs/issue-328-plan-revision-feedback.md
+++ b/docs/specs/issue-328-plan-revision-feedback.md
@@ -17,7 +17,8 @@ by the frontend work in #329. It does not change any frontend call site.
 
 ## Requirements
 
-1. `approvalReply` gains bounded revision feedback.
+1. `approvalReply` gains bounded revision feedback and retains the exact
+   three-way plan action instead of reducing the reply to a boolean.
 2. `Controller.ResolvePlanDecision` and the `Approvals` port take a trailing
    `feedback string`; all existing boolean-only `Approve` APIs remain unchanged.
 3. Feedback is trimmed and clipped to 4096 bytes on a valid UTF-8 boundary by
@@ -49,11 +50,12 @@ by the frontend work in #329. It does not change any frontend call site.
 
 ### Reply transport
 
-`approvalReply.feedback` is private in-process state. `ResolvePlanDecision`
-validates the action, clips the note, records the existing receipt, and sends
-the reply. The boolean `allow` remains true only for `start_execution`, so old
-control flow is preserved. The existing receipt continues to carry the exact
-three-way action; feedback is not added to the receipt.
+`approvalReply.feedback` and `approvalReply.planAction` are private in-process
+state. `ResolvePlanDecision` validates the action, clips the note, records the
+existing receipt, and sends both values. The boolean `allow` remains true only
+for `start_execution`, so old control flow is preserved. The existing receipt
+continues to carry the exact three-way action; feedback is not added to it.
+The legacy `Approve` path synthesizes start/revise actions for compatibility.
 
 ### Plain plan-mode gate
 

--- a/docs/specs/issue-328-plan-revision-feedback.md
+++ b/docs/specs/issue-328-plan-revision-feedback.md
@@ -1,0 +1,114 @@
+# Issue #328: plan approval revision feedback transport
+
+## Status
+
+Accepted for implementation.
+
+## Problem
+
+The plan approval API records three distinct decisions, but the in-process reply
+channel carries only a boolean. It has no field for an inline revision note,
+and both plan gates collapse the full reply before their callers can consume
+it. A declined plain plan therefore ends the turn without either starting a
+revision frame or leaving a model-visible explanation in history.
+
+This issue provides the control-layer transport and consumption behavior needed
+by the frontend work in #329. It does not change any frontend call site.
+
+## Requirements
+
+1. `approvalReply` gains bounded revision feedback.
+2. `Controller.ResolvePlanDecision` and the `Approvals` port take a trailing
+   `feedback string`; all existing boolean-only `Approve` APIs remain unchanged.
+3. Feedback is trimmed and clipped to 4096 bytes on a valid UTF-8 boundary by
+   the existing `clipUTF8` helper.
+4. The plain plan-mode gate consumes the full `approvalReply` through
+   `requestFreshApprovalDecision` rather than the boolean accessor.
+5. `revise_plan` with non-empty feedback starts a new orchestrated synthetic
+   revision frame whose user message contains the note verbatim. The revised
+   plan re-enters the same approval gate.
+6. Each revision frame owns its own `UserPromptSubmit`/`Stop` hook pair and
+   message boundary; approved execution inside one frame retains the existing
+   single hook pair.
+7. A declined plan with empty feedback makes no second provider call and
+   appends the exact marker
+   `(The user did not approve this plan; execution was not started.)`.
+8. `exit_plan` never starts a revision frame. It appends the same declined-plan
+   marker when no feedback is supplied.
+9. The planner approval adapter consumes the full reply too. Because its
+   callback surface can start execution but cannot recursively request a new
+   planner proposal, non-empty feedback is preserved as a user-role revision
+   request in session history for the next planner turn; empty denial appends
+   the shared marker. It does not silently drop feedback.
+10. Decision receipt schema and outcomes remain unchanged.
+11. No file under `harness/cli/` changes. HTTP, ACP, bot, and serve bindings keep
+    their boolean-only `Approve` behavior.
+
+## Design
+
+### Reply transport
+
+`approvalReply.feedback` is private in-process state. `ResolvePlanDecision`
+validates the action, clips the note, records the existing receipt, and sends
+the reply. The boolean `allow` remains true only for `start_execution`, so old
+control flow is preserved. The existing receipt continues to carry the exact
+three-way action; feedback is not added to the receipt.
+
+### Plain plan-mode gate
+
+The gate calls `requestFreshApprovalDecision`, which already returns the full
+reply and preserves the fresh-human posture of plan approval. On denial:
+
+- non-empty feedback while plan mode remains enabled calls
+  `runOrchestratedTurn` with a synthetic user-role prompt containing a stable
+  revision marker and the clipped note;
+- otherwise it appends the shared declined-plan marker and returns.
+
+Calling `runOrchestratedTurn` rather than `runComposedSyntheticTurn` is
+load-bearing: it creates a fresh message boundary, runs hooks, calls the model,
+and gates the resulting revised plan again.
+
+### Planner approval adapter
+
+`plannerPlanApprover.RunWithPlannerApproval` also uses the full-reply accessor.
+Its interface exposes only an execution callback and cannot safely nest a new
+coordinator run while the current coordinator is blocked. It therefore
+preserves non-empty feedback in session history as a synthetic user-role
+revision request, allowing the next planner frame to consume it. Empty denial
+uses the shared assistant-role declined marker. This explicitly removes the
+feedback drop without inventing a re-entrant planner API.
+
+### History helpers
+
+Control owns shared constants and two small helpers:
+
+- `planNotApprovedNote` is byte-for-byte identical to the agent coordinator's
+  established wording;
+- `planRevisionMessage(feedback)` composes the bounded user-role instruction.
+
+Messages are appended through the executor session. No event or persistence
+format changes are introduced.
+
+## Compatibility and scope
+
+- `Controller.Approve(id string, allow, session, persist bool)` is unchanged.
+- The `Approvals.ResolvePlanDecision` signature is intentionally widened for
+  #329; `*Controller` is its only implementation.
+- No CLI, HTTP, ACP, bot, or serve producer is rewired here.
+- Existing plan receipts keep the same kind, outcome, and attachment behavior.
+
+## Acceptance criteria
+
+- A unit test resolves `revise_plan` with `widen the retry window` and observes
+  `allow=false` plus the exact feedback on the reply channel.
+- A >4 KiB multibyte note arrives as valid UTF-8 with at most 4096 bytes.
+- A plain-gate integration test observes a second provider call whose opening
+  user message contains the note, then observes a second plan approval request.
+- Plan mode stays enabled throughout revision.
+- Empty denial performs one provider call and appends `planNotApprovedNote`.
+- Planner approval denial preserves non-empty feedback and shares the empty
+  denial marker.
+- Existing plan rejection and approved-plan hook invariants pass.
+- `go build ./...`, `go vet ./...`, and affected control tests pass; race tests
+  pass where the host toolchain supports them.
+

--- a/docs/specs/issue-328-plan-revision-feedback.md
+++ b/docs/specs/issue-328-plan-revision-feedback.md
@@ -38,8 +38,9 @@ by the frontend work in #329. It does not change any frontend call site.
 9. The planner approval adapter consumes the full reply too. Because its
    callback surface can start execution but cannot recursively request a new
    planner proposal, non-empty feedback is preserved as a user-role revision
-   request in session history for the next planner turn; empty denial appends
-   the shared marker. It does not silently drop feedback.
+   request in session history for the next planner turn. Empty denial remains
+   owned by the coordinator's existing marker path, avoiding duplicates. It
+   does not silently drop feedback.
 10. Decision receipt schema and outcomes remain unchanged.
 11. No file under `harness/cli/` changes. HTTP, ACP, bot, and serve bindings keep
     their boolean-only `Approve` behavior.
@@ -75,8 +76,9 @@ Its interface exposes only an execution callback and cannot safely nest a new
 coordinator run while the current coordinator is blocked. It therefore
 preserves non-empty feedback in session history as a synthetic user-role
 revision request, allowing the next planner frame to consume it. Empty denial
-uses the shared assistant-role declined marker. This explicitly removes the
-feedback drop without inventing a re-entrant planner API.
+is left to the coordinator's existing `plannerPlanNotApprovedNote` append after
+the adapter returns. This explicitly removes the feedback drop without
+inventing a re-entrant planner API or duplicating the established marker.
 
 ### History helpers
 
@@ -106,9 +108,8 @@ format changes are introduced.
   user message contains the note, then observes a second plan approval request.
 - Plan mode stays enabled throughout revision.
 - Empty denial performs one provider call and appends `planNotApprovedNote`.
-- Planner approval denial preserves non-empty feedback and shares the empty
-  denial marker.
+- Planner approval denial preserves non-empty feedback and leaves the existing
+  empty-denial marker responsibility with the coordinator.
 - Existing plan rejection and approved-plan hook invariants pass.
 - `go build ./...`, `go vet ./...`, and affected control tests pass; race tests
   pass where the host toolchain supports them.
-

--- a/docs/superpowers/plans/2026-08-23-issue-328-plan-revision-feedback.md
+++ b/docs/superpowers/plans/2026-08-23-issue-328-plan-revision-feedback.md
@@ -1,0 +1,182 @@
+# Issue #328 Plan Revision Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry bounded inline revision notes through plan approval and ensure neither control-layer plan gate discards them.
+
+**Architecture:** Widen the internal plan decision reply, consume the existing full-reply accessor, and re-enter the ordinary orchestrator for plain-plan revisions. Preserve planner-gate notes in session history because its callback interface cannot safely start a nested planner run.
+
+**Tech Stack:** Go, controller approval manager, agent session history, synchronous control events
+
+**Spec:** `docs/specs/issue-328-plan-revision-feedback.md`
+
+## Global Constraints
+
+- `Controller.Approve` and boolean-only external bindings remain unchanged.
+- Feedback is trimmed and UTF-8 clipped to exactly 4096 bytes maximum.
+- Receipt schema and three-way receipt outcomes remain unchanged.
+- No file under `harness/cli/` changes.
+- Revised plain plans must pass through `runOrchestratedTurn` and a second gate.
+
+---
+
+### Task 1: Add bounded plan feedback transport
+
+**Files:**
+- Modify: `harness/control/controller.go`
+- Modify: `harness/control/port.go`
+- Modify: `harness/control/controller_test.go`
+
+**Interfaces:**
+- Produces: `ResolvePlanDecision(id string, action PlanDecisionAction, feedback string) error`
+- Produces: `approvalReply.feedback string`
+- Consumes: `clipUTF8(string, int) string`
+
+- [ ] **Step 1: Add failing transport and clipping assertions**
+
+Update the existing three-way decision test to pass feedback and assert the
+reply field. Add a multibyte note longer than 4096 bytes and assert the received
+value is valid UTF-8 and bounded.
+
+- [ ] **Step 2: Run RED**
+
+Run: `go test ./harness/control -run 'TestResolvePlanDecision' -count=1`
+
+Expected: compile failure because the method and reply field do not accept
+feedback.
+
+- [ ] **Step 3: Implement the transport**
+
+Add the reply field, widen the controller and port signatures, clip feedback,
+and include it in the buffered reply. Do not change `Approve`.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `go test ./harness/control -run 'TestResolvePlanDecision' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add harness/control/controller.go harness/control/port.go harness/control/controller_test.go
+git commit -m "feat(control): transport bounded plan revision feedback"
+```
+
+### Task 2: Consume feedback in the plain plan gate
+
+**Files:**
+- Modify: `harness/control/turn_orchestrator.go`
+- Modify: `harness/control/auto_plan_e2e_test.go`
+- Modify: `harness/control/turn_orchestrator_test.go`
+
+**Interfaces:**
+- Consumes: `requestFreshApprovalDecision(...) (approvalReply, error)`
+- Produces: `planNotApprovedNote`, `planRevisionMessage(string) string`
+
+- [ ] **Step 1: Add failing causal integration tests**
+
+Script a plan, a revised plan, and approval events. Resolve the first gate with
+revision feedback, assert a second user-role model frame and second approval,
+then exit. Add the empty-feedback marker assertion.
+
+- [ ] **Step 2: Run RED**
+
+Run: `go test ./harness/control -run 'TestPlanGate(RevisionFeedbackReentersGate|EmptyRevisionPersistsMarker)$' -count=1`
+
+Expected: FAIL because the first denial ends after one provider call and no
+marker is appended.
+
+- [ ] **Step 3: Implement full-reply gate handling**
+
+Replace the boolean request with `requestFreshApprovalDecision`. Re-enter
+`runOrchestratedTurn` for non-empty revision feedback while plan mode is on;
+otherwise append the shared marker and return.
+
+- [ ] **Step 4: Run GREEN and invariants**
+
+Run: `go test ./harness/control -run 'Test(PlanGate|TurnOrchestratorApprovedPlanSharesOneStopHook)' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add harness/control/turn_orchestrator.go harness/control/auto_plan_e2e_test.go harness/control/turn_orchestrator_test.go
+git commit -m "feat(control): re-enter plan gate with revision feedback"
+```
+
+### Task 3: Preserve feedback in the planner approval adapter
+
+**Files:**
+- Modify: `harness/control/controller.go`
+- Modify: `harness/control/approval_e2e_test.go`
+
+**Interfaces:**
+- Consumes: `approvalReply.feedback`
+- Produces: persisted planner revision request or shared declined marker
+
+- [ ] **Step 1: Add failing planner denial tests**
+
+Resolve a planner approval with non-empty feedback and assert a user-role
+history message contains it. Resolve another with empty feedback and assert the
+shared declined marker.
+
+- [ ] **Step 2: Run RED**
+
+Run: `go test ./harness/control -run 'TestPlannerPlanApproval(PreservesRevisionFeedback|PersistsEmptyDenialMarker)$' -count=1`
+
+Expected: FAIL because the adapter discards the full reply.
+
+- [ ] **Step 3: Implement planner history preservation**
+
+Use `requestFreshApprovalDecision`; on denial append a user revision request
+when feedback is non-empty, otherwise append the shared assistant marker.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `go test ./harness/control -run 'TestPlannerPlanApproval' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add harness/control/controller.go harness/control/approval_e2e_test.go
+git commit -m "feat(control): preserve planner gate revision notes"
+```
+
+### Task 4: Verify and create PR
+
+**Files:**
+- No production files added.
+
+**Interfaces:**
+- Consumes: Tasks 1–3
+- Produces: verified PR closing #328
+
+- [ ] **Step 1: Format and run affected tests**
+
+Run `gofmt` on changed Go files and `go test ./harness/control/...`.
+
+Expected: PASS.
+
+- [ ] **Step 2: Build and vet**
+
+Run: `go build ./...` and `go vet ./...`.
+
+Expected: exit 0, with unrelated baseline failures reported exactly.
+
+- [ ] **Step 3: Run race verification where supported**
+
+Run: `go test ./harness/control/... -race`.
+
+Expected: PASS on a CGO/race-capable host.
+
+- [ ] **Step 4: Review and publish**
+
+Run `git diff upstream/main...HEAD --check`, push
+`codex/issue-328-plan-revision-feedback`, and create a PR against
+`Gnosil/semantix:main` with `Closes #328`, scope boundaries, hook behavior, and
+exact validation evidence.
+

--- a/docs/superpowers/plans/2026-08-23-issue-328-plan-revision-feedback.md
+++ b/docs/superpowers/plans/2026-08-23-issue-328-plan-revision-feedback.md
@@ -114,24 +114,25 @@ git commit -m "feat(control): re-enter plan gate with revision feedback"
 
 **Interfaces:**
 - Consumes: `approvalReply.feedback`
-- Produces: persisted planner revision request or shared declined marker
+- Produces: persisted planner revision request without duplicating the coordinator-owned marker
 
 - [ ] **Step 1: Add failing planner denial tests**
 
 Resolve a planner approval with non-empty feedback and assert a user-role
 history message contains it. Resolve another with empty feedback and assert the
-shared declined marker.
+adapter does not duplicate the coordinator-owned declined marker.
 
 - [ ] **Step 2: Run RED**
 
-Run: `go test ./harness/control -run 'TestPlannerPlanApproval(PreservesRevisionFeedback|PersistsEmptyDenialMarker)$' -count=1`
+Run: `go test ./harness/control -run 'TestPlannerPlanApproval(PreservesRevisionFeedback|LeavesEmptyDenialMarkerToCoordinator)$' -count=1`
 
 Expected: FAIL because the adapter discards the full reply.
 
 - [ ] **Step 3: Implement planner history preservation**
 
 Use `requestFreshApprovalDecision`; on denial append a user revision request
-when feedback is non-empty, otherwise append the shared assistant marker.
+when feedback is non-empty and leave empty-marker persistence to the existing
+coordinator caller.
 
 - [ ] **Step 4: Run GREEN**
 
@@ -179,4 +180,3 @@ Run `git diff upstream/main...HEAD --check`, push
 `codex/issue-328-plan-revision-feedback`, and create a PR against
 `Gnosil/semantix:main` with `Closes #328`, scope boundaries, hook behavior, and
 exact validation evidence.
-

--- a/harness/control/approval_e2e_test.go
+++ b/harness/control/approval_e2e_test.go
@@ -223,6 +223,69 @@ func TestApprovedPlanExecutionUsesAutoSemantics(t *testing.T) {
 	}
 }
 
+func TestPlannerPlanApprovalPreservesRevisionFeedback(t *testing.T) {
+	session := agent.NewSession("")
+	ag := agent.New(nil, nil, session, agent.Options{}, event.Discard)
+	var c *Controller
+	c = New(Options{
+		Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest && e.Approval.Tool == planApprovalTool {
+				go func() {
+					_ = c.ResolvePlanDecision(e.Approval.ID, PlanDecisionRevisePlan, "widen the retry window")
+				}()
+			}
+		}),
+	})
+	defer c.Close()
+	c.EnableInteractiveApproval()
+	runCalled := false
+	if err := (plannerPlanApprover{c: c}).RunWithPlannerApproval(t.Context(), "plan", func(context.Context) error {
+		runCalled = true
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if runCalled {
+		t.Fatal("revision denial must not execute the plan")
+	}
+	history := session.Snapshot()
+	if len(history) == 0 || history[len(history)-1].Role != provider.RoleUser ||
+		!strings.Contains(history[len(history)-1].Content, "widen the retry window") {
+		t.Fatalf("planner revision feedback was not preserved: %+v", history)
+	}
+}
+
+func TestPlannerPlanApprovalLeavesEmptyDenialMarkerToCoordinator(t *testing.T) {
+	session := agent.NewSession("")
+	ag := agent.New(nil, nil, session, agent.Options{}, event.Discard)
+	var c *Controller
+	c = New(Options{
+		Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest && e.Approval.Tool == planApprovalTool {
+				go func() {
+					_ = c.ResolvePlanDecision(e.Approval.ID, PlanDecisionRevisePlan, "")
+				}()
+			}
+		}),
+	})
+	defer c.Close()
+	c.EnableInteractiveApproval()
+	if err := (plannerPlanApprover{c: c}).RunWithPlannerApproval(t.Context(), "plan", func(context.Context) error {
+		t.Fatal("empty denial must not execute the plan")
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	history := session.Snapshot()
+	for _, message := range history {
+		if message.Content == planNotApprovedNote {
+			t.Fatalf("adapter must not duplicate coordinator-owned empty-denial marker: %+v", history)
+		}
+	}
+}
+
 // TestApprovalTimeoutDeniesWhenUnanswered verifies a positive ApprovalTimeout
 // turns an unanswered prompt into a denial (error) instead of blocking forever
 // (#4626, #4402). Ask shares the same wait context as tool-approval prompts.

--- a/harness/control/auto_plan_e2e_test.go
+++ b/harness/control/auto_plan_e2e_test.go
@@ -15,13 +15,15 @@ import (
 // so a controller turn that re-enters the agent (plan turn, then approved
 // execution turn) sees a different model response each time.
 type scriptedTurns struct {
-	turns [][]provider.Chunk
-	call  int
+	turns    [][]provider.Chunk
+	requests []provider.Request
+	call     int
 }
 
 func (s *scriptedTurns) Name() string { return "scripted" }
 
-func (s *scriptedTurns) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+func (s *scriptedTurns) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	s.requests = append(s.requests, req)
 	i := s.call
 	if i >= len(s.turns) {
 		i = len(s.turns) - 1
@@ -189,5 +191,46 @@ func TestPlanGateRejectionStaysInPlan(t *testing.T) {
 	}
 	if prov.call != 1 {
 		t.Fatalf("provider called %d times, want 1 (plan only, no execution)", prov.call)
+	}
+	history := c.History()
+	if len(history) == 0 || !strings.HasSuffix(history[len(history)-1].Content,
+		"(The user did not approve this plan; execution was not started.)") {
+		t.Fatalf("empty rejection marker missing from history: %+v", history)
+	}
+}
+
+func TestPlanGateRevisionFeedbackReentersGate(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("Plan:\n1. Use a short retry window"),
+		textTurn("Revised plan:\n1. Widen the retry window"),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	approvalIDs := make(chan string, 2)
+	c := New(Options{
+		Runner: ag, Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest && e.Approval.Tool == planApprovalTool {
+				approvalIDs <- e.Approval.ID
+			}
+		}),
+	})
+	c.SetPlanMode(true)
+	go func() {
+		_ = c.ResolvePlanDecision(<-approvalIDs, PlanDecisionRevisePlan, "widen the retry window")
+		second := <-approvalIDs
+		c.SetPlanMode(false)
+		_ = c.ResolvePlanDecision(second, PlanDecisionExitPlan, "")
+	}()
+
+	if err := c.runTurnWithRaw(context.Background(), "plan the retry change", "plan the retry change"); err != nil {
+		t.Fatalf("runTurnWithRaw: %v", err)
+	}
+	if prov.call != 2 || len(prov.requests) != 2 {
+		t.Fatalf("provider calls=%d requests=%d, want two gated plan frames", prov.call, len(prov.requests))
+	}
+	msgs := prov.requests[1].Messages
+	if len(msgs) == 0 || msgs[len(msgs)-1].Role != provider.RoleUser ||
+		!strings.Contains(msgs[len(msgs)-1].Content, "widen the retry window") {
+		t.Fatalf("second request must end with user revision note: %+v", msgs)
 	}
 }

--- a/harness/control/controller.go
+++ b/harness/control/controller.go
@@ -322,9 +322,10 @@ type Controller struct {
 }
 
 type approvalReply struct {
-	allow   bool
-	session bool
-	persist bool // true = write "always allow" rule to config
+	allow    bool
+	session  bool
+	persist  bool // true = write "always allow" rule to config
+	feedback string
 }
 
 type pendingApproval struct {
@@ -2281,7 +2282,7 @@ func (c *Controller) Approve(id string, allow, session, persist bool) {
 
 // ResolvePlanDecision answers the Plan card without collapsing revise and exit
 // into the generic approval boolean used by older clients.
-func (c *Controller) ResolvePlanDecision(id string, action PlanDecisionAction) error {
+func (c *Controller) ResolvePlanDecision(id string, action PlanDecisionAction, feedback string) error {
 	if c == nil {
 		return fmt.Errorf("controller is nil")
 	}
@@ -2300,7 +2301,10 @@ func (c *Controller) ResolvePlanDecision(id string, action PlanDecisionAction) e
 	}
 	pending.kind = "plan"
 	c.recordDecisionReceipt(pending, string(action))
-	pending.reply <- approvalReply{allow: action == PlanDecisionStartExecution}
+	pending.reply <- approvalReply{
+		allow:    action == PlanDecisionStartExecution,
+		feedback: clipUTF8(feedback, 4*1024),
+	}
 	return nil
 }
 

--- a/harness/control/controller.go
+++ b/harness/control/controller.go
@@ -322,10 +322,11 @@ type Controller struct {
 }
 
 type approvalReply struct {
-	allow    bool
-	session  bool
-	persist  bool // true = write "always allow" rule to config
-	feedback string
+	allow      bool
+	session    bool
+	persist    bool // true = write "always allow" rule to config
+	feedback   string
+	planAction PlanDecisionAction
 }
 
 type pendingApproval struct {
@@ -2261,10 +2262,13 @@ func (c *Controller) Approve(id string, allow, session, persist bool) {
 		return
 	}
 	outcome := "deny"
+	var planAction PlanDecisionAction
 	if pending.tool == planApprovalTool {
 		outcome = string(PlanDecisionRevisePlan)
+		planAction = PlanDecisionRevisePlan
 		if allow {
 			outcome = string(PlanDecisionStartExecution)
+			planAction = PlanDecisionStartExecution
 		}
 	} else if allow {
 		switch {
@@ -2277,7 +2281,7 @@ func (c *Controller) Approve(id string, allow, session, persist bool) {
 		}
 	}
 	c.recordDecisionReceipt(pending, outcome)
-	pending.reply <- approvalReply{allow: allow, session: session, persist: persist} // buffered, never blocks
+	pending.reply <- approvalReply{allow: allow, session: session, persist: persist, planAction: planAction} // buffered, never blocks
 }
 
 // ResolvePlanDecision answers the Plan card without collapsing revise and exit
@@ -2302,8 +2306,9 @@ func (c *Controller) ResolvePlanDecision(id string, action PlanDecisionAction, f
 	pending.kind = "plan"
 	c.recordDecisionReceipt(pending, string(action))
 	pending.reply <- approvalReply{
-		allow:    action == PlanDecisionStartExecution,
-		feedback: clipUTF8(feedback, 4*1024),
+		allow:      action == PlanDecisionStartExecution,
+		feedback:   clipUTF8(feedback, 4*1024),
+		planAction: action,
 	}
 	return nil
 }

--- a/harness/control/controller.go
+++ b/harness/control/controller.go
@@ -2387,11 +2387,17 @@ type plannerPlanApprover struct {
 
 func (p plannerPlanApprover) RunWithPlannerApproval(ctx context.Context, plan string, run func(context.Context) error) error {
 	c := p.c
-	allow, _, err := c.requestApprovalWithReason(ctx, planApprovalTool, "", nil, "Planner requested host approval before execution.")
+	reply, err := c.requestFreshApprovalDecision(ctx, planApprovalTool, "", nil, "Planner requested host approval before execution.")
 	if err != nil {
 		return err
 	}
-	if !allow {
+	if !reply.allow {
+		// Coordinator already persists the shared empty-denial marker after this
+		// adapter returns. Preserve only non-empty inline feedback here so it is
+		// available to the next planner frame without duplicating that marker.
+		if revision := planRevisionMessage(reply.feedback); revision != "" {
+			c.appendPlanHistory(provider.RoleUser, revision)
+		}
 		return nil
 	}
 	todoArgs := c.seedPlanTodos(plan)

--- a/harness/control/controller_test.go
+++ b/harness/control/controller_test.go
@@ -71,6 +71,9 @@ func TestResolvePlanDecisionRecordsDistinctOutcomes(t *testing.T) {
 				if got.feedback != tt.feedback {
 					t.Fatalf("reply feedback = %q, want %q", got.feedback, tt.feedback)
 				}
+				if got.planAction != tt.action {
+					t.Fatalf("reply plan action = %q, want %q", got.planAction, tt.action)
+				}
 			default:
 				t.Fatal("plan decision did not unblock the approval waiter")
 			}

--- a/harness/control/controller_test.go
+++ b/harness/control/controller_test.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"semantix/harness/agent"
 	"semantix/harness/checkpoint"
@@ -43,11 +44,12 @@ func (*typedNilControllerSink) Emit(event.Event) {}
 
 func TestResolvePlanDecisionRecordsDistinctOutcomes(t *testing.T) {
 	tests := []struct {
-		action PlanDecisionAction
-		allow  bool
+		action   PlanDecisionAction
+		allow    bool
+		feedback string
 	}{
 		{action: PlanDecisionStartExecution, allow: true},
-		{action: PlanDecisionRevisePlan, allow: false},
+		{action: PlanDecisionRevisePlan, allow: false, feedback: "widen the retry window"},
 		{action: PlanDecisionExitPlan, allow: false},
 	}
 	for _, tt := range tests {
@@ -58,13 +60,16 @@ func TestResolvePlanDecisionRecordsDistinctOutcomes(t *testing.T) {
 			c := New(Options{Executor: exec})
 			id, reply := c.approval.registerDecisionKind(planApprovalTool, "", "", true, false, "plan", nil)
 
-			if err := c.ResolvePlanDecision(id, tt.action); err != nil {
+			if err := c.ResolvePlanDecision(id, tt.action, tt.feedback); err != nil {
 				t.Fatalf("ResolvePlanDecision: %v", err)
 			}
 			select {
 			case got := <-reply:
 				if got.allow != tt.allow {
 					t.Fatalf("reply allow = %v, want %v", got.allow, tt.allow)
+				}
+				if got.feedback != tt.feedback {
+					t.Fatalf("reply feedback = %q, want %q", got.feedback, tt.feedback)
 				}
 			default:
 				t.Fatal("plan decision did not unblock the approval waiter")
@@ -79,6 +84,22 @@ func TestResolvePlanDecisionRecordsDistinctOutcomes(t *testing.T) {
 				t.Fatalf("receipt = %+v, want plan/%s", receipt, tt.action)
 			}
 		})
+	}
+}
+
+func TestResolvePlanDecisionClipsFeedbackOnUTF8Boundary(t *testing.T) {
+	c := New(Options{})
+	id, reply := c.approval.registerDecisionKind(planApprovalTool, "", "", true, false, "plan", nil)
+	feedback := strings.Repeat("界", 2000)
+	if err := c.ResolvePlanDecision(id, PlanDecisionRevisePlan, feedback); err != nil {
+		t.Fatalf("ResolvePlanDecision: %v", err)
+	}
+	got := <-reply
+	if len(got.feedback) > 4*1024 || !utf8.ValidString(got.feedback) {
+		t.Fatalf("clipped feedback bytes=%d valid=%v", len(got.feedback), utf8.ValidString(got.feedback))
+	}
+	if got.feedback == "" || !strings.HasPrefix(feedback, got.feedback) {
+		t.Fatalf("clipped feedback is not a non-empty prefix")
 	}
 }
 

--- a/harness/control/port.go
+++ b/harness/control/port.go
@@ -75,7 +75,7 @@ type TurnControl interface {
 // posture (ask/auto/yolo). It mirrors the approvalManager surface.
 type Approvals interface {
 	Approve(id string, allow, session, persist bool)
-	ResolvePlanDecision(id string, action PlanDecisionAction) error
+	ResolvePlanDecision(id string, action PlanDecisionAction, feedback string) error
 	// ResolveRecovery answers an Auto Guard card: continue|continue_task|revise. Revise
 	// refuses the mutation and steers feedback.
 	ResolveRecovery(id string, action agent.RecoveryAction, feedback string) error

--- a/harness/control/turn_orchestrator.go
+++ b/harness/control/turn_orchestrator.go
@@ -361,7 +361,7 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	if !reply.allow {
 		// A revision is a complete orchestrated frame, not a direct runner call:
 		// it owns fresh message/hook boundaries and gates the revised plan again.
-		if revision := planRevisionMessage(reply.feedback); revision != "" && c.PlanMode() {
+		if revision := planRevisionMessage(reply.feedback); reply.planAction == PlanDecisionRevisePlan && revision != "" && c.PlanMode() {
 			return o.runOrchestratedTurn(ctx, orchestratedTurn{
 				input: revision, raw: revision, synthetic: true,
 			})

--- a/harness/control/turn_orchestrator.go
+++ b/harness/control/turn_orchestrator.go
@@ -17,6 +17,26 @@ import (
 	"semantix/harness/tool"
 )
 
+const (
+	planNotApprovedNote  = "(The user did not approve this plan; execution was not started.)"
+	planRevisionPreamble = "[Plan revision requested by the user]"
+)
+
+func planRevisionMessage(feedback string) string {
+	feedback = strings.TrimSpace(feedback)
+	if feedback == "" {
+		return ""
+	}
+	return planRevisionPreamble + "\n\n" + feedback
+}
+
+func (c *Controller) appendPlanHistory(role provider.Role, content string) {
+	if c == nil || c.executor == nil || strings.TrimSpace(content) == "" {
+		return
+	}
+	c.executor.Session().Add(provider.Message{Role: role, Content: content})
+}
+
 // turnOrchestrator owns foreground turn execution while Controller keeps the
 // public ports, run-state guard, and session-scoped dependencies.
 type turnOrchestrator struct {
@@ -334,13 +354,19 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	}
 	// The plan is already visible as the assistant's answer, so the request
 	// carries no subject — it's purely the gate.
-	allow, _, err := c.requestApproval(ctx, planApprovalTool, "", nil)
+	reply, err := c.requestFreshApprovalDecision(ctx, planApprovalTool, "", nil, "")
 	if err != nil {
 		return err
 	}
-	if !allow {
-		// The host decides whether denial means "revise and keep planning" or
-		// "exit without executing" by leaving plan mode on or switching it off.
+	if !reply.allow {
+		// A revision is a complete orchestrated frame, not a direct runner call:
+		// it owns fresh message/hook boundaries and gates the revised plan again.
+		if revision := planRevisionMessage(reply.feedback); revision != "" && c.PlanMode() {
+			return o.runOrchestratedTurn(ctx, orchestratedTurn{
+				input: revision, raw: revision, synthetic: true,
+			})
+		}
+		c.appendPlanHistory(provider.RoleAssistant, planNotApprovedNote)
 		return nil
 	}
 	c.SetPlanMode(false)


### PR DESCRIPTION
## Summary

- widens the internal plan-decision channel with UTF-8-safe, 4 KiB revision feedback and retains the exact three-way action
- makes the plain plan gate consume the full reply, start a new orchestrated revision frame for `revise_plan`, and gate the revised plan again
- persists the established declined-plan marker when no revision note is supplied
- preserves planner-gate revision notes in session history without duplicating the coordinator-owned empty-denial marker
- adds the prerequisite control API that #329 will call; this PR intentionally changes no `harness/cli/` file

## Scope

- `harness/control/` only for production code
- issue #328 spec and implementation plan
- no CLI, HTTP, ACP, bot, or serve call-site rewiring

## Validation

- [x] `go build ./...`
- [x] `go vet ./harness/control/...`
- [ ] `go vet ./...` — blocked by an unrelated upstream/main test compile defect in `harness/tool/semantix_test.go` after #387 (missing `runtime`, `os`, and `filepath` imports)
- [ ] `go test ./harness/control/... -race` — local Windows Go has CGO disabled (`-race requires cgo`)
- [x] `git diff upstream/main...HEAD --check`
- [x] `go test ./harness/control/... -count=1 -timeout 8m`
- [x] `go test ./harness/control -run 'Test(ResolvePlanDecision|PlanGate|PlannerPlanApproval|TurnOrchestratorApprovedPlanSharesOneStopHook)' -count=20 -timeout 4m`

The causal tests were observed RED before implementation: revision feedback stopped after one provider call and empty denial appended no marker. The completed path makes a second user-role request containing the note and emits a second plan approval request.

## Compatibility and data impact

`Controller.Approve(id string, allow, session, persist bool)` is unchanged. `ResolvePlanDecision` intentionally gains the trailing feedback argument required by #329. Decision receipt schema and outcome strings are unchanged. Approval reply fields are private and in-process only; there is no persisted-format migration.

The plain revision frame uses `runOrchestratedTurn`, so each revision frame owns one `UserPromptSubmit`/`Stop` pair. Approved execution within a frame retains the existing exactly-one-pair invariant.

The planner adapter cannot safely start a nested coordinator run through its execution-only callback. It preserves non-empty feedback as a user-role revision request for the next planner frame; empty marker persistence remains with the coordinator's existing path to avoid duplication.

## Security and privacy

Feedback is trimmed and clipped to 4096 bytes on a valid UTF-8 boundary. No new external request, trust boundary, credential, or persistence format is introduced.

## Evidence

- transport tests assert exact text, exact action, boolean compatibility, and multibyte clipping
- plain-gate integration asserts the second provider request and second approval gate
- empty denial asserts one provider call plus the established history marker
- planner tests assert feedback preservation and no duplicate empty marker
- existing rejected-plan and approved-plan hook invariants remain green

## Related issues

Closes #328
Prerequisite for #329

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md` (not applicable; no wire contract change).