### PR TITLE
fix(harness/tool): 修复 main 编译失败——超时测例改用密封 fake kernel

### DIFF
--- a/harness/tool/semantix_test.go
+++ b/harness/tool/semantix_test.go
@@ -151,17 +151,11 @@ func TestSemantixLookupSubprocess(t *testing.T) {
 // TestSemantixLookupTimeoutFailsSoft locks in the production resilience
 // contract independently of the argv test's deliberately widened budget.
 func TestSemantixLookupTimeoutFailsSoft(t *testing.T) {
-	bin := t.TempDir()
-	scriptName := "semantix"
-	scriptBody := "#!/bin/sh\necho unexpected\n"
-	if runtime.GOOS == "windows" {
-		scriptName = "semantix.bat"
-		scriptBody = "@echo off\r\necho unexpected\r\n"
-	}
-	if err := os.WriteFile(filepath.Join(bin, scriptName), []byte(scriptBody), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// A kernel that answers immediately: the point is that an already-expired
+	// deadline degrades softly even when nothing is slow. fakeKernelPATH keeps
+	// this hermetic — the previous fixture wrote a shell script onto PATH,
+	// which is exactly the host coupling Issue #296 removed.
+	fakeKernelPATH(t, fakeKernelArgv)
 
 	out, err := (semantixLookup{timeout: time.Nanosecond}).Execute(context.Background(),
 		json.RawMessage(`{"query":"deadline"}`))


### PR DESCRIPTION
## main 现在是红的

`main` 当前 `go vet ./...` 直接编译失败，**任何提向 main 的 PR，Go checks 都会红**，与改动内容无关：

```
harness/tool/semantix_test.go:157:5:  undefined: runtime
harness/tool/semantix_test.go:161:12: undefined: os
harness/tool/semantix_test.go:161:25: undefined: filepath
harness/tool/semantix_test.go:164:30: undefined: os
```

在从 `upstream/main` 新切的干净分支上复现确认，与工作区状态无关。

## 成因：两个 PR 交叉

| PR | 做了什么 |
| --- | --- |
| #385 | 新增 `TestSemantixLookupTimeoutFailsSoft`，用手写 shell 脚本塞进 PATH 作夹具 → 需要 `runtime` / `os` / `filepath` |
| #387（Issue #296） | 把这类夹具统一换成密封的 `fakeKernelPATH`，并删掉随之不再使用的这三个 import |

#387 从 #385 之前的 main 分出，没有碰到这个新函数；两者先后落到 main 上后，合并结果**保留了 #385 的函数体 + #387 的 import 块**。Go 的 import 按文件计算，于是整个包编译不过。

## 修法：改用密封夹具，而不是把 import 加回去

把 import 加回去能让它编译，但等于把 Issue #296 要消除的宿主耦合再请回来。所以让存活下来的测例改用 #387 已经建好的密封夹具：

```diff
-	bin := t.TempDir()
-	scriptName := "semantix"
-	scriptBody := "#!/bin/sh\necho unexpected\n"
-	if runtime.GOOS == "windows" { ... }
-	if err := os.WriteFile(filepath.Join(bin, scriptName), ...); err != nil { ... }
-	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	fakeKernelPATH(t, fakeKernelArgv)
```

**断言一字未动**——`err` 必须为 nil、输出必须为空，两条 fail-soft 契约原样保留。只替换了环境准备部分。

### 为什么用 `fakeKernelArgv` 而不是 `fakeKernelHang`

这两个测例是**互补**的，都要保留：

- `TestSemantixLookupUnresponsiveKernel` → `fakeKernelHang`，测「kernel 接了活但永不回应，必须被杀掉」
- `TestSemantixLookupTimeoutFailsSoft` → `fakeKernelArgv`，测「deadline 已经过期时，**即使 kernel 立刻响应**也要软降级」

后者的原注释写明它是「独立于 argv 测试被放宽的预算，锁定生产韧性契约」，用 hang 模式会让它退化成前者的重复品。

## 验证

| 检查 | 结果 |
| --- | --- |
| `go vet ./harness/tool/` | 通过 |
| `go test ./harness/tool/` | 通过（8.3s） |
| 两个 timeout 测例 `-count=5` | 连续 10 次全绿，无抖动 |
| `go vet ./...` 全模块 | 通过 |

改动 1 个文件，`+5 -11`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XgyxBqHhLZWpGDd6JK9aC2
