### PR TITLE
feat(control): SetEffort——会话级推理深度就地切换，并定下单槽位优先级 (Issue #330)

### DIFF
--- a/docs/specs/issue-330-session-effort.md
+++ b/docs/specs/issue-330-session-effort.md
@@ -1,0 +1,199 @@
+# Spec v1 — 会话级 reasoning effort 就地切换（Issue #330）
+
+> 判级：Spec-Exempt。无 wire / 落盘格式变更——`provider.Request.EffortOverride`
+> 本就是已声明字段（`harness/provider/provider.go:225`），config schema 不动；
+> 无判定模型变更、无新顶层包。净增量是驱动端口加两个方法、Agent 加一个原子
+> 字段、一个带契约注释的解析助手。
+>
+> 基线：upstream/main `db7a936`（含 #328 / #329）。
+
+## 1. 问题
+
+除 reasoning effort 外，每个会话运行时旋钮都有就地 setter；`/effort` 是唯一一个
+为了改一个值要把会话拆了重建的。
+
+### 1.1 真源审计（2026-08-23，worktree `feat/issue-330-set-effort`）
+
+| 事实 | 证据 |
+|---|---|
+| setter 确实不存在 | `grep -rn SetEffort --include=*.go .` 全仓只有一处，还是 `harness/serve/serve.go:452` 的注释散文 |
+| 要抄的模板 | `Controller.SetAgentPreset`（`harness/control/controller.go:2792`）→ runner 接口断言 + `c.executor`；Agent 侧 `harness/agent/agent.go:1203` 写进 `agentPreset atomic.Value`（`:401`） |
+| effort 冻在构造期 | `boot.Options.EffortOverride` → `entry.Effort` → `provider.Selection{Effort: opts.EffortOverride}` |
+| 运行时通道已在线且已被占用 | `harness/agent/sampling_request.go:131` 是 `EffortOverride: a.governorOverride(),`——**只读 governor，不读任何会话值** |
+| governor 是默认关闭的实验 | `harness/agent/governor.go:17`：`var governorEnabled = os.Getenv("SEMANTIX_EXPERIMENT_GOVERNOR") == "1"`（注意：issue 正文写的是 `REASONIX_` 前缀，代码已随改名迁到 `SEMANTIX_`） |
+| 请求按 round 冻结 | `samplingRequest` 文档自述「once-prepared, frozen … All stream retries replay this exact payload」；round 循环在 `harness/agent/run_loop.go:386` 重建 |
+| 校验词表与传输词表不一致 | `config.EffortCapabilityForEntry` 会给出 `adaptive`/`enabled`/`none` 这类非深度档；`harness/provider/openai/effort.go:65-75` 的 `depthOnly` 恰好把它们剥掉 |
+| 裸 string 说不出「回到 auto」 | `config.NormalizeEffort` 对 `auto` 返回 `("", nil)` |
+| provider adapter 刻意不依赖 config | `grep -rln "semantix/harness/config" harness/provider/` **零命中** |
+
+## 2. 已定的两处选型
+
+issue 把这两条明确留给评审，本 spec 记录结论与理由，实现按此执行。
+
+### 2.1 优先级：Option A —— 用户显式级别赢
+
+`EffortOverride` 只有一个槽位。规则定为：**会话级别一旦设定（含显式 auto）
+即生效，governor 只在未设定时生效。**
+
+理由：governor 是 env 默认关闭的实验（`governor.go:17`），不是已交付的安全
+不变量；真正的成本兜底在 scheduler 的预算路径（降 tier / 硬停 round），不靠
+这个槽位；而一个实验静默压过用户的显式动作，是错误的默认。
+
+代价：用户可以钉死 `max` 多花钱，边界由上述预算机制兜住。
+
+### 2.2 一次性提示：不做
+
+issue 第 8 步与选型绑定——「选 B 才做，或评审另有要求」。既然定了 A，用户的
+命令本来就生效，没有要提醒的事。因此**不动 `event.go` 的 wire-stable 常量块**，
+也就没有 `CONTRIBUTING.md:29` 要求的 `docs/events.md` 同步义务。
+
+## 3. 设计
+
+### 3.1 三态，因此必须是 `*string`
+
+会话 effort 有三个行为各不相同的状态：
+
+| 状态 | `EffortOverride` | governor |
+|---|---|---|
+| 未设定 | governor 的值（或空） | 生效 |
+| 显式 auto | `""`（用 provider 配置的默认深度） | **被抑制** |
+| 具体深度 | 该深度 | 被抑制 |
+
+裸 `string` 分不出前两者——`NormalizeEffort("auto")` 返回 `("", nil)`，与「从未
+设过」同形，用户将永远无法从 governor 手里要回 provider 默认值。因此 Agent 侧存
+`atomic.Value` 持 `*string`。
+
+端口的 `SessionEffort() string` 用 `"auto"`（显式 auto）与 `""`（未设定）区分，
+保住 issue 指定的签名而不丢信息。
+
+### 3.2 解析助手
+
+`harness/agent/sampling_request.go:131` 由单一来源改为
+`EffortOverride: a.effectiveEffortOverride()`。该函数的**文档注释逐字写明
+§2.1 的规则**——那是将来唯一有人会看的地方，而两个方向上悄悄搞错正是本 issue
+要防的失败模式。
+
+```
+未设定 → a.governorOverride()
+已设定 → *sessionEffort（显式 auto 即 ""）
+```
+
+### 3.3 时序契约：下一个 model round，不是下一个 turn
+
+in-flight 请求已冻结并在重试时逐字重放（`sampling_request.go:152-192`），所以
+中途设定的级别最早在**下一 round 的重建**（`run_loop.go:386`）咬合。两个要写下来
+而不是留给人踩的推论：
+
+- **无工具调用的 turn 没有下一个 round**，级别落到再下一个 turn 的首个请求；
+- **`executeBatch` → `applyScheduledTier` 那个缝不需要加任何东西**——到那时本 round
+  的请求已经在线上，读它是惰性的。
+
+### 3.4 Controller 侧的 entry 从哪来
+
+`SetEffort` 需要 `*config.ProviderEntry` 才能校验，而 Controller 今天没有。
+
+**选 `config.Load()` per call**，复用 `currentEffortEntry`（`harness/control/slash.go`）
+的形状。issue 推荐的是「构建期缓存 + `/model` 切换时刷新」，本 spec 不采用：
+
+- 缓存要同时改构建路径与 `/model` 路径，多两处可能失配的状态；
+- 同样的磁盘读**今天已经在更热的路径上跑**——`effortArgItems` 的补全下拉每次
+  按键都会调 `currentEffortEntry`。`SetEffort` 是斜杠命令，频率低若干量级。
+
+若将来 profiling 证明它要紧，再升级到缓存，届时是纯内部改动。
+
+### 3.5 校验：按传输真能承载的深度词表
+
+只校验 `EffortCapabilityForEntry(entry).Levels` 会放进传输层随后静默丢弃的档位
+（例如 MiniMax 的 `adaptive`、Zhipu/LongCat 的任意值）。
+
+规则是「override 只调深度，从不调思考开关」，实现为 `harness/config` 的导出
+助手，剥掉 `auto|enabled|adaptive|disabled|none|off`。
+
+**为什么不直接从 adapter 导出**：`grep -rln "semantix/harness/config" harness/provider/`
+零命中——provider adapter 刻意不依赖用户配置。让 `harness/control` 反过来 import
+`harness/provider/openai` 也一样是破坏分层，且 `requestEffortVocabulary` 吃的是
+内部类型 `effortEndpoint`（由 `provider.Config` 而非 `config.ProviderEntry` 构造），
+导出它要连带导出那个类型。
+
+**漂移守卫用仅测试的跨包对拍**：在 `harness/provider/openai` 的测试里 import
+`harness/config`，对一张词表断言两侧结果逐一相等。测试文件的 import 不构成生产
+依赖，分层不变，而任一侧改了规则都会翻红。
+
+### 3.6 端口放 `Settings`
+
+effort 是运行时会话设置，不是 goal/plan-mode 关切，因此声明在 `Settings`
+（`harness/control/port.go:242`）而非 `Goals`。`port.go` 末尾的编译期断言块继续成立
+即可——全树没有任何手写实现 `SessionAPI` 的 double，都是内嵌接口。
+
+## 4. 非目标
+
+- `/effort` 的 CLI 改接（另开 issue；被 `harness/cli/switch_recovery_test.go` 钉住重建）。
+- `harness/acp` 的 `switchSessionEffort` 与 `harness/serve` 的 `/effort` 拦截改接。
+- 任何 effort 的 mid-turn provider 热替换。
+- 不动构造期路径：`boot.Options.EffortOverride` 仍是**起始**级别的来源，
+  `SetEffort` 在其上叠加会话覆盖。
+
+## 5. 任务拆解（TDD，逐任务一次 commit）
+
+**T1 — config 侧深度词表 + 跨包对拍**
+1. 写 `harness/config` 的表驱动测例与 openai 侧对拍测例，跑，预期 RED。
+2. 实现导出助手。跑，预期 GREEN。commit。
+
+**T2 — Agent 会话 effort 盒子 + 优先级助手**
+1. 写 `harness/agent/effort_test.go`：优先级表（governor 引擎/未引擎 × 会话未设/
+   显式 auto/具体深度），**每格都钉住 governor 状态**——同一字段两个来源，不钉
+   就是构造性 flaky。跑，预期 RED。
+2. 加 `sessionEffort atomic.Value`（持 `*string`）、`SetSessionEffort`/
+   `SessionEffort`、`effectiveEffortOverride`（注释写死规则），改 `:131`。
+3. 跑，预期 GREEN。commit。
+
+**T3 — 时序契约测例**
+1. 两 round 的 turn：round 1 请求冻结后设会话级别，断言 round 2 携带新值而
+   round 1 不带；重试 round 的请求与首次 `reflect.DeepEqual`；单 round（无工具
+   调用）turn 不受影响、级别落到下一 turn。commit。
+
+**T4 — Controller.SetEffort / SessionEffort + 端口**
+1. 写测例：不支持的 entry 报错且不改状态；`Levels` 里有但被深度过滤剥掉的档位
+   报错且不改状态；成功后 `SessionEffort()` 可读回；`SetEffort("auto")` 与从未
+   设过可区分。跑，预期 RED。
+2. 实现两个方法 + `Settings` 端口声明 + i18n 三语错误串。
+3. 跑，预期 GREEN。commit。
+
+**T5 — 不重建 + 竞态**
+1. 计数型 provider factory / tier resolver，断言 `SetEffort` 前后构造次数不变。
+2. `-race` 下另一 goroutine 在 turn 运行中调 `SetEffort`，run 干净结束。
+   （本机无 cgo，`-race` 由 CI 承担；本地跑无 -race 版本并如实标注。）commit。
+
+**T6 — 验收**：`go build ./...`、`go vet ./...`、
+`go test ./harness/agent/... ./harness/control/... ./harness/config/... ./harness/provider/openai/...`。
+spec commit，开 PR。
+
+## 6. 验收标准
+
+- `Controller.SetEffort(level string) error` 与 `SessionEffort() string` 存在并
+  声明在 `Settings`，`port.go` 编译期断言块仍成立。今天 RED（全仓只有注释）。
+- 会话级别设定后，下一个 `provider.Request` 的 `EffortOverride` 等于该级别；
+  清回 auto 后为 `""` 且 governor 仍被抑制；未设定时恢复 `a.governorOverride()`。
+- **优先级表测例**：governor 引擎 × 会话三态共 6 格，每格都显式钉住 governor
+  状态；规则与 `effectiveEffortOverride` 的文档注释逐字一致。
+- **下一 round 生效**：两 round turn 中 round 1 不带、round 2 带。
+- **冻结重放**：重试 round 的 `provider.Request` 与首次 `reflect.DeepEqual`。
+- **无工具调用 turn**：不受影响，级别落到下一 turn 首个请求（断言而非假设）。
+- `SetEffort` 对 (a) `EffortCapability.Supported` 为 false 的 entry、(b) 在
+  `Levels` 中但被深度过滤剥掉的档位（如 MiniMax 的 `adaptive`），均返回错误且
+  不改动任何状态。
+- `SetEffort` 前后无 provider 重建（计数断言）。
+- `-race` 下并发 `SetEffort` 与运行中的 turn 互不干扰。
+- `go vet ./...`、`go build ./...` 干净。
+
+### 6.1 已知残余
+
+- 本 issue 交付的是 setter，**零生产调用方**（CLI / ACP / serve 的改接是明确的
+  非目标）。这是设计意图，不是遗漏。
+- `anthropic` 与 `responses` adapter 今天完全不读 `provider.Request.EffortOverride`
+  （`grep` 零命中），所以本 issue 的效果目前只覆盖 `harness/provider/openai`。
+  这正是 #331 的存在理由；本 issue 不阻塞于它，但两者应在同一里程碑，
+  且**在 #331 落地前不得改接 CLI**——否则会把一个当前可用的 `/effort` 变成对那
+  两族的静默 no-op。
+- 本机无 C 编译器（`go test -race` 报 `-race requires cgo`），`-race` 由 CI
+  ubuntu-latest 承担。

--- a/docs/specs/issue-330-session-effort.md
+++ b/docs/specs/issue-330-session-effort.md
@@ -99,25 +99,36 @@ in-flight 请求已冻结并在重试时逐字重放（`sampling_request.go:152-
 - 同样的磁盘读**今天已经在更热的路径上跑**——`effortArgItems` 的补全下拉每次
   按键都会调 `currentEffortEntry`。`SetEffort` 是斜杠命令，频率低若干量级。
 
-若将来 profiling 证明它要紧，再升级到缓存，届时是纯内部改动。
+若将来 profiling 证明它要紧，再升级到缓存，届时是纯内部改动。取的形状对齐
+`imageInputEnabled`：`config.LoadForRoot(c.workspaceRoot)`，`modelRef` 为空时
+回落 `cfg.DefaultModel`。
+
+**校验逻辑抽成纯函数**：`resolveSessionEffort(entry, level)` 只做校验、不碰磁盘，
+`SetEffort` 只剩「取 entry + 校验 + 转发」。这样 12 格的校验表可以全程离线跑，
+而不必为了测一个词表规则去铺一份临时 config。issue 未提这一层，属实现细节。
+
+**`SessionEffort()` 的读取顺序**对齐 `AgentPreset()`：executor → runner → 本地
+副本（`c.sessionEffort`，受 `c.mu` 保护）。executor 挂上后它是权威；没挂时端口
+仍要能诚实作答。
 
 ### 3.5 校验：按传输真能承载的深度词表
 
 只校验 `EffortCapabilityForEntry(entry).Levels` 会放进传输层随后静默丢弃的档位
 （例如 MiniMax 的 `adaptive`、Zhipu/LongCat 的任意值）。
 
-规则是「override 只调深度，从不调思考开关」，实现为 `harness/config` 的导出
-助手，剥掉 `auto|enabled|adaptive|disabled|none|off`。
+规则是「override 只调深度，从不调思考开关」，剥掉
+`auto|enabled|adaptive|disabled|none|off`。
 
-**为什么不直接从 adapter 导出**：`grep -rln "semantix/harness/config" harness/provider/`
-零命中——provider adapter 刻意不依赖用户配置。让 `harness/control` 反过来 import
-`harness/provider/openai` 也一样是破坏分层，且 `requestEffortVocabulary` 吃的是
-内部类型 `effortEndpoint`（由 `provider.Config` 而非 `config.ProviderEntry` 构造），
-导出它要连带导出那个类型。
+**规则留在 adapter，config 侧只包一层。** 起草本节时我以为
+`harness/provider/openai` 与 `harness/config` 互不依赖，打算把规则镜像进 config
+再用仅测试的跨包对拍守漂移。查依赖方向后作废：**`harness/config` 本来就 import
+`harness/provider/openai`**（`effort.go:8`、`fetch.go:10`），而且 `effort.go:371`
+的 `isDeepSeekEntry` 就带着现成的注释说明为什么——「实际匹配放在 provider/openai，
+让两层在新增网关时保持同步」。
 
-**漂移守卫用仅测试的跨包对拍**：在 `harness/provider/openai` 的测试里 import
-`harness/config`，对一张词表断言两侧结果逐一相等。测试文件的 import 不构成生产
-依赖，分层不变，而任一侧改了规则都会翻红。
+所以：`depthOnly` 导出为 `openai.DepthEffortLevels`，`config.DepthEffortLevels(e)`
+包一层。单一真源，无漂移可守——而原计划的那个对拍测试方向反了，会构成 import 环，
+根本编译不过。
 
 ### 3.6 端口放 `Settings`
 
@@ -196,4 +207,12 @@ spec commit，开 PR。
   且**在 #331 落地前不得改接 CLI**——否则会把一个当前可用的 `/effort` 变成对那
   两族的静默 no-op。
 - 本机无 C 编译器（`go test -race` 报 `-race requires cgo`），`-race` 由 CI
-  ubuntu-latest 承担。
+  ubuntu-latest 承担。并发那条测例在无 `-race` 时仍然跑通该路径，并检查最终值
+  与每个 round 携带的值都必须是写过的值之一。
+- `harness/agent` 的**包级 goleak 在本改动之前就失败**（残留 `net/http`
+  keep-alive goroutine）。已在 base 复验：把本 issue 的 agent 改动还原后，同一
+  命令同样退出 1、同样只有那一条 goleak 报错，且所有测例都 PASS。属既有问题，
+  不在本 issue 范围内。
+- 变异检验（各自确认翻红后回滚）：
+  - 优先级翻成 Option B → 6 格表里恰好翻红区分两者的那 2 格；
+  - `sampling_request.go:131` 改回只读 governor → 三条时序契约测例全红。

--- a/harness/agent/agent.go
+++ b/harness/agent/agent.go
@@ -400,6 +400,18 @@ type Agent struct {
 	// update subsequent turns without rebuilding the agent.
 	agentPreset atomic.Value // string light|balanced|delivery
 
+	// sessionEffort is the session-scoped reasoning depth. Atomic for the same
+	// reason as agentPreset: subsequent rounds pick it up without a rebuild.
+	//
+	// It holds a *string, not a string, because three states behave
+	// differently and the third would otherwise be unreachable: unset (the
+	// governor may drive the slot), explicitly auto (the configured depth, and
+	// the governor stands down), and a depth. config.NormalizeEffort maps auto
+	// to "", so a bare string cannot tell "auto" from "never set" — and a user
+	// who could not express auto could never take the dial back once the
+	// governor experiment was on.
+	sessionEffort atomic.Value // *string; a typed-nil pointer means "unset"
+
 	// turn is the state of the Run currently executing; beginRunTurn replaces
 	// it wholesale. See turnruntime.go.
 	turn turnRuntime
@@ -1215,6 +1227,69 @@ func (a *Agent) SetAgentPreset(preset string) {
 		// Light may still elevate per-turn; baseline stays non-delivery.
 		a.deliveryProfile = false
 	}
+}
+
+// SetSessionEffort sets or clears the session-scoped reasoning depth used by
+// subsequent model rounds. Like SetAgentPreset it rebuilds nothing; unlike it,
+// the value reaches the wire per round rather than per turn — see
+// effectiveEffortOverride for when it bites.
+//
+// A nil level clears the override. A non-nil pointer to "" is an explicit
+// auto: use the provider's configured depth, and stand the governor down.
+func (a *Agent) SetSessionEffort(level *string) {
+	if a == nil {
+		return
+	}
+	if level == nil {
+		a.sessionEffort.Store((*string)(nil))
+		return
+	}
+	// Copy: the caller keeps its pointer and must not be able to mutate the
+	// session's level out from under a round that is being built.
+	stored := *level
+	a.sessionEffort.Store(&stored)
+}
+
+// SessionEffort returns the session-scoped depth and whether one is set. The
+// bool is the whole point: ("", true) is an explicit auto, ("", false) is an
+// untouched dial, and they resolve differently against the governor.
+func (a *Agent) SessionEffort() (string, bool) {
+	if a == nil {
+		return "", false
+	}
+	level, _ := a.sessionEffort.Load().(*string)
+	if level == nil {
+		return "", false
+	}
+	return *level, true
+}
+
+// effectiveEffortOverride resolves the single Request.EffortOverride slot
+// (provider.Request.EffortOverride) that the reasoning governor and the session
+// dial both want to write.
+//
+// The rule: an explicit session level wins whenever one is set — including an
+// explicit auto, which asks for the configured depth and therefore also stands
+// the governor down. The governor applies only when the user has never touched
+// the dial, which is the overwhelming majority of sessions.
+//
+// Why that direction: the governor is an experiment gated off by default
+// (SEMANTIX_EXPERIMENT_GOVERNOR), not a shipped safety invariant, and an
+// experiment silently beating an explicit user action is the wrong default.
+// Cost containment does not rest here either — the scheduler's budget path
+// degrades the tier or stops the round outright, so reasoning depth is not the
+// last line of defence.
+//
+// Timing: the value is read while a round's request is being built, and that
+// request is then frozen and replayed verbatim on every stream retry. A level
+// chosen mid-turn therefore engages at the next round, never mid-round; a turn
+// that answers with no tool calls has no next round, so its level lands on the
+// following turn.
+func (a *Agent) effectiveEffortOverride() string {
+	if level, ok := a.SessionEffort(); ok {
+		return level
+	}
+	return a.governorOverride()
 }
 
 // AgentPreset returns the current session role setting (never empty).

--- a/harness/agent/effort_runtime_test.go
+++ b/harness/agent/effort_runtime_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"semantix/harness/event"
+	"semantix/harness/provider"
+	"semantix/harness/tool"
+)
+
+// TestSetSessionEffortDoesNotSwapTheProvider guards the whole point of the
+// setter. Changing effort by rebuilding is exactly what the CLI does today, so
+// this failure mode is not hypothetical: a later "implementation" that reached
+// for a rebuild would still satisfy every behavioural test in this package
+// while discarding the provider, its pricing, and any fork-capture wrapper
+// installed mid-run.
+func TestSetSessionEffortDoesNotSwapTheProvider(t *testing.T) {
+	prov := &effortHookProvider{turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	before := a.svc.prov
+
+	a.SetSessionEffort(effortPtr("high"))
+	if a.svc.prov != before {
+		t.Fatal("SetSessionEffort replaced the provider")
+	}
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if a.svc.prov != before {
+		t.Fatal("the run after SetSessionEffort replaced the provider")
+	}
+	if got := prov.requests[0].EffortOverride; got != "high" {
+		t.Fatalf("override = %q, want high — the level must reach that same provider", got)
+	}
+}
+
+// TestSetSessionEffortConcurrentWithARun: the dial is a UI-goroutine action and
+// the rounds read it from the run goroutine, so the two genuinely overlap.
+// Under -race the race detector is the assertion; without it this still
+// exercises the path and checks that the value never lands somewhere incoherent.
+func TestSetSessionEffortConcurrentWithARun(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(NewAskTool())
+	prov := &effortHookProvider{turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "ask", `{"questions":["q":1]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		levels := []*string{effortPtr("low"), effortPtr("high"), effortPtr(""), nil}
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			a.SetSessionEffort(levels[i%len(levels)])
+		}
+	}()
+
+	err := a.Run(context.Background(), "go")
+	close(stop)
+	<-done
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Whatever the racing writer left behind must still be one of the values it
+	// actually wrote — a torn read would show up here as something else.
+	if level, ok := a.SessionEffort(); ok && level != "" && level != "low" && level != "high" {
+		t.Fatalf("session effort settled on %q, which was never written", level)
+	}
+	for i, req := range prov.requests {
+		switch req.EffortOverride {
+		case "", "low", "high":
+		default:
+			t.Fatalf("round %d carried %q, which was never written", i, req.EffortOverride)
+		}
+	}
+}

--- a/harness/agent/effort_test.go
+++ b/harness/agent/effort_test.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"testing"
+)
+
+func effortPtr(s string) *string { return &s }
+
+// TestEffectiveEffortOverridePrecedence pins the contract for the single
+// Request.EffortOverride slot, which the governor owned outright before a
+// session level existed. Every cell fixes the governor's state explicitly:
+// two producers write the same field, so an assertion that leaves the governor
+// unpinned is flaky by construction rather than by accident.
+//
+// The rule under test: an explicit session level wins whenever one is set —
+// including an explicit "auto", which asks for the provider's configured depth
+// and therefore also suppresses the governor. The governor applies only when
+// the user has never touched the dial.
+func TestEffectiveEffortOverridePrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		engaged  bool
+		session  *string
+		want     string
+		wantWhy  string
+	}{
+		{
+			name: "governor idle, no session level", engaged: false, session: nil,
+			want: "", wantWhy: "nothing overrides the configured depth",
+		},
+		{
+			name: "governor idle, explicit auto", engaged: false, session: effortPtr(""),
+			want: "", wantWhy: "auto means the configured depth",
+		},
+		{
+			name: "governor idle, session depth", engaged: false, session: effortPtr("high"),
+			want: "high", wantWhy: "the only producer",
+		},
+		{
+			name: "governor engaged, no session level", engaged: true, session: nil,
+			want: governorEffort, wantWhy: "the governor keeps its full effect on an untouched dial",
+		},
+		{
+			name: "governor engaged, explicit auto", engaged: true, session: effortPtr(""),
+			want: "", wantWhy: "an explicit auto is a user decision and outranks the experiment",
+		},
+		{
+			name: "governor engaged, session depth", engaged: true, session: effortPtr("max"),
+			want: "max", wantWhy: "an explicit level outranks the experiment",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := governorEnabled
+			governorEnabled = true
+			t.Cleanup(func() { governorEnabled = old })
+
+			a := &Agent{}
+			a.task.governor.engaged = tc.engaged
+			a.SetSessionEffort(tc.session)
+
+			if got := a.effectiveEffortOverride(); got != tc.want {
+				t.Errorf("effectiveEffortOverride = %q, want %q (%s)", got, tc.want, tc.wantWhy)
+			}
+		})
+	}
+}
+
+// TestSessionEffortRoundTripsThreeStates: "never set" and "explicitly auto"
+// must stay distinguishable. config.NormalizeEffort maps auto to the empty
+// string, so a bare-string box would collapse them — and the user could never
+// take the dial back from the governor once the experiment was on.
+func TestSessionEffortRoundTripsThreeStates(t *testing.T) {
+	a := &Agent{}
+
+	if level, ok := a.SessionEffort(); ok || level != "" {
+		t.Fatalf("fresh agent = (%q, %v), want unset", level, ok)
+	}
+
+	a.SetSessionEffort(effortPtr("high"))
+	if level, ok := a.SessionEffort(); !ok || level != "high" {
+		t.Fatalf("after set = (%q, %v), want (high, true)", level, ok)
+	}
+
+	a.SetSessionEffort(effortPtr(""))
+	if level, ok := a.SessionEffort(); !ok || level != "" {
+		t.Fatalf("after explicit auto = (%q, %v), want (\"\", true) — set, and set to auto", level, ok)
+	}
+
+	a.SetSessionEffort(nil)
+	if level, ok := a.SessionEffort(); ok || level != "" {
+		t.Fatalf("after clear = (%q, %v), want unset", level, ok)
+	}
+}
+
+// TestGovernorResumesAfterSessionLevelCleared: clearing is not the same as
+// setting auto — it hands the slot back to the governor.
+func TestGovernorResumesAfterSessionLevelCleared(t *testing.T) {
+	old := governorEnabled
+	governorEnabled = true
+	t.Cleanup(func() { governorEnabled = old })
+
+	a := &Agent{}
+	a.task.governor.engaged = true
+
+	a.SetSessionEffort(effortPtr("low"))
+	if got := a.effectiveEffortOverride(); got != "low" {
+		t.Fatalf("with session level = %q, want low", got)
+	}
+	a.SetSessionEffort(nil)
+	if got := a.effectiveEffortOverride(); got != governorEffort {
+		t.Fatalf("after clear = %q, want the governor's %q back", got, governorEffort)
+	}
+}

--- a/harness/agent/effort_timing_test.go
+++ b/harness/agent/effort_timing_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"semantix/harness/event"
+	"semantix/harness/provider"
+	"semantix/harness/tool"
+)
+
+// effortHookProvider records every Stream call's request and runs a hook right
+// after it, which is the only way to ask the timing question honestly: the
+// level has to change *between* the round already frozen and the one still to
+// be built, exactly as it would if a user typed the command mid-turn.
+type effortHookProvider struct {
+	turns    [][]provider.Chunk
+	call     int
+	requests []provider.Request
+	after    func(call int)
+}
+
+func (p *effortHookProvider) Name() string { return "hook" }
+
+func (p *effortHookProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.requests = append(p.requests, req)
+	i := min(p.call, len(p.turns)-1)
+	p.call++
+	ch := make(chan provider.Chunk, len(p.turns[i]))
+	for _, c := range p.turns[i] {
+		ch <- c
+	}
+	close(ch)
+	if p.after != nil {
+		p.after(len(p.requests) - 1)
+	}
+	return ch, nil
+}
+
+// TestSessionEffortReachesTheNextRoundNotTheCurrentOne: a round's request is
+// built once and frozen, so the earliest a new level can bite is the next
+// round's rebuild. Asserting both halves — round 1 unchanged, round 2 changed —
+// is what makes this a contract rather than a hope.
+func TestSessionEffortReachesTheNextRoundNotTheCurrentOne(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(NewAskTool())
+	prov := &effortHookProvider{turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "ask", `{"questions":["q":1]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	prov.after = func(call int) {
+		if call == 0 {
+			a.SetSessionEffort(effortPtr("high"))
+		}
+	}
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(prov.requests) < 2 {
+		t.Fatalf("requests = %d, want the tool round and the follow-up", len(prov.requests))
+	}
+	if got := prov.requests[0].EffortOverride; got != "" {
+		t.Errorf("round 1 override = %q, want empty — it was frozen before the level was set", got)
+	}
+	if got := prov.requests[1].EffortOverride; got != "high" {
+		t.Errorf("round 2 override = %q, want high", got)
+	}
+}
+
+// TestSessionEffortOnASingleRoundTurnLandsOnTheNextTurn pins the documented
+// limitation rather than leaving it to be discovered: a turn that answers with
+// no tool calls has no next round, so the level waits for the next turn.
+func TestSessionEffortOnASingleRoundTurnLandsOnTheNextTurn(t *testing.T) {
+	prov := &effortHookProvider{turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	prov.after = func(call int) {
+		if call == 0 {
+			a.SetSessionEffort(effortPtr("high"))
+		}
+	}
+
+	if err := a.Run(context.Background(), "first"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if len(prov.requests) != 1 {
+		t.Fatalf("first turn requests = %d, want 1 (no tool calls, no second round)", len(prov.requests))
+	}
+	if got := prov.requests[0].EffortOverride; got != "" {
+		t.Errorf("the only round of turn 1 = %q, want empty", got)
+	}
+
+	if err := a.Run(context.Background(), "second"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if len(prov.requests) < 2 {
+		t.Fatalf("requests after turn 2 = %d, want at least 2", len(prov.requests))
+	}
+	if got := prov.requests[1].EffortOverride; got != "high" {
+		t.Errorf("turn 2's first round = %q, want high", got)
+	}
+}
+
+// TestRetriedRoundReplaysTheFrozenEffort: an in-flight round is never
+// re-levelled. The retry must replay the exact payload, override included —
+// changing depth halfway through a round would make the retry a different
+// request wearing the first one's identity.
+func TestRetriedRoundReplaysTheFrozenEffort(t *testing.T) {
+	interrupted := &provider.StreamInterruptedError{
+		Err: errors.New("read stream: unexpected EOF"), Reason: provider.StreamInterruptPrematureEOF,
+	}
+	prov := &effortHookProvider{turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "partial "}, {Type: provider.ChunkError, Err: interrupted}},
+		{{Type: provider.ChunkText, Text: "continued"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, echoRegistry(), NewSession(""), Options{}, event.Discard)
+	a.SetSessionEffort(effortPtr("low"))
+	prov.after = func(call int) {
+		if call == 0 {
+			// A level set during the retry window must not reach the replay.
+			a.SetSessionEffort(effortPtr("max"))
+		}
+	}
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run should recover the interrupted stream, got %v", err)
+	}
+	if len(prov.requests) != 2 {
+		t.Fatalf("requests = %d, want the attempt and its replay", len(prov.requests))
+	}
+	if got := prov.requests[1].EffortOverride; got != "low" {
+		t.Errorf("replay override = %q, want the frozen low", got)
+	}
+	if !reflect.DeepEqual(prov.requests[0], prov.requests[1]) {
+		t.Errorf("replay is not the frozen payload:\n first %+v\nreplay %+v",
+			prov.requests[0], prov.requests[1])
+	}
+}

--- a/harness/agent/sampling_request.go
+++ b/harness/agent/sampling_request.go
@@ -128,7 +128,7 @@ func (a *Agent) buildSamplingRequest(ctx context.Context, trigger string) (sampl
 		MaxTokens:      a.maxOutputTokens,
 		Temperature:    provider.OptionalTemperature(a.temperature),
 		ResponseFormat: responseFormatFromRequest(ctx),
-		EffortOverride: a.governorOverride(),
+		EffortOverride: a.effectiveEffortOverride(),
 	}
 	// provider.request: the fully assembled request gets one last ruling
 	// (revalidated by the payload registry) before it goes on the wire.

--- a/harness/config/effort.go
+++ b/harness/config/effort.go
@@ -130,6 +130,21 @@ func EffortCapabilityForEntry(e *ProviderEntry) EffortCapability {
 	}
 }
 
+// DepthEffortLevels returns the subset of an entry's advertised /effort levels
+// that a per-request override can actually carry.
+//
+// EffortCapabilityForEntry is the right vocabulary for a config write, but the
+// wrong one for a runtime override: it advertises thinking on/off tokens
+// (adaptive, enabled, none) alongside real depths, and an override adjusts
+// depth only. Validating a session-scoped level against Levels alone would
+// accept, say, adaptive for MiniMax and then have the transport drop it with no
+// error anywhere. The rule itself lives in provider/openai so the two layers
+// stay in lockstep — see openai.DepthEffortLevels, and isDeepSeekEntry below
+// for the same delegation shape.
+func DepthEffortLevels(e *ProviderEntry) []string {
+	return openai.DepthEffortLevels(EffortCapabilityForEntry(e).Levels)
+}
+
 // NormalizeEffort maps a user-supplied /effort level into the value stored in
 // config. Empty means auto/provider default.
 func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {

--- a/harness/config/effort_depth_test.go
+++ b/harness/config/effort_depth_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestDepthEffortLevelsDropsThinkingToggles pins the gap that makes validating
+// against EffortCapabilityForEntry alone a trap: that vocabulary legitimately
+// advertises thinking on/off tokens, but a per-request override adjusts depth
+// and nothing else, so the transport drops them. A setter that validated only
+// against Levels would accept a level the wire then silently discards.
+func TestDepthEffortLevelsDropsThinkingToggles(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		entry *ProviderEntry
+		want  []string
+	}{
+		{
+			// {"auto","adaptive","disabled"} — a binary thinking knob, no depth.
+			name:  "minimax has no carryable depth",
+			entry: &ProviderEntry{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1"},
+			want:  nil,
+		},
+		{
+			name:  "zhipu has no carryable depth",
+			entry: &ProviderEntry{Kind: "openai", BaseURL: "https://open.bigmodel.cn/api/paas/v4"},
+			want:  nil,
+		},
+		{
+			name:  "longcat has no carryable depth",
+			entry: &ProviderEntry{Kind: "openai", BaseURL: "https://api.longcat.chat/openai/v1"},
+			want:  nil,
+		},
+		{
+			// {"auto","none","low","medium","high","max"} — auto and none are
+			// "omit the field", not depths.
+			name:  "ollama cloud keeps only the depths",
+			entry: &ProviderEntry{Kind: "openai", BaseURL: "https://ollama.com/v1"},
+			want:  []string{"low", "medium", "high", "max"},
+		},
+		{
+			name:  "anthropic keeps only the depths",
+			entry: &ProviderEntry{Kind: "anthropic"},
+			want:  []string{"low", "medium", "high", "xhigh", "max"},
+		},
+		{
+			name:  "entry with no reasoning support has none",
+			entry: &ProviderEntry{Kind: "openai", BaseURL: "https://example.com/v1"},
+			want:  nil,
+		},
+		{
+			name:  "nil entry has none",
+			entry: nil,
+			want:  nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DepthEffortLevels(tc.entry); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("DepthEffortLevels = %v, want %v (capability levels were %v)",
+					got, tc.want, EffortCapabilityForEntry(tc.entry).Levels)
+			}
+		})
+	}
+}
+
+// TestDepthEffortLevelsIsASubsetOfTheCapability guards the wrapper itself: the
+// depth list may only ever narrow the advertised vocabulary, never invent a
+// level the entry does not claim to support.
+func TestDepthEffortLevelsIsASubsetOfTheCapability(t *testing.T) {
+	for _, entry := range []*ProviderEntry{
+		{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1"},
+		{Kind: "openai", BaseURL: "https://ollama.com/v1"},
+		{Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro"},
+		{Kind: "anthropic"},
+	} {
+		advertised := map[string]bool{}
+		for _, level := range EffortCapabilityForEntry(entry).Levels {
+			advertised[level] = true
+		}
+		for _, level := range DepthEffortLevels(entry) {
+			if !advertised[level] {
+				t.Errorf("%s/%s: depth level %q is not advertised in the capability",
+					entry.Kind, entry.BaseURL, level)
+			}
+		}
+	}
+}

--- a/harness/control/controller.go
+++ b/harness/control/controller.go
@@ -216,6 +216,11 @@ type Controller struct {
 	// entering the provider-visible registry (Balanced dual-model Planner).
 	proxyToolsFn   func() map[string][]plugin.CachedTool
 	runtimeProfile capability.Profile
+	// sessionEffort is the local copy of the session-scoped reasoning depth,
+	// guarded by mu. The executor is authoritative once attached — this answers
+	// SessionEffort before one is, the same fallback shape AgentPreset uses.
+	// nil means the dial was never touched; a pointer to "" is an explicit auto.
+	sessionEffort *string
 	ablation       ablation.Set
 
 	// goals owns the active goal's FSM (status, intercepts, idle/turn counters)

--- a/harness/control/effort.go
+++ b/harness/control/effort.go
@@ -1,0 +1,159 @@
+// Session-scoped reasoning depth: an in-place runtime dial, the counterpart to
+// SetAgentPreset. The construction-time level (boot.Options.EffortOverride)
+// stays the session's starting point; this layers an override on top of it and
+// rebuilds nothing.
+package control
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"semantix/harness/config"
+	"semantix/harness/i18n"
+)
+
+// SetEffort sets the session-scoped reasoning depth used by subsequent model
+// rounds, without rebuilding the controller, provider, or tool schemas.
+//
+// Three inputs, three outcomes — the middle one is why the port takes a string
+// rather than a bool-plus-value:
+//
+//	""     clears the override; whatever drove the slot before drives it again
+//	"auto" is an explicit choice of the provider's configured depth
+//	a depth is that depth
+//
+// A rejected level changes nothing. Errors are translated except the one
+// forwarded from config.NormalizeEffort, which owns the vocabulary and reports
+// in the raw English its layer uses throughout.
+func (c *Controller) SetEffort(level string) error {
+	if c == nil {
+		return fmt.Errorf("controller is nil")
+	}
+	resolved, err := resolveSessionEffort(c.effortEntry(), level)
+	if err != nil {
+		return err
+	}
+	c.storeSessionEffort(resolved)
+	if setter, ok := c.runner.(interface{ SetSessionEffort(*string) }); ok {
+		setter.SetSessionEffort(resolved)
+	}
+	if c.executor != nil {
+		c.executor.SetSessionEffort(resolved)
+	}
+	return nil
+}
+
+// SessionEffort reports the session-scoped depth: "" when the dial has never
+// been touched, "auto" when it was deliberately set back to the provider
+// default, or the depth. Those first two are different states — one lets the
+// reasoning governor drive the slot, the other does not — so the port spells
+// auto out rather than collapsing both to "".
+func (c *Controller) SessionEffort() string {
+	if c == nil {
+		return ""
+	}
+	if c.executor != nil {
+		return spellSessionEffort(c.executor.SessionEffort())
+	}
+	if getter, ok := c.runner.(interface {
+		SessionEffort() (string, bool)
+	}); ok {
+		return spellSessionEffort(getter.SessionEffort())
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sessionEffort == nil {
+		return ""
+	}
+	return spellSessionEffort(*c.sessionEffort, true)
+}
+
+func spellSessionEffort(level string, set bool) string {
+	switch {
+	case !set:
+		return ""
+	case level == "":
+		return "auto"
+	default:
+		return level
+	}
+}
+
+func (c *Controller) storeSessionEffort(level *string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if level == nil {
+		c.sessionEffort = nil
+		return
+	}
+	stored := *level
+	c.sessionEffort = &stored
+}
+
+// effortEntry resolves the provider entry the current model points at.
+//
+// A disk read per call, deliberately: the alternative is caching the entry at
+// build time and refreshing it on every /model switch, which buys a rare slash
+// command some microseconds at the price of two more places for the cached
+// copy to go stale. The same read already happens on a far hotter path —
+// currentEffortEntry runs from the /effort completion dropdown, once per
+// keystroke.
+func (c *Controller) effortEntry() *config.ProviderEntry {
+	cfg, err := config.LoadForRoot(c.workspaceRoot)
+	if err != nil {
+		return nil
+	}
+	ref := strings.TrimSpace(c.modelRef)
+	if ref == "" {
+		ref = cfg.DefaultModel
+	}
+	if ref == "" {
+		return nil
+	}
+	entry, _ := cfg.ResolveModel(ref)
+	return entry
+}
+
+// resolveSessionEffort validates a requested level against the resolved entry
+// and returns the value to store: nil clears, a pointer to "" is an explicit
+// auto, otherwise the normalized depth.
+//
+// It checks the depth vocabulary, not just the capability's Levels. The two
+// disagree on purpose: EffortCapabilityForEntry advertises thinking on/off
+// tokens (adaptive, enabled, none) that are meaningful for a config write but
+// cannot ride a per-request override, so validating against Levels alone would
+// accept a level the transport then silently discards — a setter reporting
+// success for something that never reaches a request.
+func resolveSessionEffort(entry *config.ProviderEntry, level string) (*string, error) {
+	level = strings.TrimSpace(level)
+	if level == "" {
+		return nil, nil
+	}
+	if !config.EffortCapabilityForEntry(entry).Supported {
+		return nil, fmt.Errorf(i18n.M.SessionEffortUnsupportedFmt, effortEntryName(entry))
+	}
+	if strings.EqualFold(level, "auto") {
+		auto := ""
+		return &auto, nil
+	}
+	normalized, err := config.NormalizeEffort(entry, level)
+	if err != nil {
+		return nil, err
+	}
+	if normalized == "" {
+		auto := ""
+		return &auto, nil
+	}
+	if !slices.Contains(config.DepthEffortLevels(entry), normalized) {
+		return nil, fmt.Errorf(i18n.M.SessionEffortNotADepthFmt, normalized, effortEntryName(entry))
+	}
+	return &normalized, nil
+}
+
+func effortEntryName(e *config.ProviderEntry) string {
+	if e != nil && strings.TrimSpace(e.Name) != "" {
+		return e.Name
+	}
+	return "this model"
+}

--- a/harness/control/effort_test.go
+++ b/harness/control/effort_test.go
@@ -1,0 +1,131 @@
+package control
+
+import (
+	"testing"
+
+	"semantix/harness/config"
+)
+
+func ptrOf(s string) *string { return &s }
+
+// TestResolveSessionEffortValidatesAgainstCarryableDepths keeps the validation
+// exhaustive without touching disk: SetEffort's only other job is loading the
+// entry.
+//
+// The load-bearing case is "adaptive on MiniMax" — advertised by
+// EffortCapabilityForEntry and therefore accepted by any check that stops
+// there, yet dropped by the transport, which would make the setter report
+// success for a level that never reaches a request.
+func TestResolveSessionEffortValidatesAgainstCarryableDepths(t *testing.T) {
+	var (
+		noReasoning = &config.ProviderEntry{Kind: "openai", BaseURL: "https://example.com/v1", Name: "plain"}
+		minimax     = &config.ProviderEntry{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1", Name: "minimax"}
+		ollama      = &config.ProviderEntry{Kind: "openai", BaseURL: "https://ollama.com/v1", Name: "ollama"}
+	)
+	for _, tc := range []struct {
+		name    string
+		entry   *config.ProviderEntry
+		level   string
+		want    *string
+		wantErr bool
+	}{
+		{name: "empty clears the override", entry: ollama, level: "", want: nil},
+		{name: "empty clears even without a resolved entry", entry: nil, level: "", want: nil},
+		{name: "auto is an explicit level, not a clear", entry: ollama, level: "auto", want: ptrOf("")},
+		{name: "auto is case-insensitive", entry: ollama, level: "AUTO", want: ptrOf("")},
+		{name: "a carryable depth is stored", entry: ollama, level: "high", want: ptrOf("high")},
+		{name: "surrounding space is trimmed", entry: ollama, level: "  max  ", want: ptrOf("max")},
+
+		{name: "entry without reasoning is rejected", entry: noReasoning, level: "high", wantErr: true},
+		{name: "auto on an entry without reasoning is rejected", entry: noReasoning, level: "auto", wantErr: true},
+		{name: "unresolved entry is rejected", entry: nil, level: "high", wantErr: true},
+		{name: "level outside the vocabulary is rejected", entry: ollama, level: "bogus", wantErr: true},
+		{
+			// Advertised by the capability, stripped by the transport.
+			name: "advertised thinking toggle is rejected", entry: minimax, level: "adaptive", wantErr: true,
+		},
+		{name: "entry whose whole vocabulary is toggles is rejected", entry: minimax, level: "high", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveSessionEffort(tc.entry, tc.level)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveSessionEffort = %v, want an error", derefEffort(got))
+				}
+				if got != nil {
+					t.Errorf("rejected level still produced a value %q", *got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveSessionEffort: %v", err)
+			}
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("got %q, want a clear", *got)
+			case tc.want != nil && got == nil:
+				t.Errorf("got a clear, want %q", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Errorf("got %q, want %q", *got, *tc.want)
+			}
+		})
+	}
+}
+
+func derefEffort(p *string) string {
+	if p == nil {
+		return "<clear>"
+	}
+	return *p
+}
+
+// TestControllerSessionEffortRoundTripsThroughTheLocalCopy: with no executor
+// attached the Controller still has to answer its own port honestly, and the
+// three states must stay distinguishable at that surface too — "" is an
+// untouched dial, "auto" is a deliberate one.
+func TestControllerSessionEffortRoundTripsThroughTheLocalCopy(t *testing.T) {
+	c := &Controller{}
+	if got := c.SessionEffort(); got != "" {
+		t.Fatalf("fresh controller = %q, want empty", got)
+	}
+
+	c.storeSessionEffort(ptrOf("high"))
+	if got := c.SessionEffort(); got != "high" {
+		t.Fatalf("after depth = %q, want high", got)
+	}
+
+	c.storeSessionEffort(ptrOf(""))
+	if got := c.SessionEffort(); got != "auto" {
+		t.Fatalf("after explicit auto = %q, want auto — the port spells it out so it stays distinct from unset", got)
+	}
+
+	c.storeSessionEffort(nil)
+	if got := c.SessionEffort(); got != "" {
+		t.Fatalf("after clear = %q, want empty", got)
+	}
+}
+
+// TestSetEffortRejectsWithoutMutating: a rejected level must leave the dial
+// exactly where it was, not half-applied.
+func TestSetEffortRejectsWithoutMutating(t *testing.T) {
+	c := &Controller{}
+	c.storeSessionEffort(ptrOf("high"))
+
+	if err := c.SetEffort("definitely-not-a-level"); err == nil {
+		t.Fatal("want an error for an unresolvable level")
+	}
+	if got := c.SessionEffort(); got != "high" {
+		t.Errorf("rejected SetEffort changed the level to %q, want high untouched", got)
+	}
+}
+
+// TestSetEffortOnNilController stays a no-op, matching SetAgentPreset.
+func TestSetEffortOnNilController(t *testing.T) {
+	var c *Controller
+	if err := c.SetEffort("high"); err == nil {
+		t.Fatal("a nil controller must report the failure rather than pretend")
+	}
+	if got := c.SessionEffort(); got != "" {
+		t.Errorf("nil controller = %q, want empty", got)
+	}
+}

--- a/harness/control/port.go
+++ b/harness/control/port.go
@@ -243,6 +243,15 @@ type Settings interface {
 	SetResponseLanguage(lang string)
 	SetReasoningLanguage(lang string)
 	SetDisplayRecorder(fn func(content, display string))
+	// SessionEffort is the session-scoped reasoning depth: "" when the dial has
+	// never been touched, "auto" when it was deliberately set back to the
+	// provider default, or the depth itself.
+	SessionEffort() string
+	// SetEffort updates that depth for subsequent model rounds without
+	// rebuilding the controller, provider, or tool schemas — the counterpart to
+	// SetAgentPreset. "" clears the override, "auto" is an explicit choice of
+	// the provider default. A rejected level changes nothing.
+	SetEffort(level string) error
 }
 
 // SessionAPI is the full driving port — the composition of every sub-port. A

--- a/harness/i18n/i18n.go
+++ b/harness/i18n/i18n.go
@@ -324,6 +324,9 @@ type Messages struct {
 	GoalCleared                  string
 	GoalNotRunning               string
 	GoalNotPaused                string
+	// SetEffort rejections. Session-scoped runtime depth, not the config write.
+	SessionEffortUnsupportedFmt  string // %s = model name
+	SessionEffortNotADepthFmt    string // %s = level, %s = model name
 	GoalPaused                   string
 	GoalPausedReason             string
 	GoalPausedFmt                string // %s = stop cause

--- a/harness/i18n/messages_en.go
+++ b/harness/i18n/messages_en.go
@@ -336,6 +336,8 @@ var English = Messages{
 	GoalCleared:                  "goal cleared",
 	GoalNotRunning:               "no running goal to pause",
 	GoalNotPaused:                "no paused or blocked goal to resume",
+	SessionEffortUnsupportedFmt:  "reasoning depth is not configurable for %s",
+	SessionEffortNotADepthFmt:    "%s toggles thinking for %s rather than setting a depth; a runtime override can only change depth",
 	GoalPaused:                   "goal paused — /goal resume continues it",
 	GoalPausedReason:             "paused by the user",
 	GoalPausedFmt:                "goal is paused (%s) — use /goal resume to continue",

--- a/harness/i18n/messages_zh.go
+++ b/harness/i18n/messages_zh.go
@@ -337,6 +337,8 @@ var Chinese = Messages{
 	GoalCleared:                  "目标已清除",
 	GoalNotRunning:               "没有运行中的目标可暂停",
 	GoalNotPaused:                "没有已暂停或被阻塞的目标可恢复",
+	SessionEffortUnsupportedFmt:  "%s 不支持配置推理深度",
+	SessionEffortNotADepthFmt:    "%s 对 %s 是思考开关而不是深度档；运行时覆盖只能改深度",
 	GoalPaused:                   "目标已暂停 — /goal resume 可继续",
 	GoalPausedReason:             "用户手动暂停",
 	GoalPausedFmt:                "目标已暂停（%s）— 使用 /goal resume 继续",

--- a/harness/i18n/messages_zh_tw.go
+++ b/harness/i18n/messages_zh_tw.go
@@ -567,6 +567,8 @@ var ChineseTraditional = Messages{
 	GoalCleared:                "目標已清除",
 	GoalNotRunning:             "沒有執行中的目標可暫停",
 	GoalNotPaused:              "沒有已暫停或被阻擋的目標可恢復",
+	SessionEffortUnsupportedFmt: "%s 不支援設定推理深度",
+	SessionEffortNotADepthFmt:   "%s 對 %s 是思考開關而不是深度檔；執行時覆蓋只能改深度",
 	GoalPaused:                 "目標已暫停 — /goal resume 可繼續",
 	GoalPausedReason:           "使用者手動暫停",
 	GoalPausedFmt:              "目標已暫停（%s）— 使用 /goal resume 繼續",

--- a/harness/provider/openai/effort.go
+++ b/harness/provider/openai/effort.go
@@ -58,11 +58,19 @@ func requestEffortVocabulary(e effortEndpoint) []string {
 	case e.effort != "":
 		levels = []string{"low", "medium", "high"}
 	}
-	return depthOnly(levels)
+	return DepthEffortLevels(levels)
 }
 
-// depthOnly strips thinking on/off toggles from an effort vocabulary.
-func depthOnly(levels []string) []string {
+// DepthEffortLevels strips thinking on/off toggles from an effort vocabulary,
+// leaving only the depths a per-request Request.EffortOverride can carry.
+//
+// Exported because the config layer validates user-chosen levels against it:
+// EffortCapabilityForEntry legitimately advertises tokens like adaptive and
+// enabled, and a level that survives that check but not this one would be
+// accepted by the setter and then silently discarded on the wire. Same reason
+// IsDeepSeek and friends are exported — the vocabulary rule lives here, and
+// config stays in lockstep by calling it rather than restating it.
+func DepthEffortLevels(levels []string) []string {
 	var out []string
 	for _, level := range levels {
 		switch strings.ToLower(strings.TrimSpace(level)) {


### PR DESCRIPTION
Closes #330

## TL;DR

除 reasoning effort 外，每个会话运行时旋钮都有就地 setter。这补上最后一个：
`Controller.SetEffort` / `SessionEffort`，走已经在线的
`provider.Request.EffortOverride`，不重建 controller / provider / tool schema，
也不重放历史。

**两处评审选型已按你的答复落定**（记录在 spec §2）：

| 选型 | 结论 |
|---|---|
| 单槽位优先级 | **Option A** — 用户显式级别赢；governor 只在旋钮从未被动过时生效 |
| 第 8 步一次性提示 | **不做**（跟着选型走）。因此不动 `event.go` 的 wire-stable 常量块，也没有 `CONTRIBUTING.md:29` 要求的 `docs/events.md` 同步义务 |

## 为什么优先级非定不可

`provider.Request` 上只有一个 `EffortOverride` 槽位，而 `sampling_request.go:131`
今天是 `a.governorOverride()` ——只读 governor，不读任何会话值。会话级别一旦存在，
**第一版实现就替所有人定了优先级**，不管有没有人评审。Option A 的理由写进
`effectiveEffortOverride` 的文档注释，因为那是将来唯一有人会看的地方。

## 三态，因此必须是 `*string`

| 状态 | `EffortOverride` | governor |
|---|---|---|
| 未设定 | governor 的值 | 生效 |
| 显式 auto | `""` | **被抑制** |
| 具体深度 | 该深度 | 被抑制 |

`config.NormalizeEffort("auto")` 返回 `("", nil)`，与「从未设过」同形。裸 string
分不出前两者——后果不是不好看，是**用户永远无法从 governor 手里要回 provider
默认值**：`auto` 会被当成「没设」，让实验继续驱动槽位。端口的
`SessionEffort() string` 用 `"auto"` 与 `""` 区分，保住 issue 指定的签名而不丢信息。

## 校验按传输真能承载的深度

只按 `EffortCapabilityForEntry(entry).Levels` 校验是个陷阱：它合法地宣传
`adaptive` / `enabled` / `none` 这类**思考开关**，对 config 写入有意义，但上不了
per-request override。那样 `SetEffort("adaptive")` 对 MiniMax 会**报告成功**，而
该档位永远到不了任何请求，全链路无一处报错。

## 三处偏离 issue 的建议

**1. 深度词表规则留在 adapter，不镜像进 config。** 第 6 步设想的是「从 adapter
导出，或在 `harness/config` 镜像」，我起草 spec 时选了后者 + 仅测试的跨包对拍守
漂移。查依赖方向后推翻：**`harness/config` 本来就 import `harness/provider/openai`**
（`effort.go:8`、`fetch.go:10`），而且 `isDeepSeekEntry`（`effort.go:371`）就带着
现成注释说明这个模式——「实际匹配放在 provider/openai，让两层保持同步」。所以
`depthOnly` 导出为 `openai.DepthEffortLevels`，config 侧包一层。单一真源，无漂移
可守；而我原计划那个对拍测试方向反了，会构成 import 环，根本编译不过。

**2. entry 取 `config.LoadForRoot` per call，不做构建期缓存**（第 5 步推荐缓存）。
缓存要同时改构建路径与 `/model` 路径，多两处可能失配的状态；而同样的磁盘读**今天
已经在更热的路径上跑**——`effortArgItems` 的补全下拉每次按键都调
`currentEffortEntry`。`SetEffort` 是斜杠命令，频率低若干量级。形状对齐
`imageInputEnabled`。

**3. 校验抽成纯函数 `resolveSessionEffort(entry, level)`**（issue 未提，属实现细节）。
12 格校验表因此全程离线跑，不必为了测一个词表规则去铺临时 config；`SetEffort`
只剩「取 entry + 校验 + 转发」。

## 变异检验

守卫不经此步不算数。两次，各自确认翻红后回滚：

| 变异 | 结果 |
|---|---|
| 优先级翻成 Option B | 6 格表里**恰好**翻红区分两者的那 2 格（governor 引擎 × 显式 auto / 具体深度）；其余 4 格两种规则下本就相同 |
| `sampling_request.go:131` 改回 `a.governorOverride()` | 三条时序契约测例全红 |

优先级表的每一格都**显式钉住 governor 状态**——同一字段两个生产者，不钉就是构造
性 flaky，不是偶然 flaky。

## 时序契约（断言，不是口头约定）

- 中途设定的级别落在**下一个 model round**：round 1 的请求已冻结，两半都断言。
- **无工具调用的 turn 没有下一个 round**，级别顺延到下一 turn 的首个请求。文档里
  写明的限制，断言它而不是留给人踩。
- 被中断重试的 round **逐字重放**冻结载荷（`reflect.DeepEqual`，含
  `EffortOverride`）；重试窗口内改级别不得渗进重放。

测试用带 `after` 钩子的 provider：级别必须在「已冻结的 round」与「尚未构建的
round」之间改变，才等价于用户真的在 turn 中途敲了命令。

## 验收

- `go build ./...` ✅ `go vet ./...` ✅
- `go test ./harness/agent/... ./harness/control/... ./harness/config/... ./harness/provider/openai/...` ✅
- `go test ./harness/provider/openai/... -run TestEffortOverride` ✅ 5/5，adapter 契约不变
- `go test ./...`：**136 ok / 7 FAIL，无新增**——7 个与既有基线逐一相同
  （Windows symlink 权限、`TestDispatchExitCodeContract`、生成物漂移、`sessiontemp` 等）。
- 不重建：断言 `a.svc.prov` 的指针身份跨越 `SetSessionEffort` 与整个 turn。这不是
  假想的失败模式——CLI 今天的 `/effort` 就是靠重建改这个值的。

### 已知残余

- **本 PR 交付的 setter 零生产调用方**，这是设计意图不是遗漏：CLI / ACP / serve
  的改接是 issue 明确的非目标。
- **`anthropic` 与 `responses` adapter 今天完全不读 `EffortOverride`**（`grep` 零
  命中），所以效果目前只覆盖 `harness/provider/openai`。这正是 #331 的存在理由。
  本 PR 不阻塞于它，但**在 #331 落地前不得改接 CLI**——否则会把一个当前可用的
  `/effort` 变成对那两族的静默 no-op。
- 本机无 C 编译器（`-race requires cgo`），`-race` 由 CI 承担。并发测例在无
  `-race` 时仍跑通该路径，并检查最终值与每个 round 携带的值都必须是写过的值之一。
- `harness/agent` 的包级 goleak（残留 `net/http` keep-alive goroutine）**与本改动
  无关**：把 agent 侧改动还原到 base 后同样失败、同样只有那一条报错且所有测例
  PASS；全量并行那轮它甚至没有复现。
- issue 正文写的 governor 环境变量是 `REASONIX_EXPERIMENT_GOVERNOR`，代码已随改名
  迁为 `SEMANTIX_EXPERIMENT_GOVERNOR`。

Spec：`docs/specs/issue-330-session-effort.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mYwDU1J1vtYzZQDrtFXfd
