### PR TITLE
feat(provider): honour Request.EffortOverride in the anthropic and responses adapters

### DIFF
--- a/docs/specs/issue-331-effort-override.md
+++ b/docs/specs/issue-331-effort-override.md
@@ -1,0 +1,69 @@
+# Spec — Issue #331 anthropic / responses 适配器 honor `Request.EffortOverride`
+
+## 1. 目标
+
+`provider.Request.EffortOverride`（`harness/provider/provider.go:225`）是文档化的逐请求推理深度通道，但目前只有 OpenAI 家族适配器读取它（`harness/provider/openai/effort.go:79-85`）。anthropic 与 responses 适配器在构造时冻结 effort，静默丢弃该字段。本 spec 将参考实现移植到这两个适配器，并让各自的自动输出预算随 effective effort 重新推导。扩展协议（extension-hosted providers）的 `effortOverride` 字段属插件边界 wire 变更，**明确不在本 issue 范围**（另开 issue）。
+
+## 2. 词汇表（构造时计算，非逐请求）
+
+两个适配器各新增 `requestEfforts []string` 字段，在 `New()` 中填充；空值 = 忽略 override。
+
+- **anthropic**（`harness/provider/anthropic/anthropic.go`）：
+  - DeepSeek 路径：`low|high|max`（匹配 `:473-475` 的 wire 白名单）；`thinking=="disabled"` 或 `effort=="disabled"` 时为 nil（该路径不发射 `output_config`）。
+  - 原生 adaptive 路径（`thinking=="adaptive"`）：`low|medium|high|xhigh|max`（完整产品阶梯，与现有 raw 转发一致）。
+  - `thinking` 为 `enabled|disabled` 或空：nil（该路径从不发射 `output_config`）。
+- **responses**（`harness/provider/responses/responses.go`）：
+  - `vendor=="deepseek"`：模型含 `flash` 时 `low|high|max`，否则 `high|max`（与 openai 适配器的 DeepSeek 官方词汇一致）。
+  - 其他 vendor：`low|medium|high`（OpenAI Responses 官方 reasoning effort 阶梯）。
+
+## 3. 逐请求 gate
+
+新增 `func (c *client) requestEffort(req provider.Request) string`，镜像 `harness/provider/openai/effort.go:79-85`：词汇表内的小写化 override 胜出，其余情况原样返回 `c.effort`。**只 gate override，绝不 gate 构造的 effort**——现有的 `medium`/`xhigh` raw 转发行为保持不变。
+
+## 4. anthropic wire 替换点
+
+`buildRequest` 内用 `effective := c.requestEffort(req)` 替换以下位置的 `c.effort`（仅限这些点）：
+
+- `:467`（DeepSeek thinking toggle 判断）
+- `:472`（`normalizeDeepSeekAnthropicEffort(c.model, effective)`，归一化保持）
+- `:482-483`（adaptive 路径 raw 转发）
+- `:487-488`（enabled/disabled 路径 thinking toggle）
+
+**不得替换**：`:188-190` `deepSeekThinkingEnabled()`（能力谓词，位于 buildRequest 之外）、`:225-237` `MissingToolCallReasoningWarningIdentity()`（稳定诊断身份，需保持 per-client 稳定）。
+
+## 5. anthropic 自动输出预算
+
+新增 `autoMaxOutput bool` 字段（`defaultMaxTokens` 旁），在 `New()` 的 `if maxOutputTokens <= 0` 块（`:112-130`）内置 true，经 composite literal（`:135-155`）接线。`buildRequest` 的 `:442-448` 按 openai `:782-793` 模式重新推导：
+
+- `autoMaxOutput && deepseek`：`provider.AutoOutputBudget(reasoningOn, effective)`，其中 `reasoningOn` 由 `c.thinking != "disabled"` 且 effective 非 disabled/off/none 决定；
+- `autoMaxOutput` 且 thinking 为 `adaptive|enabled`（原生路径）：`provider.AutoOutputBudget(true, effective)`；
+- 其余情况回落到 `c.defaultMaxTokens`。
+
+配置的（非 auto）预算不受 override 影响。
+
+## 6. responses wire 替换点
+
+- `:303`：effort 归一化改用 `effective := c.requestEffort(req)`；
+- `:319`：`responsesAutoOutputBudget(c.vendor, effective)`（仅当 budget 为 auto 且 vendor 为 deepseek/mimo 时）。
+
+## 7. 测试计划
+
+1. 新文件 `harness/provider/anthropic/effort_override_test.go` 与 `harness/provider/responses/effort_override_test.go`，镜像 `openai/effort_override_test.go` 的五个契约：
+   - 词汇表内 override 生效（anthropic：adaptive + effort low + override max → `output_config.effort=="max"`）；
+   - 词汇表外 override（DeepSeek 路径 "medium"）被忽略、回落到构造的 `c.effort`，绝不 raw 转发；
+   - 空 `EffortOverride` 字节级一致：`json.Marshal` 请求体与改动前 golden 比对；
+   - 无词汇表（enabled/disabled thinking、无深度端点）时 override 不发明 wire 字段。
+2. 扩展两个 `output_budget_test.go`：auto budget 随 effective 重新推导的 case；配置（非 auto）预算不受 override 影响的 case。
+3. 现有 guard 测试扩展 override 参数：非 DeepSeek `enabled`/`disabled` 不发射 `output_config`（`anthropic_test.go:643-644`）；DeepSeek 空 Thinking 仍发射 `output_config.effort`（`anthropic_test.go:765-767`）。
+
+## 8. 兼容性
+
+空 `EffortOverride` 时 wire body 字节级不变；不新增配置、CLI flag、依赖；无 i18n 文案变更（`messages_*.go` 与 `catalog_parity_test.go` 不动）。扩展协议（`harness/extension/protocol/dto_provider.go`、`harness/sdk/go/types_generated.go`）不在本 spec 范围。
+
+## 9. 验收命令
+
+```sh
+go build ./...
+go vet ./...
+go test ./harness/provider/... -race
+```

--- a/harness/provider/anthropic/anthropic.go
+++ b/harness/provider/anthropic/anthropic.go
@@ -101,6 +101,9 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	thinking = strings.ToLower(strings.TrimSpace(thinking))
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
+	// requestEfforts is the per-request EffortOverride vocabulary; nil means
+	// overrides are ignored (that path emits no output_config at all).
+	requestEfforts := requestEffortVocabulary(officialDeepSeek, thinking, effort)
 	vision, _ := cfg.Extra["vision"].(bool)
 	// DeepSeek's official Anthropic-compatible endpoint is text-only. Enforce
 	// that wire constraint here as defense in depth, independent of config or
@@ -110,6 +113,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	authHeader, _ := cfg.Extra["auth_header"].(bool)
 	maxOutputTokens, _ := cfg.Extra["max_output_tokens"].(int)
+	autoMaxOutput := maxOutputTokens <= 0 // auto-derived budget — re-resolved per request
 	if maxOutputTokens <= 0 {
 		// Messages requires max_tokens. 0 = automatic; negative also falls back
 		// because the wire field is mandatory.
@@ -150,6 +154,8 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		headers:          cleanCustomHeaders(headers),
 		authHeader:       authHeader,
 		defaultMaxTokens: maxOutputTokens,
+		autoMaxOutput:    autoMaxOutput,
+		requestEfforts:   requestEfforts,
 		http:             httpClient, // no overall timeout; lifecycle is ctx-driven
 		idleTimeout:      defaultStreamIdleTimeout,
 	}, nil
@@ -178,6 +184,8 @@ type client struct {
 	headers          map[string]string
 	authHeader       bool // send Authorization: Bearer instead of Anthropic's x-api-key header
 	defaultMaxTokens int
+	autoMaxOutput    bool     // true when max_output_tokens=0 (auto-derived budget, re-resolved per request)
+	requestEfforts   []string // depth levels a per-request EffortOverride may take; empty = overrides ignored
 	http             *http.Client
 	idleTimeout      time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
 	authed           atomic.Bool   // a request has succeeded — gate transient-401 retry
@@ -216,6 +224,42 @@ func normalizeDeepSeekAnthropicEffort(model, effort string) string {
 	default:
 		return ""
 	}
+}
+
+// requestEffortVocabulary lists exactly the depth levels New would accept as a
+// per-request EffortOverride. Binary thinking knobs and disabled thinking
+// yield nil — an override adjusts depth, never whether thinking runs.
+func requestEffortVocabulary(deepseek bool, thinking, effort string) []string {
+	if deepseek {
+		if thinking == "disabled" || effort == "disabled" {
+			return nil
+		}
+		return []string{"low", "high", "max"}
+	}
+	if thinking != "adaptive" {
+		return nil
+	}
+	return []string{"low", "medium", "high", "xhigh", "max"}
+}
+
+// requestEffort resolves one request's reasoning depth: a vocabulary-approved
+// EffortOverride wins, anything else falls back to the configured effort.
+func (c *client) requestEffort(req provider.Request) string {
+	want := strings.ToLower(strings.TrimSpace(req.EffortOverride))
+	if want == "" || !supportsEffort(c.requestEfforts, want) {
+		return c.effort
+	}
+	return want
+}
+
+func supportsEffort(levels []string, want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	for _, level := range levels {
+		if strings.ToLower(strings.TrimSpace(level)) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *client) RequiresToolCallReasoning() bool {
@@ -439,7 +483,19 @@ func (c *client) buildRequest(_ context.Context, req provider.Request) anthReque
 		}
 	}
 
+	effective := c.requestEffort(req)
 	maxTokens := req.MaxTokens
+	if maxTokens <= 0 && c.autoMaxOutput {
+		// Re-resolve so a per-request EffortOverride (high/max) can raise the
+		// auto-derived budget exactly like the OpenAI adapter does.
+		if c.deepseek {
+			reasoningOn := c.thinking != "disabled" &&
+				effective != "disabled" && effective != "off" && effective != "none"
+			maxTokens = provider.AutoOutputBudget(reasoningOn, effective)
+		} else if c.thinking == "adaptive" || c.thinking == "enabled" {
+			maxTokens = provider.AutoOutputBudget(true, effective)
+		}
+	}
 	if maxTokens <= 0 {
 		maxTokens = c.defaultMaxTokens
 		if maxTokens <= 0 {
@@ -464,12 +520,12 @@ func (c *client) buildRequest(_ context.Context, req provider.Request) anthReque
 		if t != "disabled" {
 			t = "enabled"
 		}
-		if c.effort == "disabled" {
+		if effective == "disabled" {
 			t = "disabled"
 		}
 		r.Thinking = &thinkingConfig{Type: t}
 		if t != "disabled" {
-			effort := normalizeDeepSeekAnthropicEffort(c.model, c.effort)
+			effort := normalizeDeepSeekAnthropicEffort(c.model, effective)
 			switch effort {
 			case "low", "high", "max":
 				r.OutputConfig = &outputConfig{Effort: effort}
@@ -479,13 +535,13 @@ func (c *client) buildRequest(_ context.Context, req provider.Request) anthReque
 		switch c.thinking {
 		case "adaptive":
 			r.Thinking = &thinkingConfig{Type: "adaptive", Display: "summarized"}
-			if c.effort != "" {
-				r.OutputConfig = &outputConfig{Effort: c.effort}
+			if effective != "" {
+				r.OutputConfig = &outputConfig{Effort: effective}
 			}
 		case "enabled", "disabled":
 			t := c.thinking
-			if c.effort == "enabled" || c.effort == "disabled" {
-				t = c.effort
+			if effective == "enabled" || effective == "disabled" {
+				t = effective
 			}
 			r.Thinking = &thinkingConfig{Type: t}
 		}

--- a/harness/provider/anthropic/anthropic_test.go
+++ b/harness/provider/anthropic/anthropic_test.go
@@ -648,6 +648,14 @@ func TestBuildRequestThinkingEnabledGateway(t *testing.T) {
 			t.Fatalf("enabled/disabled gateway must not replay Anthropic signed thinking blocks: %+v", r.Messages[1])
 		}
 	}
+	// An EffortOverride must not invent output_config on this path either.
+	r = c.buildRequest(context.Background(), provider.Request{
+		Messages:       []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		EffortOverride: "max",
+	})
+	if r.OutputConfig != nil {
+		t.Fatalf("enabled/disabled gateway thinking must omit output_config with an override: %+v", r.OutputConfig)
+	}
 }
 
 func TestBuildRequestDeepSeekThinking(t *testing.T) {
@@ -772,6 +780,13 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 		r := (&client{model: "deepseek-v4-flash", deepseek: true}).buildRequest(context.Background(), provider.Request{})
 		if r.Thinking == nil || r.Thinking.Type != "enabled" || r.OutputConfig != nil {
 			t.Fatalf("default DeepSeek thinking = %+v / %+v, want enabled/provider-default effort", r.Thinking, r.OutputConfig)
+		}
+	})
+	t.Run("override keeps output_config", func(t *testing.T) {
+		c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4", map[string]any{"effort": "low"})
+		r := c.buildRequest(context.Background(), provider.Request{EffortOverride: "high"})
+		if r.Thinking == nil || r.Thinking.Type != "enabled" || r.OutputConfig == nil || r.OutputConfig.Effort != "high" {
+			t.Fatalf("DeepSeek path with override = %+v / %+v, want enabled/high", r.Thinking, r.OutputConfig)
 		}
 	})
 

--- a/harness/provider/anthropic/effort_override_test.go
+++ b/harness/provider/anthropic/effort_override_test.go
@@ -1,0 +1,139 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"semantix/harness/provider"
+)
+
+func newTestClient(t *testing.T, baseURL, model string, extra map[string]any) *client {
+	t.Helper()
+	cfg := provider.Config{Name: "p", BaseURL: baseURL, Model: model, APIKey: "k", Extra: extra}
+	p, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p.(*client)
+}
+
+// TestEffortOverrideNativeAdaptive pins the acceptance case: an in-vocabulary
+// override wins on the native adaptive path, and an empty override keeps the
+// constructed effort untouched.
+func TestEffortOverrideNativeAdaptive(t *testing.T) {
+	c := newTestClient(t, defaultBaseURL, "claude-opus-4-8", map[string]any{"thinking": "adaptive", "effort": "low"})
+	if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "max"}).OutputConfig; got == nil || got.Effort != "max" {
+		t.Fatalf("override max: output_config = %+v, want effort=max", got)
+	}
+	if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "low"}).OutputConfig; got == nil || got.Effort != "low" {
+		t.Fatalf("override low: output_config = %+v, want effort=low", got)
+	}
+	if got := c.buildRequest(context.Background(), provider.Request{}).OutputConfig; got == nil || got.Effort != "low" {
+		t.Fatalf("empty override must keep constructed effort low, got %+v", got)
+	}
+}
+
+// TestEffortOverrideDeepSeekVocabulary pins the DeepSeek wire vocabulary
+// (low|high|max): an out-of-vocabulary override is ignored and the constructed
+// effort is used — the override is never forwarded raw.
+func TestEffortOverrideDeepSeekVocabulary(t *testing.T) {
+	c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4", map[string]any{"effort": "high"})
+	if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "medium"}).OutputConfig; got == nil || got.Effort != "high" {
+		t.Fatalf("override medium (outside low|high|max) must keep constructed high, got %+v", got)
+	}
+	if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "max"}).OutputConfig; got == nil || got.Effort != "max" {
+		t.Fatalf("override max: output_config = %+v, want effort=max", got)
+	}
+	if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "disabled"}).OutputConfig; got == nil || got.Effort != "high" {
+		t.Fatalf("override disabled (a thinking toggle, not a depth) must keep constructed high, got %+v", got)
+	}
+}
+
+// TestEffortOverrideEmptyIsByteIdentical pins the wire-compat contract: with an
+// empty EffortOverride every request body must stay byte-identical to the
+// pre-change goldens (captured from the unmodified buildRequest).
+func TestEffortOverrideEmptyIsByteIdentical(t *testing.T) {
+	req := provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}}
+	cases := []struct {
+		name   string
+		c      *client
+		golden string
+	}{
+		{
+			name:   "native adaptive low",
+			c:      &client{model: "claude-opus-4-8", thinking: "adaptive", effort: "low"},
+			golden: `{"model":"claude-opus-4-8","max_tokens":16384,"messages":[{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}]}],"thinking":{"type":"adaptive","display":"summarized"},"output_config":{"effort":"low"},"stream":true}`,
+		},
+		{
+			name:   "deepseek high",
+			c:      &client{model: "deepseek-v4", deepseek: true, thinking: "enabled", effort: "high"},
+			golden: `{"model":"deepseek-v4","max_tokens":16384,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],"thinking":{"type":"enabled"},"output_config":{"effort":"high"},"stream":true}`,
+		},
+		{
+			name:   "deepseek provider default",
+			c:      &client{model: "deepseek-v4-flash", deepseek: true},
+			golden: `{"model":"deepseek-v4-flash","max_tokens":16384,"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],"thinking":{"type":"enabled"},"stream":true}`,
+		},
+		{
+			name:   "gateway enabled/disabled",
+			c:      &client{model: "LongCat-2.0", thinking: "enabled", effort: "disabled"},
+			golden: `{"model":"LongCat-2.0","max_tokens":16384,"messages":[{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}]}],"thinking":{"type":"disabled"},"stream":true}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.c.buildRequest(context.Background(), req))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(b) != tc.golden {
+				t.Fatalf("empty override changed the wire body:\ngot  %s\nwant %s", b, tc.golden)
+			}
+		})
+	}
+}
+
+// TestEffortOverrideIgnoredWithoutVocabulary: binary thinking knobs have no
+// depth scale, so an override must never invent wire fields.
+func TestEffortOverrideIgnoredWithoutVocabulary(t *testing.T) {
+	gateway := &client{model: "LongCat-2.0", thinking: "enabled", effort: "disabled"}
+	r := gateway.buildRequest(context.Background(), provider.Request{EffortOverride: "max"})
+	if r.OutputConfig != nil {
+		t.Fatalf("enabled/disabled thinking must omit output_config with an override: %+v", r.OutputConfig)
+	}
+	deepseekDisabled := &client{model: "deepseek-v4", deepseek: true, thinking: "enabled", effort: "disabled"}
+	r = deepseekDisabled.buildRequest(context.Background(), provider.Request{EffortOverride: "max"})
+	if r.Thinking == nil || r.Thinking.Type != "disabled" || r.OutputConfig != nil {
+		t.Fatalf("disabled DeepSeek thinking with override = %+v / %+v, want disabled/none", r.Thinking, r.OutputConfig)
+	}
+}
+
+// TestEffortOverrideAutoBudget: the auto-derived max_tokens is re-resolved from
+// the effective effort, while a configured (non-auto) budget is untouched.
+func TestEffortOverrideAutoBudget(t *testing.T) {
+	t.Run("deepseek auto", func(t *testing.T) {
+		c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4", map[string]any{"effort": "low"})
+		if got := c.buildRequest(context.Background(), provider.Request{}).MaxTokens; got != provider.DefaultReasoningOutputTokens {
+			t.Fatalf("default budget = %d, want %d", got, provider.DefaultReasoningOutputTokens)
+		}
+		if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "max"}).MaxTokens; got != provider.DefaultHighReasoningOutputTokens {
+			t.Fatalf("override max budget = %d, want %d", got, provider.DefaultHighReasoningOutputTokens)
+		}
+	})
+	t.Run("native adaptive auto", func(t *testing.T) {
+		c := newTestClient(t, defaultBaseURL, "claude-opus-4-8", map[string]any{"thinking": "adaptive", "effort": "low"})
+		if got := c.buildRequest(context.Background(), provider.Request{}).MaxTokens; got != provider.DefaultReasoningOutputTokens {
+			t.Fatalf("default budget = %d, want %d", got, provider.DefaultReasoningOutputTokens)
+		}
+		if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "max"}).MaxTokens; got != provider.DefaultHighReasoningOutputTokens {
+			t.Fatalf("override max budget = %d, want %d", got, provider.DefaultHighReasoningOutputTokens)
+		}
+	})
+	t.Run("configured budget unaffected", func(t *testing.T) {
+		c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4", map[string]any{"effort": "low", "max_output_tokens": 8192})
+		if got := c.buildRequest(context.Background(), provider.Request{EffortOverride: "max"}).MaxTokens; got != 8192 {
+			t.Fatalf("configured budget with override = %d, want 8192", got)
+		}
+	})
+}

--- a/harness/provider/responses/effort_override_test.go
+++ b/harness/provider/responses/effort_override_test.go
@@ -1,0 +1,153 @@
+package responses
+
+import (
+	"encoding/json"
+	"testing"
+
+	"semantix/harness/provider"
+)
+
+func newTestClient(t *testing.T, baseURL, model, effort string) *client {
+	t.Helper()
+	return New(Config{Name: "p", BaseURL: baseURL, Model: model, Effort: effort}).(*client)
+}
+
+func reasoningEffort(t *testing.T, c *client, req provider.Request) string {
+	t.Helper()
+	body, _, _ := c.buildRequestBody(req)
+	reasoning, _ := body["reasoning"].(map[string]any)
+	got, _ := reasoning["effort"].(string)
+	return got
+}
+
+// TestEffortOverrideDeepSeekFlash pins the official DeepSeek vocabulary:
+// flash admits low, an in-vocabulary override wins, out-of-vocabulary and
+// thinking-toggle values fall back to the constructed effort.
+func TestEffortOverrideDeepSeekFlash(t *testing.T) {
+	c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4-flash", "high")
+	if got := reasoningEffort(t, c, provider.Request{EffortOverride: "low"}); got != "low" {
+		t.Fatalf("override low: reasoning.effort = %q, want low", got)
+	}
+	if got := reasoningEffort(t, c, provider.Request{EffortOverride: "max"}); got != "max" {
+		t.Fatalf("override max: reasoning.effort = %q, want max", got)
+	}
+	if got := reasoningEffort(t, c, provider.Request{EffortOverride: "medium"}); got != "high" {
+		t.Fatalf("override outside DeepSeek vocabulary must keep the default, got %q", got)
+	}
+	if got := reasoningEffort(t, c, provider.Request{EffortOverride: "disabled"}); got != "high" {
+		t.Fatalf("override must never toggle thinking off, got %q", got)
+	}
+	if got := reasoningEffort(t, c, provider.Request{}); got != "high" {
+		t.Fatalf("empty override must keep the constructed effort, got %q", got)
+	}
+}
+
+// TestEffortOverrideDeepSeekNonFlashRejectsLow: deepseek-v4 has no low level;
+// an out-of-vocabulary override is ignored, never forwarded raw.
+func TestEffortOverrideDeepSeekNonFlashRejectsLow(t *testing.T) {
+	c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4", "max")
+	if got := reasoningEffort(t, c, provider.Request{EffortOverride: "low"}); got != "max" {
+		t.Fatalf("low is flash-only; reasoning.effort = %q, want max", got)
+	}
+	if got := reasoningEffort(t, c, provider.Request{EffortOverride: "high"}); got != "high" {
+		t.Fatalf("override high: reasoning.effort = %q, want high", got)
+	}
+}
+
+// TestEffortOverrideOtherVendors: the OpenAI Responses scale is
+// low|medium|high for non-DeepSeek endpoints.
+func TestEffortOverrideOtherVendors(t *testing.T) {
+	for _, vendor := range []struct{ baseURL, model string }{
+		{"https://api.openai.com", "gpt-5"},
+		{"https://dashscope.aliyuncs.com", "qwen3"},
+		{"https://api.xiaomimimo.com/v1", "mimo-v2.5-pro"},
+	} {
+		c := newTestClient(t, vendor.baseURL, vendor.model, "low")
+		if got := reasoningEffort(t, c, provider.Request{EffortOverride: "medium"}); got != "medium" {
+			t.Errorf("%s: override medium: reasoning.effort = %q, want medium", vendor.baseURL, got)
+		}
+		if got := reasoningEffort(t, c, provider.Request{EffortOverride: "max"}); got != "low" {
+			t.Errorf("%s: max is outside the OpenAI scale; reasoning.effort = %q, want low", vendor.baseURL, got)
+		}
+	}
+}
+
+// TestEffortOverrideIgnoredWhenThinkingDisabled: an endpoint configured with
+// effort none/disabled has no depth scale — the override must not re-enable
+// or deepen reasoning.
+func TestEffortOverrideIgnoredWhenThinkingDisabled(t *testing.T) {
+	for _, effort := range []string{"none", "disabled", "off"} {
+		c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4-flash", effort)
+		if got := reasoningEffort(t, c, provider.Request{EffortOverride: "max"}); got != "none" {
+			t.Fatalf("thinking-disabled %q with override max: reasoning.effort = %q, want none", effort, got)
+		}
+	}
+}
+
+// TestEffortOverrideEmptyIsByteIdentical pins the wire-compat contract: with an
+// empty EffortOverride every request body stays byte-identical to the
+// pre-change goldens (captured from the unmodified buildRequestBody).
+func TestEffortOverrideEmptyIsByteIdentical(t *testing.T) {
+	req := provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}}
+	cases := []struct {
+		name   string
+		c      *client
+		golden string
+	}{
+		{
+			name:   "deepseek flash high",
+			c:      &client{vendor: "deepseek", model: "deepseek-v4-flash", effort: "high", caps: capabilitiesFor("deepseek")},
+			golden: `{"input":[{"content":"hi","role":"user"}],"max_output_tokens":65536,"model":"deepseek-v4-flash","reasoning":{"effort":"high"},"stream":true}`,
+		},
+		{
+			name:   "deepseek pro low",
+			c:      &client{vendor: "deepseek", model: "deepseek-v4-pro", effort: "low", caps: capabilitiesFor("deepseek")},
+			golden: `{"input":[{"content":"hi","role":"user"}],"max_output_tokens":32768,"model":"deepseek-v4-pro","reasoning":{"effort":"low"},"stream":true}`,
+		},
+		{
+			name:   "generic medium",
+			c:      &client{vendor: "generic", model: "gpt-5", effort: "medium", caps: capabilitiesFor("generic")},
+			golden: `{"input":[{"content":"hi","role":"user"}],"model":"gpt-5","reasoning":{"effort":"medium"},"stream":true}`,
+		},
+		{
+			name:   "thinking disabled",
+			c:      &client{vendor: "deepseek", model: "deepseek-v4-flash", effort: "none", caps: capabilitiesFor("deepseek")},
+			golden: `{"input":[{"content":"hi","role":"user"}],"max_output_tokens":16384,"model":"deepseek-v4-flash","reasoning":{"effort":"none"},"stream":true}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _, _ := tc.c.buildRequestBody(req)
+			b, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(b) != tc.golden {
+				t.Fatalf("empty override changed the wire body:\ngot  %s\nwant %s", b, tc.golden)
+			}
+		})
+	}
+}
+
+// TestEffortOverrideAutoBudget: the auto-derived max_output_tokens re-resolves
+// from the effective effort, while a configured budget is untouched.
+func TestEffortOverrideAutoBudget(t *testing.T) {
+	t.Run("deepseek auto", func(t *testing.T) {
+		c := newTestClient(t, "https://api.deepseek.com", "deepseek-v4-flash", "low")
+		body, _, _ := c.buildRequestBody(provider.Request{})
+		if got := body["max_output_tokens"]; got != provider.DefaultReasoningOutputTokens {
+			t.Fatalf("default budget = %#v, want %d", got, provider.DefaultReasoningOutputTokens)
+		}
+		body, _, _ = c.buildRequestBody(provider.Request{EffortOverride: "max"})
+		if got := body["max_output_tokens"]; got != provider.DefaultHighReasoningOutputTokens {
+			t.Fatalf("override max budget = %#v, want %d", got, provider.DefaultHighReasoningOutputTokens)
+		}
+	})
+	t.Run("configured budget unaffected", func(t *testing.T) {
+		c := New(Config{Name: "p", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", Effort: "low", MaxOutputTokens: 8192}).(*client)
+		body, _, _ := c.buildRequestBody(provider.Request{EffortOverride: "max"})
+		if got := body["max_output_tokens"]; got != 8192 {
+			t.Fatalf("configured budget with override = %#v, want 8192", got)
+		}
+	})
+}

--- a/harness/provider/responses/responses.go
+++ b/harness/provider/responses/responses.go
@@ -113,7 +113,9 @@ type client struct {
 	sessionCache                       bool
 	webSearch                          bool
 	maxOutputTokens                    int
-	vision                             bool // model accepts image input; embed Images as input_image parts
+	autoMaxOutput                      bool     // budget was derived from the effort ladder; re-resolved per request
+	vision                             bool     // model accepts image input; embed Images as input_image parts
+	requestEfforts                     []string // depth levels a per-request EffortOverride may take; empty = overrides ignored
 	http                               *http.Client
 	idleTimeout                        time.Duration
 	authed                             atomic.Bool
@@ -128,6 +130,12 @@ func New(cfg Config) provider.Provider {
 	vendor := DetectVendor(cfg.BaseURL)
 	cap := capabilitiesFor(vendor)
 	maxOutputTokens := cfg.MaxOutputTokens
+	// requestEfforts is the per-request EffortOverride vocabulary; nil means
+	// overrides are ignored (thinking-disabled endpoints have no depth scale).
+	requestEfforts := requestEffortVocabulary(vendor, cfg.Model, cfg.Effort)
+	// autoMaxOutput marks budgets derived from the effort ladder (deepseek/mimo)
+	// so buildRequestBody can re-resolve them from the effective effort.
+	autoMaxOutput := maxOutputTokens == 0 && cap.defaultMaxOutputTokens > 0 && (vendor == "deepseek" || vendor == "mimo")
 	// max_output_tokens=0 is automatic. Known vendors use the 16K/32K/64K ladder;
 	// thinking-disabled DeepSeek still gets the ordinary 16K auto budget.
 	// 128K is never chosen automatically. Compact_ratio is independent.
@@ -163,8 +171,10 @@ func New(cfg Config) provider.Provider {
 		name: cfg.Name, apiKey: cfg.APIKey, keyEnv: cfg.KeyEnv, keySource: cfg.KeySource,
 		baseURL: baseURL, requestURL: requestURL, model: cfg.Model, effort: cfg.Effort,
 		vendor: vendor, caps: cap, mode: cfg.mode(), sessionCache: sessionCache, webSearch: cfg.WebSearch, maxOutputTokens: maxOutputTokens,
-		vision: vision,
-		http:   httpClient, idleTimeout: defaultStreamIdleTimeout,
+		autoMaxOutput:  autoMaxOutput,
+		requestEfforts: requestEfforts,
+		vision:         vision,
+		http:           httpClient, idleTimeout: defaultStreamIdleTimeout,
 	}
 }
 
@@ -189,6 +199,45 @@ func responsesAutoOutputBudget(vendor, effort string) int {
 		e = "high"
 	}
 	return provider.AutoOutputBudget(true, e)
+}
+
+// requestEffortVocabulary lists exactly the depth levels New would accept
+// as a per-request EffortOverride. Thinking-disabled endpoints yield nil —
+// an override adjusts depth, never whether thinking runs.
+func requestEffortVocabulary(vendor, model, effort string) []string {
+	if responsesReasoningDisabled(effort) {
+		return nil
+	}
+	switch vendor {
+	case "deepseek":
+		// Official DeepSeek vocabulary: flash is the only model with effort=low.
+		if strings.EqualFold(strings.TrimSpace(model), "deepseek-v4-flash") {
+			return []string{"low", "high", "max"}
+		}
+		return []string{"high", "max"}
+	default:
+		return []string{"low", "medium", "high"}
+	}
+}
+
+// requestEffort resolves one request's reasoning depth: a vocabulary-approved
+// EffortOverride wins, anything else falls back to the configured effort.
+func (c *client) requestEffort(req provider.Request) string {
+	want := strings.ToLower(strings.TrimSpace(req.EffortOverride))
+	if want == "" || !supportsEffort(c.requestEfforts, want) {
+		return c.effort
+	}
+	return want
+}
+
+func supportsEffort(levels []string, want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	for _, level := range levels {
+		if strings.ToLower(strings.TrimSpace(level)) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *client) Name() string { return c.name }
@@ -300,7 +349,8 @@ func (c *client) buildRequestBody(req provider.Request) (map[string]any, bool, [
 	messages := provider.SanitizeToolPairing(provider.ModelMessages(req.Messages))
 	body := map[string]any{"model": c.model, "stream": true}
 
-	effort := strings.ToLower(strings.TrimSpace(c.effort))
+	effective := c.requestEffort(req)
+	effort := strings.ToLower(strings.TrimSpace(effective))
 	switch effort {
 	case "auto":
 		effort = ""
@@ -312,11 +362,17 @@ func (c *client) buildRequestBody(req provider.Request) (map[string]any, bool, [
 	}
 	maxOutputTokens := req.MaxTokens
 	if maxOutputTokens == 0 {
-		maxOutputTokens = c.maxOutputTokens
+		if c.autoMaxOutput {
+			// Re-resolve so a per-request EffortOverride can move the auto budget
+			// up the 16K/32K/64K ladder, mirroring the OpenAI adapter.
+			maxOutputTokens = responsesAutoOutputBudget(c.vendor, effective)
+		} else {
+			maxOutputTokens = c.maxOutputTokens
+		}
 	}
 	if maxOutputTokens == 0 && c.caps.defaultMaxOutputTokens > 0 {
 		if c.vendor == "deepseek" || c.vendor == "mimo" {
-			maxOutputTokens = responsesAutoOutputBudget(c.vendor, c.effort)
+			maxOutputTokens = responsesAutoOutputBudget(c.vendor, effective)
 		} else {
 			maxOutputTokens = c.caps.defaultMaxOutputTokens
 		}


### PR DESCRIPTION
## Summary

Ports the per-request reasoning-depth contract (`provider.Request.EffortOverride`, documented at `harness/provider/provider.go:225`) to the two adapter families that silently dropped it. The OpenAI adapter was the only reader; anthropic and responses froze effort at construction. This is the adapter half of the `/effort` in-place switch (#332): landing #330 + #332 without it would strip effort control for anthropic/responses users.

Implementation mirrors the settled openai shape (`openai/effort.go`):

- **anthropic**: `requestEfforts` vocabulary computed in `New()` — `low|high|max` on the DeepSeek path, full `low|medium|high|xhigh|max` on native adaptive, nil for binary thinking knobs (that path emits no `output_config`). New `autoMaxOutput` field so the auto-derived `max_tokens` re-resolves from the effective effort per request.
- **responses**: same vocabulary pattern (`low|high|max` flash / `high|max` other DeepSeek / `low|medium|high` elsewhere, nil when thinking disabled) plus `autoMaxOutput` for the 16K/32K/64K budget ladder.
- `requestEffort` gate mirrors `openai/effort.go:79-85`: an in-vocabulary override wins, anything else returns the constructed effort untouched. The override adjusts depth only — it never toggles thinking on/off.
- `MissingToolCallReasoningWarningIdentity` and capability predicates keep reading the frozen `c.effort` (stable per client).

## Scope

- `harness/provider/anthropic` — wire sites in `buildRequest`, auto budget, tests
- `harness/provider/responses` — wire site in `buildRequestBody`, auto budget, tests
- `docs/specs/issue-331-effort-override.md` — spec
- Out of scope (stated in issue, filed separately): extension-protocol `effortOverride` wire field (`harness/extension/protocol/dto_provider.go`, `harness/sdk/go/types_generated.go`), i18n (zero user-visible strings touched)

## Validation

- [x] `go build ./harness/... ./cmd/... ./kernel/... ./internal/... ./gateway/...`
- [x] `go vet ./harness/... ./cmd/... ./kernel/... ./internal/... ./gateway/...`
- [x] `go test ./harness/provider/... -count=1` (anthropic, responses, openai, provider — all pass)
- [x] `go test ./harness/agent/ -run Governor -count=1` (the sole in-tree producer of `Request.EffortOverride`)
- [x] `go test ./harness/acp/... -count=1`
- [x] `git diff --check`
- [ ] `go test ./... -race` — **not runnable in this environment**: Windows host without a C compiler (`cgo: C compiler "gcc" not found`). Non-race provider suites pass.
- Pre-existing, unrelated failures on this dirty worktree: `harness/boot` golden `TestGoldenBaselineNoExtensions` (CRLF vs LF line endings in `system_prompt.txt` golden on Windows checkout), `harness/agent` `TestChildConstructionForksStayEnumerated` (scans `.worktrees/` + `tmp/` copies present in the worktree).

## Compatibility and data impact

Empty `EffortOverride` produces byte-identical wire bodies — pinned by golden tests captured from the unmodified `buildRequest`/`buildRequestBody` in both adapters. No config, CLI flag, or dependency changes.

## Security and privacy

None.

## Related issues

Closes #331. Hard prerequisite of #332; adjacent to #330 (can land standalone).