### PR TITLE
fix(install): 消除 macOS sed 报错 + 收尾消息讲清"需重载 shell"

### DIFF
--- a/agent-skill/scripts/install.sh
+++ b/agent-skill/scripts/install.sh
@@ -49,7 +49,7 @@ CURL="curl -fSL --retry 5 --retry-delay 2"
 # Resolve 'latest' to the newest published release tag via the GitHub API.
 if [ "$VERSION" = "latest" ]; then
   VERSION="$($CURL -s "https://api.github.com/repos/$REPO/releases/latest" \
-    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
+    | LC_ALL=C sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
   [ -n "$VERSION" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
 fi
 # Anchor the tag (reject junk that would only 404 at download time).
@@ -124,7 +124,9 @@ echo "== installed: $BIN_DIR/semantix + $BIN_DIR/semantix-agent =="
 #    `semantix` — that is what lets the one-liner "just work" without a manual
 #    step. We also print the line to run in the CURRENT shell right away.
 case ":$PATH:" in
-  *":$BIN_DIR:"*) : ;; # already reachable — nothing to do
+  *":$BIN_DIR:"*)
+    echo "== done. run 'semantix' inside any project to start the agent (that folder is the workspace). =="
+    ;;
   *)
     LINE="export PATH=\"$BIN_DIR:\$PATH\""
     case "${SHELL:-}" in
@@ -133,13 +135,19 @@ case ":$PATH:" in
       *)      RC="$HOME/.profile" ;;
     esac
     if [ -f "$RC" ] && grep -qF "$BIN_DIR" "$RC" 2>/dev/null; then
-      echo "== PATH already set in $RC (new terminals will find semantix) =="
+      echo "== PATH already set in $RC =="
     elif printf '\n# added by semantix install.sh\n%s\n' "$LINE" >> "$RC" 2>/dev/null; then
       echo "== added $BIN_DIR to PATH in $RC =="
     else
-      echo "== could not edit $RC — add this line to your shell rc: $LINE =="
+      RC=""
+      echo "== could not edit your shell rc — add this line manually: $LINE =="
     fi
-    echo "== to use it in THIS terminal right now, run: $LINE =="
+    # A piped installer runs in a child shell; it cannot change the terminal
+    # you launched it from, so the CURRENT shell still needs a reload.
+    echo ""
+    echo "== NOTE: this shell won't find 'semantix' until its PATH reloads =="
+    [ -n "$RC" ] && echo "==   do it now:  source $RC     (or just open a new terminal) =="
+    echo "==   verify anytime:  $BIN_DIR/semantix version =="
+    echo "== then run 'semantix' inside any project — that folder is the workspace. =="
     ;;
 esac
-echo "== done. run 'semantix' inside any project to start the agent (that folder is the workspace). =="


### PR DESCRIPTION
## Summary

真实 macOS 用户在 #395 的自动写 PATH 落地后跑一行安装，暴露了两个糙点，本 PR 修掉：

1. **`sed: RE error: illegal byte sequence`**。解析 `latest` tag 时，BSD sed（macOS）在非 UTF-8 locale 下解析 GitHub API JSON 里的多字节 release body（我们 release notes 有中文 + emoji）会报错。给该 sed 加 `LC_ALL=C`（按字节匹配）——我们只匹配 ASCII 的 `tag_name`，提取结果不变，报错消失。（版本解析当时其实成功了，`tag_name` 在 JSON 前部；报错只是 stderr 噪音，但很吓人。）
2. **收尾消息误导**。装完写好 PATH export 后，最后一句仍是"run 'semantix'"——但管道安装器跑在**子 shell**里、改不了启动它的父终端，用户在当前 shell 直接敲会 `command not found`（正是本次现象）。改为明确提示：当前 shell 需 `source <rc>` 或**新开终端**，并给出全路径 `<bindir>/semantix version` 随时验证。

> 注：这是所有 `curl | sh` 安装器的固有限制（uv / rustup 同理）——子进程无法修改已运行的父 shell。修不了"当前终端立即生效"，但能把该做什么讲清楚，不再误导。

## Scope

- `agent-skill/scripts/install.sh` — `latest` 解析的 sed 加 `LC_ALL=C`；step 6 收尾消息重写为清晰的"重载 shell"引导（PATH 已在时仍走原"done, run semantix"）。

## Validation

- [x] `sh -n agent-skill/scripts/install.sh` — 语法 OK
- [x] **sed 提取**：对含中文 + emoji 的样例 API JSON，`LC_ALL=C sed` 正确提取 `v0.7.2`
- [x] **端到端**（模拟 macOS zsh、`BIN_DIR` 不在 PATH）：装两个二进制 → 写入 `~/.zshrc` → 打印新的 NOTE 引导 → **新 shell `source` 后 `command -v semantix` 命中**
- [ ] `go vet` / `go test -race` — 不适用（零 Go 改动，仅 shell）

## Compatibility and data impact

- 纯提示/健壮性改动：写 rc 的逻辑、幂等性、路径选择均不变；仅收尾**文案**更清晰、sed 加了 locale 前缀。无行为回归。

## Security and privacy

- 无。下载/校验逻辑未动；`LC_ALL=C` 仅作用于本地 sed。

## Evidence

```
== added ~/.local/bin to PATH in ~/.zshrc ==

== NOTE: this shell won't find 'semantix' until its PATH reloads ==
==   do it now:  source ~/.zshrc     (or just open a new terminal) ==
==   verify anytime:  ~/.local/bin/semantix version ==
== then run 'semantix' inside any project — that folder is the workspace. ==
# 新 shell source 后： command -v semantix → FOUND ✅
```

## Related issues

承接 #395（一行安装体验打磨的收尾修复）。

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md`（无 wire 契约改动）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYV5u8eLCRH9dhZXcUcuoy)_