### PR TITLE
feat(config): 适配 GLM-5.3-Flash（智谱原生多模态）

### DIFF
--- a/harness/config/default_provider.go
+++ b/harness/config/default_provider.go
@@ -56,9 +56,10 @@ func selectDefaultModel(getenv func(string) string) string {
 func builtinGLMProvider() ProviderEntry {
 	return ProviderEntry{
 		Name: defaultProviderGLM, Kind: "openai",
-		BaseURL: "https://open.bigmodel.cn/api/paas/v4",
-		Models:  []string{"glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo"},
-		Default: "glm-5.2", APIKeyEnv: "GLM_API_KEY",
+		BaseURL:      "https://open.bigmodel.cn/api/paas/v4",
+		Models:       []string{"glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo"},
+		VisionModels: []string{"glm-5.3-flash"}, // glm-5.3-flash is natively multimodal (text+image+video)
+		Default:      "glm-5.2", APIKeyEnv: "GLM_API_KEY",
 		ContextWindow: 1_000_000,
 	}
 }

--- a/harness/config/provider_presets.go
+++ b/harness/config/provider_presets.go
@@ -98,8 +98,8 @@ var (
 	minimaxMSeriesModels       = []string{"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"}
 	minimaxMSeriesVisionModels = []string{"MiniMax-M3"}
 
-	glmAPIModels       = []string{"glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx", "glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash"}
-	glmAPIVisionModels = []string{"glm-5v-turbo"}
+	glmAPIModels       = []string{"glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx", "glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash"}
+	glmAPIVisionModels = []string{"glm-5.3-flash", "glm-5v-turbo"}
 	glmCodingModels    = []string{"glm-5.2", "glm-5.1", "glm-5", "glm-4.7"}
 	glmAnthropicModels = []string{"glm-5.3", "glm-5.2[1m]", "glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5-air"}
 


### PR DESCRIPTION
## Summary

要用 `glm-5.3-flash`，做适配。先核实模型事实（官方 docs.bigmodel.cn 被本环境 egress 拦了，用第三方权威源交叉确认）：

- **API 模型 id = `glm-5.3-flash`**（智谱 / Z.AI，bigmodel.cn；开源 `zai-org/GLM-5.3-Flash`）
- **上下文 1,048,576 tokens（~1M）** —— 与现有 GLM 预设 `context_window = 1000000` 一致，继承即可
- **原生多模态**：输入 text + image + video，输出 text
- 协议**按 host 自动识别**（bigmodel.cn / z.ai → `zhipu`，走 `thinking.type`、忽略 `reasoning_effort`），新 GLM 模型无需额外 effort/thinking 配置

## Scope

- `harness/config/provider_presets.go`
  - `glmAPIModels` 首位加 `glm-5.3-flash`（覆盖 `glm-cn` / `zai-global` 两个 pay-as-you-go openai 预设）
  - `glmAPIVisionModels` 加 `glm-5.3-flash`（标记多模态，可收图像）
- `harness/config/default_provider.go`
  - 内置零配置 GLM（`builtinGLMProvider`，`GLM_API_KEY` 命中时注入；`builtinZAIProvider` clone 同步）加 `glm-5.3-flash` + `VisionModels`

## Validation

- [x] `go build ./harness/config/... ./cmd/semantix-agent`、`go vet ./harness/config` — OK
- [x] `go test ./harness/config` — 全绿（唯一失败是既有 root 容器 symlink 权限测试 `TestSaveToUnwritableUserSymlinkTargetPreservesLink`，root 绕过 chmod 所致，与本改动无关，GitHub 非 root runner 上通过）
- [x] 断言：`glm-5.3-flash` 在 `glm-cn` 预设 Models 且标记 vision、且在内置 GLM Models

## Compatibility and data impact

- 纯增量：只往 GLM 型号表加一个模型 + 标记 vision。上下文继承 provider 级 `1_000_000`（保守，真实 1,048,576）。现有默认模型（glm-5.2）不变。
- 未加到编码套餐端点（`glmCodingModels` / `glmAnthropicModels`，`GLM_PLAN_API_KEY`）——flash 在标准 API（`GLM_API_KEY`）；若也走套餐 anthropic 端点用它，说一声即补。

## Security and privacy

- 无。仅静态模型清单；key/端点未变。

## Notes / open

- **默认模型**：本 PR 让 `glm-5.3-flash` 可选（setup 向导 GLM CN API 里能选、`/model` 可切），但**未设为默认**（预设默认仍 glm-5.2）。要不要把它设成默认 GLM 模型？一句话我调。

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with `docs/events.md`（无 wire 契约改动）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYV5u8eLCRH9dhZXcUcuoy)_