### PR TITLE
feat(gui): unify workspace event protocol and SSE replay

### DIFF
--- a/docs/gui/event-protocol.md
+++ b/docs/gui/event-protocol.md
@@ -67,4 +67,5 @@ Filtered host-internal kinds that are never forwarded:
 4. On reconnect, preserve the last received SSE `id` as `Last-Event-ID` (the
    browser `EventSource` does this automatically). Initial connections replay
    pending prompts; reconnects rely on the event log so approval cards are not
-   duplicated.
+   duplicated. If the server reports a replay gap, it replays pending prompts
+   again because the missing history cannot be trusted.

--- a/docs/gui/event-protocol.md
+++ b/docs/gui/event-protocol.md
@@ -1,0 +1,70 @@
+// Protocol: Semantix workspace frontend events (v1)
+// Issue #407 · Epic #403
+//
+// Endpoint: `GET /workspace/events` (SSE). The legacy `GET /events` raw-wire
+// stream is unchanged and remains the contract for the console/index.html and
+// desktop clients.
+
+## Envelope
+
+Every frame carries the full SSE form:
+
+	id: <seq>
+	event: <type>
+	data: {"v":1,"seq":<seq>,"type":"<type>","task_id":"<id>","time_ms":<ms>,
+	       "data":<untouched eventwire frame>}
+
+- `v` — protocol version, currently 1. Bump on breaking shape changes.
+- `seq` — broadcaster-lifetime monotonic counter assigned when an event is
+  published, shared by all connections. Delivery order equals seq order on a
+  single connection. A reconnect sends `Last-Event-ID`; the server replays the
+  retained suffix from its bounded 256-frame log before live events. A response
+  with `X-Semantix-Replay: gap` means the requested prefix has expired; the
+  client must refresh `/history` and continue consuming the stream. The counter
+  resets when the server/broadcaster restarts.
+- `task_id` — basename of the active session transcript, snapshotted when the
+  connection subscribes. A connection therefore belongs to exactly one task;
+  clients reconnect to re-snapshot after switching tasks.
+- `data` — the untouched eventwire JSON (`eventwire.ToWire`). The envelope
+  NEVER synthesizes tool results, diffs, or cache numbers.
+
+## Types
+
+| type                 | source wire kinds                                     | notes |
+|----------------------|-------------------------------------------------------|-------|
+| user_message         | steer                                                 | mid-turn steer confirmations |
+| assistant_message    | text, message, reasoning                               | deltas + final assembly ride `data.kind` |
+| tool_start           | tool_dispatch, tool_progress                           | progress chunks keep flowing under this type |
+| tool_result          | tool_result                                            | only real tool outputs |
+| permission_request   | approval_request, ask_request                          | blocks until /approve or /answer |
+| cache_status         | usage, compaction_started, compaction_done             | session hit/miss tokens live in data.Usage |
+| task_status          | turn_started, turn_phase, completion_summary, retrying, guardian_assessment, extension_status | turn lifecycle phases |
+| error                | turn_done(err≠"")                                      | payload-dependent promotion from task_status |
+| plan                 | —                                                      | **reserved**: no producer yet; never emitted in v1 |
+| diff                 | —                                                      | **reserved**: no producer yet; never emitted in v1 |
+| unknown              | any kind added after this protocol version             | forward-compat wrapper |
+
+Filtered host-internal kinds that are never forwarded:
+`stream_attempt`, `extension_surface`, `mcp_surface_ready`,
+`workspace_changed`, `context_maintenance`.
+
+## Client rules
+
+1. Treat unrecognized `event:` names (and unrecognized fields inside `data`)
+   as no-op — new backend kinds must not crash old pages.
+2. Validate ordering via `seq`; treat gaps or `X-Semantix-Replay: gap` as a
+   signal to refresh derived state, not to abort the stream.
+3. Attribute frames per `task_id`; discard stale-task frames after switching.
+4. Never trust synthesized content — everything authoritative lives inside
+   `data`.
+
+## Server rules (tested)
+
+1. One wire kind maps to exactly one canonical type; completeness tests cover
+   every kind eventwire knows, including skipped ones.
+2. Frames are emitted in delivery order with strictly increasing `seq`.
+3. Reserved types (`plan`, `diff`) are asserted absent from streams.
+4. On reconnect, preserve the last received SSE `id` as `Last-Event-ID` (the
+   browser `EventSource` does this automatically). Initial connections replay
+   pending prompts; reconnects rely on the event log so approval cards are not
+   duplicated.

--- a/harness/serve/broadcaster.go
+++ b/harness/serve/broadcaster.go
@@ -170,11 +170,11 @@ func (b *Broadcaster) EmitWebTo(target <-chan webDelivery, taskID string, e even
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	frame := b.newWebFrame(protoType, data)
 	for sub := range b.webSubs {
 		if (<-chan webDelivery)(sub.ch) != target {
 			continue
 		}
+		frame := b.newWebFrame(protoType, data)
 		select {
 		case sub.ch <- webDelivery{frame: frame, taskID: taskID}:
 		default:
@@ -234,8 +234,10 @@ func (b *Broadcaster) SubscribeWebSince(lastSeq uint64, taskID string) (<-chan w
 	defer b.mu.Unlock()
 
 	gap := false
-	if lastSeq > 0 && len(b.webHistory) > 0 && lastSeq < b.webHistory[0].seq-1 {
-		gap = true
+	if lastSeq > 0 {
+		if len(b.webHistory) == 0 || lastSeq < b.webHistory[0].seq-1 {
+			gap = true
+		}
 	}
 	replay := make([]webDelivery, 0, len(b.webHistory))
 	for _, frame := range b.webHistory {

--- a/harness/serve/broadcaster.go
+++ b/harness/serve/broadcaster.go
@@ -71,13 +71,21 @@ func (b *Broadcaster) SetDisplayCurrency(currency string) {
 	b.mu.Unlock()
 }
 
-// ResetSession clears the usage ledger for /new, /resume and /fork.
+// ResetSession clears the usage ledger for /new, /resume and /fork. Workspace
+// replay is session-scoped, so old protocol history and subscribers are closed
+// as well; EventSource clients reconnect with the new task id instead of
+// receiving frames from the previous session.
 func (b *Broadcaster) ResetSession() {
 	if b == nil {
 		return
 	}
 	b.mu.Lock()
 	b.ledger = billing.NewLedger()
+	b.webHistory = nil
+	for sub := range b.webSubs {
+		delete(b.webSubs, sub)
+		close(sub.ch)
+	}
 	b.mu.Unlock()
 }
 

--- a/harness/serve/broadcaster.go
+++ b/harness/serve/broadcaster.go
@@ -10,6 +10,31 @@ import (
 	"semantix/harness/eventwire"
 )
 
+// webHistoryLimit bounds the protocol data retained for an SSE reconnect.
+// The raw /events stream remains live-only; this history is only for the
+// versioned /workspace/events transport.
+const webHistoryLimit = 256
+
+// webFrame is the protocol-facing representation of one forwarded event. The
+// sequence is assigned once at publish time so every workspace connection
+// observes the same ordering and Last-Event-ID has stable meaning.
+type webFrame struct {
+	seq    uint64
+	type_  string
+	timeMS int64
+	data   []byte
+}
+
+type webDelivery struct {
+	frame  webFrame
+	taskID string
+}
+
+type webSubscriber struct {
+	ch     chan webDelivery
+	taskID string
+}
+
 // Broadcaster is the event.Sink the controller emits to in server mode. It
 // marshals each event once and fans it out to every connected SSE subscriber.
 // A slow subscriber's buffer is allowed to drop rather than back-pressure the
@@ -18,13 +43,20 @@ import (
 type Broadcaster struct {
 	mu              sync.Mutex
 	subs            map[chan []byte]struct{}
+	webSubs         map[*webSubscriber]struct{}
+	webHistory      []webFrame
+	webSeq          uint64
 	ledger          *billing.Ledger
 	displayCurrency string
 }
 
 // NewBroadcaster returns an empty Broadcaster ready to accept subscribers.
 func NewBroadcaster() *Broadcaster {
-	return &Broadcaster{subs: map[chan []byte]struct{}{}, ledger: billing.NewLedger()}
+	return &Broadcaster{
+		subs:    map[chan []byte]struct{}{},
+		webSubs: map[*webSubscriber]struct{}{},
+		ledger:  billing.NewLedger(),
+	}
 }
 
 // SetDisplayCurrency rebinds the session ledger to a stored valuation. Empty
@@ -70,6 +102,7 @@ func (b *Broadcaster) Emit(e event.Event) {
 	if err != nil {
 		return
 	}
+	protoType, keep, _ := classifyFrame(data)
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if e.Kind == event.Usage && e.Usage != nil && e.CostQuote != nil {
@@ -87,6 +120,15 @@ func (b *Broadcaster) Emit(e event.Event) {
 		select {
 		case ch <- data:
 		default: // subscriber is behind; drop this frame for it
+		}
+	}
+	if keep {
+		frame := b.publishWebFrame(protoType, data)
+		for sub := range b.webSubs {
+			select {
+			case sub.ch <- webDelivery{frame: frame, taskID: sub.taskID}:
+			default: // preserve agent liveness; clients can reconnect on a gap
+			}
 		}
 	}
 }
@@ -114,6 +156,57 @@ func (b *Broadcaster) EmitTo(target <-chan []byte, e event.Event) {
 	}
 }
 
+// EmitWebTo delivers a real event to one workspace subscriber without adding a
+// target-only replay to the shared history. This is used for pending approval
+// and ask prompts, which are re-emitted only to the newly attached client.
+func (b *Broadcaster) EmitWebTo(target <-chan webDelivery, taskID string, e event.Event) {
+	data, err := json.Marshal(eventwire.ToWire(e))
+	if err != nil {
+		return
+	}
+	protoType, keep, _ := classifyFrame(data)
+	if !keep {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	frame := b.newWebFrame(protoType, data)
+	for sub := range b.webSubs {
+		if (<-chan webDelivery)(sub.ch) != target {
+			continue
+		}
+		select {
+		case sub.ch <- webDelivery{frame: frame, taskID: taskID}:
+		default:
+		}
+		return
+	}
+}
+
+// publishWebFrame assigns a stable sequence and appends one protocol frame to
+// the bounded replay log. b.mu must be held by the caller.
+func (b *Broadcaster) publishWebFrame(protoType string, data []byte) webFrame {
+	frame := b.newWebFrame(protoType, data)
+	b.webHistory = append(b.webHistory, frame)
+	if excess := len(b.webHistory) - webHistoryLimit; excess > 0 {
+		copy(b.webHistory, b.webHistory[excess:])
+		b.webHistory = b.webHistory[:webHistoryLimit]
+	}
+	return frame
+}
+
+// newWebFrame allocates a sequence without retaining the frame. b.mu must be
+// held by the caller.
+func (b *Broadcaster) newWebFrame(protoType string, data []byte) webFrame {
+	b.webSeq++
+	return webFrame{
+		seq:    b.webSeq,
+		type_:  protoType,
+		timeMS: time.Now().UnixMilli(),
+		data:   append([]byte(nil), data...),
+	}
+}
+
 // Subscribe registers a new SSE client and returns its channel plus an
 // unsubscribe func the handler must call (defer) when the client disconnects.
 func (b *Broadcaster) Subscribe() (<-chan []byte, func()) {
@@ -126,6 +219,36 @@ func (b *Broadcaster) Subscribe() (<-chan []byte, func()) {
 		if _, ok := b.subs[ch]; ok {
 			delete(b.subs, ch)
 			close(ch)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// SubscribeWebSince atomically registers a workspace subscriber and snapshots
+// all retained frames after lastSeq. gap is true when the requested sequence
+// predates the retained window; callers should replay the available suffix and
+// refresh derived state from /history.
+func (b *Broadcaster) SubscribeWebSince(lastSeq uint64, taskID string) (<-chan webDelivery, []webDelivery, bool, func()) {
+	sub := &webSubscriber{ch: make(chan webDelivery, 64), taskID: taskID}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	gap := false
+	if lastSeq > 0 && len(b.webHistory) > 0 && lastSeq < b.webHistory[0].seq-1 {
+		gap = true
+	}
+	replay := make([]webDelivery, 0, len(b.webHistory))
+	for _, frame := range b.webHistory {
+		if frame.seq > lastSeq {
+			replay = append(replay, webDelivery{frame: frame, taskID: taskID})
+		}
+	}
+	b.webSubs[sub] = struct{}{}
+	return sub.ch, replay, gap, func() {
+		b.mu.Lock()
+		if _, ok := b.webSubs[sub]; ok {
+			delete(b.webSubs, sub)
+			close(sub.ch)
 		}
 		b.mu.Unlock()
 	}

--- a/harness/serve/serve.go
+++ b/harness/serve/serve.go
@@ -506,6 +506,7 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /workspace/layout.css", staticBytes("text/css; charset=utf-8", &workspaceLayoutCSS))
 	mux.HandleFunc("GET /workspace/shell.js", staticBytes("text/javascript; charset=utf-8", &workspaceShellJS))
 	mux.HandleFunc("GET /events", s.events)
+	mux.HandleFunc("GET /workspace/events", s.workspaceEvents)
 	mux.HandleFunc("GET /history", s.history)
 	mux.HandleFunc("GET /context", s.context)
 	mux.HandleFunc("POST /submit", s.submit)

--- a/harness/serve/webproto.go
+++ b/harness/serve/webproto.go
@@ -1,0 +1,259 @@
+package serve
+
+// GUI-4 (#407): the stable frontend event protocol. The existing /events
+// stream keeps emitting raw eventwire JSON for the console and desktop
+// clients; /workspace/events wraps THE SAME underlying flow in a versioned
+// envelope with canonical types, broadcaster-lifetime sequence numbers and a task id,
+// so browser surfaces can consume, validate and resume it without a second
+// data model.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"semantix/harness/event"
+)
+
+// Canonical frontend event types (issue #407). diff and plan are part of the
+// contract but RESERVED: no internal event carries them yet, and fabricating
+// frames is forbidden by the acceptance criteria — they appear once a real
+// producer exists.
+const (
+	ProtoTypeUser              = "user_message"
+	ProtoTypeAssistant         = "assistant_message"
+	ProtoTypePlan              = "plan" // reserved, never emitted in v1
+	ProtoTypeToolStart         = "tool_start"
+	ProtoTypeToolResult        = "tool_result"
+	ProtoTypeDiff              = "diff" // reserved, never emitted in v1
+	ProtoTypePermissionRequest = "permission_request"
+	ProtoTypeTaskStatus        = "task_status"
+	ProtoTypeCacheStatus       = "cache_status"
+	ProtoTypeError             = "error"
+
+	// ProtoTypeUnknown wraps kinds added after this protocol version. Clients
+	// MUST ignore types they do not recognize instead of failing.
+	ProtoTypeUnknown = "unknown"
+)
+
+var protoTypes = map[string]bool{
+	ProtoTypeUser: true, ProtoTypeAssistant: true, ProtoTypePlan: true,
+	ProtoTypeToolStart: true, ProtoTypeToolResult: true, ProtoTypeDiff: true,
+	ProtoTypePermissionRequest: true, ProtoTypeTaskStatus: true,
+	ProtoTypeCacheStatus: true, ProtoTypeError: true, ProtoTypeUnknown: true,
+}
+
+// protoSkips lists wire kinds that are host-internal or renderer noise and are
+// deliberately NOT forwarded to workspace clients (filtered, not mapped):
+// stream_attempt is host-local sampling lifecycle, extension_surface needs an
+// extension-aware renderer first, mcp_surface_ready / workspace_changed /
+// context_maintenance are console-refresh hints already reflected server-side.
+var protoSkips = map[string]bool{
+	"stream_attempt":      true,
+	"extension_surface":   true,
+	"mcp_surface_ready":   true,
+	"workspace_changed":   true,
+	"context_maintenance": true,
+}
+
+// wireKindKnown tracks every kind eventwire can emit, so forward-compat
+// classification can distinguish "known but skipped/typed" from genuinely new
+// kinds. Kept in sync with eventwire.kindNames by TestWebProtoCoversAllKinds.
+var wireKindKnown = map[string]bool{
+	"turn_started": true, "reasoning": true, "text": true, "message": true,
+	"tool_dispatch": true, "tool_result": true, "usage": true, "notice": true,
+	"phase": true, "approval_request": true, "ask_request": true,
+	"turn_done": true, "compaction_started": true, "compaction_done": true,
+	"tool_progress": true, "mcp_surface_ready": true, "retrying": true,
+	"steer": true, "guardian_assessment": true, "extension_surface": true,
+	"extension_status": true, "stream_attempt": true,
+	"context_maintenance": true, "workspace_changed": true,
+	"turn_phase": true, "completion_summary": true,
+}
+
+// ProtoTypeFor maps a wire kind to its canonical frontend type. The second
+// return reports whether the kind is forwarded at all (skipped kinds never
+// reach the wire). Unknown kinds map to ProtoTypeUnknown so newly added
+// backend events degrade gracefully on old clients instead of crashing them.
+//
+// turn_done defaults here to task_status; classifyFrame promotes it to error
+// when its Err payload is set — the ONLY real failure signal in the stream
+// (Notice carries no error Level, only info/warn).
+func ProtoTypeFor(wireKind string) (string, bool) {
+	if protoSkips[wireKind] {
+		return "", false
+	}
+	switch wireKind {
+	case "steer":
+		return ProtoTypeUser, true
+	case "text", "message", "reasoning":
+		return ProtoTypeAssistant, true
+	case "tool_dispatch", "tool_progress":
+		return ProtoTypeToolStart, true
+	case "tool_result":
+		return ProtoTypeToolResult, true
+	case "approval_request", "ask_request":
+		return ProtoTypePermissionRequest, true
+	case "usage", "compaction_started", "compaction_done":
+		// Usage carries session cache hit/miss tokens; compaction reshapes the
+		// cacheable context — both are truthful cache-status inputs.
+		return ProtoTypeCacheStatus, true
+	default:
+		if !wireKindKnown[wireKind] {
+			return ProtoTypeUnknown, true
+		}
+		return ProtoTypeTaskStatus, true
+	}
+}
+
+// frameProbe decodes just enough of a wire frame to classify it.
+type frameProbe struct {
+	Kind  string `json:"kind"`
+	Level string `json:"level,omitempty"`
+	Err   string `json:"err,omitempty"`
+}
+
+func classifyFrame(frame []byte) (protoType string, keep bool, probe frameProbe) {
+	if err := json.Unmarshal(frame, &probe); err != nil {
+		return "", false, probe // tolerate junk rather than kill the stream
+	}
+	protoType, keep = ProtoTypeFor(probe.Kind)
+	if !keep {
+		return "", false, probe
+	}
+	// turn_done is the stream's only failure signal: a non-empty Err promotes
+	// it from task_status to error. Notices never promote — they only carry
+	// info/warn levels.
+	if probe.Kind == "turn_done" && strings.TrimSpace(probe.Err) != "" {
+		protoType = ProtoTypeError
+	}
+	return protoType, true, probe
+}
+
+// WebEnvelope is one SSE frame of GET /workspace/events. Data embeds the
+// untouched eventwire frame — the single source of truth, so the protocol can
+// never fabricate tool results or cache numbers (#407 acceptance).
+type WebEnvelope struct {
+	V      int             `json:"v"`
+	Seq    uint64          `json:"seq"`
+	Type   string          `json:"type"`
+	TaskID string          `json:"task_id"`
+	TimeMS int64           `json:"time_ms"`
+	Data   json.RawMessage `json:"data"`
+}
+
+// workspaceEvents streams GET /workspace/events as SSE envelopes. A connection
+// is bound to ONE task: task_id snapshots the active session path at subscribe
+// time, so consumers can validate ordering and attribution per task, and
+// reconnect around task switches with a fresh snapshot.
+//
+// Frame form (full SSE, ahead of the bare data:-only /events stream):
+//
+//	retry: 3000            reconnect cadence hint
+//	id: <seq>              monotonic, gap-detectable
+//	event: <canonical type>
+//	data: {"v":1,...,"data":<untouched wire frame>}
+//
+// Unknown event types still arrive as valid SSE — EventSource dispatches
+// unrecognized names to consumers that registered for them and drops the rest;
+// clients MUST treat unregistered types as no-op rather than throwing
+// (acceptance: 未知事件不会导致页面崩溃).
+func (s *Server) workspaceEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	taskID := filepath.Base(s.ctl().SessionPath())
+	if taskID == "" || taskID == "." || taskID == string(os.PathSeparator) {
+		taskID = "current"
+	}
+	lastSeq := parseLastEventID(r.Header.Get("Last-Event-ID"))
+	ch, replay, gap, unsubscribe := s.bc.SubscribeWebSince(lastSeq, taskID)
+	defer unsubscribe()
+	if gap {
+		w.Header().Set("X-Semantix-Replay", "gap")
+	} else if lastSeq > 0 {
+		w.Header().Set("X-Semantix-Replay", "complete")
+	} else {
+		w.Header().Set("X-Semantix-Replay", "initial")
+	}
+
+	fmt.Fprint(w, ": connected\n\nretry: 3000\n\n")
+	flusher.Flush()
+	if gap {
+		// This is a transport comment, not a fabricated protocol event. The
+		// client must refresh /history because the missing prefix is outside
+		// the bounded replay window.
+		fmt.Fprint(w, ": replay-gap; refresh /history\n\n")
+		flusher.Flush()
+	}
+	for _, delivery := range replay {
+		writeWebDelivery(w, flusher, delivery)
+	}
+	if lastSeq == 0 {
+		// Initial clients need actionable prompts that may have been emitted
+		// before they connected. Reconnects receive those events from history
+		// instead, avoiding duplicate approval cards.
+		s.ctl().ReplayPendingPromptsWith(func() event.Sink {
+			return event.FuncSink(func(e event.Event) {
+				s.bc.EmitWebTo(ch, taskID, e)
+			})
+		})
+	}
+
+	keepalive := time.NewTicker(sseKeepaliveInterval)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case delivery, ok := <-ch:
+			if !ok {
+				return
+			}
+			writeWebDelivery(w, flusher, delivery)
+		case <-keepalive.C:
+			fmt.Fprint(w, ": ping\n\n")
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func parseLastEventID(value string) uint64 {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	seq, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return seq
+}
+
+func writeWebDelivery(w http.ResponseWriter, flusher http.Flusher, delivery webDelivery) {
+	payload, err := json.Marshal(WebEnvelope{
+		V:      1,
+		Seq:    delivery.frame.seq,
+		Type:   delivery.frame.type_,
+		TaskID: delivery.taskID,
+		TimeMS: delivery.frame.timeMS,
+		Data:   delivery.frame.data,
+	})
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", delivery.frame.seq, delivery.frame.type_, payload)
+	flusher.Flush()
+}

--- a/harness/serve/webproto.go
+++ b/harness/serve/webproto.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"semantix/harness/event"
+	"semantix/harness/eventwire"
 )
 
 // Canonical frontend event types (issue #407). diff and plan are part of the
@@ -63,18 +64,14 @@ var protoSkips = map[string]bool{
 
 // wireKindKnown tracks every kind eventwire can emit, so forward-compat
 // classification can distinguish "known but skipped/typed" from genuinely new
-// kinds. Kept in sync with eventwire.kindNames by TestWebProtoCoversAllKinds.
-var wireKindKnown = map[string]bool{
-	"turn_started": true, "reasoning": true, "text": true, "message": true,
-	"tool_dispatch": true, "tool_result": true, "usage": true, "notice": true,
-	"phase": true, "approval_request": true, "ask_request": true,
-	"turn_done": true, "compaction_started": true, "compaction_done": true,
-	"tool_progress": true, "mcp_surface_ready": true, "retrying": true,
-	"steer": true, "guardian_assessment": true, "extension_surface": true,
-	"extension_status": true, "stream_attempt": true,
-	"context_maintenance": true, "workspace_changed": true,
-	"turn_phase": true, "completion_summary": true,
-}
+// kinds without duplicating eventwire's registry in this package.
+var wireKindKnown = func() map[string]bool {
+	known := make(map[string]bool)
+	for _, name := range eventwire.KindNames() {
+		known[name] = true
+	}
+	return known
+}()
 
 // ProtoTypeFor maps a wire kind to its canonical frontend type. The second
 // return reports whether the kind is forwarded at all (skipped kinds never

--- a/harness/serve/webproto.go
+++ b/harness/serve/webproto.go
@@ -197,10 +197,11 @@ func (s *Server) workspaceEvents(w http.ResponseWriter, r *http.Request) {
 	for _, delivery := range replay {
 		writeWebDelivery(w, flusher, delivery)
 	}
-	if lastSeq == 0 {
+	if lastSeq == 0 || gap {
 		// Initial clients need actionable prompts that may have been emitted
 		// before they connected. Reconnects receive those events from history
-		// instead, avoiding duplicate approval cards.
+		// when available; a replay gap has no trustworthy history, so prompts
+		// are safely re-emitted for the new connection.
 		s.ctl().ReplayPendingPromptsWith(func() event.Sink {
 			return event.FuncSink(func(e event.Event) {
 				s.bc.EmitWebTo(ch, taskID, e)

--- a/harness/serve/webproto_test.go
+++ b/harness/serve/webproto_test.go
@@ -1,0 +1,383 @@
+package serve
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"semantix/harness/config"
+	"semantix/harness/control"
+	"semantix/harness/event"
+	"semantix/harness/provider"
+)
+
+// TestWebProtoMappingCompleteness walks every wire kind this package knows
+// and requires the classifier to output exactly one canonical type — or
+// explicitly skip host-internal noise. Genuinely new kinds must degrade to
+// ProtoTypeUnknown (the forward-compat contract), never to an empty type.
+func TestWebProtoMappingCompleteness(t *testing.T) {
+	for kind := range wireKindKnown {
+		protoType, keep := ProtoTypeFor(kind)
+		if !keep {
+			if !protoSkips[kind] {
+				t.Fatalf("kind %q skipped but not listed in protoSkips", kind)
+			}
+			continue
+		}
+		if !protoTypes[protoType] {
+			t.Errorf("kind %q mapped to %q which is not a canonical type", kind, protoType)
+		}
+	}
+
+	// Reserved types must never be reachable through the mapping while no
+	// producer exists (same family as the no-fabrication acceptance rule).
+	for _, reserved := range []string{ProtoTypePlan, ProtoTypeDiff} {
+		for kind := range wireKindKnown {
+			if protoType, keep := ProtoTypeFor(kind); keep && protoType == reserved {
+				t.Errorf("reserved type %q mapped from kind %q", reserved, kind)
+			}
+		}
+	}
+
+	// Forward compatibility: unseen kinds become unknown, not crashes.
+	if protoType, keep := ProtoTypeFor("brand_new_kind_from_the_future"); !keep || protoType != ProtoTypeUnknown {
+		t.Errorf("unseen kind => (%q,%v), want (unknown,true)", protoType, keep)
+	}
+}
+
+// TestWebProtoPayloadRefinement pins turn_done as the stream's only failure
+// signal and confirms junk frames are dropped without killing the stream.
+func TestWebProtoPayloadRefinement(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame []byte
+		want  string
+	}{
+		{"notice info", []byte(`{"kind":"notice","level":"info"}`), ProtoTypeTaskStatus},
+		{"notice warn", []byte(`{"kind":"notice","level":"warn"}`), ProtoTypeTaskStatus},
+		{"turn_done ok", []byte(`{"kind":"turn_done","err":""}`), ProtoTypeTaskStatus},
+		{"turn_done failed", []byte(`{"kind":"turn_done","err":"boom"}`), ProtoTypeError},
+		{"usage carries cache", []byte(`{"kind":"usage","sessionCacheHitTokens":5}`), ProtoTypeCacheStatus},
+		{"compaction is cache", []byte(`{"kind":"compaction_done"}`), ProtoTypeCacheStatus},
+	}
+	for _, tc := range cases {
+		got, keep, _ := classifyFrame(tc.frame)
+		if !keep {
+			t.Errorf("%s: unexpectedly filtered", tc.name)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: type = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+
+	// Junk frames are tolerated: dropped, stream stays alive (#407 acceptance).
+	if _, keep, _ := classifyFrame([]byte("{not json")); keep {
+		t.Error("junk frame should be dropped, not forwarded")
+	}
+}
+
+// sseRecord is one parsed SSE frame from /workspace/events.
+type sseRecord struct {
+	id      string
+	ssetype string
+	data    json.RawMessage
+}
+
+// wireKindOf maps the synthetic emission list to its stable wire name so the
+// order assertion below can double-check the inner data.kind too.
+func wireKindOf(idx int) string {
+	names := []string{
+		"steer", "message", "tool_dispatch", "tool_result",
+		"approval_request", "ask_request", "usage", "compaction_done",
+		"turn_started", "retrying", "notice", "turn_done", // err variant
+		"turn_done", // ok variant
+	}
+	return names[idx]
+}
+
+// TestWorkspaceEventsProtocolFrames emits the synthetic event sequence through
+// the live broadcaster and validates the resulting SSE stream end to end:
+// strictly increasing ids, event:-line parity with envelope.type, stable
+// task_id, per-frame canonical types in emission order, zero reserved types,
+// and filtered host-internal kinds producing no frames at all (#407).
+func TestWorkspaceEventsProtocolFrames(t *testing.T) {
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc})
+	srv := New(ctrl, bc, config.ServeConfig{})
+	httpSrv := httptest.NewServer(srv.Handler())
+	defer httpSrv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, httpSrv.URL+"/workspace/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	frames := make(chan sseRecord, 64)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		var cur *sseRecord
+		for sc.Scan() {
+			line := sc.Text()
+			switch {
+			case strings.HasPrefix(line, ":"):
+				continue // ": connected" + keepalive comments
+			case strings.HasPrefix(line, "id: "):
+				cur = &sseRecord{id: strings.TrimPrefix(line, "id: ")}
+			case strings.HasPrefix(line, "event: "):
+				if cur == nil {
+					cur = &sseRecord{}
+				}
+				cur.ssetype = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				if cur == nil {
+					cur = &sseRecord{}
+				}
+				cur.data = json.RawMessage(strings.TrimPrefix(line, "data: "))
+				frames <- *cur
+				cur = nil
+			}
+		}
+		close(frames)
+	}()
+
+	errBoom := errors.New("upstream gone")
+	emitSeq := []event.Event{
+		{Kind: event.Steer, Text: "收到"},
+		{Kind: event.Message, Text: "完整回答"},
+		{Kind: event.ToolDispatch, Tool: event.Tool{ID: "t1", Name: "read_file"}},
+		{Kind: event.ToolResult, Tool: event.Tool{ID: "t1", Output: "42 bytes"}},
+		{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "a1"}},
+		{Kind: event.AskRequest},
+		{Kind: event.Usage, Usage: &provider.Usage{CacheHitTokens: 7}},
+		{Kind: event.CompactionDone},
+		{Kind: event.TurnStarted},
+		{Kind: event.Retrying},
+		{Kind: event.Notice, Level: event.LevelWarn},
+		{Kind: event.TurnDone, Err: errBoom},
+		{Kind: event.TurnDone}, // user cancellation / clean finish
+		// Filtered host-internal kinds must produce NO frames:
+		{Kind: event.StreamAttempt},
+		{Kind: event.WorkspaceChanged},
+	}
+	wantTypes := []string{
+		ProtoTypeUser, ProtoTypeAssistant, ProtoTypeToolStart, ProtoTypeToolResult,
+		ProtoTypePermissionRequest, ProtoTypePermissionRequest,
+		ProtoTypeCacheStatus, ProtoTypeCacheStatus,
+		ProtoTypeTaskStatus, ProtoTypeTaskStatus, ProtoTypeTaskStatus,
+		ProtoTypeError, ProtoTypeTaskStatus,
+	}
+
+	bc.Emit(emitSeq[0]) // warm the subscription before the collector loops
+	for _, ev := range emitSeq[1:] {
+		bc.Emit(ev)
+	}
+
+	// Broadcaster fan-out preserves emission order (FIFO byte channel), so
+	// collecting until the context deadline yields every non-filtered frame,
+	// in order.
+	var records []sseRecord
+collect:
+	for {
+		select {
+		case rec, ok := <-frames:
+			if !ok {
+				break collect
+			}
+			records = append(records, rec)
+		case <-ctx.Done():
+			break collect
+		}
+	}
+
+	if len(records) != len(wantTypes) {
+		t.Fatalf("frames = %d, want %d; types seen:", len(records), len(wantTypes))
+	}
+
+	expectedTaskID := filepath.Base(ctrl.SessionPath())
+	if expectedTaskID == "" || expectedTaskID == "." {
+		expectedTaskID = "current"
+	}
+
+	var lastSeq uint64
+	for i, rec := range records {
+		var env WebEnvelope
+		if err := json.Unmarshal(rec.data, &env); err != nil {
+			t.Fatalf("frame %d: decode envelope: %v", i, err)
+		}
+		if env.V != 1 {
+			t.Errorf("frame %d: v = %d, want 1", i, env.V)
+		}
+		if fmt.Sprint(env.Seq) != rec.id {
+			t.Errorf("frame %d: id %q != envelope seq %d", i, rec.id, env.Seq)
+		}
+		if env.Seq <= lastSeq {
+			t.Errorf("frame %d: seq %d not increasing after %d", i, env.Seq, lastSeq)
+		}
+		lastSeq = env.Seq
+		if env.TaskID != expectedTaskID {
+			t.Errorf("frame %d: task_id = %q, want %q", i, env.TaskID, expectedTaskID)
+		}
+		if rec.ssetype != env.Type {
+			t.Errorf("frame %d: event line %q != envelope type %q", i, rec.ssetype, env.Type)
+		}
+		if env.Type != wantTypes[i] {
+			t.Errorf("frame %d (%s): type = %q, want %q", i, wireKindOf(i), env.Type, wantTypes[i])
+		}
+		var inner struct {
+			Kind string `json:"kind"`
+		}
+		if err := json.Unmarshal(env.Data, &inner); err != nil {
+			t.Fatalf("frame %d: decode inner wire frame: %v", i, err)
+		}
+		if inner.Kind != wireKindOf(i) {
+			t.Errorf("frame %d: inner kind = %q, want %q (order must mirror emissions)", i, inner.Kind, wireKindOf(i))
+		}
+	}
+}
+
+func TestBroadcasterWebReplayAndGap(t *testing.T) {
+	bc := NewBroadcaster()
+	for i := 0; i < 3; i++ {
+		bc.Emit(event.Event{Kind: event.Message, Text: fmt.Sprintf("message-%d", i)})
+	}
+
+	ch, replay, gap, unsubscribe := bc.SubscribeWebSince(1, "task-1")
+	defer unsubscribe()
+	if gap {
+		t.Fatal("recent Last-Event-ID unexpectedly reported a replay gap")
+	}
+	if len(replay) != 2 || replay[0].frame.seq != 2 || replay[1].frame.seq != 3 {
+		t.Fatalf("replay = %#v, want seq 2 and 3", replay)
+	}
+	bc.Emit(event.Event{Kind: event.Message, Text: "live"})
+	select {
+	case delivery := <-ch:
+		if delivery.frame.seq != 4 {
+			t.Fatalf("live seq = %d, want 4", delivery.frame.seq)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for live workspace frame")
+	}
+
+	// The retained window is bounded. Once the caller's cursor predates it,
+	// replay still returns the suffix and reports that /history must be
+	// refreshed for the missing prefix.
+	for i := 0; i < webHistoryLimit+2; i++ {
+		bc.Emit(event.Event{Kind: event.Message, Text: "overflow"})
+	}
+	_, suffix, gap, unsubscribe2 := bc.SubscribeWebSince(1, "task-2")
+	defer unsubscribe2()
+	if !gap {
+		t.Fatal("expired Last-Event-ID did not report a replay gap")
+	}
+	if len(suffix) != webHistoryLimit {
+		t.Fatalf("replay suffix = %d, want bounded history %d", len(suffix), webHistoryLimit)
+	}
+}
+
+func readOneSSE(sc *bufio.Scanner) (sseRecord, error) {
+	var rec sseRecord
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, ":") || line == "retry: 3000":
+			continue
+		case strings.HasPrefix(line, "id: "):
+			rec.id = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "event: "):
+			rec.ssetype = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			rec.data = json.RawMessage(strings.TrimPrefix(line, "data: "))
+			return rec, nil
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return rec, err
+	}
+	return rec, errors.New("SSE stream ended before a data frame")
+}
+
+func TestWorkspaceEventsReplaysAfterReconnect(t *testing.T) {
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc})
+	srv := New(ctrl, bc, config.ServeConfig{})
+	httpSrv := httptest.NewServer(srv.Handler())
+	defer httpSrv.Close()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	req1, _ := http.NewRequestWithContext(ctx1, http.MethodGet, httpSrv.URL+"/workspace/events", nil)
+	resp1, err := http.DefaultClient.Do(req1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc1 := bufio.NewScanner(resp1.Body)
+	bc.Emit(event.Event{Kind: event.Message, Text: "first"})
+	first, err := readOneSSE(sc1)
+	if err != nil {
+		resp1.Body.Close()
+		cancel1()
+		t.Fatal(err)
+	}
+	var firstEnv WebEnvelope
+	if err := json.Unmarshal(first.data, &firstEnv); err != nil {
+		resp1.Body.Close()
+		cancel1()
+		t.Fatal(err)
+	}
+	if firstEnv.Seq == 0 {
+		t.Fatal("first frame did not receive a sequence")
+	}
+	resp1.Body.Close()
+	cancel1()
+
+	bc.Emit(event.Event{Kind: event.Message, Text: "second"})
+	bc.Emit(event.Event{Kind: event.Message, Text: "third"})
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	req2, _ := http.NewRequestWithContext(ctx2, http.MethodGet, httpSrv.URL+"/workspace/events", nil)
+	req2.Header.Set("Last-Event-ID", fmt.Sprint(firstEnv.Seq))
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if got := resp2.Header.Get("X-Semantix-Replay"); got != "complete" {
+		t.Fatalf("replay header = %q, want complete", got)
+	}
+	sc2 := bufio.NewScanner(resp2.Body)
+	second, err := readOneSSE(sc2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	third, err := readOneSSE(sc2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var secondEnv, thirdEnv WebEnvelope
+	if err := json.Unmarshal(second.data, &secondEnv); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(third.data, &thirdEnv); err != nil {
+		t.Fatal(err)
+	}
+	if secondEnv.Seq != firstEnv.Seq+1 || thirdEnv.Seq != secondEnv.Seq+1 {
+		t.Fatalf("replay seqs = %d, %d after %d", secondEnv.Seq, thirdEnv.Seq, firstEnv.Seq)
+	}
+	if second.ssetype != ProtoTypeAssistant || third.ssetype != ProtoTypeAssistant {
+		t.Fatalf("replay types = %q, %q", second.ssetype, third.ssetype)
+	}
+}

--- a/harness/serve/webproto_test.go
+++ b/harness/serve/webproto_test.go
@@ -288,6 +288,27 @@ func TestBroadcasterWebReplayAndGap(t *testing.T) {
 	}
 }
 
+func TestBroadcasterResetSessionDropsWorkspaceHistory(t *testing.T) {
+	bc := NewBroadcaster()
+	bc.Emit(event.Event{Kind: event.Message, Text: "old task"})
+	ch, _, _, unsubscribe := bc.SubscribeWebSince(0, "old-task")
+	bc.ResetSession()
+	defer unsubscribe()
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("workspace subscriber remained open across session reset")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("workspace subscriber was not closed on session reset")
+	}
+	_, replay, gap, unsubscribe2 := bc.SubscribeWebSince(1, "new-task")
+	defer unsubscribe2()
+	if !gap || len(replay) != 0 {
+		t.Fatalf("after reset replay=(%d frames, gap=%v), want empty history with gap", len(replay), gap)
+	}
+}
+
 func readOneSSE(sc *bufio.Scanner) (sseRecord, error) {
 	var rec sseRecord
 	for sc.Scan() {

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -106,6 +106,28 @@
   };
   var openMenu = null; // currently open dropdown element or null
 
+  // GUI-4 (#407): consume the versioned workspace stream as a transport
+  // contract. The shell does not synthesize chat/tool/cache cards here; it
+  // only validates ordering and lets the existing refresh paths react to a
+  // gap. Unknown event names and malformed payloads are deliberately ignored
+  // so a newer server cannot crash an older workspace page.
+  var workspaceEvents = null;
+  var lastEventSeq = 0;
+  var eventTaskID = "";
+  var canonicalEventTypes = {
+    user_message: true,
+    assistant_message: true,
+    plan: true,
+    tool_start: true,
+    tool_result: true,
+    diff: true,
+    permission_request: true,
+    task_status: true,
+    cache_status: true,
+    error: true,
+    unknown: true
+  };
+
   // ── tiny view helpers ──
   function setState(chip, state) {
     chip.setAttribute("data-ws-state", state);
@@ -123,6 +145,41 @@
     el.notice.hidden = false;
     clearTimeout(showNotice.timer);
     showNotice.timer = setTimeout(function () { el.notice.hidden = true; }, 6000);
+  }
+
+  function handleWorkspaceEvent(message) {
+    var payload;
+    try {
+      payload = JSON.parse(message.data || "");
+    } catch (_) {
+      return;
+    }
+    if (!payload || payload.v !== 1 || !Number.isSafeInteger(payload.seq) || payload.seq < 1) return;
+    if (eventTaskID && payload.task_id !== eventTaskID) return;
+    if (!eventTaskID && typeof payload.task_id === "string") eventTaskID = payload.task_id;
+    if (payload.seq <= lastEventSeq) return;
+    if (lastEventSeq && payload.seq > lastEventSeq + 1) {
+      // A dropped frame or expired replay window is a signal to refresh
+      // derived state, never a reason to terminate the EventSource.
+      refreshTasks();
+      showNotice("事件流存在缺口，已刷新任务状态。", "warn");
+    }
+    lastEventSeq = payload.seq;
+    if (!canonicalEventTypes[payload.type]) return;
+    // The payload's inner eventwire data remains the sole source of truth.
+    // Rendering of each canonical type belongs to the conversation UI; this
+    // shell only keeps the stream alive and validates its envelope.
+  }
+
+  function connectWorkspaceEvents() {
+    if (!window.EventSource) return;
+    if (workspaceEvents) workspaceEvents.close();
+    eventTaskID = "";
+    lastEventSeq = 0;
+    workspaceEvents = new EventSource("/workspace/events");
+    Object.keys(canonicalEventTypes).forEach(function (type) {
+      workspaceEvents.addEventListener(type, handleWorkspaceEvent);
+    });
   }
 
   function closeMenus() {
@@ -251,7 +308,7 @@
   function switchTask(s) {
     postJSON("/resume", { path: s.path }).then(refreshTasks).catch(function (err) {
       showNotice("切换任务失败：" + err.message, "error");
-    });
+    }).then(connectWorkspaceEvents);
   }
 
   function loadBranches() {
@@ -366,6 +423,7 @@
           showNotice("创建任务失败：" + err.message, "error");
         }).finally(function () {
           setState(el.newTask, "ok");
+          connectWorkspaceEvents();
         });
       });
     }
@@ -375,6 +433,7 @@
   }
 
   initSelectors();
+  connectWorkspaceEvents();
 
   // ── #404 side drawer (narrow viewports only) ──
   var sideToggle = document.querySelector("[data-ws-side-toggle]");

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -124,6 +124,7 @@ func TestServeWorkspaceSelectorContract(t *testing.T) {
 		`"/sessions"`, // task list = live sessions, no second data model (#406)
 		`"/resume"`,   // task switching keeps session content server-side
 		`"/new"`,      // creating a task enters a fresh session
+		`"/workspace/events"`, // GUI-4 versioned SSE transport
 		`模型不可用`,       // explicit unavailable-model signal (#405 acceptance)
 	} {
 		if !strings.Contains(js, want) {
@@ -132,7 +133,7 @@ func TestServeWorkspaceSelectorContract(t *testing.T) {
 	}
 
 	// Guard rails: the shell talks only to the whitelisted endpoints above —
-	// it must not stream events or read history like the full console does.
+	// it must not use the legacy raw stream or invent a second history model.
 	for _, forbidden := range []string{`"/events"`, `/history`} {
 		if strings.Contains(js, forbidden) {
 			t.Errorf("workspace shell.js dials out-of-contract endpoint %s", forbidden)


### PR DESCRIPTION
## Summary

- add the versioned /workspace/events SSE envelope with canonical frontend event types, stable task IDs, and raw eventwire payloads
- add publish-time sequencing, bounded replay, Last-Event-ID reconnect support, and explicit replay-gap signaling while preserving legacy /events`n- safely consume the protocol in the workspace shell; unknown or malformed events are ignored without crashing the page
- add protocol, ordering, task-ID, reconnect, replay-gap, reset, and compatibility tests plus documentation

Closes #407

## Verification

- go test ./harness/serve ./harness/eventwire`n- go test -race ./harness/serve -count=1`n- go vet ./harness/serve ./harness/eventwire`n- 
ode --check harness/serve/workspace/shell.js`n- git diff --check HEAD~3..HEAD`n
Full go test ./... was attempted with Go temp/cache on D:. Existing environment-dependent baseline failures remain in CLI exit-code, Windows symlink privilege, Git Bash, cross-device rename, and PowerShell shell-command tests; harness/serve passes.