### PR TITLE
feat(gui): add right workbench context panels

### DIFF
--- a/docs/gui/event-protocol.md
+++ b/docs/gui/event-protocol.md
@@ -41,12 +41,39 @@ Every frame carries the full SSE form:
 | task_status          | turn_started, turn_phase, completion_summary, retrying, guardian_assessment, extension_status | turn lifecycle phases |
 | error                | turn_done(err≠"")                                      | payload-dependent promotion from task_status |
 | plan                 | —                                                      | **reserved**: no producer yet; never emitted in v1 |
-| diff                 | —                                                      | **reserved**: no producer yet; never emitted in v1 |
+| diff                 | —                                                      | **reserved** as a standalone event; file changes ride on `tool_start` / `tool_result` |
 | unknown              | any kind added after this protocol version             | forward-compat wrapper |
 
 Filtered host-internal kinds that are never forwarded:
 `stream_attempt`, `extension_surface`, `mcp_surface_ready`,
 `workspace_changed`, `context_maintenance`.
+
+## File diff payload (GUI-6)
+
+Writer tool events may include `data.tool.fileDiff`. It is the backend's
+authoritative file-change model:
+
+```json
+{
+  "path": "internal/cache.go",
+  "status": "modified",
+  "language": "go",
+  "diff": "--- a/internal/cache.go\n+++ b/internal/cache.go\n...",
+  "added": 1,
+  "removed": 1,
+  "lines": [
+    {"kind": "hunk", "text": "@@ -1 +1 @@"},
+    {"kind": "deleted", "oldLine": 1, "text": "old"},
+    {"kind": "added", "newLine": 1, "text": "new"}
+  ]
+}
+```
+
+`status` is one of `added`, `modified`, or `deleted`; `added`/`removed` and
+the line numbers are computed by the host. A client renders `lines` as-is and
+copies `diff` verbatim, so UI labels, gutters, and fold controls never become
+part of copied source. Binary previews set `binary: true` and omit textual
+rows. Older clients may continue using the legacy flat `tool.diff` fields.
 
 ## Client rules
 

--- a/docs/gui/workbench.md
+++ b/docs/gui/workbench.md
@@ -1,0 +1,22 @@
+# Workspace context workbench
+
+The right-hand context area of `/workspace` is a single, collapsible panel with
+four tabbed views. The tabs are a presentation layer over the existing
+`GET /workspace/events` stream; they do not introduce a second workspace or
+history data model.
+
+| View | Source of truth | What it shows |
+| --- | --- | --- |
+| 文件 | existing workspace shell + the latest `tool.fileDiff` | project tree, current file, and the latest file preview |
+| Diff | `tool.fileDiff` on tool events | each structured file diff received during the current turn |
+| 终端 | `tool.args`, `tool.output`, `tool.err`, `tool.execution` | shell command, live/result output, execution state, and exit code |
+| Review | `tool.fileDiff` and `approval_request` events | changed files, server-reported mutation risk, and pending permission decisions |
+
+Review decisions call the existing `POST /approve` endpoint with one-shot
+`allow`/`deny` values. The browser never enables a session or persistent grant,
+and it cannot bypass the controller's permission policy. If no matching event
+has arrived, the panel shows an explicit empty state instead of sample data.
+
+The tab controller uses ARIA `tab`/`tabpanel` relationships and roving
+`tabindex`; switching views only changes the panel's visibility, so collapsing
+the right rail keeps the center work area layout unchanged.

--- a/harness/agent/agent.go
+++ b/harness/agent/agent.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2290,10 +2291,15 @@ func (a *Agent) emitFullToolDispatch(ctx context.Context, c provider.ToolCall, r
 	t, _, ambiguous := a.svc.tools.ResolveCall(c.Name)
 	ok := t != nil && len(ambiguous) == 0
 	ev := event.Tool{ID: c.ID, Name: c.Name, Args: c.Arguments, ReadOnly: ok && t.ReadOnly(), Refreshed: refreshed}
-	ev.FileDiff = event.FileDiff{Diff: c.Diff, Added: c.Added, Removed: c.Removed}
-	if ok && ev.Diff == "" && ev.Added == 0 && ev.Removed == 0 {
-		if ch, ok := tool.PreviewChange(ctx, t, json.RawMessage(c.Arguments)); ok {
-			ev.FileDiff = event.FileDiff{Diff: ch.Diff, Added: ch.Added, Removed: ch.Removed}
+	ev.FileDiff = fileDiffFromToolCall(c)
+	if ok && !t.ReadOnly() {
+		// Re-run the same preview used by execution. Besides retaining the
+		// existing diff, this supplies backend-owned path/status/line metadata
+		// to workspace clients without making them inspect tool arguments.
+		if pv, previewable := t.(tool.Previewer); previewable {
+			if ch, err := pv.Preview(ctx, json.RawMessage(c.Arguments)); err == nil {
+				ev.FileDiff = fileDiffFromChange(ch, toolPathFromArgs(c.Arguments))
+			}
 		}
 	}
 	if ok {
@@ -2304,6 +2310,68 @@ func (a *Agent) emitFullToolDispatch(ctx context.Context, c provider.ToolCall, r
 		}
 	}
 	a.svc.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: ev})
+}
+
+func fileDiffFromChange(ch diff.Change, requestedPath string) event.FileDiff {
+	path := strings.TrimSpace(requestedPath)
+	if path == "" {
+		path = ch.Path
+	}
+	status := "modified"
+	switch ch.Kind {
+	case diff.Create:
+		status = "added"
+	case diff.Delete:
+		status = "deleted"
+	}
+	out := event.FileDiff{
+		Path: path, Status: status, Language: languageForPath(path),
+		Diff: ch.Diff, Added: ch.Added, Removed: ch.Removed,
+		Binary: ch.Binary, Hunks: ch.Hunks,
+	}
+	for _, line := range diff.ParseUnified(ch.Diff) {
+		out.Lines = append(out.Lines, event.DiffLine{
+			Kind: string(line.Kind), OldLine: line.OldLine,
+			NewLine: line.NewLine, Text: line.Text,
+		})
+	}
+	return out
+}
+
+func fileDiffFromToolCall(c provider.ToolCall) event.FileDiff {
+	if c.Diff == "" && c.Added == 0 && c.Removed == 0 {
+		return event.FileDiff{}
+	}
+	path := toolPathFromArgs(c.Arguments)
+	out := event.FileDiff{
+		Path: path, Status: "modified", Language: languageForPath(path),
+		Diff: c.Diff, Added: c.Added, Removed: c.Removed,
+	}
+	for _, line := range diff.ParseUnified(c.Diff) {
+		out.Lines = append(out.Lines, event.DiffLine{
+			Kind: string(line.Kind), OldLine: line.OldLine,
+			NewLine: line.NewLine, Text: line.Text,
+		})
+	}
+	return out
+}
+
+func toolPathFromArgs(args string) string {
+	var input struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(args), &input); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(input.Path)
+}
+
+func languageForPath(path string) string {
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+	if ext == "" {
+		return "text"
+	}
+	return ext
 }
 
 // emitResolvedToolDispatch upserts the real target classification of a stable

--- a/harness/agent/diff_payload_test.go
+++ b/harness/agent/diff_payload_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"testing"
+
+	"semantix/harness/diff"
+	"semantix/harness/provider"
+)
+
+func TestFileDiffFromChangeKeepsBackendMetadata(t *testing.T) {
+	change := diff.Build("internal/cache.go", "package cache\nold\n", "package cache\nnew\n", diff.Modify)
+	got := fileDiffFromChange(change, "internal/cache.go")
+	if got.Path != "internal/cache.go" || got.Status != "modified" || got.Language != "go" {
+		t.Fatalf("metadata = %+v", got)
+	}
+	if got.Added != 1 || got.Removed != 1 || got.Hunks != 1 || len(got.Lines) == 0 {
+		t.Fatalf("stats/rows = %+v", got)
+	}
+	if got.Lines[len(got.Lines)-2].Kind != "deleted" || got.Lines[len(got.Lines)-1].Kind != "added" {
+		t.Fatalf("change rows = %+v", got.Lines)
+	}
+}
+
+func TestFileDiffFromChangeUsesCreateAndDeleteStatuses(t *testing.T) {
+	created := fileDiffFromChange(diff.Build("new.txt", "", "hello\n", diff.Create), "new.txt")
+	if created.Status != "added" || created.Added != 1 {
+		t.Fatalf("create = %+v", created)
+	}
+	deleted := fileDiffFromChange(diff.Build("gone.txt", "hello\n", "", diff.Delete), "gone.txt")
+	if deleted.Status != "deleted" || deleted.Removed != 1 {
+		t.Fatalf("delete = %+v", deleted)
+	}
+}
+
+func TestFileDiffFromToolCallKeepsLegacyDiffUsable(t *testing.T) {
+	got := fileDiffFromToolCall(provider.ToolCall{
+		Arguments: `{"path":"pkg/main.go"}`,
+		Diff:      "@@ -1 +1 @@\n-old\n+new\n",
+		Added:     1,
+		Removed:   1,
+	})
+	if got.Path != "pkg/main.go" || got.Status != "modified" || len(got.Lines) != 3 {
+		t.Fatalf("legacy payload = %+v", got)
+	}
+}

--- a/harness/diff/diff_test.go
+++ b/harness/diff/diff_test.go
@@ -130,6 +130,13 @@ func TestBuild_Binary(t *testing.T) {
 	}
 }
 
+func TestParseUnifiedNormalizesCRLFRows(t *testing.T) {
+	rows := ParseUnified("--- a/x.go\r\n+++ b/x.go\r\n@@ -1 +1 @@\r\n-old\r\n+new\r\n")
+	if len(rows) != 5 || rows[2].Kind != LineHunk || rows[3].Text != "old" || rows[4].Text != "new" {
+		t.Fatalf("CRLF rows = %+v", rows)
+	}
+}
+
 // TestBuild_MinimalEditScript checks the third-party line diff keeps the same
 // user-visible contract: a single line inserted into a run of identical lines
 // must not be rendered as a block delete+insert.
@@ -164,5 +171,25 @@ func TestExactDiffTooLarge(t *testing.T) {
 	}
 	if !exactDiffTooLarge(oldLines, newLines) {
 		t.Fatal("large changed window should skip exact diff")
+	}
+}
+
+func TestParseUnifiedCarriesKindsAndLineNumbers(t *testing.T) {
+	src := "--- a/demo.go\n+++ b/demo.go\n@@ -2,3 +2,3 @@\n context\n-old\n+new\n"
+	rows := ParseUnified(src)
+	if len(rows) != 6 {
+		t.Fatalf("rows = %d, want 6: %+v", len(rows), rows)
+	}
+	if rows[2].Kind != LineHunk || rows[2].Text != "@@ -2,3 +2,3 @@" {
+		t.Fatalf("hunk row = %+v", rows[2])
+	}
+	if rows[3].Kind != LineContext || rows[3].OldLine != 2 || rows[3].NewLine != 2 || rows[3].Text != "context" {
+		t.Fatalf("context row = %+v", rows[3])
+	}
+	if rows[4].Kind != LineDeleted || rows[4].OldLine != 3 || rows[4].NewLine != 0 || rows[4].Text != "old" {
+		t.Fatalf("deleted row = %+v", rows[4])
+	}
+	if rows[5].Kind != LineAdded || rows[5].OldLine != 0 || rows[5].NewLine != 3 || rows[5].Text != "new" {
+		t.Fatalf("added row = %+v", rows[5])
 	}
 }

--- a/harness/diff/structured.go
+++ b/harness/diff/structured.go
@@ -1,0 +1,86 @@
+package diff
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// LineKind identifies the presentation role of a unified-diff row. The
+// change kind (added/modified/deleted) remains metadata on Change; rows only
+// describe what the server has already rendered.
+type LineKind string
+
+const (
+	LineHunk    LineKind = "hunk"
+	LineContext LineKind = "context"
+	LineAdded   LineKind = "added"
+	LineDeleted LineKind = "deleted"
+	LineMeta    LineKind = "meta"
+)
+
+// Line is the authoritative, line-numbered form of one unified-diff row.
+// Zero line numbers mean that the row does not belong to that side (for
+// example, an added row has no old line number).
+type Line struct {
+	Kind    LineKind
+	OldLine int
+	NewLine int
+	Text    string
+}
+
+var unifiedHunkRE = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@`)
+
+// ParseUnified turns a unified diff into line-numbered rows. It is deliberately
+// tolerant: malformed or non-unified input is kept as meta rows instead of
+// being discarded. The parser never changes the original Diff string, which
+// remains the exact value used by copy operations.
+func ParseUnified(src string) []Line {
+	if strings.TrimSpace(src) == "" {
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(src, "\n"), "\n")
+	rows := make([]Line, 0, len(lines))
+	oldLine, newLine := 0, 0
+	for i, raw := range lines {
+		raw = strings.TrimSuffix(raw, "\r")
+		// The first two file labels are metadata, not code rows. Keep any
+		// later ---/+++ content because it may be a legitimate changed line.
+		if i < 2 && (strings.HasPrefix(raw, "--- ") || strings.HasPrefix(raw, "+++ ")) {
+			rows = append(rows, Line{Kind: LineMeta, Text: raw})
+			continue
+		}
+		if m := unifiedHunkRE.FindStringSubmatch(raw); m != nil {
+			oldLine = atoi(m[1])
+			newLine = atoi(m[3])
+			rows = append(rows, Line{Kind: LineHunk, Text: raw})
+			continue
+		}
+		if raw == "" {
+			rows = append(rows, Line{Kind: LineMeta, Text: raw})
+			continue
+		}
+		switch raw[0] {
+		case '+':
+			rows = append(rows, Line{Kind: LineAdded, NewLine: newLine, Text: raw[1:]})
+			newLine++
+		case '-':
+			rows = append(rows, Line{Kind: LineDeleted, OldLine: oldLine, Text: raw[1:]})
+			oldLine++
+		case ' ':
+			rows = append(rows, Line{Kind: LineContext, OldLine: oldLine, NewLine: newLine, Text: raw[1:]})
+			oldLine++
+			newLine++
+		case '\\':
+			rows = append(rows, Line{Kind: LineMeta, Text: raw})
+		default:
+			rows = append(rows, Line{Kind: LineMeta, Text: raw})
+		}
+	}
+	return rows
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/harness/event/event.go
+++ b/harness/event/event.go
@@ -285,12 +285,28 @@ type ShellExecution struct {
 
 // FileDiff is a previewed change carried on a writer tool's full ToolDispatch
 // and on its ApprovalRequest, so a frontend can render +/- lines before the
-// call runs. Diff is the unified diff (empty for read-only tools, binary files,
-// or no-op changes); Added/Removed are its line tallies.
+// call runs. The structured metadata is produced by the host; clients must
+// not infer status or line numbers from Diff. Diff remains the exact unified
+// diff used for copying (empty for no-op changes and binary files).
 type FileDiff struct {
-	Diff    string
-	Added   int
-	Removed int
+	Path     string
+	Status   string
+	Language string
+	Diff     string
+	Added    int
+	Removed  int
+	Binary   bool
+	Hunks    int
+	Lines    []DiffLine
+}
+
+// DiffLine is one server-parsed row of a unified diff. OldLine/NewLine are
+// zero when the row has no corresponding side (added/deleted rows).
+type DiffLine struct {
+	Kind    string
+	OldLine int
+	NewLine int
+	Text    string
 }
 
 // Approval identifies a pending tool-call approval for an ApprovalRequest

--- a/harness/eventwire/wire.go
+++ b/harness/eventwire/wire.go
@@ -121,6 +121,7 @@ func ToWire(e event.Event) Event {
 			ParentID: e.Tool.ParentID, AttemptID: e.Tool.AttemptID,
 			Diff: e.Tool.Diff, Added: e.Tool.Added, Removed: e.Tool.Removed,
 		}
+		wt.FileDiff = toWireFileDiff(e.Tool.FileDiff)
 		if e.Tool.Profile != nil {
 			wt.Profile = &Profile{Model: e.Tool.Profile.Model, Effort: e.Tool.Profile.Effort}
 		}
@@ -384,8 +385,48 @@ type Tool struct {
 	Diff         string          `json:"diff,omitempty" externalizable:"true"`
 	Added        int             `json:"added,omitempty"`
 	Removed      int             `json:"removed,omitempty"`
+	FileDiff     *FileDiff       `json:"fileDiff,omitempty"`
 	Profile      *Profile        `json:"profile,omitempty"`
 	Execution    *ShellExecution `json:"execution,omitempty"`
+}
+
+// FileDiff is the workspace-safe structured form of event.FileDiff. The
+// legacy flat diff/added/removed fields on Tool stay for older clients.
+type FileDiff struct {
+	Path     string     `json:"path"`
+	Status   string     `json:"status"`
+	Language string     `json:"language,omitempty"`
+	Diff     string     `json:"diff,omitempty" externalizable:"true"`
+	Added    int        `json:"added"`
+	Removed  int        `json:"removed"`
+	Binary   bool       `json:"binary,omitempty"`
+	Hunks    int        `json:"hunks,omitempty"`
+	Lines    []DiffLine `json:"lines,omitempty"`
+}
+
+type DiffLine struct {
+	Kind    string `json:"kind"`
+	OldLine int    `json:"oldLine,omitempty"`
+	NewLine int    `json:"newLine,omitempty"`
+	Text    string `json:"text" externalizable:"true"`
+}
+
+func toWireFileDiff(in event.FileDiff) *FileDiff {
+	if in.Path == "" && in.Status == "" && in.Diff == "" && len(in.Lines) == 0 && !in.Binary {
+		return nil
+	}
+	out := &FileDiff{
+		Path: in.Path, Status: in.Status, Language: in.Language,
+		Diff: in.Diff, Added: in.Added, Removed: in.Removed,
+		Binary: in.Binary, Hunks: in.Hunks,
+	}
+	if len(in.Lines) > 0 {
+		out.Lines = make([]DiffLine, len(in.Lines))
+		for i, line := range in.Lines {
+			out.Lines[i] = DiffLine{Kind: line.Kind, OldLine: line.OldLine, NewLine: line.NewLine, Text: line.Text}
+		}
+	}
+	return out
 }
 
 // ShellExecution is the JSON form of event.ShellExecution (local UI metadata).

--- a/harness/eventwire/wire_test.go
+++ b/harness/eventwire/wire_test.go
@@ -290,6 +290,33 @@ func TestToWireToolPayloadJSON(t *testing.T) {
 	}
 }
 
+func TestToWireToolStructuredFileDiff(t *testing.T) {
+	w := ToWire(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID: "c1", Name: "edit_file", FileDiff: event.FileDiff{
+			Path: "internal/cache.go", Status: "modified", Language: "go",
+			Diff:  "--- a/internal/cache.go\n+++ b/internal/cache.go\n@@ -1 +1 @@\n-old\n+new\n",
+			Added: 1, Removed: 1, Hunks: 1,
+			Lines: []event.DiffLine{{Kind: "hunk", Text: "@@ -1 +1 @@"}, {Kind: "deleted", OldLine: 1, Text: "old"}, {Kind: "added", NewLine: 1, Text: "new"}},
+		},
+	}})
+	if w.Tool == nil || w.Tool.FileDiff == nil {
+		t.Fatalf("structured file diff missing: %+v", w.Tool)
+	}
+	fd := w.Tool.FileDiff
+	if fd.Path != "internal/cache.go" || fd.Status != "modified" || fd.Language != "go" || fd.Added != 1 || fd.Removed != 1 || len(fd.Lines) != 3 {
+		t.Fatalf("structured file diff = %+v", fd)
+	}
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"fileDiff"`, `"status":"modified"`, `"oldLine":1`, `"newLine":1`} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("tool JSON = %s, want %s", b, want)
+		}
+	}
+}
+
 func TestToWireUsagePayloadJSON(t *testing.T) {
 	w := ToWire(event.Event{
 		Kind: event.Usage,

--- a/harness/serve/workspace/layout.css
+++ b/harness/serve/workspace/layout.css
@@ -134,6 +134,84 @@ body.ws-right-collapsed .ws-context { display: none; }
 .tag.is-agent { background: #10241c; border-color: var(--sx-green-border); color: var(--sx-green-strong); }
 .ws-bubble p { margin: 2px 0; font-size: 13.5px; line-height: 1.55; color: var(--sx-text); }
 
+/* ---------- Live workflow timeline (GUI-5 #408) ---------- */
+
+.ws-demo.is-hidden { display: none; }
+.ws-timeline {
+  display: flex; flex-direction: column; gap: 12px;
+  min-width: 0;
+}
+.ws-timeline:empty { display: none; }
+.ws-event {
+  min-width: 0; background: var(--sx-surface);
+  border: 1px solid var(--sx-border); border-radius: var(--sx-radius-m);
+  overflow: hidden;
+}
+.ws-event__head {
+  display: flex; align-items: center; gap: 9px;
+  min-width: 0; padding: 10px 14px;
+  font-size: 13px; line-height: 1.4;
+}
+.ws-event__label { font-weight: 700; }
+.ws-event__meta {
+  margin-left: auto; flex: none; color: var(--sx-text-3);
+  font: 500 11px/1.3 var(--sx-font-mono);
+}
+.ws-event__body {
+  padding: 0 14px 13px; color: var(--sx-text-2);
+  font-size: 13.5px; line-height: 1.6; overflow-wrap: anywhere;
+}
+.ws-event__body:empty { display: none; }
+.ws-event--user { border-left: 3px solid var(--sx-text-2); }
+.ws-event--assistant { border-left: 3px solid var(--sx-green); }
+.ws-event--plan { border-left: 3px solid var(--sx-green-strong); }
+.ws-event--tool { border-left: 3px solid var(--sx-orange); }
+.ws-event--error { border-color: var(--sx-del); border-left: 3px solid var(--sx-del); }
+.ws-event--status { border-left: 3px solid var(--sx-text-3); }
+.ws-event--cache { border-left: 3px solid var(--sx-green-border); }
+.ws-event__icon { width: 15px; height: 15px; flex: none; color: var(--sx-text-3); }
+.ws-event--assistant .ws-event__icon,
+.ws-event--plan .ws-event__icon { color: var(--sx-green-strong); }
+.ws-event--tool .ws-event__icon { color: var(--sx-orange); }
+.ws-event--error .ws-event__icon { color: var(--sx-del); }
+.ws-event__status { color: var(--sx-text-3); }
+.ws-event__status.is-running { color: var(--sx-orange); }
+.ws-event__status.is-done { color: var(--sx-green-strong); }
+.ws-event__status.is-failed { color: var(--sx-del); }
+.ws-event__detail {
+  margin-top: 8px; padding: 9px 10px; border-radius: 7px;
+  background: var(--sx-chip); color: var(--sx-text-2);
+  font: 400 12px/1.55 var(--sx-font-mono); white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.ws-event__detail[hidden] { display: none; }
+.ws-event__toggle {
+  margin-top: 8px; padding: 0; border: 0; background: none;
+  color: var(--sx-green-strong); cursor: pointer;
+  font: 600 12px/1.4 var(--sx-font-sans);
+}
+.ws-event__toggle:hover { text-decoration: underline; }
+.ws-plan { margin: 0; padding: 0 14px 13px 34px; display: grid; gap: 6px; }
+.ws-plan li { color: var(--sx-text-2); font-size: 13px; line-height: 1.5; }
+.ws-plan li.is-done { color: var(--sx-text-3); text-decoration: line-through; }
+.ws-tool-preview {
+  margin: 0 14px 13px; padding: 9px 10px; border-radius: 7px;
+  background: var(--sx-chip); color: var(--sx-text-2);
+  font: 400 12px/1.55 var(--sx-font-mono); white-space: pre-wrap;
+  overflow-wrap: anywhere; max-height: 220px; overflow: auto;
+}
+.ws-event--tool .ws-tool-preview { border-left: 2px solid var(--sx-border-strong); }
+.ws-event--tool[data-ws-tool-state="running"] .ws-tool-preview { border-left-color: var(--sx-orange); }
+.ws-event--tool[data-ws-tool-state="failed"] .ws-tool-preview { border-left-color: var(--sx-del); }
+.ws-event--tool[data-ws-tool-state="done"] .ws-tool-preview { border-left-color: var(--sx-green); }
+.ws-event--retry { border-left: 3px solid var(--sx-orange); }
+.ws-event--retry .ws-event__body { color: var(--sx-orange); }
+.ws-timeline__notice {
+  padding: 8px 12px; border: 1px dashed var(--sx-orange-border);
+  border-radius: var(--sx-radius-s); color: var(--sx-orange);
+  font-size: 12px; line-height: 1.5;
+}
+
 .card {
   background: var(--sx-surface); border: 1px solid var(--sx-border);
   border-radius: var(--sx-radius-m); overflow: hidden;

--- a/harness/serve/workspace/layout.css
+++ b/harness/serve/workspace/layout.css
@@ -204,6 +204,51 @@ body.ws-right-collapsed .ws-context { display: none; }
 .ws-event--tool[data-ws-tool-state="running"] .ws-tool-preview { border-left-color: var(--sx-orange); }
 .ws-event--tool[data-ws-tool-state="failed"] .ws-tool-preview { border-left-color: var(--sx-del); }
 .ws-event--tool[data-ws-tool-state="done"] .ws-tool-preview { border-left-color: var(--sx-green); }
+.ws-diff-view { margin: 8px 14px 13px; border: 1px solid var(--sx-border-strong); border-radius: var(--sx-radius-s); overflow: hidden; background: var(--sx-chip); white-space: normal; }
+.ws-diff-view--context { margin: 0; border: 0; border-radius: 0; background: transparent; }
+.ws-diff-view__head { display: flex; align-items: center; gap: 10px; padding: 9px 10px; border-bottom: 1px solid var(--sx-border); font: 500 12px/1.4 var(--sx-font-sans); }
+.ws-diff-view__identity { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.ws-diff-view__path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--sx-font-mono); color: var(--sx-text); }
+.ws-diff-view__status { flex: none; padding: 2px 6px; border-radius: 999px; font-size: 10px; font-weight: 700; }
+.ws-diff-view__status--added { color: var(--sx-add); background: var(--sx-add-bg); }
+.ws-diff-view__status--modified { color: var(--sx-orange); background: var(--sx-orange-dim); }
+.ws-diff-view__status--deleted { color: var(--sx-del); background: var(--sx-del-bg); }
+.ws-diff-view__stats { margin-left: auto; flex: none; color: var(--sx-text-3); font-family: var(--sx-font-mono); }
+.ws-diff-view__copy { flex: none; padding: 4px 7px; border: 1px solid var(--sx-border-strong); border-radius: 5px; background: transparent; color: var(--sx-green-strong); cursor: pointer; font: 600 11px/1.2 var(--sx-font-sans); }
+.ws-diff-view__copy:hover { background: var(--sx-green-dim); }
+.ws-diff-view__body { max-height: 420px; overflow: auto; font: 400 11.5px/1.65 var(--sx-font-mono); }
+.ws-diff-line { display: grid; grid-template-columns: 38px 38px 18px minmax(0, 1fr); min-width: max-content; padding: 0 9px; white-space: pre; }
+.ws-diff-line__number { color: var(--sx-text-3); text-align: right; user-select: none; padding-right: 8px; }
+.ws-diff-line__marker { color: var(--sx-text-3); text-align: center; user-select: none; }
+.ws-diff-line__code { color: var(--sx-text-2); }
+.ws-diff-line--added { background: var(--sx-add-bg); }
+.ws-diff-line--added .ws-diff-line__marker, .ws-diff-line--added .ws-diff-line__code { color: var(--sx-add); }
+.ws-diff-line--deleted { background: var(--sx-del-bg); }
+.ws-diff-line--deleted .ws-diff-line__marker, .ws-diff-line--deleted .ws-diff-line__code { color: var(--sx-del); }
+.ws-diff-line--hunk { display: block; margin: 5px 9px; padding: 2px 7px; border-radius: 5px; color: var(--sx-text-3); background: var(--sx-surface-2); }
+.ws-diff-line--meta { display: block; color: var(--sx-text-3); padding-inline: 9px; }
+.ws-diff-view__fold { border-top: 1px solid var(--sx-border); padding: 7px 10px; }
+.ws-diff-view__fold summary { color: var(--sx-green-strong); cursor: pointer; font: 600 11px/1.4 var(--sx-font-sans); }
+.ws-diff-view__legacy { margin: 0; padding: 9px 10px; white-space: pre; color: var(--sx-text-2); }
+.ws-terminal-entry, .ws-review-entry { margin: 0 0 10px; border: 1px solid var(--sx-border); border-radius: var(--sx-radius-s); background: var(--sx-chip); overflow: hidden; }
+.ws-terminal-head, .ws-review-head { display: flex; align-items: center; gap: 7px; padding: 9px 10px; border-bottom: 1px solid var(--sx-border); font: 600 11.5px/1.4 var(--sx-font-sans); color: var(--sx-text); }
+.ws-terminal-command { padding: 9px 10px; color: var(--sx-text-2); font: 400 11.5px/1.55 var(--sx-font-mono); white-space: pre-wrap; word-break: break-word; }
+.ws-terminal-output { margin: 0; padding: 9px 10px; max-height: 240px; overflow: auto; color: var(--sx-text-2); font: 400 11px/1.6 var(--sx-font-mono); white-space: pre-wrap; word-break: break-word; }
+.ws-terminal-status, .ws-review-status { margin-left: auto; color: var(--sx-text-3); font: 600 10.5px/1.4 var(--sx-font-mono); }
+.ws-terminal-status.is-failed, .ws-review-status.is-rejected { color: var(--sx-del); }
+.ws-terminal-status.is-done, .ws-review-status.is-approved { color: var(--sx-green-strong); }
+.ws-review-body { padding: 9px 10px; color: var(--sx-text-2); font: 400 12px/1.55 var(--sx-font-sans); }
+.ws-review-path { font: 600 11.5px/1.4 var(--sx-font-mono); color: var(--sx-text); overflow-wrap: anywhere; }
+.ws-review-risk { margin-top: 5px; color: var(--sx-orange); }
+.ws-review-actions { display: flex; gap: 7px; margin-top: 9px; }
+.ws-review-actions button { border: 1px solid var(--sx-border-strong); border-radius: 5px; padding: 5px 9px; background: transparent; color: var(--sx-text-2); cursor: pointer; font: 600 11px/1.3 var(--sx-font-sans); }
+.ws-review-actions button:hover { background: var(--sx-hover); color: var(--sx-text); }
+.ws-review-actions button[data-ws-review-allow="true"] { border-color: var(--sx-green-border); color: var(--sx-green-strong); }
+.ws-review-actions button[data-ws-review-allow="false"] { border-color: rgba(244, 114, 114, .35); color: var(--sx-del); }
+.ws-syntax-keyword { color: #c792ea; }
+.ws-syntax-string { color: #c3e88d; }
+.ws-syntax-number { color: #f78c6c; }
+.ws-syntax-comment { color: var(--sx-text-3); }
 .ws-event--retry { border-left: 3px solid var(--sx-orange); }
 .ws-event--retry .ws-event__body { color: var(--sx-orange); }
 .ws-timeline__notice {
@@ -288,6 +333,10 @@ body.ws-right-collapsed .ws-context { display: none; }
   border-bottom: 2px solid transparent;
 }
 .ws-tab.is-active { color: var(--sx-text); border-bottom-color: var(--sx-green); }
+.ws-context-panel { display: none; flex: 1; min-height: 0; flex-direction: column; }
+.ws-context-panel.is-active { display: flex; }
+.ws-context-scroll { flex: 1; min-height: 0; overflow: auto; padding: 12px 14px 18px; }
+.ws-context-empty { margin: 18px 8px; color: var(--sx-text-3); font: 400 12.5px/1.6 var(--sx-font-sans); }
 .ws-tree { margin: 0; padding: 14px 22px 10px; list-style: none; overflow-y: auto; flex: 1; }
 .ws-tree ul { list-style: none; margin: 0; padding-left: 18px; }
 .tree-row {
@@ -305,6 +354,7 @@ body.ws-right-collapsed .ws-context { display: none; }
   font: 600 12.5px/1.4 var(--sx-font-mono);
 }
 .ws-filehead .modified { margin-left: 0; }
+.ws-filehead__status { margin-left: 0 !important; }
 .ws-filehead .more { margin-left: auto; color: var(--sx-text-3); letter-spacing: 2px; }
 .ws-diff {
   margin: 0; padding: 10px 22px 18px; overflow: auto;

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -93,7 +93,14 @@
     newTask: document.querySelector("[data-ws-new-task]"),
     sideProjectName: document.querySelector("[data-ws-side-project-name]"),
     timeline: document.querySelector("[data-ws-timeline]"),
-    demo: document.querySelector("[data-ws-demo]")
+    demo: document.querySelector("[data-ws-demo]"),
+    fileHead: document.querySelector("[data-ws-file-head]"),
+    contextDiff: document.querySelector("[data-ws-context-diff], .ws-diff"),
+    tabs: document.querySelectorAll("[data-ws-tab]"),
+    panels: document.querySelectorAll("[data-ws-panel]"),
+    diffList: document.querySelector("[data-ws-diff-list]"),
+    terminalList: document.querySelector("[data-ws-terminal-list]"),
+    reviewList: document.querySelector("[data-ws-review-list]")
   };
 
   // Sidebar/project shared state (GUI-3): whether the CURRENT session is
@@ -139,6 +146,8 @@
     assistant: null,
     plan: null,
     tools: Object.create(null),
+    diffs: Object.create(null),
+    approvals: Object.create(null),
     active: false
   };
 
@@ -156,9 +165,49 @@
     workflow.assistant = null;
     workflow.plan = null;
     workflow.tools = Object.create(null);
+    workflow.diffs = Object.create(null);
+    workflow.approvals = Object.create(null);
     workflow.active = false;
     clearNode(el.timeline);
     if (el.demo) el.demo.classList.remove("is-hidden");
+    renderDiffList();
+    renderTerminalList();
+    renderReviewList();
+  }
+
+  function activateContextTab(name) {
+    var active = String(name || "files");
+    if (!el.tabs || !el.tabs.length) return;
+    el.tabs.forEach(function (tab) {
+      var selected = tab.getAttribute("data-ws-tab") === active;
+      tab.classList.toggle("is-active", selected);
+      tab.setAttribute("aria-selected", String(selected));
+      tab.setAttribute("tabindex", selected ? "0" : "-1");
+    });
+    if (el.panels) el.panels.forEach(function (panel) {
+      var visible = panel.getAttribute("data-ws-panel") === active;
+      panel.classList.toggle("is-active", visible);
+      panel.hidden = !visible;
+    });
+  }
+
+  function initContextTabs() {
+    if (!el.tabs || !el.tabs.length) return;
+    el.tabs.forEach(function (tab, index) {
+      tab.addEventListener("click", function () { activateContextTab(tab.getAttribute("data-ws-tab")); });
+      tab.addEventListener("keydown", function (event) {
+        var next = index;
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") next = (index + 1) % el.tabs.length;
+        else if (event.key === "ArrowLeft" || event.key === "ArrowUp") next = (index + el.tabs.length - 1) % el.tabs.length;
+        else if (event.key === "Home") next = 0;
+        else if (event.key === "End") next = el.tabs.length - 1;
+        else return;
+        event.preventDefault();
+        el.tabs[next].focus();
+        activateContextTab(el.tabs[next].getAttribute("data-ws-tab"));
+      });
+    });
+    activateContextTab("files");
   }
 
   function makeEvent(kind, label, icon) {
@@ -224,6 +273,377 @@
     parent.appendChild(details);
   }
 
+  var diffStatusLabels = { added: "新增", modified: "修改", deleted: "删除" };
+  var syntaxKeywords = {
+    go: "break case chan const continue default defer else fallthrough for func go goto if import interface map package range return select struct switch type var",
+    js: "break case catch class const continue debugger default delete do else export extends finally for function if import in instanceof let new return super switch this throw try typeof var void while with yield async await",
+    ts: "break case catch class const continue debugger default delete do else export extends finally for function if import in instanceof let new return super switch this throw try typeof var void while with yield async await interface type enum implements public private readonly",
+    py: "and as assert async await break case class continue def del elif else except finally for from global if import in is lambda match nonlocal not or pass raise return try while with yield",
+    rs: "as async await break const continue crate dyn else enum extern false fn for if impl in let loop match mod move mut pub ref return self Self static struct super trait true type unsafe use where while",
+    json: "true false null",
+    sh: "if then else elif fi for while in do done case esac function",
+    bash: "if then else elif fi for while in do done case esac function"
+  };
+
+  function syntaxClass(token, language) {
+    if (/^(?:\"|\\'|`)/.test(token)) return "ws-syntax-string";
+    if (/^(?:\/\/|#)/.test(token)) return "ws-syntax-comment";
+    if (/^\d/.test(token)) return "ws-syntax-number";
+    if ((syntaxKeywords[language] || "").split(" ").indexOf(token) !== -1) return "ws-syntax-keyword";
+    return "";
+  }
+
+  function appendHighlightedCode(parent, text, language) {
+    var source = String(text || "");
+    var re = /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`|\/\/.*|#.*|\b\d+(?:\.\d+)?\b|\b[A-Za-z_$][\w$]*\b)/g;
+    var cursor = 0;
+    var match;
+    while ((match = re.exec(source)) !== null) {
+      if (match.index > cursor) parent.appendChild(document.createTextNode(source.slice(cursor, match.index)));
+      var token = match[0];
+      var className = syntaxClass(token, language);
+      if (!className) parent.appendChild(document.createTextNode(token));
+      else {
+        var span = document.createElement("span");
+        span.className = className;
+        span.textContent = token;
+        parent.appendChild(span);
+      }
+      cursor = match.index + token.length;
+    }
+    if (cursor < source.length) parent.appendChild(document.createTextNode(source.slice(cursor)));
+  }
+
+  function appendDiffRows(parent, rows, language) {
+    rows.forEach(function (row) {
+      if (!row || typeof row !== "object") return;
+      var kind = String(row.kind || "meta");
+      var line = document.createElement("div");
+      line.className = "ws-diff-line ws-diff-line--" + kind;
+      var oldNo = document.createElement("span");
+      oldNo.className = "ws-diff-line__number";
+      oldNo.textContent = row.oldLine ? String(row.oldLine) : "";
+      var newNo = document.createElement("span");
+      newNo.className = "ws-diff-line__number";
+      newNo.textContent = row.newLine ? String(row.newLine) : "";
+      var marker = document.createElement("span");
+      marker.className = "ws-diff-line__marker";
+      marker.textContent = kind === "added" ? "+" : kind === "deleted" ? "−" : kind === "context" ? " " : "";
+      var code = document.createElement("code");
+      code.className = "ws-diff-line__code";
+      if (kind === "hunk" || kind === "meta") code.textContent = String(row.text || "");
+      else appendHighlightedCode(code, row.text, language);
+      line.appendChild(oldNo);
+      line.appendChild(newNo);
+      line.appendChild(marker);
+      line.appendChild(code);
+      parent.appendChild(line);
+    });
+  }
+
+  function copyText(value, button) {
+    var text = String(value || "");
+    var success = function () {
+      if (!button) return;
+      var original = button.textContent;
+      button.textContent = "已复制";
+      setTimeout(function () { button.textContent = original; }, 1400);
+    };
+    var fallback = function () {
+      var input = document.createElement("textarea");
+      input.value = text;
+      input.setAttribute("readonly", "true");
+      input.style.position = "fixed";
+      input.style.opacity = "0";
+      document.body.appendChild(input);
+      input.select();
+      try { if (document.execCommand("copy")) success(); } catch (_) {}
+      document.body.removeChild(input);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(success).catch(fallback);
+      return;
+    }
+    fallback();
+  }
+
+  function renderDiff(parent, fileDiff, options) {
+    if (!parent || !fileDiff || typeof fileDiff !== "object") return;
+    options = options || {};
+    var view = document.createElement("section");
+    view.className = "ws-diff-view" + (options.context ? " ws-diff-view--context" : "");
+    if (!options.hideHeader) {
+      var head = document.createElement("header");
+      head.className = "ws-diff-view__head";
+      var identity = document.createElement("div");
+      identity.className = "ws-diff-view__identity";
+      var path = document.createElement("strong");
+      path.className = "ws-diff-view__path";
+      path.textContent = String(fileDiff.path || "未命名文件");
+      var status = document.createElement("span");
+      status.className = "ws-diff-view__status ws-diff-view__status--" + String(fileDiff.status || "unknown");
+      status.textContent = diffStatusLabels[fileDiff.status] || "变更";
+      identity.appendChild(path);
+      identity.appendChild(status);
+      var stats = document.createElement("span");
+      stats.className = "ws-diff-view__stats";
+      stats.textContent = "+" + Number(fileDiff.added || 0) + " / −" + Number(fileDiff.removed || 0);
+      var copy = document.createElement("button");
+      copy.type = "button";
+      copy.className = "ws-diff-view__copy";
+      copy.textContent = "复制 Diff";
+      copy.setAttribute("aria-label", "复制 " + String(fileDiff.path || "文件") + " 的 Diff");
+      copy.addEventListener("click", function () { copyText(fileDiff.diff, copy); });
+      head.appendChild(identity);
+      head.appendChild(stats);
+      head.appendChild(copy);
+      view.appendChild(head);
+    }
+    var body = document.createElement("div");
+    body.className = "ws-diff-view__body";
+    if (fileDiff.binary) body.textContent = "二进制文件，服务端未生成文本 Diff。";
+    else {
+      var rows = Array.isArray(fileDiff.lines) ? fileDiff.lines : [];
+      if (rows.length) {
+        var limit = 180;
+        var language = String(fileDiff.language || "text").toLowerCase();
+        appendDiffRows(body, rows.slice(0, limit), language);
+        if (rows.length > limit) {
+          var details = document.createElement("details");
+          details.className = "ws-diff-view__fold";
+          var summary = document.createElement("summary");
+          summary.textContent = "展开剩余 " + (rows.length - limit) + " 行";
+          details.appendChild(summary);
+          var rest = document.createElement("div");
+          appendDiffRows(rest, rows.slice(limit), language);
+          details.appendChild(rest);
+          body.appendChild(details);
+        }
+      } else if (fileDiff.diff) {
+        // Legacy servers still expose the exact unified diff. Do not derive
+        // status or line numbers client-side; show the raw source instead.
+        var legacy = document.createElement("pre");
+        legacy.className = "ws-diff-view__legacy";
+        legacy.textContent = String(fileDiff.diff);
+        body.appendChild(legacy);
+      } else body.textContent = "没有可展示的文本 Diff。";
+    }
+    view.appendChild(body);
+    parent.appendChild(view);
+  }
+
+  function renderContextDiff(fileDiff) {
+    if (!el.contextDiff || !fileDiff) return;
+    if (el.fileHead) {
+      clearNode(el.fileHead);
+      var path = document.createElement("span");
+      path.textContent = String(fileDiff.path || "未命名文件");
+      var status = document.createElement("span");
+      status.className = "modified ws-filehead__status";
+      status.textContent = diffStatusLabels[fileDiff.status] || "变更";
+      el.fileHead.appendChild(path);
+      el.fileHead.appendChild(status);
+    }
+    clearNode(el.contextDiff);
+    renderDiff(el.contextDiff, fileDiff, { context: true, hideHeader: true });
+  }
+
+  function syncTreeSelection(path) {
+    var target = String(path || "").replace(/\\/g, "/");
+    if (!target) return;
+    var rows = document.querySelectorAll(".ws-tree .tree-row");
+    var exact = null;
+    var fallback = null;
+    rows.forEach(function (row) {
+      row.classList.remove("is-selected");
+      var name = row.querySelector(".name");
+      if (!name) return;
+      var label = String(name.textContent || "").replace(/\\/g, "/");
+      var declared = row.getAttribute("data-ws-path");
+      if (declared && declared === target) exact = row;
+      if (!fallback && (label === target || target.endsWith("/" + label))) fallback = row;
+    });
+    var selected = exact || fallback;
+    if (selected) selected.classList.add("is-selected");
+  }
+
+  function renderDiffList() {
+    if (!el.diffList) return;
+    clearNode(el.diffList);
+    var paths = Object.keys(workflow.diffs);
+    if (!paths.length) {
+      var empty = document.createElement("p");
+      empty.className = "ws-context-empty";
+      empty.textContent = "收到变更后，Diff 会显示在这里。";
+      el.diffList.appendChild(empty);
+      return;
+    }
+    paths.forEach(function (path) {
+      renderDiff(el.diffList, workflow.diffs[path]);
+    });
+  }
+
+  function terminalCommand(args) {
+    if (!args) return "";
+    var raw = args;
+    if (typeof args === "string") {
+      try { raw = JSON.parse(args); } catch (_) { return args; }
+    }
+    if (raw && typeof raw === "object") {
+      if (typeof raw.command === "string") return raw.command;
+      if (typeof raw.cmd === "string") return raw.cmd;
+      if (Array.isArray(raw.argv)) return raw.argv.map(String).join(" ");
+    }
+    return String(args);
+  }
+
+  function renderTerminalList() {
+    if (!el.terminalList) return;
+    clearNode(el.terminalList);
+    var records = Object.keys(workflow.tools).map(function (key) { return workflow.tools[key]; }).filter(function (record) {
+      return record && record.terminal;
+    });
+    if (!records.length) {
+      var empty = document.createElement("p");
+      empty.className = "ws-context-empty";
+      empty.textContent = "执行命令后，终端输出会显示在这里。";
+      el.terminalList.appendChild(empty);
+      return;
+    }
+    records.forEach(function (record) {
+      var entry = document.createElement("article");
+      entry.className = "ws-terminal-entry";
+      var head = document.createElement("header");
+      head.className = "ws-terminal-head";
+      head.textContent = record.name || "终端";
+      var status = document.createElement("span");
+      status.className = "ws-terminal-status";
+      var state = record.state === "running" ? "进行中" : record.err ? "失败" : "已完成";
+      status.textContent = state;
+      if (record.err) status.classList.add("is-failed");
+      else if (record.state === "done") status.classList.add("is-done");
+      if (record.execution && typeof record.execution.exitCode === "number") {
+        status.textContent += " · 退出 " + record.execution.exitCode;
+      }
+      head.appendChild(status);
+      entry.appendChild(head);
+      var command = document.createElement("div");
+      command.className = "ws-terminal-command";
+      command.textContent = "$ " + terminalCommand(record.args);
+      entry.appendChild(command);
+      var output = record.output || (record.execution && record.execution.outputTail) || record.err || "";
+      if (output) {
+        var pre = document.createElement("pre");
+        pre.className = "ws-terminal-output";
+        pre.textContent = String(output);
+        entry.appendChild(pre);
+      }
+      el.terminalList.appendChild(entry);
+    });
+  }
+
+  function reviewRisk(record) {
+    if (record.execution && record.execution.mutationRisk) return String(record.execution.mutationRisk);
+    if (record.state === "running") return "等待服务端完成执行并返回风险状态";
+    return "风险由服务端权限策略判定";
+  }
+
+  function resolveReviewApproval(id, allow) {
+    var record = workflow.approvals[id];
+    if (!record || record.status !== "pending") return;
+    record.status = "submitting";
+    renderReviewList();
+    postJSON("/approve", { id: id, allow: !!allow, session: false, persist: false }).then(function () {
+      record.status = allow ? "approved" : "rejected";
+      renderReviewList();
+    }).catch(function (err) {
+      record.status = "pending";
+      renderReviewList();
+      showNotice("Review 决策未提交：" + err.message, "error");
+    });
+  }
+
+  function renderReviewList() {
+    if (!el.reviewList) return;
+    clearNode(el.reviewList);
+    var changes = Object.keys(workflow.tools).map(function (key) { return workflow.tools[key]; }).filter(function (record) {
+      return record && record.fileDiff;
+    });
+    var approvals = Object.keys(workflow.approvals).map(function (key) { return workflow.approvals[key]; });
+    if (!changes.length && !approvals.length) {
+      var empty = document.createElement("p");
+      empty.className = "ws-context-empty";
+      empty.textContent = "暂无待审阅变更或权限请求。";
+      el.reviewList.appendChild(empty);
+      return;
+    }
+    changes.forEach(function (record) {
+      var entry = document.createElement("article");
+      entry.className = "ws-review-entry";
+      var head = document.createElement("header");
+      head.className = "ws-review-head";
+      head.textContent = "文件变更";
+      var status = document.createElement("span");
+      status.className = "ws-review-status";
+      status.textContent = record.state === "running" ? "待执行" : record.err ? "执行失败" : "已报告";
+      if (record.err) status.classList.add("is-rejected");
+      else if (record.state === "done") status.classList.add("is-approved");
+      head.appendChild(status);
+      entry.appendChild(head);
+      var body = document.createElement("div");
+      body.className = "ws-review-body";
+      var path = document.createElement("div");
+      path.className = "ws-review-path";
+      path.textContent = String(record.fileDiff.path || "未命名文件") + "  +" + Number(record.fileDiff.added || 0) + " / −" + Number(record.fileDiff.removed || 0);
+      body.appendChild(path);
+      var risk = document.createElement("div");
+      risk.className = "ws-review-risk";
+      risk.textContent = reviewRisk(record);
+      body.appendChild(risk);
+      entry.appendChild(body);
+      el.reviewList.appendChild(entry);
+    });
+    approvals.forEach(function (record) {
+      var approval = record.approval || {};
+      var entry = document.createElement("article");
+      entry.className = "ws-review-entry";
+      var head = document.createElement("header");
+      head.className = "ws-review-head";
+      head.textContent = "权限请求 · " + String(approval.tool || "工具");
+      var status = document.createElement("span");
+      status.className = "ws-review-status";
+      status.textContent = record.status === "approved" ? "已通过" : record.status === "rejected" ? "已拒绝" : record.status === "submitting" ? "提交中" : "待确认";
+      if (record.status === "approved") status.classList.add("is-approved");
+      if (record.status === "rejected") status.classList.add("is-rejected");
+      head.appendChild(status);
+      entry.appendChild(head);
+      var body = document.createElement("div");
+      body.className = "ws-review-body";
+      body.textContent = String(approval.subject || approval.reason || "服务端要求确认后才会执行。");
+      if (approval.reason && approval.subject) {
+        var reason = document.createElement("div");
+        reason.className = "ws-review-risk";
+        reason.textContent = String(approval.reason);
+        body.appendChild(reason);
+      }
+      if (record.status === "pending" && approval.id) {
+        var actions = document.createElement("div");
+        actions.className = "ws-review-actions";
+        [true, false].forEach(function (allow) {
+          var button = document.createElement("button");
+          button.type = "button";
+          button.textContent = allow ? "通过" : "拒绝";
+          button.setAttribute("data-ws-review-allow", String(allow));
+          button.addEventListener("click", function () { resolveReviewApproval(String(approval.id), allow); });
+          actions.appendChild(button);
+        });
+        body.appendChild(actions);
+      }
+      entry.appendChild(body);
+      el.reviewList.appendChild(entry);
+    });
+  }
+
   function toolLabel(name) {
     var labels = {
       read_file: "读取文件", read_files: "读取文件", glob: "查找文件",
@@ -243,6 +663,7 @@
     record.progressEl = null;
     clearNode(card.body);
     if (record.args) appendExpandable(card.body, record.args, "展开参数", "ws-tool-preview");
+    if (record.fileDiff) renderDiff(card.body, record.fileDiff);
     if (record.output) appendExpandable(card.body, record.output, "展开输出", "ws-tool-preview");
     if (record.err) appendExpandable(card.body, record.err, "展开错误", "ws-tool-preview");
     if (record.truncated) {
@@ -332,12 +753,23 @@
     var key = toolKey(tool, seq);
     var record = workflow.tools[key];
     if (!record) {
-      record = { args: "", output: "", err: "", truncated: false, progress: "" };
+      record = { args: "", output: "", err: "", truncated: false, progress: "", fileDiff: null, terminal: false, name: "" };
       record.card = makeEvent("tool", toolLabel(tool.name), "⚙");
       workflow.tools[key] = record;
     }
-    if (tool.name) record.card.label.textContent = toolLabel(tool.name) + " · " + tool.name;
+    if (tool.name) {
+      record.name = String(tool.name);
+      record.terminal = record.terminal || tool.name === "bash" || tool.name === "shell" || !!tool.execution;
+      record.card.label.textContent = toolLabel(tool.name) + " · " + tool.name;
+    }
     if (tool.args) record.args = String(tool.args);
+    if (tool.fileDiff) {
+      record.fileDiff = tool.fileDiff;
+      workflow.diffs[String(tool.fileDiff.path || key)] = tool.fileDiff;
+      renderContextDiff(tool.fileDiff);
+      syncTreeSelection(tool.fileDiff.path);
+    }
+    if (tool.execution) record.execution = tool.execution;
     if (kind === "tool_start") {
       record.state = "running";
       setStatus(record.card, "进行中", "running");
@@ -373,6 +805,9 @@
     } else {
       renderTool(record.card, record);
     }
+    renderDiffList();
+    renderTerminalList();
+    renderReviewList();
     if (tool.name === "todo_write" && tool.args) renderPlan(parsePlan(tool.args));
   }
 
@@ -449,6 +884,11 @@
       workflow.assistant = null;
       workflow.plan = null;
       workflow.tools = Object.create(null);
+      workflow.diffs = Object.create(null);
+      workflow.approvals = Object.create(null);
+      renderDiffList();
+      renderTerminalList();
+      renderReviewList();
     }
     switch (payload.type) {
       case "user_message":
@@ -481,6 +921,10 @@
         break;
       case "permission_request":
         var approval = data.approval || data.ask || {};
+        if (approval.id) {
+          workflow.approvals[String(approval.id)] = { approval: approval, status: "pending" };
+          renderReviewList();
+        }
         var permission = makeEvent("status", "需要确认", "?");
         if (permission) {
           permission.body.textContent = String(approval.subject || approval.reason || approval.tool || "等待用户确认");
@@ -752,6 +1196,7 @@
     loadModels(); // effort arrives piggybacked on GET /models
   }
 
+  initContextTabs();
   initSelectors();
   connectWorkspaceEvents();
 

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -241,6 +241,7 @@
 
   function renderTool(card, record) {
     if (!card || !record) return;
+    record.progressEl = null;
     clearNode(card.body);
     if (record.args) appendExpandable(card.body, record.args, "展开参数", "ws-tool-preview");
     if (record.output) appendExpandable(card.body, record.output, "展开输出", "ws-tool-preview");
@@ -296,23 +297,34 @@
       workflow.assistant.text = String(data.text || "");
       workflow.assistant.reasoning = String(data.reasoning || "");
       workflow.assistant.finalized = true;
+      clearNode(workflow.assistant.body);
+      workflow.assistant.textEl = null;
+      workflow.assistant.reasoningEl = null;
+      if (workflow.assistant.text) appendExpandable(workflow.assistant.body, workflow.assistant.text, "展开回复");
+      if (workflow.assistant.reasoning) appendExpandable(workflow.assistant.body, workflow.assistant.reasoning, "展开思考过程");
     } else if (workflow.assistant.finalized) {
       // A completed message is authoritative. Ignore a late duplicate delta
       // instead of appending it a second time to the visible answer.
       return;
     } else if (kind === "reasoning") {
-      workflow.assistant.reasoning = (workflow.assistant.reasoning || "") + String(data.reasoning || data.text || "");
+      var reasoningDelta = String(data.reasoning || data.text || "");
+      workflow.assistant.reasoning = (workflow.assistant.reasoning || "") + reasoningDelta;
+      if (!workflow.assistant.reasoningEl) {
+        workflow.assistant.reasoningEl = document.createElement("pre");
+        workflow.assistant.reasoningEl.className = "ws-event__detail";
+        workflow.assistant.body.appendChild(workflow.assistant.reasoningEl);
+      }
+      workflow.assistant.reasoningEl.appendChild(document.createTextNode(reasoningDelta));
     } else {
-      workflow.assistant.text = (workflow.assistant.text || "") + String(data.text || "");
+      var textDelta = String(data.text || "");
+      workflow.assistant.text = (workflow.assistant.text || "") + textDelta;
+      if (!workflow.assistant.textEl) {
+        workflow.assistant.textEl = document.createElement("div");
+        workflow.assistant.textEl.className = "ws-event__text";
+        workflow.assistant.body.appendChild(workflow.assistant.textEl);
+      }
+      workflow.assistant.textEl.appendChild(document.createTextNode(textDelta));
     }
-    clearNode(workflow.assistant.body);
-    if (workflow.assistant.text) {
-      var text = document.createElement("div");
-      text.className = "ws-event__text";
-      text.textContent = workflow.assistant.text;
-      workflow.assistant.body.appendChild(text);
-    }
-    if (workflow.assistant.reasoning) appendExpandable(workflow.assistant.body, workflow.assistant.reasoning, "展开思考过程");
     setStatus(workflow.assistant, kind === "message" ? "已完成" : "生成中", kind === "message" ? "done" : "running");
   }
 
@@ -331,20 +343,37 @@
       record.state = "running";
       setStatus(record.card, "进行中", "running");
     } else if (kind === "tool_result") {
-      record.output = String(tool.output || "");
-      record.err = String(tool.err || "");
+      record.output = String(tool.output || "").slice(0, MAX_RENDER_CHARS);
+      record.err = String(tool.err || "").slice(0, MAX_RENDER_CHARS);
       record.truncated = !!tool.truncated;
       record.state = record.err ? "failed" : "done";
       setStatus(record.card, record.err ? "失败" : "已完成", record.err ? "failed" : "done");
       if (tool.durationMs) record.card.status.textContent += " · " + tool.durationMs + " ms";
     } else {
-      record.progress += String(tool.output || "");
+      var chunk = String(tool.output || "");
+      if (record.progress.length < MAX_RENDER_CHARS) {
+        var previousLength = record.progress.length;
+        record.progress += chunk.slice(0, MAX_RENDER_CHARS - record.progress.length);
+        if (record.progress.length < previousLength + chunk.length) record.truncated = true;
+      } else if (chunk) {
+        record.truncated = true;
+      }
       record.output = record.progress;
       record.state = "running";
       setStatus(record.card, "进行中", "running");
     }
     record.card.article.setAttribute("data-ws-tool-state", record.state || "running");
-    renderTool(record.card, record);
+    if (kind === "tool_progress") {
+      if (!record.progressEl) {
+        renderTool(record.card, record);
+        record.progressEl = document.createElement("pre");
+        record.progressEl.className = "ws-tool-preview";
+        record.card.body.appendChild(record.progressEl);
+      }
+      record.progressEl.textContent = record.output + (record.truncated ? "\n…（输出已限制）" : "");
+    } else {
+      renderTool(record.card, record);
+    }
     if (tool.name === "todo_write" && tool.args) renderPlan(parsePlan(tool.args));
   }
 

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -108,11 +108,10 @@
   };
   var openMenu = null; // currently open dropdown element or null
 
-  // GUI-4 (#407): consume the versioned workspace stream as a transport
-  // contract. The shell does not synthesize chat/tool/cache cards here; it
-  // only validates ordering and lets the existing refresh paths react to a
-  // gap. Unknown event names and malformed payloads are deliberately ignored
-  // so a newer server cannot crash an older workspace page.
+  // GUI-4 (#407) + GUI-5 (#408): consume the versioned workspace stream as a
+  // transport contract and project it into the live workflow timeline.
+  // Unknown event names and malformed payloads are deliberately ignored so a
+  // newer server cannot crash an older workspace page.
   var workspaceEvents = null;
   var lastEventSeq = 0;
   var eventTaskID = "";
@@ -446,7 +445,11 @@
     if (!data || typeof data !== "object") return;
     // The inner eventwire frame remains the source of truth. The renderer only
     // projects it into cards; it never treats text as markup or invents data.
-    if (data.kind === "turn_started") workflow.assistant = null;
+    if (data.kind === "turn_started") {
+      workflow.assistant = null;
+      workflow.plan = null;
+      workflow.tools = Object.create(null);
+    }
     switch (payload.type) {
       case "user_message":
         var user = makeEvent("user", "用户", "›");

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -91,7 +91,9 @@
     notice: document.querySelector("[data-ws-notice]"),
     taskList: document.querySelector("[data-ws-task-list]"),
     newTask: document.querySelector("[data-ws-new-task]"),
-    sideProjectName: document.querySelector("[data-ws-side-project-name]")
+    sideProjectName: document.querySelector("[data-ws-side-project-name]"),
+    timeline: document.querySelector("[data-ws-timeline]"),
+    demo: document.querySelector("[data-ws-demo]")
   };
 
   // Sidebar/project shared state (GUI-3): whether the CURRENT session is
@@ -127,6 +129,244 @@
     error: true,
     unknown: true
   };
+
+  // GUI-5 (#408): the timeline is a projection of the versioned stream. The
+  // stream sequence is the only ordering authority; tool IDs are the only
+  // merge key. This keeps deltas idempotent without creating a second history
+  // store or guessing at events the server did not publish.
+  var MAX_INLINE_CHARS = 1200;
+  var MAX_RENDER_CHARS = 200000;
+  var workflow = {
+    assistant: null,
+    plan: null,
+    tools: Object.create(null),
+    active: false
+  };
+
+  function clearNode(node) {
+    while (node && node.firstChild) node.removeChild(node.firstChild);
+  }
+
+  function activateWorkflow() {
+    if (workflow.active) return;
+    workflow.active = true;
+    if (el.demo) el.demo.classList.add("is-hidden");
+  }
+
+  function resetWorkflow() {
+    workflow.assistant = null;
+    workflow.plan = null;
+    workflow.tools = Object.create(null);
+    workflow.active = false;
+    clearNode(el.timeline);
+    if (el.demo) el.demo.classList.remove("is-hidden");
+  }
+
+  function makeEvent(kind, label, icon) {
+    if (!el.timeline) return null;
+    activateWorkflow();
+    var article = document.createElement("article");
+    article.className = "ws-event ws-event--" + kind;
+    article.setAttribute("data-ws-event-kind", kind);
+    var head = document.createElement("header");
+    head.className = "ws-event__head";
+    var iconEl = document.createElement("span");
+    iconEl.className = "ws-event__icon";
+    iconEl.setAttribute("aria-hidden", "true");
+    iconEl.textContent = icon || "•";
+    var labelEl = document.createElement("strong");
+    labelEl.className = "ws-event__label";
+    labelEl.textContent = label || "事件";
+    var statusEl = document.createElement("span");
+    statusEl.className = "ws-event__status";
+    var body = document.createElement("div");
+    body.className = "ws-event__body";
+    head.appendChild(iconEl);
+    head.appendChild(labelEl);
+    head.appendChild(statusEl);
+    article.appendChild(head);
+    article.appendChild(body);
+    el.timeline.appendChild(article);
+    return { article: article, head: head, label: labelEl, status: statusEl, body: body };
+  }
+
+  function setStatus(card, text, state) {
+    if (!card || !card.status) return;
+    card.status.textContent = text || "";
+    card.status.className = "ws-event__status" + (state ? " is-" + state : "");
+    if (state === "failed") card.article.classList.add("ws-event--error");
+  }
+
+  function appendExpandable(parent, value, label, className) {
+    if (!parent || value === undefined || value === null) return;
+    var text = String(value);
+    if (!text) return;
+    var bounded = text.length > MAX_RENDER_CHARS ? text.slice(0, MAX_RENDER_CHARS) + "\n…（输出已限制为 200000 字符）" : text;
+    if (bounded.length <= MAX_INLINE_CHARS) {
+      var inline = document.createElement("pre");
+      inline.className = className || "ws-event__detail";
+      inline.textContent = bounded;
+      parent.appendChild(inline);
+      return;
+    }
+    var details = document.createElement("details");
+    details.className = "ws-event__detail";
+    var summary = document.createElement("summary");
+    summary.className = "ws-event__toggle";
+    summary.textContent = (label || "展开内容") + "（" + bounded.length + " 字符）";
+    var pre = document.createElement("pre");
+    pre.className = className || "ws-event__detail";
+    pre.textContent = bounded.slice(0, MAX_INLINE_CHARS) + "\n…";
+    details.addEventListener("toggle", function () {
+      if (details.open && pre.textContent.indexOf("\n…") !== -1) pre.textContent = bounded;
+    });
+    details.appendChild(summary);
+    details.appendChild(pre);
+    parent.appendChild(details);
+  }
+
+  function toolLabel(name) {
+    var labels = {
+      read_file: "读取文件", read_files: "读取文件", glob: "查找文件",
+      grep: "搜索内容", bash: "执行命令", shell: "执行命令",
+      write_file: "写入文件", edit_file: "编辑文件", apply_patch: "应用补丁",
+      todo_write: "更新计划", complete_step: "完成计划项"
+    };
+    return labels[name] || name || "工具";
+  }
+
+  function toolKey(tool, seq) {
+    return tool && tool.id ? String(tool.id) : "anonymous-tool-" + String(seq || lastEventSeq);
+  }
+
+  function renderTool(card, record) {
+    if (!card || !record) return;
+    clearNode(card.body);
+    if (record.args) appendExpandable(card.body, record.args, "展开参数", "ws-tool-preview");
+    if (record.output) appendExpandable(card.body, record.output, "展开输出", "ws-tool-preview");
+    if (record.err) appendExpandable(card.body, record.err, "展开错误", "ws-tool-preview");
+    if (record.truncated) {
+      var note = document.createElement("div");
+      note.className = "ws-timeline__notice";
+      note.textContent = "输出过长，服务端已截断显示。";
+      card.body.appendChild(note);
+    }
+  }
+
+  function parsePlan(value) {
+    if (!value) return null;
+    var raw = value;
+    if (typeof value === "string") {
+      try { raw = JSON.parse(value); } catch (_) {
+        return value.split(/\r?\n/).map(function (line) {
+          return line.replace(/^\s*(?:[-*]|\d+[.)])\s*/, "").trim();
+        }).filter(Boolean).map(function (content) { return { content: content, status: "pending" }; });
+      }
+    }
+    var items = Array.isArray(raw) ? raw : raw.todos || raw.items || raw.plan;
+    if (!Array.isArray(items)) return null;
+    return items.map(function (item) {
+      if (typeof item === "string") return { content: item, status: "pending" };
+      return { content: String(item.content || item.title || item.label || ""), status: String(item.status || "pending") };
+    }).filter(function (item) { return item.content; });
+  }
+
+  function renderPlan(items) {
+    if (!el.timeline || !items) return;
+    if (!workflow.plan) workflow.plan = makeEvent("plan", "计划", "✓");
+    if (!workflow.plan) return;
+    clearNode(workflow.plan.body);
+    var list = document.createElement("ol");
+    list.className = "ws-plan";
+    items.forEach(function (item) {
+      var li = document.createElement("li");
+      li.textContent = item.content;
+      if (item.status === "completed" || item.status === "done") li.className = "is-done";
+      list.appendChild(li);
+    });
+    workflow.plan.body.appendChild(list);
+    setStatus(workflow.plan, items.length + " 项", "done");
+  }
+
+  function renderAssistant(data) {
+    var kind = data.kind || "text";
+    if (!workflow.assistant) workflow.assistant = makeEvent("assistant", "semantix", "✦");
+    if (!workflow.assistant) return;
+    if (kind === "message") {
+      workflow.assistant.text = String(data.text || "");
+      workflow.assistant.reasoning = String(data.reasoning || "");
+    } else if (kind === "reasoning") {
+      workflow.assistant.reasoning = (workflow.assistant.reasoning || "") + String(data.reasoning || data.text || "");
+    } else {
+      workflow.assistant.text = (workflow.assistant.text || "") + String(data.text || "");
+    }
+    clearNode(workflow.assistant.body);
+    if (workflow.assistant.text) {
+      var text = document.createElement("div");
+      text.className = "ws-event__text";
+      text.textContent = workflow.assistant.text;
+      workflow.assistant.body.appendChild(text);
+    }
+    if (workflow.assistant.reasoning) appendExpandable(workflow.assistant.body, workflow.assistant.reasoning, "展开思考过程");
+    setStatus(workflow.assistant, kind === "message" ? "已完成" : "生成中", kind === "message" ? "done" : "running");
+  }
+
+  function renderToolEvent(kind, tool, seq) {
+    if (!tool) return;
+    var key = toolKey(tool, seq);
+    var record = workflow.tools[key];
+    if (!record) {
+      record = { args: "", output: "", err: "", truncated: false, progress: "" };
+      record.card = makeEvent("tool", toolLabel(tool.name), "⚙");
+      workflow.tools[key] = record;
+    }
+    if (tool.name) record.card.label.textContent = toolLabel(tool.name) + " · " + tool.name;
+    if (tool.args) record.args = String(tool.args);
+    if (kind === "tool_start") {
+      record.state = "running";
+      setStatus(record.card, "进行中", "running");
+    } else if (kind === "tool_result") {
+      record.output = String(tool.output || "");
+      record.err = String(tool.err || "");
+      record.truncated = !!tool.truncated;
+      record.state = record.err ? "failed" : "done";
+      setStatus(record.card, record.err ? "失败" : "已完成", record.err ? "failed" : "done");
+      if (tool.durationMs) record.card.status.textContent += " · " + tool.durationMs + " ms";
+    } else {
+      record.progress += String(tool.output || "");
+      record.output = record.progress;
+      record.state = "running";
+      setStatus(record.card, "进行中", "running");
+    }
+    renderTool(record.card, record);
+    if (tool.name === "todo_write" && tool.args) renderPlan(parsePlan(tool.args));
+  }
+
+  function renderStatus(kind, data) {
+    var card;
+    if (kind === "error") {
+      card = makeEvent("error", "执行失败", "!");
+      if (card) { appendExpandable(card.body, data.err || data.text || data.detail, "查看错误"); setStatus(card, "失败", "failed"); }
+      return;
+    }
+    if (kind === "cache_status") {
+      card = makeEvent("cache", "缓存状态", "◌");
+      if (card) {
+        var u = data.usage || {};
+        var hit = Number(u.cacheHitTokens || 0), miss = Number(u.cacheMissTokens || 0);
+        card.body.textContent = "命中 " + hit + " · 未命中 " + miss;
+        setStatus(card, "已更新", "done");
+      }
+      return;
+    }
+    if (kind === "plan") { renderPlan(parsePlan(data.plan || data.text || data.detail)); return; }
+    card = makeEvent(kind === "retry" ? "retry" : "status", kind === "retry" ? "重试" : "任务状态", kind === "retry" ? "↻" : "•");
+    if (!card) return;
+    var text = data.text || data.detail || data.phase || data.outcome || "";
+    if (kind === "retry") text = "第 " + (data.retryAttempt || "?") + " / " + (data.retryMax || "?") + " 次重试" + (data.retryScope ? " · " + data.retryScope : "");
+    if (text) card.body.textContent = String(text);
+    setStatus(card, kind === "retry" ? "等待中" : "已记录", kind === "retry" ? "running" : "done");
+  }
 
   // ── tiny view helpers ──
   function setState(chip, state) {
@@ -166,14 +406,56 @@
     }
     lastEventSeq = payload.seq;
     if (!canonicalEventTypes[payload.type]) return;
-    // The payload's inner eventwire data remains the sole source of truth.
-    // Rendering of each canonical type belongs to the conversation UI; this
-    // shell only keeps the stream alive and validates its envelope.
+    var data;
+    try { data = typeof payload.data === "string" ? JSON.parse(payload.data || "{}") : payload.data; } catch (_) { return; }
+    if (!data || typeof data !== "object") return;
+    // The inner eventwire frame remains the source of truth. The renderer only
+    // projects it into cards; it never treats text as markup or invents data.
+    if (data.kind === "turn_started") workflow.assistant = null;
+    switch (payload.type) {
+      case "user_message":
+        var user = makeEvent("user", "用户", "›");
+        if (user) { user.body.textContent = String(data.text || ""); setStatus(user, "已发送", "done"); }
+        break;
+      case "assistant_message":
+        renderAssistant(data);
+        break;
+      case "plan":
+        renderStatus("plan", data);
+        break;
+      case "tool_start":
+      case "tool_result":
+        renderToolEvent(data.kind === "tool_progress" ? "tool_progress" : payload.type, data.tool, payload.seq);
+        break;
+      case "error":
+        renderStatus("error", data);
+        break;
+      case "cache_status":
+        renderStatus("cache_status", data);
+        break;
+      case "task_status":
+        renderStatus(data.kind === "retrying" ? "retry" : "task_status", data);
+        break;
+      case "unknown":
+        // Forward-compatible frames remain visible as a neutral status card;
+        // malformed/unknown inner data still cannot break the page.
+        renderStatus("task_status", { text: data.text || data.detail || "收到未识别事件" });
+        break;
+      case "permission_request":
+        var approval = data.approval || data.ask || {};
+        var permission = makeEvent("status", "需要确认", "?");
+        if (permission) {
+          permission.body.textContent = String(approval.subject || approval.reason || approval.tool || "等待用户确认");
+          setStatus(permission, "等待中", "running");
+        }
+        break;
+    }
   }
 
   function connectWorkspaceEvents() {
     if (!window.EventSource) return;
     if (workspaceEvents) workspaceEvents.close();
+    resetWorkflow();
     eventTaskID = "";
     lastEventSeq = 0;
     workspaceEvents = new EventSource("/workspace/events");

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -295,6 +295,11 @@
     if (kind === "message") {
       workflow.assistant.text = String(data.text || "");
       workflow.assistant.reasoning = String(data.reasoning || "");
+      workflow.assistant.finalized = true;
+    } else if (workflow.assistant.finalized) {
+      // A completed message is authoritative. Ignore a late duplicate delta
+      // instead of appending it a second time to the visible answer.
+      return;
     } else if (kind === "reasoning") {
       workflow.assistant.reasoning = (workflow.assistant.reasoning || "") + String(data.reasoning || data.text || "");
     } else {
@@ -338,6 +343,7 @@
       record.state = "running";
       setStatus(record.card, "进行中", "running");
     }
+    record.card.article.setAttribute("data-ws-tool-state", record.state || "running");
     renderTool(record.card, record);
     if (tool.name === "todo_write" && tool.args) renderPlan(parsePlan(tool.args));
   }

--- a/harness/serve/workspace/workspace.html
+++ b/harness/serve/workspace/workspace.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="/workspace/layout.css">
 </head>
 <body>
-<!-- Demo shell (issue #404): every visible string is inert placeholder
-     content standing in for the GUI-1 mockup. No backend calls. -->
+<!-- Workspace shell (issue #404): the visible preview is a useful empty-state
+     fallback; GUI-5 replaces it with cards as versioned events arrive. -->
 
 <aside id="ws-side" class="ws-side" aria-label="项目与任务导航">
   <div class="ws-brand" data-ws-brand>

--- a/harness/serve/workspace/workspace.html
+++ b/harness/serve/workspace/workspace.html
@@ -78,8 +78,14 @@
         <p class="ws-meta">读取仓库 · 复用现有抽象 · 运行验证</p>
       </article>
 
-      <div class="ws-bubble"><span class="tag">用户</span><p>现有 prefix cache 的命中率偏低，请分析原因并优化。</p></div>
-      <div class="ws-bubble"><span class="tag is-agent">semantix</span><p>收到。我将先读取仓库，定位缓存实现与调用链路，找出低命中原因并提出改进方案。</p></div>
+      <!-- GUI-5 (#408): live events replace the preview below once the first
+           protocol frame arrives. Keeping the preview makes the standalone
+           shell useful before a session has produced any events. -->
+      <div class="ws-timeline" data-ws-timeline aria-live="polite" aria-label="Agent 工作流时间线"></div>
+
+      <div class="ws-demo" data-ws-demo>
+        <div class="ws-bubble"><span class="tag">用户</span><p>现有 prefix cache 的命中率偏低，请分析原因并优化。</p></div>
+        <div class="ws-bubble"><span class="tag is-agent">semantix</span><p>收到。我将先读取仓库，定位缓存实现与调用链路，找出低命中原因并提出改进方案。</p></div>
 
       <section class="card">
         <header class="card-head"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="2.5" width="12" height="11" rx="2"/><path d="M5.2 8.4 7 10.2l3.8-4.4"/></svg>计划</header>
@@ -101,7 +107,8 @@
         <pre class="diff-mini"><code><span class="d-ctx"><span class="ln">112</span><span class="ln">112</span> func (c *Cache) makeKey(</span><span class="d-del"><span class="ln">113</span><span class="ln"></span>- key := hash(prefix)</span><span class="d-del"><span class="ln">114</span><span class="ln"></span>- return key</span><span class="d-add"><span class="ln"></span><span class="ln">113</span>+ // 优化：加入模型与分片因子，提升命中率</span><span class="d-add"><span class="ln">113</span><span class="ln">114</span>+ key := hash(prefix + modelID + "|" + shardFactor)</span><span class="d-add"><span class="ln"></span><span class="ln">115</span>+ return key</span><span class="d-ctx"><span class="ln">116</span><span class="ln">116</span>}</span></code></pre>
       </section>
 
-      <div class="ws-statusbar"><span class="ws-dot is-on"></span>L1 prefix 命中&nbsp;&nbsp;·&nbsp;&nbsp;L2 4 slices&nbsp;&nbsp;·&nbsp;&nbsp;本轮缓存已复用<span class="chev">›</span></div>
+        <div class="ws-statusbar"><span class="ws-dot is-on"></span>L1 prefix 命中&nbsp;&nbsp;·&nbsp;&nbsp;L2 4 slices&nbsp;&nbsp;·&nbsp;&nbsp;本轮缓存已复用<span class="chev">›</span></div>
+      </div>
 
       <form class="composer" data-demo="static">
         <textarea placeholder="提出后续修改要求" rows="2" aria-label="提出后续修改要求"></textarea>

--- a/harness/serve/workspace/workspace.html
+++ b/harness/serve/workspace/workspace.html
@@ -125,13 +125,14 @@
     </section>
 
     <aside id="ws-context" class="ws-context" aria-label="上下文面板">
-      <nav class="ws-tabs" role="tablist">
-        <button class="ws-tab is-active" role="tab" aria-selected="true" type="button">文件</button>
-        <button class="ws-tab" role="tab" aria-selected="false" type="button">Diff</button>
-        <button class="ws-tab" role="tab" aria-selected="false" type="button">终端</button>
-        <button class="ws-tab" role="tab" aria-selected="false" type="button">Review</button>
+      <nav class="ws-tabs" role="tablist" aria-label="上下文视图">
+        <button id="ws-tab-files" class="ws-tab is-active" data-ws-tab="files" aria-controls="ws-panel-files" role="tab" aria-selected="true" type="button">文件</button>
+        <button id="ws-tab-diff" class="ws-tab" data-ws-tab="diff" aria-controls="ws-panel-diff" role="tab" aria-selected="false" type="button" tabindex="-1">Diff</button>
+        <button id="ws-tab-terminal" class="ws-tab" data-ws-tab="terminal" aria-controls="ws-panel-terminal" role="tab" aria-selected="false" type="button" tabindex="-1">终端</button>
+        <button id="ws-tab-review" class="ws-tab" data-ws-tab="review" aria-controls="ws-panel-review" role="tab" aria-selected="false" type="button" tabindex="-1">Review</button>
       </nav>
 
+      <section id="ws-panel-files" class="ws-context-panel is-active" data-ws-panel="files" role="tabpanel" aria-labelledby="ws-tab-files">
       <ul class="ws-tree">
         <li><div class="tree-row" style="color:var(--sx-text)"><svg class="tree-chevron" width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="m6 4 4 4-4 4"/></svg><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><circle cx="8" cy="8" r="2.4"/><ellipse cx="8" cy="8" rx="6.2" ry="2.6"/><ellipse cx="8" cy="8" rx="6.2" ry="2.6" transform="rotate(60 8 8)"/></svg><span class="name">semantix</span></div>
           <ul>
@@ -157,8 +158,27 @@
         </li>
       </ul>
 
-      <div class="ws-filehead">src/cache/prefix_cache.go<span class="modified">M</span><span class="more">···</span></div>
+      <div class="ws-filehead" data-ws-file-head>src/cache/prefix_cache.go<span class="modified">M</span><span class="more">···</span></div>
       <pre class="ws-diff"><code><span class="hunk">@@ -110,7 +110,12 @@ func (c *Cache) makeKey(</span><span class="d-ctx"><span class="ln">110</span><span class="ln">110</span>              func (c *Cache) makeKey(</span><span class="d-ctx"><span class="ln">111</span><span class="ln">111</span>                prefix string, modelID string,</span><span class="d-ctx"><span class="ln">112</span><span class="ln">112</span>                shardFactor int,</span><span class="d-del"><span class="ln">113</span><span class="ln"></span>- key := hash(prefix)</span><span class="d-del"><span class="ln">114</span><span class="ln"></span>- return key</span><span class="d-add"><span class="ln"></span><span class="ln">113</span>+ // 优化：加入模型与分片因子，提升命中率</span><span class="d-add"><span class="ln">113</span><span class="ln">114</span>+ key := hash(prefix + modelID + "|" + shardFactor)</span><span class="d-add"><span class="ln">114</span><span class="ln">115</span>+ return key</span><span class="d-ctx"><span class="ln">116</span><span class="ln">116</span>}</span></code></pre>
+      </section>
+
+      <section id="ws-panel-diff" class="ws-context-panel" data-ws-panel="diff" role="tabpanel" aria-labelledby="ws-tab-diff" hidden>
+        <div class="ws-context-scroll" data-ws-diff-list>
+          <p class="ws-context-empty">收到变更后，Diff 会显示在这里。</p>
+        </div>
+      </section>
+
+      <section id="ws-panel-terminal" class="ws-context-panel" data-ws-panel="terminal" role="tabpanel" aria-labelledby="ws-tab-terminal" hidden>
+        <div class="ws-context-scroll" data-ws-terminal-list>
+          <p class="ws-context-empty">执行命令后，终端输出会显示在这里。</p>
+        </div>
+      </section>
+
+      <section id="ws-panel-review" class="ws-context-panel" data-ws-panel="review" role="tabpanel" aria-labelledby="ws-tab-review" hidden>
+        <div class="ws-context-scroll" data-ws-review-list>
+          <p class="ws-context-empty">暂无待审阅变更或权限请求。</p>
+        </div>
+      </section>
     </aside>
   </div>
   <button class="ws-side-scrim" type="button" data-ws-side-close aria-label="关闭项目导航"></button>

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -141,6 +141,40 @@ func TestServeWorkspaceSelectorContract(t *testing.T) {
 	}
 }
 
+// TestServeWorkspaceWorkflowContract pins the GUI-5 projection boundary. The
+// browser must consume the versioned stream, merge by tool identity, and use
+// safe text nodes for untrusted event content rather than injecting markup.
+func TestServeWorkspaceWorkflowContract(t *testing.T) {
+	html := string(workspaceHTML)
+	for _, want := range []string{
+		`data-ws-timeline`, `data-ws-demo`, `aria-label="Agent 工作流时间线"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("workspace page missing workflow hook %q", want)
+		}
+	}
+
+	js := string(workspaceShellJS)
+	for _, want := range []string{
+		`Number.isSafeInteger(payload.seq)`,
+		`payload.seq <= lastEventSeq`,
+		`toolKey(tool, seq)`,
+		`data.kind === "tool_progress"`,
+		`renderPlan(parsePlan(tool.args))`,
+		`MAX_INLINE_CHARS`,
+		`MAX_RENDER_CHARS`,
+		`details.addEventListener("toggle"`,
+		`textContent`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("workflow renderer missing %q", want)
+		}
+	}
+	if strings.Contains(js, `innerHTML`) {
+		t.Error("workflow renderer must not inject event content through innerHTML")
+	}
+}
+
 // TestServeSessionsExposeInFlight verifies the /sessions payload the sidebar
 // consumes: entries keep name/path identity and can flag running sessions via
 // the existing branch sidecar marker — still one shared data model (#406).

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -115,17 +115,17 @@ func TestServeWorkspaceSelectorContract(t *testing.T) {
 		`URLSearchParams(window.location.hash.slice(1))`, // fragment-token bootstrap,
 		`/auth/token`, // same house contract as index.html
 		`window.history.replaceState`,
-		`"/status"`,   // project name from real backend state
-		`"/branches"`, // branch display from real backend state
-		`"/models"`,   // model list + current + effort
-		`"/submit"`,   // switches reuse the CLI command surface
-		`"/model "`,   //   .../model <ref>
-		`"/effort "`,  //   .../effort <level>
-		`"/sessions"`, // task list = live sessions, no second data model (#406)
-		`"/resume"`,   // task switching keeps session content server-side
-		`"/new"`,      // creating a task enters a fresh session
+		`"/status"`,           // project name from real backend state
+		`"/branches"`,         // branch display from real backend state
+		`"/models"`,           // model list + current + effort
+		`"/submit"`,           // switches reuse the CLI command surface
+		`"/model "`,           //   .../model <ref>
+		`"/effort "`,          //   .../effort <level>
+		`"/sessions"`,         // task list = live sessions, no second data model (#406)
+		`"/resume"`,           // task switching keeps session content server-side
+		`"/new"`,              // creating a task enters a fresh session
 		`"/workspace/events"`, // GUI-4 versioned SSE transport
-		`模型不可用`,       // explicit unavailable-model signal (#405 acceptance)
+		`模型不可用`,               // explicit unavailable-model signal (#405 acceptance)
 	} {
 		if !strings.Contains(js, want) {
 			t.Errorf("workspace shell.js missing %q", want)
@@ -172,6 +172,79 @@ func TestServeWorkspaceWorkflowContract(t *testing.T) {
 	}
 	if strings.Contains(js, `innerHTML`) {
 		t.Error("workflow renderer must not inject event content through innerHTML")
+	}
+}
+
+// TestServeWorkspaceDiffContract pins GUI-6's source-of-truth boundary: the
+// browser renders the server's structured fileDiff rows and copies the exact
+// unified diff string, without rebuilding status, counts, or line numbers.
+func TestServeWorkspaceDiffContract(t *testing.T) {
+	html := string(workspaceHTML)
+	for _, want := range []string{`data-ws-file-head`, `class="ws-diff"`} {
+		if !strings.Contains(html, want) {
+			t.Errorf("workspace page missing diff hook %q", want)
+		}
+	}
+	js := string(workspaceShellJS)
+	for _, want := range []string{
+		`function renderDiff`, `fileDiff.lines`, `fileDiff.diff`,
+		`navigator.clipboard.writeText`, `appendDiffRows`,
+		`展开剩余`, `ws-diff-line__number`, `ws-syntax-keyword`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("workspace diff renderer missing %q", want)
+		}
+	}
+	if strings.Contains(js, `innerHTML`) {
+		t.Error("workspace diff renderer must not inject event content through innerHTML")
+	}
+	css := string(workspaceLayoutCSS)
+	for _, want := range []string{`.ws-diff-view`, `.ws-diff-line--added`, `.ws-diff-view__copy`, `.ws-diff-view__fold`} {
+		if !strings.Contains(css, want) {
+			t.Errorf("workspace diff styles missing %q", want)
+		}
+	}
+}
+
+// TestServeWorkspaceWorkbenchContract pins GUI-7's context-panel boundary:
+// all four views are real tab/panel pairs, and terminal/review data is
+// projected from the existing workspace event and approval contracts.
+func TestServeWorkspaceWorkbenchContract(t *testing.T) {
+	html := string(workspaceHTML)
+	for _, want := range []string{
+		`data-ws-tab="files"`, `data-ws-tab="diff"`,
+		`data-ws-tab="terminal"`, `data-ws-tab="review"`,
+		`data-ws-panel="files"`, `data-ws-panel="diff"`,
+		`data-ws-panel="terminal"`, `data-ws-panel="review"`,
+		`role="tabpanel"`, `aria-controls="ws-panel-review"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("workspace page missing workbench hook %q", want)
+		}
+	}
+
+	js := string(workspaceShellJS)
+	for _, want := range []string{
+		`function activateContextTab`, `function initContextTabs`,
+		`function syncTreeSelection`, `function renderDiffList`,
+		`function renderTerminalList`, `function renderReviewList`,
+		`tool.execution`, `execution.exitCode`, `execution.outputTail`,
+		`postJSON("/approve"`, `session: false`, `persist: false`,
+		`data-ws-review-allow`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("workspace workbench projection missing %q", want)
+		}
+	}
+	if strings.Contains(js, `innerHTML`) {
+		t.Error("workspace workbench renderer must not inject event content through innerHTML")
+	}
+
+	css := string(workspaceLayoutCSS)
+	for _, want := range []string{`.ws-context-panel`, `.ws-terminal-entry`, `.ws-review-entry`, `.ws-context-scroll`} {
+		if !strings.Contains(css, want) {
+			t.Errorf("workspace workbench styles missing %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add accessible Files / Diff / Terminal / Review context tabs to the workspace shell
- project structured file diffs, shell execution metadata, and permission requests from the existing workspace event stream
- keep Review decisions on the existing `/approve` endpoint with one-shot allow/deny semantics
- document the workbench event projections and add GUI-7 contract coverage

## Scope and dependency
Closes #410.

This branch is stacked on the open GUI workflow/diff work (PR #423 and the preceding GUI-6 commits). It does not add a second workspace data model, new permission path, or command semantics.

## Verification
- `go test ./harness/serve ./harness/event ./harness/eventwire ./harness/diff ./harness/agent -run 'TestServeWorkspace|TestServeEvents|Test(ParseUnified|ToWireToolStructuredFileDiff|FileDiffFrom)' -count=1`
- `node --check harness/serve/workspace/shell.js`
- `git diff --check`