### PR TITLE
feat(gui): add composer controls and permission confirmation

### DIFF
--- a/harness/eventwire/wire.go
+++ b/harness/eventwire/wire.go
@@ -30,6 +30,7 @@ type Event struct {
 	DecisionReceipt *DecisionReceipt    `json:"decisionReceipt,omitempty"`
 	Extension       *ExtensionSurface   `json:"extension,omitempty"`
 	Err             string              `json:"err,omitempty" externalizable:"true"`
+	Cancelled       bool                `json:"cancelled,omitempty"`
 	Outcome         string              `json:"outcome,omitempty"`
 	Readiness       *FinalReadiness     `json:"readiness,omitempty"`
 	Receipt         *CompletionReceipt  `json:"receipt,omitempty"`
@@ -190,6 +191,7 @@ func ToWire(e event.Event) Event {
 	case event.ExtensionSurface, event.ExtensionStatus:
 		w.Extension = ToWireExtensionSurface(e.Extension)
 	case event.TurnDone:
+		w.Cancelled = e.Cancelled
 		w.Outcome = e.Outcome
 		w.CheckpointTurn = e.CheckpointTurn
 		w.Receipt = completionReceiptWire(e.Receipt)

--- a/harness/eventwire/wire_test.go
+++ b/harness/eventwire/wire_test.go
@@ -214,6 +214,20 @@ func TestToWireTurnOutcomeIsOptionalAndMachineReadable(t *testing.T) {
 	}
 }
 
+func TestToWireTurnDoneCarriesCancellation(t *testing.T) {
+	w := ToWire(event.Event{Kind: event.TurnDone, Cancelled: true})
+	if !w.Cancelled {
+		t.Fatal("cancelled TurnDone lost its cancellation flag")
+	}
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal cancelled turn: %v", err)
+	}
+	if !strings.Contains(string(b), `"cancelled":true`) {
+		t.Fatalf("cancelled TurnDone JSON = %s, want cancellation flag", b)
+	}
+}
+
 func TestToWireTurnDoneCheckpointTurnPreservesZeroAndOmitsNil(t *testing.T) {
 	turn := 0
 	withCheckpoint, err := json.Marshal(ToWire(event.Event{Kind: event.TurnDone, CheckpointTurn: &turn}))

--- a/harness/serve/workspace/layout.css
+++ b/harness/serve/workspace/layout.css
@@ -307,6 +307,8 @@ body.ws-right-collapsed .ws-context { display: none; }
 }
 .composer textarea::placeholder { color: var(--sx-text-3); }
 .composer-row { display: flex; align-items: center; gap: 10px; }
+.composer-attachments { display: inline-flex; flex-wrap: wrap; gap: 5px; min-width: 0; }
+.composer-attachment { max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 4px 7px; border: 1px solid var(--sx-border-strong); border-radius: 5px; color: var(--sx-text-3); font: 500 10.5px/1.2 var(--sx-font-mono); }
 .perm-chip {
   display: inline-flex; align-items: center; gap: 8px;
   padding: 7px 12px; border-radius: 999px;
@@ -318,6 +320,8 @@ body.ws-right-collapsed .ws-context { display: none; }
   border: 0; background: var(--sx-green); color: #04140c;
   display: inline-flex; align-items: center; justify-content: center; cursor: pointer;
 }
+.send-btn:disabled { background: var(--sx-text-3); cursor: not-allowed; opacity: .55; }
+.ws-cancel-btn { background: var(--sx-del); color: #fff; }
 
 /* ---------- Context panel ---------- */
 

--- a/harness/serve/workspace/layout.css
+++ b/harness/serve/workspace/layout.css
@@ -176,6 +176,7 @@ body.ws-right-collapsed .ws-context { display: none; }
 .ws-event--error .ws-event__icon { color: var(--sx-del); }
 .ws-event__status { color: var(--sx-text-3); }
 .ws-event__status.is-running { color: var(--sx-orange); }
+.ws-event__status.is-cancelled { color: var(--sx-orange); }
 .ws-event__status.is-done { color: var(--sx-green-strong); }
 .ws-event__status.is-failed { color: var(--sx-del); }
 .ws-event__detail {
@@ -236,6 +237,7 @@ body.ws-right-collapsed .ws-context { display: none; }
 .ws-terminal-output { margin: 0; padding: 9px 10px; max-height: 240px; overflow: auto; color: var(--sx-text-2); font: 400 11px/1.6 var(--sx-font-mono); white-space: pre-wrap; word-break: break-word; }
 .ws-terminal-status, .ws-review-status { margin-left: auto; color: var(--sx-text-3); font: 600 10.5px/1.4 var(--sx-font-mono); }
 .ws-terminal-status.is-failed, .ws-review-status.is-rejected { color: var(--sx-del); }
+.ws-review-status.is-cancelled { color: var(--sx-orange); }
 .ws-terminal-status.is-done, .ws-review-status.is-approved { color: var(--sx-green-strong); }
 .ws-review-body { padding: 9px 10px; color: var(--sx-text-2); font: 400 12px/1.55 var(--sx-font-sans); }
 .ws-review-path { font: 600 11.5px/1.4 var(--sx-font-mono); color: var(--sx-text); overflow-wrap: anywhere; }

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -100,12 +100,23 @@
     panels: document.querySelectorAll("[data-ws-panel]"),
     diffList: document.querySelector("[data-ws-diff-list]"),
     terminalList: document.querySelector("[data-ws-terminal-list]"),
-    reviewList: document.querySelector("[data-ws-review-list]")
+    reviewList: document.querySelector("[data-ws-review-list]"),
+    composer: document.querySelector("[data-ws-composer]"),
+    input: document.querySelector("[data-ws-input]"),
+    send: document.querySelector("[data-ws-send]"),
+    cancel: document.querySelector("[data-ws-cancel]"),
+    attach: document.querySelector("[data-ws-attach]"),
+    attachmentInput: document.querySelector("[data-ws-attachment-input]"),
+    attachments: document.querySelector("[data-ws-attachments]"),
+    permission: document.querySelector("[data-ws-permission]"),
+    permissionLabel: document.querySelector("[data-ws-permission-label]")
   };
 
   // Sidebar/project shared state (GUI-3): whether the CURRENT session is
   // running drives the 运行中 pill for the highlighted task row.
   var sessionRunning = false;
+  var composerBusy = false;
+  var composerAttachments = [];
   var EFFORT_LABELS = { low: "低", medium: "中", high: "高", max: "max" };
   var EFFORT_LEVELS = ["low", "medium", "high"];
   var TASK_PILLS = {
@@ -148,6 +159,7 @@
     tools: Object.create(null),
     diffs: Object.create(null),
     approvals: Object.create(null),
+    localUser: null,
     active: false
   };
 
@@ -167,6 +179,7 @@
     workflow.tools = Object.create(null);
     workflow.diffs = Object.create(null);
     workflow.approvals = Object.create(null);
+    workflow.localUser = null;
     workflow.active = false;
     clearNode(el.timeline);
     if (el.demo) el.demo.classList.remove("is-hidden");
@@ -856,6 +869,121 @@
     showNotice.timer = setTimeout(function () { el.notice.hidden = true; }, 6000);
   }
 
+  function updateComposerControls() {
+    var busy = composerBusy || sessionRunning;
+    if (el.send) {
+      el.send.disabled = busy || !el.input || !String(el.input.value || "").trim();
+      el.send.hidden = busy;
+    }
+    if (el.cancel) el.cancel.hidden = !busy;
+  }
+
+  function setComposerRunning(running) {
+    composerBusy = !!running;
+    updateComposerControls();
+  }
+
+  function renderComposerAttachments() {
+    if (!el.attachments) return;
+    clearNode(el.attachments);
+    composerAttachments.forEach(function (name) {
+      var item = document.createElement("span");
+      item.className = "composer-attachment";
+      item.textContent = name;
+      item.title = name + "（仅记录文件名，当前服务端不上传附件内容）";
+      el.attachments.appendChild(item);
+    });
+  }
+
+  function addOptimisticUserMessage(text) {
+    var card = makeEvent("user", "用户", "›");
+    if (!card) return;
+    card.body.textContent = text;
+    setStatus(card, "发送中", "running");
+    card.article.setAttribute("data-ws-local-user", "true");
+    workflow.localUser = { text: text, card: card };
+  }
+
+  function sendComposer() {
+    if (!el.input) return;
+    var text = String(el.input.value || "").trim();
+    if (!text) return;
+    if (sessionRunning || composerBusy) {
+      showNotice("当前任务正在运行，请等待完成或先中止。", "warn");
+      return;
+    }
+    var submitted = text;
+    if (composerAttachments.length) {
+      submitted += "\n\n附件文件名（内容未上传）： " + composerAttachments.join(", ");
+    }
+    addOptimisticUserMessage(text);
+    setComposerRunning(true);
+    postJSON("/submit", { input: submitted }).then(function () {
+      el.input.value = "";
+      composerAttachments = [];
+      renderComposerAttachments();
+      refreshTasks();
+    }).catch(function (err) {
+      setComposerRunning(false);
+      if (workflow.localUser && workflow.localUser.card) {
+        setStatus(workflow.localUser.card, "未发送", "failed");
+      }
+      showNotice("发送失败：" + err.message, "error");
+    }).finally(function () {
+    if (el.input) el.input.dispatchEvent(new Event("input"));
+    });
+  }
+
+  function cancelComposer() {
+    if (!composerBusy && !sessionRunning) return;
+    postJSON("/cancel").then(function () {
+      showNotice("已请求中止当前任务。", "warn");
+    }).catch(function (err) {
+      showNotice("中止失败：" + err.message, "error");
+    });
+  }
+
+  function renderPermission(mode) {
+    if (!el.permissionLabel) return;
+    var labels = { ask: "每次确认", auto: "自动确认", yolo: "完全访问" };
+    var value = labels[String(mode || "ask").toLowerCase()] || "服务端权限";
+    el.permissionLabel.textContent = value;
+    if (el.permission) el.permission.title = "当前权限：" + value + "。权限由服务端策略控制。";
+  }
+
+  function initComposer() {
+    if (!el.composer || !el.input) return;
+    if (el.send) el.send.addEventListener("click", function (event) { event.preventDefault(); sendComposer(); });
+    if (el.cancel) el.cancel.addEventListener("click", cancelComposer);
+    el.composer.addEventListener("submit", function (event) { event.preventDefault(); sendComposer(); });
+    el.input.addEventListener("input", function () { setComposerRunning(composerBusy); });
+    el.input.addEventListener("keydown", function (event) {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        sendComposer();
+      }
+      if (event.key === "Escape" && (composerBusy || sessionRunning)) {
+        event.preventDefault();
+        cancelComposer();
+      }
+    });
+    if (el.attach && el.attachmentInput) {
+      el.attach.addEventListener("click", function () { el.attachmentInput.click(); });
+      el.attachmentInput.addEventListener("change", function () {
+        Array.prototype.forEach.call(el.attachmentInput.files || [], function (file) {
+          if (file && file.name && composerAttachments.indexOf(file.name) === -1) composerAttachments.push(file.name);
+        });
+        renderComposerAttachments();
+        el.attachmentInput.value = "";
+      });
+    }
+    if (el.permission) el.permission.addEventListener("click", function () {
+      showNotice("权限由服务端策略控制；高风险操作会单独请求确认。", "warn");
+    });
+    renderComposerAttachments();
+    setComposerRunning(false);
+  }
+
   function handleWorkspaceEvent(message) {
     var payload;
     try {
@@ -886,12 +1014,18 @@
       workflow.tools = Object.create(null);
       workflow.diffs = Object.create(null);
       workflow.approvals = Object.create(null);
+      workflow.localUser = null;
       renderDiffList();
       renderTerminalList();
       renderReviewList();
     }
     switch (payload.type) {
       case "user_message":
+        if (workflow.localUser && workflow.localUser.text === String(data.text || "")) {
+          setStatus(workflow.localUser.card, "已发送", "done");
+          workflow.localUser = null;
+          break;
+        }
         var user = makeEvent("user", "用户", "›");
         if (user) { user.body.textContent = String(data.text || ""); setStatus(user, "已发送", "done"); }
         break;
@@ -906,12 +1040,18 @@
         renderToolEvent(data.kind === "tool_progress" ? "tool_progress" : payload.type, data.tool, payload.seq);
         break;
       case "error":
+        composerBusy = false;
+        updateComposerControls();
         renderStatus("error", data);
         break;
       case "cache_status":
         renderStatus("cache_status", data);
         break;
       case "task_status":
+        if (data.kind === "turn_done") {
+          composerBusy = false;
+          updateComposerControls();
+        }
         renderStatus(data.kind === "retrying" ? "retry" : "task_status", data);
         break;
       case "unknown":
@@ -998,11 +1138,15 @@
       setValue(el.projectName, name);
       if (el.sideProjectName) el.sideProjectName.textContent = name;
       sessionRunning = !!status.running;
+      renderPermission(status.toolApprovalMode);
+      updateComposerControls();
       setState(el.project, "ok");
       return getJSON("/sessions").then(renderTasks);
     }).catch(function () {
       setValue(el.projectName, "未知项目");
       setState(el.project, "error");
+      renderPermission("ask");
+      updateComposerControls();
       renderTasks(null);
     });
   }
@@ -1197,6 +1341,7 @@
   }
 
   initContextTabs();
+  initComposer();
   initSelectors();
   connectWorkspaceEvents();
 

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -625,9 +625,10 @@
       head.textContent = "权限请求 · " + String(approval.tool || "工具");
       var status = document.createElement("span");
       status.className = "ws-review-status";
-      status.textContent = record.status === "approved" ? "已通过" : record.status === "rejected" ? "已拒绝" : record.status === "submitting" ? "提交中" : "待确认";
+      status.textContent = record.status === "approved" ? "已通过" : record.status === "rejected" ? "已拒绝" : record.status === "cancelled" ? "已取消" : record.status === "submitting" ? "提交中" : "待确认";
       if (record.status === "approved") status.classList.add("is-approved");
       if (record.status === "rejected") status.classList.add("is-rejected");
+      if (record.status === "cancelled") status.classList.add("is-cancelled");
       head.appendChild(status);
       entry.appendChild(head);
       var body = document.createElement("div");
@@ -929,6 +930,7 @@
         setStatus(workflow.localUser.card, "未发送", "failed");
       }
       showNotice("发送失败：" + err.message, "error");
+      workflow.localUser = null;
     }).finally(function () {
       if (el.input) el.input.dispatchEvent(new Event("input"));
     });
@@ -1041,6 +1043,10 @@
       case "error":
         composerBusy = false;
         updateComposerControls();
+        if (workflow.localUser) {
+          setStatus(workflow.localUser.card, "未发送", "failed");
+          workflow.localUser = null;
+        }
         renderStatus("error", data);
         break;
       case "cache_status":
@@ -1048,8 +1054,20 @@
         break;
       case "task_status":
         if (data.kind === "turn_done") {
+          var cancelled = !!data.cancelled || String(data.outcome || "").toLowerCase() === "cancelled";
           composerBusy = false;
           updateComposerControls();
+          if (workflow.localUser) {
+            setStatus(workflow.localUser.card, cancelled ? "已取消" : "已发送", cancelled ? "cancelled" : "done");
+            workflow.localUser = null;
+          }
+          if (cancelled) {
+            Object.keys(workflow.approvals).forEach(function (id) {
+              var record = workflow.approvals[id];
+              if (record && (record.status === "pending" || record.status === "submitting")) record.status = "cancelled";
+            });
+            renderReviewList();
+          }
         }
         renderStatus(data.kind === "retrying" ? "retry" : "task_status", data);
         break;

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -930,7 +930,7 @@
       }
       showNotice("发送失败：" + err.message, "error");
     }).finally(function () {
-    if (el.input) el.input.dispatchEvent(new Event("input"));
+      if (el.input) el.input.dispatchEvent(new Event("input"));
     });
   }
 
@@ -1014,7 +1014,6 @@
       workflow.tools = Object.create(null);
       workflow.diffs = Object.create(null);
       workflow.approvals = Object.create(null);
-      workflow.localUser = null;
       renderDiffList();
       renderTerminalList();
       renderReviewList();

--- a/harness/serve/workspace/workspace.html
+++ b/harness/serve/workspace/workspace.html
@@ -110,15 +110,18 @@
         <div class="ws-statusbar"><span class="ws-dot is-on"></span>L1 prefix 命中&nbsp;&nbsp;·&nbsp;&nbsp;L2 4 slices&nbsp;&nbsp;·&nbsp;&nbsp;本轮缓存已复用<span class="chev">›</span></div>
       </div>
 
-      <form class="composer" data-demo="static">
-        <textarea placeholder="提出后续修改要求" rows="2" aria-label="提出后续修改要求"></textarea>
+      <form class="composer" data-ws-composer data-demo="static">
+        <textarea data-ws-input placeholder="提出后续修改要求" rows="2" aria-label="提出后续修改要求"></textarea>
         <div class="composer-row">
-          <button class="icon-btn" type="button" aria-label="添加附件" style="border-radius:50%"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 3v10M3 8h10"/></svg></button>
-          <button class="perm-chip" type="button"><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 1.5 13 3.4v3.4c0 3.1-2.1 5.9-5 7.7-2.9-1.8-5-4.6-5-7.7V3.4L8 1.5Z"/><path d="m5.7 7.9 1.6 1.6 3-3.2"/></svg>完全访问<svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4 6 4 4 4-4"/></svg></button>
+          <button class="icon-btn" data-ws-attach type="button" aria-label="添加附件" style="border-radius:50%"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 3v10M3 8h10"/></svg></button>
+          <input data-ws-attachment-input type="file" hidden multiple>
+          <span data-ws-attachments class="composer-attachments" aria-live="polite"></span>
+          <button class="perm-chip" data-ws-permission type="button" title="权限由服务端策略控制"><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 1.5 13 3.4v3.4c0 3.1-2.1 5.9-5 7.7-2.9-1.8-5-4.6-5-7.7V3.4L8 1.5Z"/><path d="m5.7 7.9 1.6 1.6 3-3.2"/></svg><span data-ws-permission-label>服务端权限</span><svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4 6 4 4 4-4"/></svg></button>
           <span class="ws-spacer"></span>
           <button class="ws-chip is-plain" type="button" style="color:var(--sx-text-2);font-weight:500">GLM-5.3-Flash<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4 6 4 4 4-4"/></svg></button>
           <button class="ws-chip is-plain" type="button" style="color:var(--sx-text-2)"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 2v2.5M8 11.5V14M2 8h2.5M11.5 8H14"/><circle cx="8" cy="8" r="2.5"/></svg>高<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="m4 6 4 4 4-4"/></svg></button>
-          <button class="send-btn" type="button" aria-label="发送"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M8 13V3M4 7l4-4 4 4"/></svg></button>
+          <button class="send-btn" data-ws-send type="submit" aria-label="发送" disabled><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M8 13V3M4 7l4-4 4 4"/></svg></button>
+          <button class="send-btn ws-cancel-btn" data-ws-cancel type="button" aria-label="中止当前任务" title="中止当前任务" hidden><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="4" width="8" height="8" rx="1"/></svg></button>
         </div>
       </form>
 

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -248,6 +248,34 @@ func TestServeWorkspaceWorkbenchContract(t *testing.T) {
 	}
 }
 
+// TestServeWorkspaceComposerContract pins GUI-8's composer boundary: browser
+// actions use the existing HTTP routes and never alter permission mode locally.
+func TestServeWorkspaceComposerContract(t *testing.T) {
+	html := string(workspaceHTML)
+	for _, want := range []string{
+		`data-ws-composer`, `data-ws-input`, `data-ws-send`, `data-ws-cancel`,
+		`data-ws-attach`, `data-ws-attachment-input`, `data-ws-permission`,
+		`type="submit"`, `hidden`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("workspace composer missing hook %q", want)
+		}
+	}
+	js := string(workspaceShellJS)
+	for _, want := range []string{
+		`function sendComposer`, `function cancelComposer`, `function initComposer`,
+		`postJSON("/submit"`, `postJSON("/cancel"`, `data-ws-permission-label`,
+		`当前任务正在运行，请等待完成或先中止`, `内容未上传`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("workspace composer behavior missing %q", want)
+		}
+	}
+	if strings.Contains(js, `postJSON("/tool-approval-mode"`) || strings.Contains(js, `postJSON("/bypass"`) {
+		t.Error("workspace composer must not change permission mode from the browser")
+	}
+}
+
 // TestServeSessionsExposeInFlight verifies the /sessions payload the sidebar
 // consumes: entries keep name/path identity and can flag running sessions via
 // the existing branch sidecar marker — still one shared data model (#406).

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -265,7 +265,7 @@ func TestServeWorkspaceComposerContract(t *testing.T) {
 	for _, want := range []string{
 		`function sendComposer`, `function cancelComposer`, `function initComposer`,
 		`postJSON("/submit"`, `postJSON("/cancel"`, `data-ws-permission-label`,
-		`当前任务正在运行，请等待完成或先中止`, `内容未上传`,
+		`当前任务正在运行，请等待完成或先中止`, `内容未上传`, `已取消`, `cancelled`,
 	} {
 		if !strings.Contains(js, want) {
 			t.Errorf("workspace composer behavior missing %q", want)


### PR DESCRIPTION
## Summary

- add the workspace composer input, native file entry, send, and cancel controls
- show the server-reported read-only / project-write / full-access permission posture
- reuse the existing `/submit`, `/cancel`, and `/approve` boundaries without allowing browser-side privilege changes
- expose existing turn cancellation state and settle pending approval cards safely
- add GUI-8 contract coverage for composer and cancellation behavior

## Scope and dependency

Closes #411.

This branch is stacked on PR #424 (GUI-7 workbench projections). Merge #424 first, then this PR. The composer intentionally reuses the existing server routes. Selected attachment names are shown and included as prompt metadata; file contents are not uploaded because the current HTTP protocol has no attachment transport.

## Verification

- `go test ./harness/serve ./harness/event ./harness/eventwire ./harness/diff ./harness/agent -run 'TestServeWorkspace|TestServeEvents|Test(ParseUnified|ToWireToolStructuredFileDiff|FileDiffFrom)|TestToWireTurnDoneCarriesCancellation' -count=1`
- `node --check harness/serve/workspace/shell.js`
- `git diff --check`