### PR TITLE
feat(gui): expose truthful Semantix cache status (#412)

### DIFF
--- a/harness/event/event.go
+++ b/harness/event/event.go
@@ -120,6 +120,10 @@ const (
 	// CompletionSummary reports a content-free end-of-turn quality summary for
 	// role-setting strategies (preset, verdict, check counts, review status).
 	CompletionSummary
+	// KernelCache reports an observed Semantix kernel cache operation. It is
+	// separate from Usage: Usage carries provider prefix-cache accounting (L1),
+	// while this event carries semantic slice observations (L2/L3).
+	KernelCache
 	// KindCount is a sentinel one past the last real Kind. New event kinds must
 	// be inserted above it so completeness tests cover them automatically.
 	KindCount
@@ -523,6 +527,18 @@ type CacheDiagnostics struct {
 	CacheHitTokens      int
 }
 
+// KernelCachePayload is the host-to-frontend projection of one observed
+// Semantix kernel cache operation. Op is "hit", "inject", "miss", or
+// "degraded"; Layer is "L2" or "L3". It carries observations only, never
+// unmeasured cost or performance claims.
+type KernelCachePayload struct {
+	Op       string   `json:"op,omitempty"`
+	Layer    string   `json:"layer,omitempty"`
+	SliceIDs []string `json:"sliceIds,omitempty"`
+	Bytes    int      `json:"bytes,omitempty"`
+	Reason   string   `json:"reason,omitempty"`
+}
+
 // FinalReadiness carries machine-readable recovery requirements on TurnDone.
 // Missing values are stable category ids; user-facing detail stays localized in
 // the frontend instead of scraping the diagnostic error string.
@@ -623,6 +639,8 @@ type Event struct {
 	PhaseName TurnPhaseName
 	// Completion is set on CompletionSummary events.
 	Completion *CompletionSummaryInfo
+	// KernelCache is set on KernelCache events.
+	KernelCache *KernelCachePayload
 }
 
 type WorkspaceWatchState string

--- a/harness/eventwire/wire.go
+++ b/harness/eventwire/wire.go
@@ -47,6 +47,17 @@ type Event struct {
 	Phase string `json:"phase,omitempty"`
 	// Completion is set on completion_summary events (content-free quality summary).
 	Completion *CompletionSummary `json:"completion,omitempty"`
+	// KernelCache is set on kernel_cache events (observed L2/L3 cache activity).
+	KernelCache *KernelCache `json:"kernelCache,omitempty"`
+}
+
+// KernelCache is the JSON form of event.KernelCachePayload.
+type KernelCache struct {
+	Op       string   `json:"op,omitempty"`
+	Layer    string   `json:"layer,omitempty"`
+	SliceIDs []string `json:"sliceIds,omitempty"`
+	Bytes    int      `json:"bytes,omitempty"`
+	Reason   string   `json:"reason,omitempty"`
 }
 
 // CompletionSummary is the JSON form of event.CompletionSummaryInfo.
@@ -233,6 +244,10 @@ func ToWire(e event.Event) Event {
 				GapKinds:           append([]string(nil), c.GapKinds...),
 				ConstraintDegraded: c.ConstraintDegraded,
 			}
+		}
+	case event.KernelCache:
+		if c := e.KernelCache; c != nil {
+			w.KernelCache = &KernelCache{Op: c.Op, Layer: c.Layer, SliceIDs: append([]string(nil), c.SliceIDs...), Bytes: c.Bytes, Reason: c.Reason}
 		}
 	}
 	return w
@@ -665,6 +680,7 @@ var kindNames = map[event.Kind]string{
 	event.WorkspaceChanged:        "workspace_changed",
 	event.TurnPhase:               "turn_phase",
 	event.CompletionSummary:       "completion_summary",
+	event.KernelCache:             "kernel_cache",
 }
 
 // ContextMaintenance is the JSON form of event.ContextMaintenance.

--- a/harness/eventwire/wire_test.go
+++ b/harness/eventwire/wire_test.go
@@ -78,6 +78,24 @@ func TestToWireContextMaintenanceJSON(t *testing.T) {
 	}
 }
 
+func TestToWireKernelCacheJSON(t *testing.T) {
+	w := ToWire(event.Event{Kind: event.KernelCache, KernelCache: &event.KernelCachePayload{
+		Op: "degraded", Layer: "L2", SliceIDs: []string{"b", "a"}, Bytes: 128, Reason: "budget",
+	}})
+	if w.Kind != "kernel_cache" || w.KernelCache == nil {
+		t.Fatalf("kernel cache wire = %+v", w)
+	}
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"kind":"kernel_cache"`, `"op":"degraded"`, `"layer":"L2"`, `"sliceIds":["b","a"]`, `"reason":"budget"`} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("kernel cache JSON = %s, missing %s", b, want)
+		}
+	}
+}
+
 func TestToWireNoticeCarriesCode(t *testing.T) {
 	w := ToWire(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeFinalReadiness, Text: "readiness copy"})
 	b, err := json.Marshal(w)

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -60,6 +60,7 @@ type Bridge struct {
 
 	mu    sync.Mutex
 	hs    *HarnessSink // lazily created once a session label is known
+	sink  event.Sink   // live harness sink for frontend cache observations
 	dir   string       // resolved sessions dir ("" = not yet)
 	label string       // controller session label (first real session id)
 	// lastSavings is the last observed cumulative usage savings, used to
@@ -124,6 +125,9 @@ func (b *Bridge) Sink(inner event.Sink) event.Sink {
 	if !b.Enabled() {
 		return inner
 	}
+	b.mu.Lock()
+	b.sink = inner
+	b.mu.Unlock()
 	return &mirrorSink{bridge: b, inner: inner}
 }
 
@@ -172,6 +176,7 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 	}
 	store, idx, err := b.kernelIndex()
 	if err != nil {
+		b.emitKernelCache("miss", "L2", nil, 0, "slice store unavailable")
 		return InjectResult{}
 	}
 	closeSliceStore(store)
@@ -183,7 +188,20 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		Budget: budget,
 		Zones:  &z,
 	}).Build(query)
-	if err != nil || inj == nil || len(inj.Slices) == 0 {
+	if err != nil {
+		op := "miss"
+		if budget < b.cfg.Budget {
+			op = "degraded"
+		}
+		b.emitKernelCache(op, "L2", nil, 0, err.Error())
+		return InjectResult{}
+	}
+	if inj == nil || len(inj.Slices) == 0 {
+		op := "miss"
+		if budget < b.cfg.Budget {
+			op = "degraded"
+		}
+		b.emitKernelCache(op, "L2", nil, 0, "no matching slices")
 		return InjectResult{}
 	}
 	targets := make([]string, 0, len(inj.Slices))
@@ -194,7 +212,32 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 	}
 	sort.Strings(targets)
 	b.recordInjection(targets, inj.Bytes)
+	op := "inject"
+	if budget < b.cfg.Budget {
+		op = "degraded"
+	}
+	b.emitKernelCache(op, "L2", targets, inj.Bytes, "")
 	return InjectResult{Text: inj.Text, Targets: targets}
+}
+
+// emitKernelCache forwards an observed kernel cache operation to the live
+// harness sink. The kernel bus remains the source of truth for its own JSONL
+// mirror; this small projection is only for the workspace SSE/UI and is
+// fail-open when no frontend sink is attached.
+func (b *Bridge) emitKernelCache(op, layer string, ids []string, bytes int, reason string) {
+	if b == nil || !b.Enabled() {
+		return
+	}
+	ids = append([]string(nil), ids...)
+	b.mu.Lock()
+	sink := b.sink
+	label := b.label
+	b.mu.Unlock()
+	if sink == nil {
+		return
+	}
+	sink.Emit(event.Event{Kind: event.KernelCache, Text: op, Source: label,
+		KernelCache: &event.KernelCachePayload{Op: op, Layer: layer, SliceIDs: ids, Bytes: bytes, Reason: reason}})
 }
 
 func (b *Bridge) recordInjection(ids []string, bytes int) {
@@ -293,11 +336,17 @@ func (b *Bridge) Reuse(ctx context.Context, query string) ReuseSummary {
 	if err != nil {
 		return ReuseSummary{}
 	}
+	ids := make([]string, 0, len(hits))
 	sessions := make([]string, 0, len(hits))
 	for _, h := range hits {
 		if h.Slice != nil {
+			ids = append(ids, h.Slice.ID)
 			sessions = append(sessions, h.Slice.Meta.SourceSession)
 		}
+	}
+	if len(ids) > 0 {
+		sort.Strings(ids)
+		b.emitKernelCache("hit", "L2", ids, 0, "")
 	}
 	sum := ReuseSummary{Hits: len(hits), Sources: topSources(sessions)}
 	if s, err := usage.Summarize(b.usagePath(), b.costMiss(), b.costHit()); err == nil {
@@ -441,6 +490,7 @@ func (b *Bridge) Close() error {
 	b.mu.Lock()
 	hs := b.hs
 	b.hs = nil
+	b.sink = nil
 	b.mu.Unlock()
 	if hs == nil {
 		return nil

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -346,6 +346,13 @@ func (b *Bridge) Reuse(ctx context.Context, query string) ReuseSummary {
 	}
 	if len(ids) > 0 {
 		sort.Strings(ids)
+		data, marshalErr := json.Marshal(kernelevent.SliceHitPayload{Layer: "L2", SliceIDs: ids})
+		if marshalErr == nil {
+			b.mu.Lock()
+			session := b.label
+			b.mu.Unlock()
+			b.events.Emit(kernelevent.Event{Kind: kernelevent.SliceHit, SessionID: session, At: time.Now().UTC(), Data: data})
+		}
 		b.emitKernelCache("hit", "L2", ids, 0, "")
 	}
 	sum := ReuseSummary{Hits: len(hits), Sources: topSources(sessions)}

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"semantix/harness/event"
 	kernelevent "semantix/kernel/event"
 	"semantix/kernel/slice"
 )
@@ -64,7 +65,10 @@ func TestReuseSummaryLineTaskTime(t *testing.T) {
 }
 
 func TestFormatTaskDuration(t *testing.T) {
-	cases := []struct{ in float64; want string }{
+	cases := []struct {
+		in   float64
+		want string
+	}{
 		{42, "42s"},
 		{59.4, "59s"},
 		{60, "1m0s"},
@@ -80,7 +84,10 @@ func TestFormatTaskDuration(t *testing.T) {
 }
 
 func TestFormatUSD(t *testing.T) {
-	cases := []struct{ in float64; want string }{
+	cases := []struct {
+		in   float64
+		want string
+	}{
 		{0.0042, "0.0042"},
 		{0.12, "0.12"},
 		{1.5, "1.5"},
@@ -156,6 +163,23 @@ func TestBridgeReuseHitsAndSources(t *testing.T) {
 	}
 	if sum.SavingsUSD != 0.0054 {
 		t.Errorf("SavingsUSD = %v, want 0.0054 (first cumulative snapshot)", sum.SavingsUSD)
+	}
+}
+
+func TestBridgeReuseForwardsKernelCacheObservation(t *testing.T) {
+	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
+	var events []event.Event
+	b := NewBridge(Config{Enabled: true, ProjectDir: dir})
+	b.SetLabel("reuse-observation")
+	b.Sink(event.FuncSink(func(e event.Event) { events = append(events, e) }))
+	if got := b.Reuse(context.Background(), "修复 go 测试"); got.Hits == 0 {
+		t.Fatal("Reuse returned no hits")
+	}
+	if len(events) != 1 || events[0].Kind != event.KernelCache || events[0].KernelCache == nil {
+		t.Fatalf("forwarded events = %+v, want one kernel cache event", events)
+	}
+	if events[0].KernelCache.Op != "hit" || events[0].KernelCache.Layer != "L2" || len(events[0].KernelCache.SliceIDs) != 3 {
+		t.Fatalf("kernel cache payload = %+v", events[0].KernelCache)
 	}
 }
 
@@ -269,6 +293,7 @@ func TestBridgeReuseEmptySources(t *testing.T) {
 		t.Errorf("Sources = %v, want empty (legacy slices)", sum.Sources)
 	}
 }
+
 // TestBridgeInjectDegradedShrinksBlock (Issue #270 step 2): the
 // degrade_inject tier halves the block budget. The degraded block must
 // never exceed the full-budget one (whole-slice truncation is monotone

--- a/harness/serve/webproto.go
+++ b/harness/serve/webproto.go
@@ -100,6 +100,9 @@ func ProtoTypeFor(wireKind string) (string, bool) {
 		// Usage carries session cache hit/miss tokens; compaction reshapes the
 		// cacheable context — both are truthful cache-status inputs.
 		return ProtoTypeCacheStatus, true
+	case "kernel_cache":
+		// Kernel cache observations share the cache-status renderer with Usage.
+		return ProtoTypeCacheStatus, true
 	default:
 		if !wireKindKnown[wireKind] {
 			return ProtoTypeUnknown, true

--- a/harness/serve/webproto_test.go
+++ b/harness/serve/webproto_test.go
@@ -67,6 +67,7 @@ func TestWebProtoPayloadRefinement(t *testing.T) {
 		{"turn_done failed", []byte(`{"kind":"turn_done","err":"boom"}`), ProtoTypeError},
 		{"usage carries cache", []byte(`{"kind":"usage","sessionCacheHitTokens":5}`), ProtoTypeCacheStatus},
 		{"compaction is cache", []byte(`{"kind":"compaction_done"}`), ProtoTypeCacheStatus},
+		{"kernel cache is cache", []byte(`{"kind":"kernel_cache"}`), ProtoTypeCacheStatus},
 	}
 	for _, tc := range cases {
 		got, keep, _ := classifyFrame(tc.frame)

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -109,7 +109,9 @@
     attachmentInput: document.querySelector("[data-ws-attachment-input]"),
     attachments: document.querySelector("[data-ws-attachments]"),
     permission: document.querySelector("[data-ws-permission]"),
-    permissionLabel: document.querySelector("[data-ws-permission-label]")
+    permissionLabel: document.querySelector("[data-ws-permission-label]"),
+    cacheStatus: document.querySelector("[data-ws-cache-status]"),
+    cacheStatusText: document.querySelector("[data-ws-cache-status-text]")
   };
 
   // Sidebar/project shared state (GUI-3): whether the CURRENT session is
@@ -125,6 +127,65 @@
     empty: ["空会话", "ws-state-empty"]
   };
   var openMenu = null; // currently open dropdown element or null
+
+  // GUI-9 (#412): cache status is a projection of observed events only. A
+  // null value means the corresponding layer has not produced telemetry yet;
+  // it must never be replaced with a demo number.
+  var cacheView = {
+    l1Hit: null,
+    l1Miss: null,
+    l2Hits: null,
+    l3Observed: null,
+    reason: ""
+  };
+
+  function renderCacheBar() {
+    if (!el.cacheStatusText) return;
+    var parts = [];
+    parts.push("L1 prefix：" + (cacheView.l1Hit === null ? "暂无数据" : "命中 " + cacheView.l1Hit + " · 未命中 " + cacheView.l1Miss));
+    parts.push("L2 语义切片：" + (cacheView.l2Hits === null ? "暂无数据" : "复用 " + cacheView.l2Hits + " slices"));
+    parts.push("L3 安全复用：" + (cacheView.l3Observed === null ? "暂无数据" : (cacheView.l3Observed ? "已观测" : "未命中")));
+    if (cacheView.reason) parts.push("原因：" + cacheView.reason);
+    el.cacheStatusText.textContent = parts.join("  ·  ");
+    if (el.cacheStatus) {
+      var observed = cacheView.l1Hit !== null || cacheView.l2Hits !== null || cacheView.l3Observed !== null;
+      var dot = el.cacheStatus.querySelector(".ws-dot");
+      if (dot) dot.classList.toggle("is-on", observed);
+    }
+  }
+
+  function updateCacheView(data) {
+    if (!data || typeof data !== "object") return;
+    var usage = data.usage || {};
+    if (data.kind === "usage" || data.usage) {
+      if (Number.isFinite(Number(usage.cacheHitTokens)) || Number.isFinite(Number(usage.cacheMissTokens))) {
+        cacheView.l1Hit = Number(usage.cacheHitTokens || 0);
+        cacheView.l1Miss = Number(usage.cacheMissTokens || 0);
+      }
+      var diagnostics = usage.cacheDiagnostics || {};
+      if (Array.isArray(diagnostics.prefixChangeReasons) && diagnostics.prefixChangeReasons.length) {
+        cacheView.reason = diagnostics.prefixChangeReasons.join(", ");
+      }
+    }
+    var kernel = data.kernelCache || {};
+    if (kernel.layer) {
+      if (kernel.layer === "L2") {
+        if (kernel.op === "hit" || kernel.op === "inject") cacheView.l2Hits = Array.isArray(kernel.sliceIds) ? kernel.sliceIds.length : 0;
+        if (kernel.op === "miss" || kernel.op === "degraded") cacheView.l2Hits = 0;
+      }
+      if (kernel.layer === "L3") cacheView.l3Observed = kernel.op === "hit";
+      if (kernel.reason) cacheView.reason = String(kernel.reason);
+    }
+    if (data.code === "semantix_reuse" && data.detail) {
+      try {
+        var reuse = JSON.parse(data.detail);
+        if (Number.isFinite(Number(reuse.hits))) cacheView.l2Hits = Number(reuse.hits);
+      } catch (_) { /* malformed optional detail is ignored */ }
+    }
+    renderCacheBar();
+  }
+
+  renderCacheBar();
 
   // GUI-4 (#407) + GUI-5 (#408): consume the versioned workspace stream as a
   // transport contract and project it into the live workflow timeline.
@@ -833,11 +894,14 @@
       return;
     }
     if (kind === "cache_status") {
+      updateCacheView(data);
       card = makeEvent("cache", "缓存状态", "◌");
       if (card) {
         var u = data.usage || {};
         var hit = Number(u.cacheHitTokens || 0), miss = Number(u.cacheMissTokens || 0);
-        card.body.textContent = "命中 " + hit + " · 未命中 " + miss;
+        var kernel = data.kernelCache || {};
+        var detail = kernel.layer ? (kernel.layer + " " + (kernel.op || "observed") + (Array.isArray(kernel.sliceIds) ? " · " + kernel.sliceIds.length + " slices" : "")) : (data.usage ? "L1 命中 " + hit + " · 未命中 " + miss : "已观测");
+        card.body.textContent = detail;
         setStatus(card, "已更新", "done");
       }
       return;
@@ -1069,6 +1133,7 @@
             renderReviewList();
           }
         }
+        if (data.code === "semantix_reuse") updateCacheView(data);
         renderStatus(data.kind === "retrying" ? "retry" : "task_status", data);
         break;
       case "unknown":

--- a/harness/serve/workspace/workspace.html
+++ b/harness/serve/workspace/workspace.html
@@ -107,8 +107,9 @@
         <pre class="diff-mini"><code><span class="d-ctx"><span class="ln">112</span><span class="ln">112</span> func (c *Cache) makeKey(</span><span class="d-del"><span class="ln">113</span><span class="ln"></span>- key := hash(prefix)</span><span class="d-del"><span class="ln">114</span><span class="ln"></span>- return key</span><span class="d-add"><span class="ln"></span><span class="ln">113</span>+ // 优化：加入模型与分片因子，提升命中率</span><span class="d-add"><span class="ln">113</span><span class="ln">114</span>+ key := hash(prefix + modelID + "|" + shardFactor)</span><span class="d-add"><span class="ln"></span><span class="ln">115</span>+ return key</span><span class="d-ctx"><span class="ln">116</span><span class="ln">116</span>}</span></code></pre>
       </section>
 
-        <div class="ws-statusbar" data-ws-cache-status aria-live="polite"><span class="ws-dot"></span><span data-ws-cache-status-text>缓存状态：暂无数据</span><span class="chev">›</span></div>
       </div>
+
+      <div class="ws-statusbar" data-ws-cache-status aria-live="polite"><span class="ws-dot"></span><span data-ws-cache-status-text>缓存状态：暂无数据</span><span class="chev">›</span></div>
 
       <form class="composer" data-ws-composer data-demo="static">
         <textarea data-ws-input placeholder="提出后续修改要求" rows="2" aria-label="提出后续修改要求"></textarea>

--- a/harness/serve/workspace/workspace.html
+++ b/harness/serve/workspace/workspace.html
@@ -107,7 +107,7 @@
         <pre class="diff-mini"><code><span class="d-ctx"><span class="ln">112</span><span class="ln">112</span> func (c *Cache) makeKey(</span><span class="d-del"><span class="ln">113</span><span class="ln"></span>- key := hash(prefix)</span><span class="d-del"><span class="ln">114</span><span class="ln"></span>- return key</span><span class="d-add"><span class="ln"></span><span class="ln">113</span>+ // 优化：加入模型与分片因子，提升命中率</span><span class="d-add"><span class="ln">113</span><span class="ln">114</span>+ key := hash(prefix + modelID + "|" + shardFactor)</span><span class="d-add"><span class="ln"></span><span class="ln">115</span>+ return key</span><span class="d-ctx"><span class="ln">116</span><span class="ln">116</span>}</span></code></pre>
       </section>
 
-        <div class="ws-statusbar"><span class="ws-dot is-on"></span>L1 prefix 命中&nbsp;&nbsp;·&nbsp;&nbsp;L2 4 slices&nbsp;&nbsp;·&nbsp;&nbsp;本轮缓存已复用<span class="chev">›</span></div>
+        <div class="ws-statusbar" data-ws-cache-status aria-live="polite"><span class="ws-dot"></span><span data-ws-cache-status-text>缓存状态：暂无数据</span><span class="chev">›</span></div>
       </div>
 
       <form class="composer" data-ws-composer data-demo="static">

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -57,10 +57,30 @@ func TestServeWorkspaceShellRenders(t *testing.T) {
 		`提出后续修改要求`,                  // composer placeholder
 		`实现高缓存命中率`,                  // demo task title from the GUI-1 mockup
 		`src/cache/prefix_cache.go`, // file tree + diff headers
+		`data-ws-cache-status`,       // GUI-9 cache observability hook
+		`缓存状态：暂无数据`,                // no fabricated cache numbers before telemetry
 	} {
 		if !strings.Contains(html, want) {
 			t.Errorf("workspace shell missing %q", want)
 		}
+	}
+}
+
+func TestServeWorkspaceCacheStatusContract(t *testing.T) {
+	html := string(workspaceHTML)
+	js := string(workspaceShellJS)
+	for _, want := range []string{
+		`data-ws-cache-status-text`, `aria-live="polite"`,
+		`function renderCacheBar`, `function updateCacheView`,
+		`kernelCache`, `cacheDiagnostics`, `semantix_reuse`,
+		`L1 prefix`, `L2 语义切片`, `L3 安全复用`, `暂无数据`,
+	} {
+		if !strings.Contains(html, want) && !strings.Contains(js, want) {
+			t.Errorf("workspace cache status missing %q", want)
+		}
+	}
+	if strings.Contains(html, "L2 4 slices") || strings.Contains(html, "本轮缓存已复用") {
+		t.Error("workspace cache status must not ship fabricated demo metrics")
 	}
 }
 


### PR DESCRIPTION
## Summary\n- add a versioned kernel_cache event mapped into the existing cache_status SSE type\n- forward observed L2 hit, injection, miss, and degraded operations from the in-process bridge\n- replace fabricated workspace cache metrics with live L1/L2/L3 status and explicit no-data states\n\n## Verification\n- go test ./harness/eventwire ./harness/serve ./harness/semantix\n- 
ode --check harness/serve/workspace/shell.js\n- git diff --check\n\nCloses #412