### PR TITLE
fix(memory): 记忆内核四连修落地 main + kernel 消融模块 (#425-428)

### DIFF
--- a/docs/specs/swebench-memory-arm.md
+++ b/docs/specs/swebench-memory-arm.md
@@ -1,0 +1,55 @@
+# Spec：SWE-bench 记忆内核实验臂（memory arm）
+
+状态：已实现（见「实现与验证」）。背景：50 题 campaign 复盘发现 semantix 臂全程运行在**记忆内核关闭态**——语义库零写入、零检索、无学习曲线（顺序×步数相关性 -0.00），报告 §2.1 的两臂差异全部来自 agent 策略层而非语义层。本 spec 定义把记忆内核真正接入基准所需的四项修复、实验臂协议与可观测口径。
+
+## 1. 根因链（四个独立缺陷，缺一即全链失效）
+
+| # | 缺陷 | 位置 | 后果 |
+|---|---|---|---|
+| R1 | runner 生成的 config.toml 没有 `[semantix]` 段，`SemantixConfig.Enabled/Inject` 默认 false | `scripts/swebench/run_bench.py` SemantixAdapter.prepare | 内核桥整体短路（`bridge.Enabled()==false`） |
+| R2 | `RenderTOML` 模板不渲染 `[semantix]` 段 | `harness/config/render.go` | 任何配置保存/迁移（如缺 `config_version` 触发的落盘迁移）**静默删除**该段——install.sh 开启的记忆在第一次配置保存后即消失；同进程二次加载读到已重写文件 |
+| R3 | 会话镜像永远空：同步 run 从不发 `TurnDone`，headless 退出不经过 `Close`；且 `TurnStarted` 不带用户文本、sink 构造 `firstUserText` 恒空 | `harness/agent/run_loop.go`、`harness/semantix/{bridge,sink}.go` | 镜像 JSONL 0 字节且永无 user 行 → `semantix extract` 无输入，Prompt 切片不可能产生 |
+| R4 | 内核计数不进 `--metrics` | `harness/cli/run_metrics.go` | 「记忆臂真的注入了」与「记忆臂冷跑」不可区分，实验不可判读 |
+
+另有两项非本次范围的既有事实（见 issue）：`--ablate` 只覆盖 harness 侧模块、不控制内核（`full-fold` 模块无消费者）；L3 判定链只部署在 gateway，agent 路径不经过 `DecideL3`。
+
+## 2. 修复设计
+
+### R1/切片库共享（runner）
+
+- 新 flag `--semantix-memory on|off`（默认 **on**）。on 时 config.toml 写入
+  `[semantix] enabled/inject/budget=4096/project_dir/sessions_dir`；off 为消融孪生臂（不写段）。
+- **每实例独立 `SEMANTIX_HOME`**（`semantix-home/inst/<iid>/`）：会话镜像、stats、projects 天然按实例隔离，`--workers` 并发下归属无竞态；**只有切片库共享**——所有实例的 `project_dir` 指向同一 `semantix-home/kernel/`（库文件 `kernel/.semantix/project.db`）。
+- 每实例结束后 runner 以 `semantix extract --input <mirror> --scope project --project-db <shared>` 收割切片（`threading.Lock` 串行化：库的 append journal 是单写者）；extract 结果尾部写入该实例 metrics 的 `raw.extract`。
+- 新 flag `--semantix-kernel-bin`（默认 `bin/semantix`）。
+
+### R2（config 渲染往返）
+
+`RenderTOML` 增加 `[semantix]` 段渲染：布尔恒打印，可选字段非零才打印、否则注释示例（house style）。既有 render 往返测试覆盖。
+
+### R3（镜像管线）
+
+- `TurnStarted` 事件携带该轮用户文本（`run_loop.go`）；`HarnessSink` 在 TurnStarted 用它填 `first`。
+- 新增 `HarnessSink.EndTurn()` / `Bridge.EndTurn()`：flush 并关闭当前轮；`Agent.emitReuse`（所有 Run 返回路径必经）调用之。TurnDone 语义不变（同步 run 依旧不向 UI 流发 TurnDone）。
+
+### R4（可观测）
+
+- 新 Notice 码 `semantix_inject`（Detail `{"bytes":n}`），每用户轮注入块非空时发一次。
+- `RunMetrics` 新增：`semantix_inject_turns` / `semantix_inject_bytes` / `semantix_reuse_hits` / `semantix_reuse_savings_usd`（omitempty，旧读者无感）。metricsSink 消费 `semantix_inject` 与既有 `semantix_reuse` Notice。
+
+## 3. 实验臂协议（替代旧 §4「--ablate all 隔离记忆内核」的错误设想）
+
+- **记忆对照 = `--semantix-memory on` vs `off` 两臂**（同子集、同模型、同 preset）。`--ablate` 不用于记忆对照（它只关 harness 侧 planner/subagent/evidence/harness-memory/compaction）。
+- on 臂按 preds.jsonl 处理序天然形成课程：判读时报告 (a) 全臂 resolve；(b) 注入覆盖率 `semantix_inject_turns>0` 的实例占比；(c) 处理序前/后半 resolve 与步数差（学习曲线）；(d) 每注入字节的边际成本。
+- 由于处理序影响 on 臂（先跑的题喂后跑的题），跨臂公平性以「同 50 题整体」比较；更严谨的顺序敏感性留待多 seed 重复。
+
+## 4. 实现与验证
+
+- 代码：上述四点全部落地（本 PR）。`go build ./...`、`go vet`、touched 包 `-race` 测试绿（唯一失败 `TestSaveToUnwritableUserSymlinkTargetPreservesLink` 为 root 容器环境既有问题，与改动无关）。
+- 端到端冒烟（mock provider，2 实例串行）：实例 1 `extracted=2 stored=2`、无注入（冷库，符合预期）；实例 2 提取入库并 **`semantix_inject_turns=1 / semantix_inject_bytes=3252`**——跨实例记忆闭环打通。`--semantix-memory off` 回归旧行为（无 extract/注入）。
+
+## 5. 已知边界
+
+- extract 的切片为浅统计提取（Prompt/Context/ToolPattern/Result）；LLM 蒸馏式经验（ReasoningBank/AWM 路线）不在本 spec 范围。
+- agent 路径检索为 BM25-only（`bridge.kernelIndex` 硬编码），嵌入/混合检索与 L3 接入 agent 路径均为后续工作。
+- 镜像不含 reasoning 与 tool 输出全文截断策略沿用 sink 现状。

--- a/docs/specs/swebench-memory-arm.md
+++ b/docs/specs/swebench-memory-arm.md
@@ -11,7 +11,7 @@
 | R3 | 会话镜像永远空：同步 run 从不发 `TurnDone`，headless 退出不经过 `Close`；且 `TurnStarted` 不带用户文本、sink 构造 `firstUserText` 恒空 | `harness/agent/run_loop.go`、`harness/semantix/{bridge,sink}.go` | 镜像 JSONL 0 字节且永无 user 行 → `semantix extract` 无输入，Prompt 切片不可能产生 |
 | R4 | 内核计数不进 `--metrics` | `harness/cli/run_metrics.go` | 「记忆臂真的注入了」与「记忆臂冷跑」不可区分，实验不可判读 |
 
-另有两项非本次范围的既有事实（见 issue）：`--ablate` 只覆盖 harness 侧模块、不控制内核（`full-fold` 模块无消费者）；L3 判定链只部署在 gateway，agent 路径不经过 `DecideL3`。
+另有两项 issue 遗留（#428-B，已随本分支补完）：`--ablate` 此前只覆盖 harness 侧模块、不控制内核（且 `full-fold` 模块无消费者，已移除）——现新增 `kernel` 消融模块，`--ablate kernel` 在 boot 时强制关桥，单进程内即可做记忆消融；L3 判定链只部署在 gateway，agent 路径不经过 `DecideL3`（仍未变）。
 
 ## 2. 修复设计
 

--- a/harness/ablation/ablation.go
+++ b/harness/ablation/ablation.go
@@ -16,14 +16,14 @@ const (
 	Subagent   Module = "subagent"
 	Retrieval  Module = "retrieval"
 	Compaction Module = "compaction"
-	// FullFold off means a fold reads the previous projection instead of
-	// re-deriving its digest from the canonical transcript.
-	FullFold Module = "full-fold"
+	// Kernel off forces the memory-kernel bridge disabled for this process —
+	// the in-process twin of the runner's --semantix-memory off arm.
+	Kernel Module = "kernel"
 )
 
 // Modules returns every switchable module in the order arm names use.
 func Modules() []Module {
-	return []Module{Evidence, Planner, Subagent, Retrieval, Compaction, FullFold}
+	return []Module{Evidence, Planner, Subagent, Retrieval, Compaction, Kernel}
 }
 
 // Set is the group of modules disabled for a run. The zero value is the

--- a/harness/ablation/ablation_test.go
+++ b/harness/ablation/ablation_test.go
@@ -14,7 +14,8 @@ func TestParseAcceptsSpecFormsAndRejectsUnknownModules(t *testing.T) {
 		{"planner,evidence", "no-evidence+no-planner"},
 		{"planner evidence", "no-evidence+no-planner"},
 		{" Evidence , Retrieval ", "no-evidence+no-retrieval"},
-		{"all", "no-evidence+no-planner+no-subagent+no-retrieval+no-compaction+no-full-fold"},
+		{"kernel", "no-kernel"},
+		{"all", "no-evidence+no-planner+no-subagent+no-retrieval+no-compaction+no-kernel"},
 	} {
 		set, err := Parse(tc.spec)
 		if err != nil {

--- a/harness/agent/reuse.go
+++ b/harness/agent/reuse.go
@@ -51,4 +51,8 @@ func (a *Agent) emitReuse(state *turnRuntime) {
 	if notice, ok := reuseNotice(state.reuse); ok {
 		a.svc.sink.Emit(notice)
 	}
+	// Seal the kernel session mirror's turn on every Run return path:
+	// synchronous runs never emit TurnDone, and headless processes can exit
+	// without reaching the bridge's deferred Close.
+	a.semantix.EndTurn()
 }

--- a/harness/agent/run_loop.go
+++ b/harness/agent/run_loop.go
@@ -225,7 +225,11 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// once; the user's raw text remains the classifier source above.
 	providerInput = withInterruptedRecovery(providerInput, a.pendingInterruptedRecovery())
 	a.task.prepareScope(scoped, scope.ID)
-	a.svc.sink.Emit(event.Event{Kind: event.TurnStarted})
+	// Carry the turn's user text on TurnStarted so downstream sinks that
+	// reconstruct transcripts (the semantix kernel session mirror) can write
+	// a user line — extraction needs it for Prompt slices. Sinks that ignore
+	// Text on lifecycle events are unaffected.
+	a.svc.sink.Emit(event.Event{Kind: event.TurnStarted, Text: providerInput})
 	a.emitTurnPhase(event.TurnPhaseWorking)
 	input = a.withTurnPreferences(providerInput)
 	// Persist the short execution-policy block in provider Content; keep the
@@ -266,18 +270,27 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// an empty block — the harness never blocks on the kernel.
 	if a.semantix != nil && a.semantix.Enabled() {
 		// Issue #270 step 2: the degrade_inject tier shrinks the injection
-	// (halved block budget) instead of dropping it, so tight budgets still
-	// get some reuse context. Any other action keeps the full injection.
-	if a.budgetCtrl != nil && a.budgetCtrl.Action() == sched.BudgetActionDegradeInject {
-		state.injectBlock = a.semantix.InjectDegraded(ctx, input)
-	} else {
-		state.injectBlock = a.semantix.InjectDetailed(ctx, input).Text
-	}
+		// (halved block budget) instead of dropping it, so tight budgets still
+		// get some reuse context. Any other action keeps the full injection.
+		if a.budgetCtrl != nil && a.budgetCtrl.Action() == sched.BudgetActionDegradeInject {
+			state.injectBlock = a.semantix.InjectDegraded(ctx, input)
+		} else {
+			state.injectBlock = a.semantix.InjectDetailed(ctx, input).Text
+		}
 		// U33/H4a reuse panel: capture the kernel's per-turn reuse summary
 		// (hit slices + incremental cost savings + top source sessions)
 		// alongside the injection block. Same soft-degrade contract: a zero
 		// summary hides the panel, never blocks the turn.
 		state.reuse = a.semantix.Reuse(ctx, input)
+		if blk := state.injectBlock; blk != "" {
+			detail, _ := json.Marshal(map[string]int{"bytes": len(blk)})
+			a.svc.sink.Emit(event.Event{
+				Kind: event.Notice, Level: event.LevelInfo,
+				Code:   event.NoticeCodeSemantixInject,
+				Text:   fmt.Sprintf("semantix inject: %d bytes", len(blk)),
+				Detail: string(detail),
+			})
+		}
 	}
 	return rawInput, state
 }

--- a/harness/boot/boot.go
+++ b/harness/boot/boot.go
@@ -302,6 +302,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		Inject:      cfg.Semantix.Inject,
 		Budget:      cfg.Semantix.Budget,
 		SessionsDir: cfg.Semantix.SessionsDir,
+		ProjectDir:  cfg.Semantix.ProjectDir,
 		CostMissUSD: cfg.Semantix.CostInputPriceUSD,
 		CostHitUSD:  cfg.Semantix.CostCachePriceUSD,
 	})

--- a/harness/boot/boot.go
+++ b/harness/boot/boot.go
@@ -293,11 +293,11 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 
 	// Semantix memory kernel wiring (U8/H1): build the optional bridge and
 	// mirror every event into the kernel session JSONL. When [semantix] is
-	// not enabled the bridge returns the sink unchanged (zero overhead on
-	// the hot path); a broken kernel degrades fail-open, never blocking the
-	// main loop.
+	// not enabled (or the kernel ablation module is off) the bridge returns
+	// the sink unchanged (zero overhead on the hot path); a broken kernel
+	// degrades fail-open, never blocking the main loop.
 	semantixBridge := semantix.NewBridge(semantix.Config{
-		Enabled:     cfg.Semantix.Enabled,
+		Enabled:     cfg.Semantix.Enabled && !opts.Ablation.Off(ablation.Kernel),
 		Binary:      cfg.Semantix.Binary,
 		Inject:      cfg.Semantix.Inject,
 		Budget:      cfg.Semantix.Budget,

--- a/harness/cli/cli.go
+++ b/harness/cli/cli.go
@@ -494,7 +494,7 @@ func runAgent(args []string, version string) int {
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
 	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
 	trajectoryPath := fs.String("trajectory", "", "append a timestamped JSONL trajectory of the run's full event stream (tool calls, reasoning, decisions) to this path")
-	ablateFlag := fs.String("ablate", "", "benchmark arm: comma-separated subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
+	ablateFlag := fs.String("ablate", "", "benchmark arm: comma-separated subsystems to switch off (evidence, planner, subagent, retrieval, compaction, kernel; none|all)")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	cont := registerContinueFlag(fs)
 	resume := fs.String("resume", "", "resume by session file path, session ID, or machine session ID (takes precedence over --continue)")

--- a/harness/cli/run_metrics.go
+++ b/harness/cli/run_metrics.go
@@ -116,6 +116,15 @@ type RunMetrics struct {
 	CapabilityRouterCompletionTok  int     `json:"capability_router_completion_tokens,omitempty"`
 	CapabilityRouterCost           float64 `json:"capability_router_cost,omitempty"`
 	CapabilityRouterLatencyMs      int64   `json:"capability_router_latency_ms,omitempty"`
+	// Semantix memory-kernel counters (zero when [semantix] is off): how many
+	// turns received a non-empty L2 [semantix-reuse] block, its total bytes,
+	// and the kernel-reported reuse hits / savings — so a benchmark can tell
+	// "memory arm actually injected" from "memory arm ran cold" without
+	// scraping transcripts.
+	SemantixInjectTurns     int     `json:"semantix_inject_turns,omitempty"`
+	SemantixInjectBytes     int     `json:"semantix_inject_bytes,omitempty"`
+	SemantixReuseHits       int     `json:"semantix_reuse_hits,omitempty"`
+	SemantixReuseSavingsUSD float64 `json:"semantix_reuse_savings_usd,omitempty"`
 
 	// Run accounting: what a benchmark needs to price one solved task and name
 	// the guard that ended a failed one.
@@ -335,6 +344,27 @@ func (s *metricsSink) record(e event.Event) {
 	}
 	if e.Kind == event.CompactionStarted {
 		s.m.Compactions++
+	}
+	if e.Kind == event.Notice {
+		switch e.Code {
+		case event.NoticeCodeSemantixInject:
+			s.m.SemantixInjectTurns++
+			var d struct {
+				Bytes int `json:"bytes"`
+			}
+			if json.Unmarshal([]byte(e.Detail), &d) == nil {
+				s.m.SemantixInjectBytes += d.Bytes
+			}
+		case event.NoticeCodeSemantixReuse:
+			var d struct {
+				Hits       int     `json:"hits"`
+				SavingsUSD float64 `json:"savings_usd"`
+			}
+			if json.Unmarshal([]byte(e.Detail), &d) == nil {
+				s.m.SemantixReuseHits += d.Hits
+				s.m.SemantixReuseSavingsUSD += d.SavingsUSD
+			}
+		}
 	}
 	if e.Kind == event.ToolResult {
 		s.recordToolResult(e.Tool)

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -964,6 +964,12 @@ type SemantixConfig struct {
 	// SessionsDir is where the session JSONL mirror is written; empty uses
 	// <controller session dir>/sessions.
 	SessionsDir string `toml:"sessions_dir"`
+	// ProjectDir is the kernel project directory the slice store and usage
+	// log resolve against (kernel CLI semantics: <dir>/.semantix/...). Empty
+	// uses the process working directory. Point several agent runs at one
+	// directory to share a slice library across workspaces (e.g. benchmark
+	// arms measuring cross-session reuse).
+	ProjectDir string `toml:"project_dir"`
 	// CostInputPriceUSD / CostCachePriceUSD override the usage cost model
 	// prices (USD per 1M tokens at cache miss / hit) used by the reuse panel
 	// savings delta. Zero keeps the kernel defaults — mirror semantix.toml

--- a/harness/config/render.go
+++ b/harness/config/render.go
@@ -513,6 +513,45 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	fmt.Fprintf(&b, "network = %v\n", c.Sandbox.Network)
 	b.WriteString("\n")
 
+	// [semantix] must round-trip: before this section was rendered, any config
+	// save (setup, migration, edits) silently DROPPED it — disabling the
+	// memory kernel that install.sh had enabled. Booleans always print;
+	// optional fields comment their defaults, house style.
+	b.WriteString("[semantix]\n")
+	b.WriteString("# Memory kernel: mirror sessions to the kernel JSONL sink (enabled) and\n")
+	b.WriteString("# inject the [semantix-reuse] block on similar tasks (inject).\n")
+	fmt.Fprintf(&b, "enabled = %v\n", c.Semantix.Enabled)
+	fmt.Fprintf(&b, "inject  = %v\n", c.Semantix.Inject)
+	if c.Semantix.Binary != "" {
+		fmt.Fprintf(&b, "binary  = %q\n", c.Semantix.Binary)
+	} else {
+		b.WriteString("# binary  = \"semantix\"   # kernel CLI on PATH (legacy lookup tool only)\n")
+	}
+	if c.Semantix.Budget != 0 {
+		fmt.Fprintf(&b, "budget  = %d\n", c.Semantix.Budget)
+	} else {
+		b.WriteString("# budget  = 4096          # L2 injection block byte cap\n")
+	}
+	if c.Semantix.SessionsDir != "" {
+		fmt.Fprintf(&b, "sessions_dir = %q\n", c.Semantix.SessionsDir)
+	}
+	if c.Semantix.ProjectDir != "" {
+		fmt.Fprintf(&b, "project_dir = %q   # shared slice library root (<dir>/.semantix/...)\n", c.Semantix.ProjectDir)
+	}
+	if c.Semantix.CostInputPriceUSD != 0 {
+		fmt.Fprintf(&b, "cost_input_price_usd = %s\n", formatFloat(c.Semantix.CostInputPriceUSD))
+	}
+	if c.Semantix.CostCachePriceUSD != 0 {
+		fmt.Fprintf(&b, "cost_cache_price_usd = %s\n", formatFloat(c.Semantix.CostCachePriceUSD))
+	}
+	if c.Semantix.LimitUSD != 0 {
+		fmt.Fprintf(&b, "limit_usd = %s\n", formatFloat(c.Semantix.LimitUSD))
+	}
+	if c.Semantix.Window != "" {
+		fmt.Fprintf(&b, "window = %q   # session|day\n", c.Semantix.Window)
+	}
+	b.WriteString("\n")
+
 	b.WriteString("[statusline]\n")
 	b.WriteString("# A custom status line: a command whose first stdout line replaces the built-in\n")
 	b.WriteString("# data row. It receives {\"model\",\"contextUsed\",\"contextWindow\",\"cwd\"} as JSON on stdin.\n")

--- a/harness/event/event.go
+++ b/harness/event/event.go
@@ -573,6 +573,11 @@ const (
 	// (U33/H4a): Detail holds the JSON ReuseSummary (hits / savings_usd /
 	// sources), Text the one-line form for sinks without a panel.
 	NoticeCodeSemantixReuse = "semantix_reuse"
+	// NoticeCodeSemantixInject reports a non-empty [semantix-reuse] L2 block
+	// was assembled for a turn; Detail carries {"bytes": n}. Emitted at most
+	// once per user turn so metrics can count injection coverage without
+	// scraping the prompt.
+	NoticeCodeSemantixInject = "semantix_inject"
 )
 
 type Event struct {

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -429,6 +429,18 @@ func (b *Bridge) sessionSink() *HarnessSink {
 	return hs
 }
 
+// EndTurn flushes and closes the mirror's open turn. The agent calls this on
+// every Run return path because synchronous runs never emit TurnDone and a
+// headless process can exit without running Close.
+func (b *Bridge) EndTurn() {
+	if b == nil || !b.Enabled() {
+		return
+	}
+	if hs := b.sessionSink(); hs != nil {
+		hs.EndTurn()
+	}
+}
+
 // Close flushes and closes the mirror sink, if created.
 func (b *Bridge) Close() error {
 	b.mu.Lock()

--- a/harness/semantix/sink.go
+++ b/harness/semantix/sink.go
@@ -105,6 +105,12 @@ func (s *HarnessSink) Emit(e event.Event) {
 		s.flushLocked()
 		s.turn = true
 		s.text, s.reason, s.tools = "", "", nil
+		// The harness sends the turn's user text on TurnStarted; without it
+		// the mirrored transcript has no user lines and the kernel extractor
+		// can never produce Prompt slices from these sessions.
+		if e.Text != "" {
+			s.first = e.Text
+		}
 	case event.Reasoning:
 		s.reason += e.Text
 	case event.Text:
@@ -173,6 +179,19 @@ func (s *HarnessSink) flushLocked() {
 	if s.err == nil {
 		s.err = s.file.Sync()
 	}
+}
+
+// EndTurn flushes the open turn and closes it. Synchronous controller runs
+// deliberately never emit TurnDone into the event stream (see stats.Recorder),
+// and a headless single-turn process can exit without reaching Close — so the
+// harness calls this at the end of each Run. Without it, `run -p` sessions
+// leave a permanently empty mirror and the kernel extractor has no input.
+func (s *HarnessSink) EndTurn() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.flushLocked()
+	s.turn = false
+	s.text, s.reason, s.tools = "", "", nil
 }
 
 // Close flushes and closes the underlying file.

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -62,8 +62,20 @@ python3 report.py --runs results/semantix.* results/dsh.* results/claude-code.* 
 python3 mock_provider.py --port 8139 &
 python3 run_bench.py --harness semantix --model deepseek-v4-flash \
   --dataset <smoke.jsonl> --run-id smoke --openai-base http://127.0.0.1:8139 \
-  --semantix-bin ../../bin/semantix-agent
+  --semantix-bin ../../bin/semantix-agent --semantix-kernel-bin ../../bin/semantix
 ```
+
+### semantix 记忆内核臂（`--semantix-memory`，默认 on）
+
+`--semantix-memory on`（默认）把记忆内核真正接入基准：config 写入 `[semantix]`
+enabled/inject；**每实例独立 `SEMANTIX_HOME`**（并发归属无竞态），所有实例的
+`project_dir` 指向**同一共享切片库**（`semantix-home/kernel/`）；每实例结束后
+runner 跑 `semantix extract` 把该会话蒸馏进库，后续实例即可检索注入（跨实例
+记忆闭环，需 `go build -o bin/semantix ./cmd/semantix`）。`off` 为消融孪生臂
+（内核关闭，等价旧行为）。记忆对照请用这对臂，**不要用 `--ablate`**（它只关
+harness 侧模块，不触碰内核）。判读字段（metrics `raw`）：
+`semantix_inject_turns` / `semantix_inject_bytes` / `semantix_reuse_hits` /
+`raw.extract`（每实例入库量）。设计与根因：`docs/specs/swebench-memory-arm.md`。
 
 ## 方法学要点（对比公平性）
 

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -82,7 +82,7 @@ harness 侧模块，不触碰内核）。判读字段（metrics `raw`）：
 - **同一 prompt 模板**（`common.PROMPT_TEMPLATE`）喂给所有 harness；system prompt 保持各 harness 原生（那正是 harness 差异的一部分）。
 - **同一冻结子集**（`--sample N --seed S` 或 `--ids` 文件），同一模型、同一时段（DeepSeek 2026-08-16 起分峰谷计价，跨时段跑会引入成本噪声；成本按 off-peak 表折算，峰时 ×2）。
 - patch 提取统一为 `git add -A && git diff --cached`（工作区全部改动，含新文件）。
-- semantix 的 `SEMANTIX_HOME` 在 run 内共享——跨实例记忆/缓存正是被测对象；如需无记忆对照，用 `--ablate` 或换 `--run-id` 清空 state。
+- 切片库（`project_dir`）在 run 内跨实例共享——跨实例记忆/缓存正是被测对象；如需无记忆对照，用 `--semantix-memory off`，或换 `--run-id` 清空 state。
 - 单实例 exit code 不作成败信号（semantix 有已知的非零退出怪癖），以 diff 非空 + 官方评测为准。
 - 每实例默认 2400s 超时；超时/崩溃记为 error，patch 照常提取（可能为空）。
 

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -27,6 +27,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 from common import (
@@ -130,21 +131,60 @@ class SemantixAdapter(Adapter):
     name = "semantix"
 
     def prepare(self) -> None:
-        # Shared across the run's instances on purpose: the memory kernel's
-        # cross-session slice library is part of what this benchmark measures.
+        # Memory-kernel arm wiring (issue: the original campaign wrote no
+        # [semantix] section, so SemantixConfig.Enabled defaulted to false and
+        # the whole kernel was off). With --semantix-memory on (the default)
+        # every instance gets its OWN home (so session mirrors are attributed
+        # race-free under --workers), while [semantix].project_dir points all
+        # of them at ONE shared slice library; after each instance the runner
+        # runs `semantix extract` so later instances can retrieve its slices.
         self.home = self.args.state_path / "semantix-home"
         self.home.mkdir(parents=True, exist_ok=True)
+        self.memory_on = self.args.semantix_memory == "on"
+        self.kernel_dir = self.home / "kernel"
+        self.extract_lock = threading.Lock()
+        if self.memory_on:
+            (self.kernel_dir / ".semantix").mkdir(parents=True, exist_ok=True)
+            self.kernel_bin = self.args.semantix_kernel_bin or shutil.which("semantix") or str(
+                HERE.parent.parent / "bin" / "semantix")
+            if not Path(self.kernel_bin).exists():
+                raise SystemExit(
+                    f"semantix kernel CLI not found ({self.kernel_bin}); build with "
+                    "`go build -o bin/semantix ./cmd/semantix` or pass --semantix-kernel-bin "
+                    "(or run with --semantix-memory off)")
+        self.binary = self.args.semantix_bin or shutil.which("semantix-agent") or str(
+            HERE.parent.parent / "bin" / "semantix-agent"
+        )
+        if not Path(self.binary).exists():
+            raise SystemExit(
+                f"semantix-agent binary not found ({self.binary}); build with "
+                "`go build -o bin/semantix-agent ./cmd/semantix-agent` or pass --semantix-bin"
+            )
+
+    def _write_home(self, home: Path, sessions_dir: Path) -> None:
+        home.mkdir(parents=True, exist_ok=True)
         # Provider keys resolve ONLY from Semantix's global .env (never the
         # process environment) — see ProviderEntry.APIKey in harness/config.
-        env_file = self.home / ".env"
+        env_file = home / ".env"
         env_file.write_text(
             f"DEEPSEEK_API_KEY={os.environ.get('DEEPSEEK_API_KEY', 'smoke')}\n")
         env_file.chmod(0o600)
         base = self.args.openai_base or DEEPSEEK_OPENAI_BASE
         effort = f'effort      = "{self.args.effort}"\n' if self.args.effort else ""
-        (self.home / "config.toml").write_text(
+        memory_section = ""
+        if self.memory_on:
+            sessions_dir.mkdir(parents=True, exist_ok=True)
+            memory_section = f'''
+[semantix]
+enabled      = true
+inject       = true
+budget       = 4096
+project_dir  = "{self.kernel_dir}"
+sessions_dir = "{sessions_dir}"
+'''
+        (home / "config.toml").write_text(
             f'''default_model = "deepseek"
-
+{memory_section}
 # Benchmark convention: every arm runs in its max-permission mode (codex
 # danger-full-access, claude --dangerously-skip-permissions, dsh
 # danger-full-access), so the bash OS-sandbox is off here too.
@@ -162,27 +202,17 @@ context_window = 128000
 {effort}'''
         )
         # Runtime credential resolution reads only $SEMANTIX_HOME/.env (process
-        # env is setup-probe only), so materialize the key into the run's home.
-        key = os.environ.get("DEEPSEEK_API_KEY", "")
-        if key:
-            env_file = self.home / ".env"
-            env_file.touch(mode=0o600, exist_ok=True)
-            env_file.write_text(f"DEEPSEEK_API_KEY={key}\n")
-        self.binary = self.args.semantix_bin or shutil.which("semantix-agent") or str(
-            HERE.parent.parent / "bin" / "semantix-agent"
-        )
-        if not Path(self.binary).exists():
-            raise SystemExit(
-                f"semantix-agent binary not found ({self.binary}); build with "
-                "`go build -o bin/semantix-agent ./cmd/semantix-agent` or pass --semantix-bin"
-            )
+        # env is setup-probe only); _write_home materializes the key there.
 
     def run_instance(self, ws: Path, prompt: str, inst: dict):
         mfile = self.run_dir / "native" / f"{inst['instance_id']}.semantix.json"
         mfile.parent.mkdir(parents=True, exist_ok=True)
+        home = self.home / "inst" / inst["instance_id"]
+        sessions_dir = home / "kernel-sessions"
+        self._write_home(home, sessions_dir)
         env = clean_env()
         env.update({
-            "SEMANTIX_HOME": str(self.home),
+            "SEMANTIX_HOME": str(home),
             "SEMANTIX_NO_INTRO": "1",
             "SEMANTIX_LANG": "en",
         })
@@ -208,7 +238,35 @@ context_window = 128000
             if candidate.exists():
                 raw = json.loads(candidate.read_text())
                 break
+        if self.memory_on:
+            raw["extract"] = self._extract_slices(sessions_dir, inst["instance_id"])
         return exit_code, raw, err
+
+    def _extract_slices(self, sessions_dir: Path, instance_id: str) -> dict:
+        """Close the memory loop: distill this instance's session mirrors into
+        the shared slice library so later instances can retrieve them. The
+        agent never extracts on its own (extraction is `semantix extract` /
+        gateway-side by design), so the runner does it here. The sessions dir
+        is per-instance, so every mirror in it belongs to this instance; the
+        lock serializes store writes (the append journal is single-writer)."""
+        mirrors = sorted(sessions_dir.glob("*.jsonl"))
+        out = {"mirrors": len(mirrors), "runs": []}
+        db = self.kernel_dir / ".semantix" / "project.db"
+        for mirror in mirrors:
+            ecmd = [self.kernel_bin, "extract",
+                    "--input", str(mirror),
+                    "--scope", "project",
+                    "--project-db", str(db),
+                    "--session", instance_id,
+                    "--project", "swebench"]
+            try:
+                with self.extract_lock:
+                    ep = subprocess.run(ecmd, capture_output=True, text=True, timeout=120)
+                out["runs"].append({"mirror": mirror.name, "exit": ep.returncode,
+                                    "out": (ep.stdout or ep.stderr).strip()[-300:]})
+            except Exception as exc:  # extraction is best-effort, never fails the instance
+                out["runs"].append({"mirror": mirror.name, "error": str(exc)[:200]})
+        return out
 
     def fill_metrics(self, m: InstanceMetrics, raw: dict) -> None:
         m.input_tokens = raw.get("prompt_tokens", 0)
@@ -668,8 +726,14 @@ def main() -> None:
     ap.add_argument("--max-turns", type=int, default=120, help="claude-code turn cap")
     ap.add_argument("--preset", default="balanced", help="semantix preset")
     ap.add_argument("--effort", default="", help="semantix provider effort override")
-    ap.add_argument("--ablate", default="", help="semantix --ablate arm")
+    ap.add_argument("--ablate", default="", help="semantix --ablate arm (harness-side modules only; "
+                    "it does NOT toggle the memory kernel — use --semantix-memory for that)")
+    ap.add_argument("--semantix-memory", default="on", choices=("on", "off"),
+                    help="semantix memory-kernel arm: on = [semantix] enabled+inject, shared slice "
+                    "library across instances, per-instance extract; off = kernel disabled (ablation twin)")
     ap.add_argument("--semantix-bin", default="")
+    ap.add_argument("--semantix-kernel-bin", default="",
+                    help="path to the semantix kernel CLI (default: bin/semantix) used for slice extraction")
     ap.add_argument("--codex-bin", default="", help="codex binary override (chat wire needs ≤0.80.0)")
     ap.add_argument("--codex-wire-api", default="responses", choices=["responses", "chat"])
     ap.add_argument("--state-dir", default=os.path.expanduser("~/.cache/semantix-swebench"),


### PR DESCRIPTION
## 拆分说明

Draft PR #402 里的 benchmark 重跑数据等账户余额恢复后再续；但其中的**四个内核修复（R1–R4）不该等**——R2 意味着任何配置保存/迁移都会静默禁用记忆内核，这是主线上活着的 bug。本 PR 把四个修复 cherry-pick 到 main（报告叙述以 #398 已合入的实测完成版为准，仅保留代码与 spec），并补完 #428-B。

## 修复内容（R1–R4，修复 #425 #426 #427，部分修复 #428）

- **R1 runner**（#425）：SWE-bench runner 生成 config.toml 时写入 `[semantix]` 段；新 flag `--semantix-memory on|off`（默认 on）——每实例独立 `SEMANTIX_HOME`，`project_dir` 指向共享切片库，每实例结束后跑 `semantix extract` 关闭记忆闭环
- **R2 config 渲染**（#426，紧急）：`RenderTOML` 补渲染 `[semantix]` 段（布尔恒打印、可选字段注释默认值），配置保存/迁移不再静默删除该段；往返测试覆盖
- **R3 会话镜像**（#427）：同步 run 从不发 TurnDone、headless 退出跳过 Close → 镜像永远 0 字节。TurnStarted 携带用户文本；HarnessSink/Bridge 新增 EndTurn()，emitReuse 覆盖所有 Run 返回路径
- **R4 观测**（#428-A）：RunMetrics 新增 `semantix_inject_turns/bytes`、`reuse_hits/savings`（omitempty）与 Notice 码 `semantix_inject`；[semantix] 新增 project_dir

## 补完 #428-B

- 移除从无消费者的 `full-fold` 消融模块（仓库内也不存在 fold/projection 逻辑）
- 新增 `kernel` 消融模块：`--ablate kernel` 在 boot 建 bridge 时强制关内核——单进程内即可做记忆消融；`--ablate all` 随之包含内核

## Validation

- [x] `go build ./...` 通过
- [x] `go vet ./harness/...` 通过
- [x] `go test -race` ablation / config / semantix / event / kernel/... / agent / cli 全绿
- [ ] kernel-on SWE-bench 重跑（等账户余额恢复，留在 #402）

## 兼容性

- `--ablate all` 的 arm 名从 `...+no-full-fold` 变为 `...+no-kernel`（full-fold 本就无行为，结果等价）
- `--ablate kernel` / `--semantix-memory off` 两条消融路径并存：前者单进程、后者跨实例

Fixes #425, fixes #426, fixes #427, closes #428