### PR TITLE
feat(gui): add searchable session history (#413)

### DIFF
--- a/harness/serve/serve.go
+++ b/harness/serve/serve.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1530,12 +1531,16 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	type sessionEntry struct {
-		Name     string `json:"name"`
-		Path     string `json:"path"`
-		Title    string `json:"title,omitempty"`
-		Turns    int    `json:"turns,omitempty"`
-		Current  bool   `json:"current,omitempty"`
-		InFlight bool   `json:"in_flight,omitempty"`
+		Name      string    `json:"name"`
+		Path      string    `json:"path"`
+		Title     string    `json:"title,omitempty"`
+		Turns     int       `json:"turns,omitempty"`
+		Current   bool      `json:"current,omitempty"`
+		InFlight  bool      `json:"in_flight,omitempty"`
+		Status    string    `json:"status"`
+		Project   string    `json:"project,omitempty"`
+		UpdatedAt time.Time `json:"updated_at,omitempty"`
+		Failure   string    `json:"failure,omitempty"`
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -1553,11 +1558,21 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		name := strings.TrimSuffix(e.Name(), ".jsonl")
-		entry := sessionEntry{Name: name, Path: path, Current: filepath.Clean(path) == current}
+		entry := sessionEntry{Name: name, Path: path, Current: filepath.Clean(path) == current, Status: "empty"}
+		updatedAt := agent.SessionContentModTime(path)
 		// GUI-3 (#406): the branch sidecar carries the in-flight turn marker,
 		// so the task sidebar can show 运行中 without a second data structure.
 		if meta, ok, metaErr := agent.LoadBranchMeta(path); metaErr == nil && ok {
 			entry.InFlight = meta.InFlightTurn != nil
+			if meta.WorkspaceRoot != "" {
+				entry.Project = filepath.Base(filepath.Clean(meta.WorkspaceRoot))
+			}
+			if meta.UpdatedAt.After(updatedAt) {
+				updatedAt = meta.UpdatedAt
+			}
+			if meta.RecoveryReason != "" {
+				entry.Failure = meta.RecoveryReason
+			}
 		}
 		// Event-log aware: reading the .jsonl checkpoint directly would freeze
 		// turn counts and titles at the last checkpoint write.
@@ -1565,12 +1580,25 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 			entry.Turns = turns
 			entry.Title = s.sessionTitle(r.Context(), e.Name(), first, agent.SessionContentModTime(path).UnixNano())
 		}
+		entry.UpdatedAt = updatedAt
+		switch {
+		case entry.InFlight:
+			entry.Status = "running"
+		case entry.Failure != "":
+			entry.Status = "recovered"
+		case entry.Turns > 0:
+			entry.Status = "done"
+		}
 		out = append(out, entry)
 	}
-	// reverse so newest first
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
-	}
+	// Directory enumeration order is not a history order. Sort by the same
+	// persisted/content timestamps the sidebar exposes, newest first.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
+			return out[i].Name > out[j].Name
+		}
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
 	if out == nil {
 		out = []sessionEntry{}
 	}

--- a/harness/serve/workspace/layout.css
+++ b/harness/serve/workspace/layout.css
@@ -68,6 +68,13 @@ kbd {
 .ws-sub { margin-left: 27px; display: flex; flex-direction: column; gap: 1px; }
 .ws-task { position: relative; }
 .ws-task.is-current { background: var(--sx-hover); }
+.ws-session-filters { margin: 6px 10px 0 27px; display: grid; gap: 5px; }
+.ws-session-search, .ws-session-select {
+  width: 100%; min-width: 0; border: 1px solid var(--sx-border-strong);
+  border-radius: var(--sx-radius-s); background: var(--sx-chip); color: var(--sx-text-2);
+  padding: 6px 8px; font: 500 11px/1.2 var(--sx-font-sans);
+}
+.ws-session-search::placeholder { color: var(--sx-text-3); }
 
 .ws-side-foot { margin-top: auto; padding-top: 12px; border-top: 1px solid var(--sx-border); }
 

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -93,6 +93,9 @@
     newTask: document.querySelector("[data-ws-new-task]"),
     sideProjectName: document.querySelector("[data-ws-side-project-name]"),
     timeline: document.querySelector("[data-ws-timeline]"),
+    sessionSearch: document.querySelector("[data-ws-session-search]"),
+    sessionProject: document.querySelector("[data-ws-session-project]"),
+    sessionStatus: document.querySelector("[data-ws-session-status]"),
     demo: document.querySelector("[data-ws-demo]"),
     fileHead: document.querySelector("[data-ws-file-head]"),
     contextDiff: document.querySelector("[data-ws-context-diff], .ws-diff"),
@@ -127,6 +130,8 @@
   var openMenu = null; // currently open dropdown element or null
 
   // GUI-4 (#407) + GUI-5 (#408): consume the versioned workspace stream as a
+  var sessionRows = [];
+  var SESSION_STATUS_LABELS = { running: "运行中", done: "已完成", recovered: "待恢复", empty: "空会话" };
   // transport contract and project it into the live workflow timeline.
   // Unknown event names and malformed payloads are deliberately ignored so a
   // newer server cannot crash an older workspace page.
@@ -1184,14 +1189,17 @@
       el.taskList.appendChild(err);
       return;
     }
-    if (!sessions.length) {
+    sessionRows = sessions;
+    refreshSessionProjectFilter();
+    var visible = filterSessions();
+    if (!visible.length) {
       var empty = document.createElement("li");
       empty.className = "ws-tasks-note";
-      empty.textContent = "还没有任务：点击上方「新建任务」开始第一个会话。";
+      empty.textContent = sessions.length ? "没有符合筛选条件的会话。" : "还没有任务：点击上方「新建任务」开始第一个会话。";
       el.taskList.appendChild(empty);
       return;
     }
-    sessions.forEach(function (s) {
+    visible.forEach(function (s) {
       var li = document.createElement("li");
       var row = document.createElement("button");
       row.type = "button";
@@ -1206,9 +1214,10 @@
 
       var meta = document.createElement("span");
       meta.className = "ws-task-meta";
-      meta.textContent = s.turns ? s.turns + " 轮" : "";
+      var updated = formatSessionTime(s.updated_at);
+      meta.textContent = (s.turns ? s.turns + " 轮" : "") + (updated ? " · " + updated : "");
 
-      var stateKey = deriveTaskState(s);
+      var stateKey = sessionStatus(s);
       var pill = document.createElement("span");
       pill.className = "ws-state-pill " + TASK_PILLS[stateKey][1];
       pill.textContent = TASK_PILLS[stateKey][0];
@@ -1239,6 +1248,45 @@
   function loadBranches() {
     setState(el.branch, "loading");
     return getJSON("/branches").then(function (data) {
+  function sessionStatus(s) {
+    var status = String(s && s.status || "").toLowerCase();
+    return SESSION_STATUS_LABELS[status] ? status : deriveTaskState(s);
+  }
+
+  function formatSessionTime(value) {
+    if (!value) return "";
+    var date = new Date(value);
+    if (isNaN(date.getTime())) return "";
+    return date.toLocaleString([], { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" });
+  }
+
+  function refreshSessionProjectFilter() {
+    if (!el.sessionProject) return;
+    var selected = el.sessionProject.value;
+    while (el.sessionProject.options.length > 1) el.sessionProject.remove(1);
+    var projects = [];
+    sessionRows.forEach(function (s) {
+      var project = String(s.project || "").trim();
+      if (project && projects.indexOf(project) === -1) projects.push(project);
+    });
+    projects.sort().forEach(function (project) {
+      var option = document.createElement("option");
+      option.value = project; option.textContent = project;
+      el.sessionProject.appendChild(option);
+    });
+    el.sessionProject.value = projects.indexOf(selected) >= 0 ? selected : "";
+  }
+
+  function filterSessions() {
+    var keyword = String(el.sessionSearch && el.sessionSearch.value || "").trim().toLowerCase();
+    var project = String(el.sessionProject && el.sessionProject.value || "");
+    var status = String(el.sessionStatus && el.sessionStatus.value || "");
+    return sessionRows.filter(function (s) {
+      var haystack = [s.name, s.title, s.failure, s.project].join(" ").toLowerCase();
+      return (!keyword || haystack.indexOf(keyword) !== -1) && (!project || s.project === project) && (!status || sessionStatus(s) === status);
+    });
+  }
+
       var branches = Array.isArray(data.branches) ? data.branches : [];
       // Session branches are informational for the shell: read-only display
       // keeps fork/resume flows in the sessions picker where they belong.
@@ -1291,10 +1339,24 @@
         // #405 acceptance: an explicit, visible unavailable-model signal.
         setValue(el.modelName, "模型不可用");
         setState(el.model, "error");
+      if (s.failure) row.title += "；恢复提示：" + s.failure;
         el.model.title = "没有任何已配置的可用模型；请在 provider 设置中添加后刷新";
         fillList(el.modelMenu, [{ label: "模型不可用：未配置任何模型", disabled: true }]);
         showNotice("模型不可用：未发现已配置的聊天模型，请检查 provider 配置。", "warn");
         return;
+  function initSessionFilters() {
+    [el.sessionSearch, el.sessionProject, el.sessionStatus].forEach(function (control) {
+      if (!control) return;
+      control.addEventListener("input", function () { renderTasks(sessionRows); });
+      control.addEventListener("change", function () { renderTasks(sessionRows); });
+    });
+    document.addEventListener("keydown", function (event) {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "k" && el.sessionSearch) {
+        event.preventDefault(); el.sessionSearch.focus();
+      }
+    });
+  }
+
       }
       var activeRef = null;
       fillList(el.modelMenu, models.map(function (m) {
@@ -1389,3 +1451,4 @@
   window.addEventListener("resize", function () { setSideOpen(document.body.classList.contains("ws-side-open")); });
   setSideOpen(false);
 })();
+  initSessionFilters();

--- a/harness/serve/workspace/workspace.html
+++ b/harness/serve/workspace/workspace.html
@@ -37,6 +37,11 @@
   <ul id="ws-task-list" class="ws-sub" data-ws-task-list role="list">
     <li class="ws-item ws-task" data-ws-tasks-loading aria-busy="true">正在读取任务…</li>
   </ul>
+  <div class="ws-session-filters" data-ws-session-filters>
+    <input class="ws-session-search" data-ws-session-search type="search" placeholder="搜索会话" aria-label="按关键词搜索会话">
+    <select class="ws-session-select" data-ws-session-project aria-label="按项目筛选"><option value="">全部项目</option></select>
+    <select class="ws-session-select" data-ws-session-status aria-label="按状态筛选"><option value="">全部状态</option><option value="running">运行中</option><option value="done">已完成</option><option value="recovered">待恢复</option><option value="empty">空会话</option></select>
+  </div>
 
   <footer class="ws-side-foot ws-nav">
     <button class="ws-item" type="button"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="8" cy="8" r="2.2"/><path d="M8 1.8v2M8 12.2v2M1.8 8h2M12.2 8h2M3.6 3.6l1.4 1.4M11 11l1.4 1.4M12.4 3.6 11 5M5 11l-1.4 1.4"/></svg>设置</button>

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -125,6 +125,11 @@ func TestServeWorkspaceSelectorContract(t *testing.T) {
 		`"/resume"`,           // task switching keeps session content server-side
 		`"/new"`,              // creating a task enters a fresh session
 		`"/workspace/events"`, // GUI-4 versioned SSE transport
+		`data-ws-session-search`,
+		`data-ws-session-project`,
+		`data-ws-session-status`,
+		`function filterSessions`,
+		`function initSessionFilters`,
 		`模型不可用`,               // explicit unavailable-model signal (#405 acceptance)
 	} {
 		if !strings.Contains(js, want) {
@@ -302,7 +307,7 @@ func TestServeSessionsExposeInFlight(t *testing.T) {
 		if _, ok := row["path"].(string); !ok {
 			t.Errorf("/sessions[%d] missing string path", i)
 		}
-		for key, want := range map[string]string{"in_flight": "bool", "current": "bool", "turns": "number", "title": "string"} {
+		for key, want := range map[string]string{"in_flight": "bool", "current": "bool", "turns": "number", "title": "string", "status": "string", "project": "string", "updated_at": "string", "failure": "string"} {
 			v, ok := row[key]
 			if !ok {
 				continue


### PR DESCRIPTION
## Summary\n- expose persisted session status, project, updated timestamp, and recovery reason\n- sort history by actual activity time instead of directory enumeration order\n- add keyword, project, and status filters while reusing the existing /resume flow\n\n## Verification\n- go test ./harness/serve\n- 
ode --check harness/serve/workspace/shell.js\n- git diff --check\n\nCloses #413