### PR TITLE
feat(desktop): add Windows workspace launcher (#414)

### DIFF
--- a/docs/gui/desktop-shell.md
+++ b/docs/gui/desktop-shell.md
@@ -1,0 +1,39 @@
+# Windows desktop shell
+
+Issue #414 introduces a desktop entry point without creating a second agent
+runtime. The supported Windows launcher is `scripts/semantix-desktop.cmd` (or
+the PowerShell script directly):
+
+```powershell
+scripts\semantix-desktop.cmd -ProjectPath C:\work\my-project
+scripts\semantix-desktop.cmd -Stop
+```
+
+## Lifecycle contract
+
+- The launcher starts the existing `semantix-agent web` command in a hidden
+  child process. The child uses the selected project as its working directory,
+  so its session store, config and tools resolve exactly as they do from the
+  CLI.
+- `--port-file` is used to read the actual bound address. The `web` command's
+  existing retry behavior handles a busy requested port; the launcher reports
+  the selected port instead of guessing it.
+- The web command owns authentication and opens its tokenized URL. No API key
+  or token is copied into launcher arguments or persisted by this script.
+- Closing the browser window does not terminate the child, so an active task
+  keeps running. `-Stop` terminates only the PID recorded by this launcher.
+- `semantix-agent` and `semantix-agent serve` remain unchanged and can run
+  independently of the launcher.
+
+## Native-shell decision
+
+The repository has no Wails/Tauri module today. Wails v2 is the follow-up
+native-shell choice because the backend is Go and the current web workspace can
+be embedded without changing the controller/event contracts. It is deliberately
+not added to this phase: a native wrapper would add CGO/WebView2 build and
+distribution requirements before the web workbench contract is stable. The
+launcher above is the low-risk desktop adapter and is the migration seam for a
+future Wails window.
+
+Non-goals for this phase are auto-update, installers, system-tray behavior,
+cross-platform packaging, and a second IPC/event model.

--- a/scripts/semantix-desktop.cmd
+++ b/scripts/semantix-desktop.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0semantix-desktop.ps1" %*
+endlocal

--- a/scripts/semantix-desktop.ps1
+++ b/scripts/semantix-desktop.ps1
@@ -1,0 +1,67 @@
+[CmdletBinding()]
+param(
+  [string]$ProjectPath = (Get-Location).Path,
+  [string]$Address = "127.0.0.1:8787",
+  [string]$AgentPath = "semantix-agent",
+  [switch]$Stop
+)
+
+$ErrorActionPreference = "Stop"
+$stateRoot = Join-Path ([System.IO.Path]::GetTempPath()) "semantix-desktop"
+$portFile = Join-Path $stateRoot "address.txt"
+$pidFile = Join-Path $stateRoot "agent.pid"
+$stdoutFile = Join-Path $stateRoot "agent.stdout.log"
+$stderrFile = Join-Path $stateRoot "agent.stderr.log"
+
+New-Item -ItemType Directory -Force -Path $stateRoot | Out-Null
+
+if ($Stop) {
+  if (-not (Test-Path -LiteralPath $pidFile)) {
+    Write-Output "No Semantix desktop process is recorded."
+    exit 0
+  }
+  $pid = [int](Get-Content -LiteralPath $pidFile -Raw).Trim()
+  $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+  if ($null -ne $process) {
+    if ($process.ProcessName -ne "semantix-agent") {
+      throw "Refusing to stop PID $pid because it is not semantix-agent. Remove $pidFile after checking it."
+    }
+    Stop-Process -Id $pid -Force
+    Write-Output "Stopped semantix-agent (PID $pid)."
+  } else {
+    Write-Output "Semantix desktop process $pid is no longer running."
+  }
+  Remove-Item -LiteralPath $pidFile -Force -ErrorAction SilentlyContinue
+  Remove-Item -LiteralPath $portFile -Force -ErrorAction SilentlyContinue
+  exit 0
+}
+
+$project = (Resolve-Path -LiteralPath $ProjectPath).Path
+Remove-Item -LiteralPath $portFile -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $stdoutFile, $stderrFile -Force -ErrorAction SilentlyContinue
+
+$arguments = @("web", "--addr", $Address, "--port-file", $portFile, "--open")
+$process = Start-Process -FilePath $AgentPath -ArgumentList $arguments -WorkingDirectory $project -WindowStyle Hidden -PassThru -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
+$process.Id | Set-Content -LiteralPath $pidFile -Encoding ascii
+
+$deadline = (Get-Date).AddSeconds(15)
+$actualAddress = $null
+while ((Get-Date) -lt $deadline) {
+  if (Test-Path -LiteralPath $portFile) {
+    $actualAddress = (Get-Content -LiteralPath $portFile -Raw).Trim()
+    if ($actualAddress) { break }
+  }
+  if ($process.HasExited) {
+    $errorText = if (Test-Path -LiteralPath $stderrFile) { Get-Content -LiteralPath $stderrFile -Raw } else { "" }
+    throw "semantix-agent web exited with code $($process.ExitCode). $errorText"
+  }
+  Start-Sleep -Milliseconds 150
+}
+
+if (-not $actualAddress) {
+  throw "Timed out waiting for semantix-agent web to bind. See $stderrFile"
+}
+
+Write-Output "Semantix desktop workspace is running at http://$actualAddress/"
+Write-Output "Project: $project"
+Write-Output "PID: $($process.Id) (browser-window close does not stop the task; run with -Stop to stop it)"

--- a/scripts/semantix-desktop_test.ps1
+++ b/scripts/semantix-desktop_test.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$launcher = Get-Content -LiteralPath (Join-Path $PSScriptRoot "semantix-desktop.ps1") -Raw
+$doc = Get-Content -LiteralPath (Join-Path $root "docs\gui\desktop-shell.md") -Raw
+foreach ($needle in @("--port-file", "-WorkingDirectory", "-WindowStyle Hidden", "-Stop", "semantix-agent web")) {
+  if ($launcher -notmatch [regex]::Escape($needle)) { throw "launcher missing $needle" }
+}
+foreach ($needle in @("Lifecycle contract", "Wails v2", "Closing the browser window")) {
+  if ($doc -notmatch [regex]::Escape($needle)) { throw "desktop doc missing $needle" }
+}
+Write-Output "desktop launcher contract passed"


### PR DESCRIPTION
## Summary\n- add a one-click Windows launcher around the existing semantix-agent web runtime\n- preserve project working-directory semantics and report the actual retried port\n- keep browser-window closure independent from the running task and provide a guarded -Stop action\n- document the Wails v2 native-shell decision seam and current non-goals\n\n## Verification\n- powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/semantix-desktop_test.ps1\n- go test ./harness/serve\n- git diff --check\n\nCloses #414