### PR TITLE
docs: 社区就绪——去滞后文档 + 英文 ROADMAP + 社区入口

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,48 @@
 # 贡献指南（Contributing）
 
-感谢你参与 Semantix！本文档描述贡献流程与验收标准。
+感谢你参与 Semantix！本文档描述贡献流程与验收标准。English speakers are very welcome — issues / PRs / reviews in English are fine, and we will reply in kind.
+
+- 🗺️ 路线图：[`docs/Agile路线图.md`](docs/Agile路线图.md)（唯一事实来源）
+- 🐛 报 bug / 提需求：[Issue 模板](https://github.com/Gnosil/semantix/issues/new/choose)
+- 💬 讨论：[GitHub Discussions](https://github.com/Gnosil/semantix/discussions)
+- 🔒 安全漏洞：不要开公开 issue，见 [SECURITY.md](SECURITY.md)
 
 ## 项目结构
 
 ```
-kernel/          内核包（事件/切片/BM25/缓存/调度/预取/进化）
-cmd/semantix     CLI 入口（extract / search）
-docs/            架构与契约文档（events.md = 事件契约权威来源）
+kernel/          内核包（切片/BM25/embed/缓存/调度/预取/进化/事件/审计）
+harness/         随仓的 agent runtime（provider/工具/权限/会话/UI），harness/semantix 为事件桥
+gateway/         OpenAI 兼容网关（检索注入、L3 复用、fail-open 上游）
+cmd/             三个入口：semantix（CLI）/ semantix-agent（agent）/ semantix-gateway
+docs/            架构与契约文档（events.md = 事件契约权威来源；specs/ = 行为契约；reports/ = 验收报告）
+site/            官网（semantix.ensureok.ai，Next.js 静态导出）
 ```
 
-## 工作流（M0 阶段）
+## 工作流
 
-1. **认领单元**：在对应 Issue（如 `M0-2`）下评论认领（如 `U5 BM25`），避免重复劳动。
-2. **建分支**：从最新 `feat/kernel-skeleton`（或 `main`）切出 `feat/uN-<主题>`。
-3. **实现 + 测试**：每个单元必须带单元测试；接口变更先对齐 `kernel/` 已冻结契约。
-4. **本地验证**（必过）：
+1. **认领**：在目标 issue 下评论认领，避免重复劳动。没有 issue 的新想法请先开 issue（或到 Discussions 提案）对齐方向。标了 `good first issue` 的是给新人的入门任务，动手前随时在 issue 里提问。
+2. **建分支**：从最新 `main` 切出，命名 `feat/issue-<N>-<主题>` / `fix/issue-<N>-<主题>` / `docs/<主题>`。
+3. **Spec 先行**：跨包行为变更（kernel↔harness 契约、事件、配置面）先在 `docs/specs/` 写清契约与验收，评审通过再写实现；纯 bug 修复与文档可省略。
+4. **实现 + 测试**：每个行为变更必须带单元测试；新增事件 Kind / payload 字段只增不改。
+5. **本地验证**（必过）：
    ```bash
    go vet ./...
    go test ./... -race
    git diff --check
    ```
-5. **开 PR**：target `feat/kernel-skeleton`（合并入 main 前先汇主线）；标题 `U<N>: <描述>`；描述里勾选对应 Issue checklist 并写 `Fixes #N`（收尾单元）。
-6. **合并**：至少 1 人 review；fork 提交者注意——PR head 在自己 fork 时，修改后需推回 fork 分支（主仓库同名分支不会更新 PR）。
+   改了 `site/` 还需过 `cd site && npm run test:content`。
+6. **开 PR**：target `main`；标题用 `feat(scope): 描述 (Issue #N)` / `fix(scope): 描述 (Issue #N)`，描述里勾选 PR 模板 checklist、写 `Fixes #N`；行为变更需附验收说明（报告放 `docs/reports/`）。
+7. **合并**：至少 1 人 review；fork 提交者注意——PR head 在自己 fork 时，修改后需推回 fork 分支（主仓库同名分支不会更新 PR）。
 
 ## 契约纪律
 
 - `kernel/event`：Kind 序号与 payload 字段名是 **wire 契约**，只增不改；改事件必须同步 `docs/events.md`。
 - 依赖：保持零第三方依赖（MVP 原则）；确需引入时在 PR 描述说明理由。
 - 敏感数据：store 文件权限 `0o600`；不得提交凭据/本地绝对路径。
+- 文档同步：改 CLI 命令面/配置键要同步 `docs/QUICKSTART.md`；改架构行为要同步 `docs/Agent-Infra-架构设计.md`。
 
-## 验收标准（M0-Gate）
+## 验收标准
 
-- `go vet ./... && go test ./... -race` 全绿
-- 真实会话提取 ≥500 切片；search 相关率 ≥70%（人工抽 10 条 query）
-- 事件契约与 docs/events.md 一致；安全 review 无 blocking 项
+- `go vet ./... && go test ./... -race` 全绿，CI 无红
+- spec（如有）的验收清单全部勾选并在 PR 描述可追溯
+- 事件契约与 `docs/events.md` 一致；安全 review 无 blocking 项

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Cursor, Windsurf, Codex CLI, Gemini CLI, Copilot agent mode and Cline / Continue
 
 | Doc | What's inside |
 | --- | --- |
+| [ROADMAP.md](./ROADMAP.md) | Shipped / in progress / next (English summary) |
 | [docs/TECHNICAL-OVERVIEW.md](./docs/TECHNICAL-OVERVIEW.md) | **Start here** — concepts, cache layers, scheduler, prefetch, evolution loop, architecture, module map, status, roadmap, metrics |
 | [docs/QUICKSTART.md](./docs/QUICKSTART.md) | Install, 30-second demo, command reference, configuration |
 | [docs/Agent-Infra-架构设计.md](./docs/Agent-Infra-架构设计.md) | Full architecture design (Chinese) |
@@ -136,9 +137,15 @@ Cursor, Windsurf, Codex CLI, Gemini CLI, Copilot agent mode and Cline / Continue
 | [agent-skill/SKILL.md](./agent-skill/SKILL.md) | Self-serve integration for any harness |
 | [semantix.ensureok.ai](https://semantix.ensureok.ai) | Website, product docs and the blog |
 
+## Community
+
+- 💬 [GitHub Discussions](https://github.com/Gnosil/semantix/discussions) — Q&A, ideas, show & tell
+- 🐛 [Issue tracker](https://github.com/Gnosil/semantix/issues) — `good first issue` is the place to start
+- 📖 [Blog](https://semantix.ensureok.ai/blog) — semantic caching and agent-memory write-ups
+
 ## Contributing
 
-Semantix is early-stage. Contributions are welcome across semantic caching, retrieval, scheduling, speculative execution, evaluation methodology and harness adapters — see [CONTRIBUTING.md](./CONTRIBUTING.md). Branch naming `feat/<unit>`; PRs require green `go vet` and `go test -race`.
+Semantix is early-stage. Contributions are welcome across semantic caching, retrieval, scheduling, speculative execution, evaluation methodology and harness adapters — see [CONTRIBUTING.md](./CONTRIBUTING.md) for the workflow (branch from `main`, PRs require green `go vet` and `go test -race`). Issues and PRs in English or Chinese are both fine.
 
 **Without writing code:** run `semantix verify` against your own sessions and post the resulting hit rate to [#58](https://github.com/Gnosil/semantix/issues/58). Aggregated community results decide the v1.0 gate.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,6 +128,7 @@ Cursor、Windsurf、Codex CLI、Gemini CLI、Copilot agent 模式、Cline / Cont
 
 | 文档 | 内容 |
 | --- | --- |
+| [ROADMAP.md](./ROADMAP.md) | 已发布 / 进行中 / 下一步（英文摘要，中文版为唯一事实来源） |
 | [docs/TECHNICAL-OVERVIEW.zh-CN.md](./docs/TECHNICAL-OVERVIEW.zh-CN.md) | **从这里开始** —— 核心概念、三级缓存、调度与预取、复用可视化、模块地图、项目状态、安全设计 |
 | [docs/QUICKSTART.md](./docs/QUICKSTART.md) | 安装、命令参考、shell 补全、配置 |
 | [docs/Agent-Infra-架构设计.md](./docs/Agent-Infra-架构设计.md) | 完整架构设计（问题、分层、组件、风险、指标） |
@@ -137,9 +138,15 @@ Cursor、Windsurf、Codex CLI、Gemini CLI、Copilot agent 模式、Cline / Cont
 | [agent-skill/SKILL.md](./agent-skill/SKILL.md) | 面向任意 harness 的自助集成 |
 | [semantix.ensureok.ai](https://semantix.ensureok.ai) | 官网、产品文档与博客 |
 
+## 社区
+
+- 💬 [GitHub Discussions](https://github.com/Gnosil/semantix/discussions) — 问答、想法、展示
+- 🐛 [Issue 列表](https://github.com/Gnosil/semantix/issues) — 认领 `good first issue` 入门
+- 📖 [博客](https://semantix.ensureok.ai/blog) — 语义缓存与 agent 记忆层系列文章
+
 ## 参与贡献
 
-Semantix 处于早期阶段。语义缓存、检索、调度、投机执行、评测方法、harness 适配器等方向均欢迎贡献，参与方式见 [CONTRIBUTING.md](./CONTRIBUTING.md)。分支命名 `feat/<unit>`，PR 需 `go vet` 与 `go test -race` 全绿。
+Semantix 处于早期阶段。语义缓存、检索、调度、投机执行、评测方法、harness 适配器等方向均欢迎贡献，工作流见 [CONTRIBUTING.md](./CONTRIBUTING.md)（从 `main` 切分支，PR 需 `go vet` 与 `go test -race` 全绿）。中英文 issue / PR 均可。
 
 **无需写代码的参与方式：** 以自有会话运行 `semantix verify`，将命中率结果提交至 [#58](https://github.com/Gnosil/semantix/issues/58)。社区汇总结果决定 v1.0 门禁是否通过。
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,29 @@
+# Roadmap
+
+> Source of truth: [`docs/Agile路线图.md`](docs/Agile路线图.md) (Chinese). This file is the English summary kept in sync at each release. Last updated: 2026-08-29 (v0.7.2).
+
+## Shipped
+
+| Milestone | Goal | Status |
+| --- | --- | --- |
+| **Agile 1** (M0 + M1 + CLI v2) | First downloadable branded agent: kernel + agent bundle, install-and-run, visible reuse metrics | ✅ v0.4.1 (CLI v2 complete: command tree, config, `--json` envelope, completion, doctor, install, gc, serve) |
+| **Agile 2** — self-evolving loop | Kernel orchestrates the harness: resource scheduling, model tiers, speculative prefetch, evolution loop with causal before/after curves | ✅ v0.6.0 (2026-08-21) |
+| **v0.7.x** — GLM adaptation + gateway economics | Zhipu GLM-5.x adaptation (prefix hygiene, hit telemetry → tier mapping, quality gates), gateway billing, config protection | ✅ v0.7.2 |
+
+## In progress
+
+- **Coding-agent desktop GUI (v0.8.0)** — epic [#403](https://github.com/Gnosil/semantix/issues/403), GUI-1…GUI-12 tracked as [#404](https://github.com/Gnosil/semantix/issues/404)–[#415](https://github.com/Gnosil/semantix/issues/415): workspace shell, session sidebar, conversation/tool cards, diff review, composer, observability status bar, history, desktop shell, release checks.
+- **Credibility gate [#58](https://github.com/Gnosil/semantix/issues/58)** — real-data hit-rate ≥ 70% over a 30-day window (`semantix verify` replay). This is the single remaining Agile 1 gate for v1.0. Community-run `verify` results count: post yours to the issue.
+- **Memory-arm benchmark rerun** — kernel-on SWE-bench arms after the four memory-kernel fixes (R1–R4, [#425](https://github.com/Gnosil/semantix/issues/425)–[#428](https://github.com/Gnosil/semantix/issues/428)) landed; see [`docs/reports/swebench-harness-comparison.md`](docs/reports/swebench-harness-comparison.md).
+
+## Next
+
+- **Agile 3 — multi-harness ecosystem**: ≥3 external harnesses formally integrated (serve/watch already shipped in CLI v2). Integration paths: [agent skill](agent-skill/SKILL.md), tool registration, OpenAI-compatible gateway.
+- **Gateway line (GW2–GW7)**: streaming memory side-writes, deployment artifacts + healthz, full-chain acceptance (second-hit + cost saving ≥ 30%), Anthropic adaptation, config reconciliation.
+- **v1.0**: single-binary bundle install-and-run + hit-rate gate passed + reuse visualization in TUI/desktop.
+
+## Principles
+
+- Every behavior change lands as **spec → implementation → acceptance report** (`docs/specs/`, `docs/reports/`).
+- The event wire contract (`docs/events.md`) is append-only.
+- Fail-open everywhere: a broken kernel never blocks the agent's normal path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,10 +12,11 @@ Semantix 是架设在 agent harness 与资源之间的**自进化 Agent Kernel �
 
 | 版本 | 状态 | 安全支持 |
 |---|---|---|
-| `main`（设计/原型阶段） | 活跃开发 | ✅ 修复直接合入 main |
-| 首个稳定发布（尚未发布） | — | 发布后：最新稳定标签 + 前一个次版本 |
+| latest release（[v0.7.x](https://github.com/Gnosil/semantix/releases) 及之后） | 活跃维护 | ✅ 安全修复以 patch release 发布 |
+| `main` | 活跃开发 | ✅ 修复优先合入 main，随下一个版本发布 |
+| 更早的 release 标签 | — | ❌ 请升级到最新版本 |
 
-> 项目当前处于设计阶段（架构文档 v2 完成，P0 未开工）。安全修复将优先合入 `main`，随下一个版本发布。
+> 项目处于快速迭代期（当前 v0.7.x）。安全修复将优先合入 `main`，并随下一个 patch/minor release 发布；涉及已发布版本的修复会在 Release Notes 中标注。
 
 ---
 


### PR DESCRIPTION
## 内容

推广前置的社区基建（对应推广计划阶段一.2 + 阶段二.5）：

- **SECURITY.md**：支持版本表还停在「设计阶段 P0 未开工」，更新到 v0.7.x release 维护口径——外部安全研究者第一眼看的就是这张表
- **CONTRIBUTING.md**：工作流从 M0 阶段（feat/kernel-skeleton 分支 / U 编号认领）重写为当前实践：main 切分支、spec 先行、文档同步、site 内容测试；补 Discussions / good first issue / 安全报告入口；声明中英文 issue/PR 均可
- **新增顶层 ROADMAP.md（英文）**：shipped（v0.4.1 / v0.6.0 / v0.7.x）· in progress（GUI v0.8.0 epic、#58 命中率门禁、memory-arm 重跑）· next（Agile 3、GW2–GW7、v1.0）；中文 `docs/Agile路线图.md` 仍为唯一事实来源，本文件随 release 同步
- **两份 README**：新增 Community 节（Discussions / issues / blog）；参与贡献节去掉过时的 `feat/<unit>` 分支命名；文档表加 ROADMAP 行

## Validation

- [x] 纯文档改动，无代码影响
- [x] 链接均为仓库内相对路径或已存在的 GitHub 资源（Discussions 需先开启，见下方备注）

## 备注

- README 中的 Discussions 链接在本 PR 合并前先由仓库设置开启 Discussions（Announcements / Q&A / Ideas / Show and tell 四个分类）