### PR TITLE
release: v0.7.3 发版记录 + 版本徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Semantic Caching · Adaptive Scheduling · Speculative Prefetch · Cross-Session Learning**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](./LICENSE)
-[![Version](https://img.shields.io/badge/release-0.7.2-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
+[![Version](https://img.shields.io/badge/release-0.7.3-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
 [![GitHub stars](https://img.shields.io/github/stars/Gnosil/semantix?style=flat-square&logo=github)](https://github.com/Gnosil/semantix/stargazers)
 [![GitHub contributors](https://img.shields.io/github/contributors/Gnosil/semantix?style=flat-square&logo=github)](https://github.com/Gnosil/semantix/graphs/contributors)
 [![Website](https://img.shields.io/badge/website-semantix.ensureok.ai-168b6d?style=flat-square)](https://semantix.ensureok.ai)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 **语义缓存 · 自适应调度 · 投机预取 · 跨会话学习**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](./LICENSE)
-[![Version](https://img.shields.io/badge/release-0.7.2-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
+[![Version](https://img.shields.io/badge/release-0.7.3-blue?style=flat-square)](https://github.com/Gnosil/semantix/releases)
 [![GitHub stars](https://img.shields.io/github/stars/Gnosil/semantix?style=flat-square&logo=github)](https://github.com/Gnosil/semantix/stargazers)
 [![GitHub contributors](https://img.shields.io/github/contributors/Gnosil/semantix?style=flat-square&logo=github)](https://github.com/Gnosil/semantix/graphs/contributors)
 [![Website](https://img.shields.io/badge/website-semantix.ensureok.ai-168b6d?style=flat-square)](https://semantix.ensureok.ai)

--- a/docs/releases/v0.7.3.md
+++ b/docs/releases/v0.7.3.md
@@ -1,0 +1,45 @@
+# v0.7.3 — 记忆内核四连修 + kernel 消融
+
+> 发版日期：2026-08-28 · tag：`v0.7.3` · 范围：v0.7.2 之后合入 main 的 [#431](https://github.com/Gnosil/semantix/pull/431)（PR #402 的代码修复拆分落地）
+
+## 升级须知
+
+**本版无破坏性变更。** 配置面只增不改（`[semantix].project_dir` 新键可选）；CLI 只改了 `--ablate` 帮助文案与 `--ablate all` 的模块集合（`full-fold` → `kernel`，见下）。
+
+**强烈建议所有用户升级**：本版修复了一个会让记忆内核静默失效的 main 线 bug（R2）——如果你的 `[semantix]` 配置"莫名消失过"，就是它。
+
+## 背景：SWE-bench 记忆臂复盘（#425–#428）
+
+50 题 SWE-bench campaign 复盘发现 semantix 臂**全程运行在记忆内核关闭态**——语义库零写入、零检索、无学习曲线，且三天无人察觉。根因是四个相互独立的缺陷（缺一即全链失效），完整根因链见 [`docs/specs/swebench-memory-arm.md`](../specs/swebench-memory-arm.md)。
+
+### R2 — RenderTOML 静默删除 `[semantix]` 段（#426，紧急）
+
+`RenderTOML` 模板此前不渲染 `[semantix]` 段：任何配置保存/迁移（如缺 `config_version` 触发的落盘迁移）都会**静默删除**该段，内核就此关闭且无任何报错。现补渲染（布尔恒打印、可选字段注释默认值），往返测试覆盖。
+
+### R1 — SWE-bench runner 未接入内核（#425）
+
+runner 生成的 config.toml 没有 `[semantix]` 段，内核整体短路。新增 flag `--semantix-memory on|off`（默认 **on**）：每实例独立 `SEMANTIX_HOME`（并发归属无竞态），`project_dir` 指向共享切片库，每实例结束后 runner 跑 `semantix extract` 关闭记忆闭环。记忆对照实验请用这对臂，不要用 `--ablate`。
+
+### R3 — 会话镜像永远为空（#427）
+
+同步 run 从不发 `TurnDone`、headless 退出跳过 `Close`，镜像 JSONL 恒 0 字节；且 `TurnStarted` 不带用户文本，user 行与 Prompt 切片不可能产生。修复：`TurnStarted` 携带用户文本；`HarnessSink`/`Bridge` 新增 `EndTurn()`，`emitReuse` 覆盖所有 Run 返回路径。端到端冒烟（双实例）已验证跨实例切片注入闭环。
+
+### R4 — 内核计数进 `--metrics`（#428-A）
+
+`RunMetrics` 新增 `semantix_inject_turns` / `semantix_inject_bytes` / `reuse_hits` / `reuse_savings`（omitempty）与新 Notice 码 `semantix_inject`——"记忆臂真的注入了"与"记忆臂冷跑"从此可判读。
+
+## `--ablate kernel` 消融模块（#428-B）
+
+- 新增 `kernel` 消融模块：`--ablate kernel` 在 boot 建 bridge 时强制关闭记忆内核，**单进程内**即可做记忆消融，不再依赖 runner 层两臂配置；`--ablate all` 随之包含内核。
+- 移除从无消费者的 `full-fold` 模块（仓库内不存在 fold/projection 逻辑，属死配置）。
+- `--ablate all` 的 arm 名从 `…+no-full-fold` 变为 `…+no-kernel`（full-fold 本就无行为，结果等价）。
+
+## 其他
+
+- `[semantix]` 新增可选键 `project_dir`：多实例共享同一切片库。
+- 社区基建：GitHub Discussions 开张（[欢迎帖](https://github.com/Gnosil/semantix/discussions/435)）、SECURITY.md / CONTRIBUTING.md 去滞后、新增英文 [ROADMAP.md](../../ROADMAP.md)。
+
+## 下一步
+
+- kernel-on 的 SWE-bench 重跑留在 [draft PR #402](https://github.com/Gnosil/semantix/pull/402)（等 API 余额恢复）；记忆对照以 `--semantix-memory on|off` 两臂为准。
+- [#58 真实数据命中率 ≥ 70%](https://github.com/Gnosil/semantix/issues/58) 仍是 v1.0 的唯一 P0 门禁，欢迎用自有会话跑 `semantix verify` 并回帖。


### PR DESCRIPTION
## 内容

- `docs/releases/v0.7.3.md`：记忆内核四连修（R1–R4）+ `--ablate kernel` 消融模块的发版记录，含升级须知（无破坏性变更）
- README（中英）版本徽章 → 0.7.3

## 合并后操作

合并即发 tag `v0.7.3`（annotated tag，注释随 tag message），release.yml 构建四平台资产。

## Validation

- [x] 纯文档改动