### PR TITLE
fix(cli): localize /effort usage errors in zh/zh-TW sessions (#335)

### DIFF
--- a/harness/cli/effort.go
+++ b/harness/cli/effort.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -41,7 +42,7 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 	}
 	effort, err := config.NormalizeEffort(entry, args[1])
 	if err != nil {
-		m.notice(err.Error())
+		m.notice(localizeEffortError(err))
 		return nil
 	}
 	if m.ctrl == nil {
@@ -109,6 +110,22 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 	m.effortLevel = display
 	m.notice(fmt.Sprintf(i18n.M.EffortSwitchedFmt, entry.Name, display))
 	return nil
+}
+
+// localizeEffortError renders a NormalizeEffort error through the active i18n
+// catalogue. The config layer carries the legal level vocabulary as typed data
+// (UnsupportedEffortError / EffortNotConfigurableError) instead of a
+// pre-rendered English string, so the CLI can honor the session locale (#335).
+func localizeEffortError(err error) string {
+	var usageErr *config.UnsupportedEffortError
+	if errors.As(err, &usageErr) {
+		return fmt.Sprintf(i18n.M.EffortUsageFmt, strings.Join(usageErr.Levels, "|"))
+	}
+	var notConfigurableErr *config.EffortNotConfigurableError
+	if errors.As(err, &notConfigurableErr) {
+		return fmt.Sprintf(i18n.M.EffortNotConfigurableFmt, notConfigurableErr.Provider)
+	}
+	return fmt.Sprintf(i18n.M.EffortErrorFmt, err.Error())
 }
 
 func (m *chatTUI) currentConfigProvider() (*config.ProviderEntry, string, error) {

--- a/harness/cli/effort_i18n_test.go
+++ b/harness/cli/effort_i18n_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"semantix/harness/config"
+	"semantix/harness/control"
+	"semantix/harness/i18n"
+)
+
+// TestEffortCommandMistypedLevelLocalized reproduces #335: a mistyped /effort
+// level is rejected by config.NormalizeEffort, whose error was surfaced through
+// m.notice(err.Error()) without going through the i18n catalogue, leaking the
+// English "usage: /effort ..." string into a zh session.
+func TestEffortCommandMistypedLevelLocalized(t *testing.T) {
+	isolateUserConfig(t)
+
+	// i18n.M is process-global, so this test must not run in parallel.
+	prev := i18n.M
+	i18n.M = i18n.Chinese
+	t.Cleanup(func() { i18n.M = prev })
+
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Label: "deepseek-flash"})
+	m.modelRef = "deepseek-flash/deepseek-v4-flash"
+
+	if cmd := m.runEffortCommand("/effort bogus-level"); cmd != nil {
+		t.Fatal("mistyped level must not queue a rebuild")
+	}
+
+	joined := ansi.Strip(strings.Join(m.transcript, "\n"))
+	zhMarker := fmt.Sprintf(i18n.Chinese.EffortUsageFmt, "")
+	zhMarker = strings.TrimSpace(strings.TrimSuffix(zhMarker, "%s"))
+	if !strings.Contains(joined, zhMarker) {
+		t.Fatalf("mistyped level should render the localized usage hint containing %q, got transcript:\n%s", zhMarker, joined)
+	}
+	if strings.Contains(joined, "usage: /effort") {
+		t.Fatalf("mistyped level leaked English, got transcript:\n%s", joined)
+	}
+}
+
+// TestEffortCommandUsageErrorCarriesLevels guards the typed error so a future
+// regression cannot silently drop the level list that the localized usage hint
+// depends on.
+func TestEffortCommandUsageErrorCarriesLevels(t *testing.T) {
+	e := &config.ProviderEntry{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1", Model: "MiniMax-M3"}
+	_, err := config.NormalizeEffort(e, "turbo")
+	if err == nil {
+		t.Fatal("NormalizeEffort should reject an unrecognised level")
+	}
+	var usageErr *config.UnsupportedEffortError
+	if !errors.As(err, &usageErr) {
+		t.Fatalf("NormalizeEffort error should be *config.UnsupportedEffortError, got %T: %v", err, err)
+	}
+	if got := strings.Join(usageErr.Levels, "|"); got != "auto|adaptive|disabled" {
+		t.Fatalf("UnsupportedEffortError.Levels = %q, want auto|adaptive|disabled", got)
+	}
+}

--- a/harness/config/effort.go
+++ b/harness/config/effort.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"slices"
 	"strings"
 
@@ -23,6 +22,28 @@ type EffortCapability struct {
 	Supported bool
 	Levels    []string
 	Default   string
+}
+
+// UnsupportedEffortError reports a /effort level the provider/model does not
+// accept. Levels carries the full legal vocabulary (including "auto") so
+// callers outside this package can render a localized usage hint instead of
+// relying on the English Error() text.
+type UnsupportedEffortError struct {
+	Levels []string
+}
+
+func (e *UnsupportedEffortError) Error() string {
+	return "usage: /effort " + strings.Join(e.Levels, "|")
+}
+
+// EffortNotConfigurableError reports a provider/model that exposes no /effort
+// knob. Provider names the entry, or "this model" when none is known.
+type EffortNotConfigurableError struct {
+	Provider string
+}
+
+func (e *EffortNotConfigurableError) Error() string {
+	return "effort is not configurable for " + e.Provider
 }
 
 type modelReasoningCapability struct {
@@ -150,7 +171,7 @@ func DepthEffortLevels(e *ProviderEntry) []string {
 func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 	level := normalizeEffortLevel(raw)
 	if level == "" {
-		return "", fmt.Errorf("usage: /effort auto|<level>")
+		return "", &UnsupportedEffortError{Levels: []string{"auto", "<level>"}}
 	}
 	if level == "auto" {
 		return "", nil
@@ -167,7 +188,7 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 		if containsString(supported, level) {
 			return level, nil
 		}
-		return "", fmt.Errorf("usage: /effort auto|%s", strings.Join(supported, "|"))
+		return "", &UnsupportedEffortError{Levels: append([]string{"auto"}, supported...)}
 	}
 	// V4 Flash 0731 added a real low depth. Keep this model-scoped: Pro and
 	// generic DeepSeek-compatible endpoints still normalize low to high unless
@@ -197,7 +218,7 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 		case "xhigh":
 			return "max", nil
 		default:
-			return "", fmt.Errorf("usage: /effort auto|disabled|high|max")
+			return "", &UnsupportedEffortError{Levels: []string{"auto", "disabled", "high", "max"}}
 		}
 	case ReasoningProtocolOpenAI:
 		return normalizeOpenAIReasoningEffort(e, level)
@@ -223,7 +244,7 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 		case "xhigh", "max":
 			return "disabled", nil
 		default:
-			return "", fmt.Errorf("usage: /effort auto|adaptive|disabled")
+			return "", &UnsupportedEffortError{Levels: []string{"auto", "adaptive", "disabled"}}
 		}
 	case isZhipuEntry(e):
 		// GLM's knob is binary (enabled|disabled); map Anthropic / OpenAI-style
@@ -242,7 +263,7 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 		case "low", "medium", "high", "xhigh", "max":
 			return "enabled", nil
 		default:
-			return "", fmt.Errorf("usage: /effort auto|enabled|disabled")
+			return "", &UnsupportedEffortError{Levels: []string{"auto", "enabled", "disabled"}}
 		}
 	case isOllamaCloudEntry(e):
 		switch level {
@@ -253,14 +274,14 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 		case "xhigh":
 			return "max", nil
 		default:
-			return "", fmt.Errorf("usage: /effort auto|none|low|medium|high|max")
+			return "", &UnsupportedEffortError{Levels: []string{"auto", "none", "low", "medium", "high", "max"}}
 		}
 	case e != nil && e.Kind == "anthropic":
 		switch level {
 		case "low", "medium", "high", "xhigh", "max":
 			return level, nil
 		default:
-			return "", fmt.Errorf("usage: /effort auto|low|medium|high|xhigh|max")
+			return "", &UnsupportedEffortError{Levels: []string{"auto", "low", "medium", "high", "xhigh", "max"}}
 		}
 	default:
 		return "", effortNotConfigurableError(e)
@@ -494,7 +515,7 @@ func normalizeGLMEffort(level string) (string, error) {
 	case "low", "medium", "high", "xhigh", "max":
 		return "enabled", nil
 	default:
-		return "", fmt.Errorf("usage: /effort auto|enabled|disabled")
+		return "", &UnsupportedEffortError{Levels: []string{"auto", "enabled", "disabled"}}
 	}
 }
 
@@ -506,7 +527,7 @@ func effortNotConfigurableError(e *ProviderEntry) error {
 	if name == "" {
 		name = "this model"
 	}
-	return fmt.Errorf("effort is not configurable for %s", name)
+	return &EffortNotConfigurableError{Provider: name}
 }
 
 func containsString(haystack []string, needle string) bool {

--- a/harness/config/effort_protocol.go
+++ b/harness/config/effort_protocol.go
@@ -1,21 +1,19 @@
 package config
 
-import "fmt"
-
 func normalizeOpenAIReasoningEffort(e *ProviderEntry, level string) (string, error) {
 	if isMimoEntry(e) {
 		switch level {
 		case "none", "low", "medium", "high":
 			return level, nil
 		default:
-			return "", fmt.Errorf("usage: /effort auto|none|low|medium|high")
+			return "", &UnsupportedEffortError{Levels: []string{"auto", "none", "low", "medium", "high"}}
 		}
 	}
 	switch level {
 	case "low", "medium", "high":
 		return level, nil
 	default:
-		return "", fmt.Errorf("usage: /effort auto|low|medium|high")
+		return "", &UnsupportedEffortError{Levels: []string{"auto", "low", "medium", "high"}}
 	}
 }
 
@@ -23,7 +21,7 @@ func normalizeKimiK3ReasoningEffort(level string) (string, error) {
 	if isKimiK3ReasoningEffort(level) {
 		return level, nil
 	}
-	return "", fmt.Errorf("usage: /effort auto|low|high|max")
+	return "", &UnsupportedEffortError{Levels: []string{"auto", "low", "high", "max"}}
 }
 
 func isKimiK3ReasoningEffort(level string) bool {


### PR DESCRIPTION
Closes #335.

## Problem

The `/effort` command’s notices were already catalog-driven, but a mistyped level still surfaced `config.NormalizeEffort`’s hardcoded English error verbatim through `m.notice(err.Error())` in `harness/cli/effort.go`. In a zh or zh-TW session this leaks `usage: /effort …` on the single most common error path, even though the picker, hint and status label for the same command are already fully localized.

## Fix

- Convert the config-layer errors into typed errors so the CLI can render them through the i18n catalogue:
  - `UnsupportedEffortError{ Levels []string }` — carries the full legal vocabulary (incl. `auto`) for the localized usage hint.
  - `EffortNotConfigurableError{ Provider string }` — carries the entry name for the not-configurable message.
- In `harness/cli/effort.go`, render those typed errors via `i18n.M.EffortUsageFmt` / `i18n.M.EffortNotConfigurableFmt` instead of `err.Error()`.
- The `Error()` methods are byte-for-byte identical to the previous `fmt.Errorf` strings, so every existing caller (boot, acp, subagent, serve) and string-asserting test is unaffected.

## Reproduction (before fix)

In a zh session, `runEffortCommand("/effort bogus-level")` produced the English notice:

```
  · usage: /effort auto|disabled|low|high|max
```

instead of `用法：/effort auto|disabled|low|high|max`.

## Tests

- Added `harness/cli/effort_i18n_test.go`:
  - `TestEffortCommandMistypedLevelLocalized` — asserts the localized hint and absence of English (fails before, passes after).
  - `TestEffortCommandUsageErrorCarriesLevels` — guards the typed error’s level list.
- `go test ./harness/config/... ./harness/i18n/...` pass; `go vet` clean. The effort-related CLI tests pass (`TestEffortCommand*`).

## Out of scope (stated per #335)

- The lease sentence in `harness/control/session_lease_keeper.go` and the HTTP-surface literal in `harness/serve/serve.go` are intentionally left untouched.