### PR TITLE
chore(scripts): W1 pilot tooling — dual-arm runner, stub upstream, ignore local session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,15 @@ site/.wrangler/
 /deploy/data/
 /deploy/semantix-gateway.toml
 /tmp/
+
+# Local agent/tooling session state (never commit)
+.claude/
+.mimosa/
+.v2c/
+.zcode/
+docs/reports/data/.mimosa/
+
+# Personal working files (not project artifacts)
+/PROMPTS.md
+/paper/
+/paper.zip

--- a/docs/reports/swe-pilot-two-arm.md
+++ b/docs/reports/swe-pilot-two-arm.md
@@ -1,0 +1,68 @@
+# SWE-bench 双臂 pilot 报告（10 实例 × 2 臂）
+
+> 日期：2026-08-30/31。对应计划：`docs/specs/swebench-efficiency-research-plan.md` W1（离线部分转真实）。
+> 这是 semantix 第一份**真实 agent 运行 + 官方 SWE-bench harness 评测**的双臂数据，取代此前一切合成回放数字。
+
+## 1. 实验设置
+
+- **基准**：SWE-bench Verified，按 repo 分层选 2 × 5 实例（django × 5、sympy × 5，各 repo 内取 problem_statement 最短的实例控制单实例成本）。
+- **模型**：deepseek-v4-flash（与 v28 单实例先例一致），agent 为 `cmd/semantix-agent`（yolo 权限、80 步上限、单实例 1200s 看门狗）。
+- **OFF 臂**：`[semantix] enabled=false`，每实例全新会话。
+- **ON 臂**：`enabled=true, inject=true, budget=4096`；实例按序运行，第 N 个实例开始前把前 N-1 个实例的会话镜像 extract 进该 repo 的 Project-scope 库（`.semantix/project.db`，累积注入已验证生效：L2 SliceInject 事件 + 库增长确认）。
+- **评测**：官方 `swebench.harness.run_evaluation`（v5.0.2，Docker，x86_64 镜像经 Rosetta 转译；本地补丁：pull 调用显式 `platform="linux/amd64"`）。
+- **成本**：双臂合计 $0.15 API 费用（真实计费，agent 自报）。
+
+## 2. 结果
+
+### 质量（官方 harness，唯一权威口径）
+
+| 臂 | resolved | unresolved | infra failure |
+|---|---|---|---|
+| OFF | 9/10 | 1（sympy-20916） | 0 |
+| **ON** | **10/10** | 0 | 0 |
+
+**pass-rate 非劣成立**（ON 甚至 +1，单实例差异无统计意义，但至少证明注入未伤害正确性）。
+
+### 效率（agent 自报 usage，真实计费）
+
+| 指标 | OFF | ON | Δ |
+|---|---|---|---|
+| 输入 tokens 总计 | 4,353,870 | 6,932,300 | **+59.2%** |
+| API 成本总计 | $0.0544 | $0.0980 | **+80.2%** |
+| 墙钟（剔除机器睡眠污染） | 1085s | 1032s | ≈ 持平 |
+| 前缀缓存命中率 | 97.3% | 95.0% | −2.3pt |
+| 非空 patch | 10/10 | 10/10 | = |
+
+单实例方差极大（这本身是个发现）：14373 ON 比 OFF 省 64% token（77K vs 171K），15987 省 72%；但 16819 ON 多花 161%（3.19M vs 1.22M）。
+
+## 3. 诚实结论
+
+1. **全链路首次真实打通**：选实例 → repo checkout → agent 双臂运行 → 跨实例切片库累积 → L2 注入进真实 LLM 请求 → 官方 Docker 评测。管线、看门狗、镜像去重等工程问题全部解决并沉淀在 `scripts/experiments/swe_pilot/run_arm.sh`。
+2. **本 pilot 的 ON 臂在 token/成本上是负收益（+80%）**。这符合研究计划 W0 的预测：当前抽取器产出的 turn 级 Prompt 切片和工具名级 T-Slice，对同 repo 的后续实例是弱信号——注入字节本身有成本，检索到的切片又可能引导 agent 多探索。**切片质量问题现在是唯一的主要矛盾**，且有两个现成的修复方向：
+   - W4 已落地的 `gc --consolidate-context`（近重复合并成 repo 概览卡）尚未接入 agent 库的日常维护路径；
+   - 注入门控过松：灰区 audit 模式 + 全类型注入应改为「仅 zone.Hit 且仅 C/M 类型注入」，#259 的分型阈值正好提供机制。
+3. **质量非劣 + 成本上升**说明系统当前处于「正确性优先」设计原则的正确一侧（fail-open 没有伤害 pass-rate），但「等效最省」的目标尚未达成——瓶颈不在机制在内容。
+4. 协同因素：本 pilot 的库只累积了 0–9 个同 repo 实例（冷启动),而注入对每个 turn 都发生。真实使用场景中库会更厚；但反向结论同样成立——**库薄时注入应有更高的准入门槛**。
+
+## 4. 下一步（按杠杆排序）
+
+1. 把注入准入改为：仅 zone.Hit + per-type 阈值（T/R 缺省不注入，#259/#268 机制已就位），重跑本 pilot 对比。
+2. 接入 Context consolidation：实例完成后跑 `gc --consolidate-context`，让后续实例注入「repo 概览卡」而非原始 turn 切片。
+3. 扩到 20 实例 × 3 重复（消除单次方差），预算 < $5。
+4. 评测镜像磁盘占用 ~40GB，复跑前无需重拉（cache 已在本地 Docker）。
+
+## 5. 复现
+
+```bash
+# 数据与实例选择
+/tmp/femb/bin/python - <<'EOF'  # 见 git 历史: 选取 django×5 + sympy×5 最短 problem_statement
+EOF
+# 双臂运行（需 ~/.semantix/.env 提供 DEEPSEEK_API_KEY）
+MAX_STEPS=80 AGENT_TIMEOUT_SECS=1200 bash scripts/experiments/swe_pilot/run_arm.sh off /tmp/semantix-run/pilot-off
+MAX_STEPS=80 AGENT_TIMEOUT_SECS=1200 bash scripts/experiments/swe_pilot/run_arm.sh on  /tmp/semantix-run/pilot-on
+# 官方评测（arm64 宿主机需 platform 补丁，见下）
+/tmp/femb/bin/python -m swebench.harness.run_evaluation --dataset_name SWE-bench/SWE-bench --split test \
+  --predictions_path /tmp/semantix-run/pilot-on/predictions.jsonl --max_workers 1 -id swe_pilot_on
+```
+
+已知的三个坑（脚本已内置修复）：`--permission-mode yolo`（acceptEdits 会拒掉全部 shell 命令）；LLM 连接偶发挂死需独立杀手进程看门狗；bridge 会话 label 是模型名常量、镜像文件需每轮运行前清空后搬运。

--- a/scripts/experiments/stub_chat_upstream.py
+++ b/scripts/experiments/stub_chat_upstream.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Stub OpenAI chat-completions upstream for the live gateway smoke test.
+Echoes the request's system+messages tail into the completion text (so the
+L2 injection block is observable), emits DeepSeek-style usage fields, and
+logs every request body it receives to a JSONL file for inspection."""
+import json
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+LOG = sys.argv[2] if len(sys.argv) > 2 else "/tmp/semantix-run/upstream.jsonl"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if not self.path.endswith("/chat/completions"):
+            self.send_error(404)
+            return
+        n = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(n))
+        with open(LOG, "a") as f:
+            f.write(json.dumps({"ts": time.time(), "body": req}, ensure_ascii=False) + "\n")
+        # Surface the injection block: last system segment + last user turn.
+        sys_txt = " ".join(m.get("content", "") for m in req.get("messages", []) if m.get("role") == "system")
+        has_reuse = "[semantix-reuse]" in sys_txt
+        tail = sys_txt[-260:] if has_reuse else "(no injection block)"
+        prompt_tokens = sum(len(str(m.get("content", ""))) // 4 for m in req.get("messages", []))
+        out = {
+            "id": "chatcmpl-stub",
+            "object": "chat.completion",
+            "model": req.get("model", "stub"),
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": f"stub-ok injection={has_reuse} tail={tail}"},
+                "finish_reason": "stop",
+            }],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": 30,
+                "total_tokens": prompt_tokens + 30,
+                "prompt_tokens_details": {"cached_tokens": 0},
+                "prompt_cache_hit_tokens": 0,
+                "prompt_cache_miss_tokens": prompt_tokens,
+            },
+        }
+        payload = json.dumps(out).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self):
+        if self.path.endswith("/models"):
+            body = b'{"data":[{"id":"stub-chat"}]}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_error(404)
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+if __name__ == "__main__":
+    addr = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:8690"
+    host, _, port = addr.rpartition(":")
+    HTTPServer((host or "127.0.0.1", int(port)), Handler).serve_forever()

--- a/scripts/experiments/swe_pilot/run_arm.sh
+++ b/scripts/experiments/swe_pilot/run_arm.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# run_arm.sh — SWE-bench pilot runner (efficiency research plan W1).
+#
+# Drives semantix-agent non-interactively over the pilot instances for one
+# arm, producing SWE-bench predictions + per-run metrics.
+#
+#   ON  arm: the repo's .semantix/project.db persists across instances and
+#            every completed instance's session JSONL is extracted into it —
+#            instance N starts with instance 0..N-1's slices (Project scope,
+#            same-repo cross-instance transfer).
+#   OFF arm: semantix disabled entirely; .semantix wiped before every run.
+#
+# Usage: run_arm.sh <on|off> <out_dir>
+set -u
+ARM="$1"; OUT="$2"
+BIN=/tmp/semantix-agent
+KBIN=/tmp/semantix
+PILOT="${PILOT_DIR:-/tmp/semantix-run/pilot}"
+REPOS=/tmp/semantix-run/repos
+MAX_STEPS="${MAX_STEPS:-40}"
+mkdir -p "$OUT"
+
+for inst_file in "$PILOT"/*.json; do
+  id=$(python3.12 -c "import json;print(json.load(open('$inst_file'))['instance_id'])")
+  repo=$(python3.12 -c "import json;print(json.load(open('$inst_file'))['repo'])")
+  commit=$(python3.12 -c "import json;print(json.load(open('$inst_file'))['base_commit'])")
+  short_repo=${repo#*/}
+  echo "=== [$ARM] $id ($commit) ==="
+
+  rd="$REPOS/$short_repo"
+  cd "$rd" || exit 1
+  git checkout -f "$commit" 2>&1 | tail -1
+  git clean -fdx -q -e .semantix 2>/dev/null
+  git log --oneline -1
+
+  # Local excludes so runtime artifacts never enter the model diff.
+  cat .git/info/exclude 2>/dev/null | grep -q "semantix-agent.toml" || printf "semantix-agent.toml\n.semantix/\n" >> .git/info/exclude
+
+  # Arm-specific kernel wiring.
+  if [ "$ARM" = "on" ]; then
+    cat > semantix-agent.toml <<EOF
+[semantix]
+enabled = true
+binary = "/tmp/semantix"
+inject = true
+budget = 4096
+sessions_dir = "$OUT/sessions"
+EOF
+    mkdir -p "$OUT/sessions"
+  else
+    cat > semantix-agent.toml <<EOF
+[semantix]
+enabled = false
+EOF
+    rm -rf .semantix
+  fi
+
+  # Warm the ON arm: extract every previous session JSONL of this repo.
+  if [ "$ARM" = "on" ]; then
+    for prev in "$OUT/sessions"/*.jsonl; do
+      [ -e "$prev" ] || continue
+      pname=$(basename "$prev")
+      case "$pname" in
+        django_*) prev_repo=django ;;
+        sympy_*)  prev_repo=sympy ;;
+        *) continue ;;
+      esac
+      [ "$prev_repo" = "$short_repo" ] || continue
+      $KBIN extract --input "$prev" --db "$rd/.semantix/project.db" --session "${pname%.jsonl}" > /dev/null 2>&1
+    done
+  fi
+
+  task=$(python3.12 - "$inst_file" <<'PYEOF'
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(f"""You are solving a real GitHub issue in this repository (your cwd is the repo root at the pre-fix commit).
+
+Issue:
+{d['problem_statement']}
+
+Instructions:
+- Locate the code responsible and implement the minimal, correct fix.
+- Do NOT modify test files.
+- Python dependencies for running the full test suite may not be installed in this environment; prefer careful code reasoning over executing the full suite. You may run quick syntax checks.
+- Keep changes focused; no unrelated refactoring.
+- When the fix is complete, stop.""")
+PYEOF
+)
+
+  # Snapshot existing session mirrors so we can identify this run's file.
+  # The bridge's session label is the model name (harness/boot: label :=
+  # entry.Model), so every run appends to the SAME mirror file. Wipe it
+  # before the run and move it after — each run's mirror is then exactly
+  # the delta it produced.
+  rm -f "$OUT/sessions"/*.jsonl 2>/dev/null
+  ls "$OUT/sessions" 2>/dev/null | sort > "$OUT/.sessions.before"
+
+  start=$(date +%s)
+  # Resume support: a completed run (parseable result JSON) is not redone —
+  # the ON arm accumulates its library across instances, so a restart must
+  # skip instead of re-running.
+  if [ -s "$OUT/${id}.result.json" ] && python3.12 -c "import json,sys; json.load(open(sys.argv[1]))" "$OUT/${id}.result.json" 2>/dev/null; then
+    echo "=== [$ARM] $id: already done, skipping ==="
+    continue
+  fi
+  # Watchdog: a hung LLM connection previously stalled a run indefinitely.
+  # A dedicated killer subshell fires kill -9 at the deadline — immune to
+  # kill -0 race artifacts of a polling loop. rc 124 marks the timeout.
+  $BIN -p --output-format json --max-steps "$MAX_STEPS" --permission-mode yolo "$task" > "$OUT/${id}.result.json" 2> "$OUT/${id}.stderr" &
+  apid=$!
+  limit="${AGENT_TIMEOUT_SECS:-1800}"
+  ( sleep "$limit" && kill -9 "$apid" 2>/dev/null ) & killer=$!
+  wait "$apid"
+  rc=$?
+  kill "$killer" 2>/dev/null
+  if [ "$rc" = "137" ]; then rc=124; fi
+  end=$(date +%s)
+  echo "agent exit=$rc elapsed=$((end-start))s"
+
+  # Model patch: tracked-file diff (runtime artifacts are locally excluded).
+  git add -A -- . ':!.semantix' ':!semantix-agent.toml' 2>/dev/null
+  git diff --cached HEAD --binary > "$OUT/${id}.patch" 2>/dev/null
+  git reset -q
+  # Tag this run's session mirror with repo+instance for the warm-up glob.
+  for f in "$OUT/sessions"/*.jsonl; do
+    [ -s "$f" ] || continue
+    mv "$f" "$OUT/sessions/${short_repo}_${id}.jsonl"
+  done
+
+  # Metrics summary from the agent's JSON result.
+  python3.12 - "$OUT/${id}.result.json" "$ARM" "$id" "$((end-start))" "$rc" <<'PYEOF' >> "$OUT/metrics.tsv"
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    u = d.get("usage", {})
+    print("\t".join(map(str, [sys.argv[3], sys.argv[2], sys.argv[4], sys.argv[5],
+        d.get("num_turns"), u.get("input_tokens"), u.get("output_tokens"),
+        u.get("cache_read_input_tokens"), u.get("cache_creation_input_tokens"),
+        d.get("total_cost_usd")])))
+except Exception as e:
+    print("\t".join(map(str, [sys.argv[3], sys.argv[2], sys.argv[4], sys.argv[5], "ERR", e])))
+PYEOF
+  echo "patch bytes: $(wc -c < "$OUT/${id}.patch")"
+done
+echo "[$ARM] done -> $OUT"


### PR DESCRIPTION
Follow-up to #439 (W5–W6). Everything in the working tree now lands under an issue or a PR:

- **scripts/experiments/swe_pilot/run_arm.sh** — the W1 pilot runner from the [efficiency research plan](docs/specs/swebench-efficiency-research-plan.md) §3 W1 (the plan's remaining gap). ON arm persists the slice library across pilot instances and extracts each completed session into it (same-repo cross-instance transfer, H1); OFF arm wipes `.semantix` before every run. Emits SWE-bench predictions + per-run metrics for the M-R0 exit criteria.
- **scripts/experiments/stub_chat_upstream.py** — echo-style OpenAI-compatible stub upstream for live gateway smoke tests: echoes the request tail into the completion so the L2 injection block is observable, logs every request body to JSONL.
- **.gitignore** — local agent/tooling session state (`.claude/`, `.mimosa/`, `.v2c/`, `.zcode/`, `docs/reports/data/.mimosa/`) and personal working files (`/PROMPTS.md`, `/paper/`, `paper.zip`) are explicitly not project artifacts and are now ignored, so `git status` shows only real changes.

No production code is touched; `go build ./...` unaffected. The pilot runs themselves (and their numbers) will land in a W1 report PR once executed against the budget.