### PR TITLE
feat(workspace): make live decision flow interactive

### DIFF
--- a/harness/serve/workspace/layout.css
+++ b/harness/serve/workspace/layout.css
@@ -183,6 +183,7 @@ body.ws-right-collapsed .ws-context { display: none; }
 .ws-event--error { border-color: var(--sx-del); border-left: 3px solid var(--sx-del); }
 .ws-event--status { border-left: 3px solid var(--sx-text-3); }
 .ws-event--cache { border-left: 3px solid var(--sx-green-border); }
+.ws-event--ask { border-left: 3px solid var(--sx-green); }
 .ws-event__icon { width: 15px; height: 15px; flex: none; color: var(--sx-text-3); }
 .ws-event--assistant .ws-event__icon,
 .ws-event--plan .ws-event__icon { color: var(--sx-green-strong); }
@@ -206,6 +207,29 @@ body.ws-right-collapsed .ws-context { display: none; }
   font: 600 12px/1.4 var(--sx-font-sans);
 }
 .ws-event__toggle:hover { text-decoration: underline; }
+.ws-ask__question + .ws-ask__question { margin-top: 14px; }
+.ws-ask__prompt { margin-bottom: 8px; color: var(--sx-text); font-weight: 600; }
+.ws-ask__options { display: grid; gap: 7px; }
+.ws-ask__option {
+  display: grid; gap: 2px; width: 100%; padding: 8px 10px;
+  border: 1px solid var(--sx-border-strong); border-radius: 7px;
+  background: var(--sx-chip); color: var(--sx-text); cursor: pointer;
+  text-align: left; font: 400 12.5px/1.4 var(--sx-font-sans);
+}
+.ws-ask__option:hover { border-color: var(--sx-green-border); background: var(--sx-hover); }
+.ws-ask__option.is-selected { border-color: var(--sx-green); background: var(--sx-green-dim); }
+.ws-ask__option:disabled { cursor: default; opacity: .78; }
+.ws-ask__option-label { font-weight: 600; }
+.ws-ask__option-description { color: var(--sx-text-3); }
+.ws-ask__empty { margin: 0; color: var(--sx-text-3); }
+.ws-ask__submit {
+  width: 100%; margin-top: 12px; padding: 8px 10px;
+  border: 1px solid var(--sx-green-border); border-radius: 7px;
+  background: var(--sx-green-dim); color: var(--sx-green-strong); cursor: pointer;
+  font: 600 12px/1.3 var(--sx-font-sans);
+}
+.ws-ask__submit:hover:not(:disabled) { background: var(--sx-green); color: var(--sx-bg-canvas); }
+.ws-ask__submit:disabled { cursor: default; opacity: .55; }
 .ws-plan { margin: 0; padding: 0 14px 13px 34px; display: grid; gap: 6px; }
 .ws-plan li { color: var(--sx-text-2); font-size: 13px; line-height: 1.5; }
 .ws-plan li.is-done { color: var(--sx-text-3); text-decoration: line-through; }

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -225,6 +225,7 @@
     tools: Object.create(null),
     diffs: Object.create(null),
     approvals: Object.create(null),
+    asks: Object.create(null),
     localUser: null,
     active: false
   };
@@ -245,6 +246,7 @@
     workflow.tools = Object.create(null);
     workflow.diffs = Object.create(null);
     workflow.approvals = Object.create(null);
+    workflow.asks = Object.create(null);
     workflow.localUser = null;
     workflow.active = false;
     clearNode(el.timeline);
@@ -651,6 +653,133 @@
       renderReviewList();
       showNotice("Review 决策未提交：" + err.message, "error");
     });
+  }
+
+  function askSelection(record, questionID) {
+    if (!record.selected[questionID]) record.selected[questionID] = [];
+    return record.selected[questionID];
+  }
+
+  function askReady(record) {
+    var questions = record && record.ask && Array.isArray(record.ask.questions) ? record.ask.questions : [];
+    return questions.length > 0 && questions.every(function (question, index) {
+      var id = String(question.id || "question-" + index);
+      return askSelection(record, id).length > 0;
+    });
+  }
+
+  function submitAskAnswer(record) {
+    if (!record || record.status !== "pending" || !askReady(record)) return;
+    var questions = Array.isArray(record.ask.questions) ? record.ask.questions : [];
+    var answers = questions.map(function (question, index) {
+      var id = String(question.id || "question-" + index);
+      var selected = askSelection(record, id);
+      var options = Array.isArray(question.options) ? question.options : [];
+      return {
+        questionId: id,
+        selected: selected.map(function (optionIndex) {
+          return options[optionIndex] && String(options[optionIndex].label || "");
+        }).filter(Boolean)
+      };
+    });
+    record.status = "submitting";
+    renderAskCard(record);
+    postJSON("/answer", { id: String(record.ask.id), answers: answers }).then(function () {
+      record.status = "answered";
+      renderAskCard(record);
+    }).catch(function (err) {
+      record.status = "pending";
+      renderAskCard(record);
+      showNotice("选择未提交：" + err.message, "error");
+    });
+  }
+
+  function renderAskCard(record) {
+    if (!record || !record.card || !record.ask) return;
+    clearNode(record.card.body);
+    var questions = Array.isArray(record.ask.questions) ? record.ask.questions : [];
+    if (!questions.length) {
+      record.card.body.textContent = "服务端未提供可选问题。";
+      setStatus(record.card, "无选项", "failed");
+      return;
+    }
+    questions.forEach(function (question, questionIndex) {
+      var questionID = String(question.id || "question-" + questionIndex);
+      var block = document.createElement("section");
+      block.className = "ws-ask__question";
+      var prompt = document.createElement("div");
+      prompt.className = "ws-ask__prompt";
+      var header = String(question.header || "").trim();
+      prompt.textContent = header ? header + " · " + cleanVisibleText(question.prompt || "") : cleanVisibleText(question.prompt || "");
+      block.appendChild(prompt);
+      var options = document.createElement("div");
+      options.className = "ws-ask__options";
+      var selected = askSelection(record, questionID);
+      var optionList = Array.isArray(question.options) ? question.options : [];
+      optionList.forEach(function (option, optionIndex) {
+        var button = document.createElement("button");
+        button.type = "button";
+        button.className = "ws-ask__option";
+        button.disabled = record.status !== "pending";
+        button.setAttribute("aria-pressed", String(selected.indexOf(optionIndex) !== -1));
+        if (selected.indexOf(optionIndex) !== -1) button.classList.add("is-selected");
+        var label = document.createElement("strong");
+        label.className = "ws-ask__option-label";
+        label.textContent = String(option && option.label || "选项 " + (optionIndex + 1));
+        button.appendChild(label);
+        if (option && option.description) {
+          var description = document.createElement("span");
+          description.className = "ws-ask__option-description";
+          description.textContent = cleanVisibleText(option.description);
+          button.appendChild(description);
+        }
+        button.addEventListener("click", function () {
+          if (record.status !== "pending") return;
+          var next = selected.slice();
+          var current = next.indexOf(optionIndex);
+          if (question.multi) {
+            if (current === -1) next.push(optionIndex);
+            else next.splice(current, 1);
+          } else {
+            next = [optionIndex];
+          }
+          record.selected[questionID] = next;
+          renderAskCard(record);
+        });
+        options.appendChild(button);
+      });
+      if (!optionList.length) {
+        var noOptions = document.createElement("p");
+        noOptions.className = "ws-ask__empty";
+        noOptions.textContent = "服务端未提供选项。";
+        options.appendChild(noOptions);
+      }
+      block.appendChild(options);
+      record.card.body.appendChild(block);
+    });
+    var submit = document.createElement("button");
+    submit.type = "button";
+    submit.className = "ws-ask__submit";
+    submit.textContent = record.status === "answered" ? "已提交" : record.status === "submitting" ? "提交中…" : record.status === "cancelled" ? "已取消" : "提交选择";
+    submit.disabled = record.status !== "pending" || !askReady(record);
+    submit.addEventListener("click", function () { submitAskAnswer(record); });
+    record.card.body.appendChild(submit);
+    var status = record.status === "answered" ? "已提交" : record.status === "submitting" ? "提交中" : record.status === "cancelled" ? "已取消" : "待选择";
+    var state = record.status === "answered" ? "done" : record.status === "cancelled" ? "cancelled" : "running";
+    setStatus(record.card, status, state);
+  }
+
+  function renderAskRequest(ask) {
+    if (!ask || !ask.id || !Array.isArray(ask.questions)) return;
+    var id = String(ask.id);
+    var record = workflow.asks[id];
+    if (!record) {
+      record = { ask: ask, selected: Object.create(null), status: "pending", card: makeEvent("ask", "需要选择", "?") };
+      workflow.asks[id] = record;
+    } else {
+      record.ask = ask;
+    }
+    renderAskCard(record);
   }
 
   function renderReviewList() {
@@ -1110,6 +1239,7 @@
       workflow.tools = Object.create(null);
       workflow.diffs = Object.create(null);
       workflow.approvals = Object.create(null);
+      workflow.asks = Object.create(null);
       renderDiffList();
       renderTerminalList();
       renderReviewList();
@@ -1160,6 +1290,13 @@
               var record = workflow.approvals[id];
               if (record && (record.status === "pending" || record.status === "submitting")) record.status = "cancelled";
             });
+            Object.keys(workflow.asks).forEach(function (id) {
+              var askRecord = workflow.asks[id];
+              if (askRecord && (askRecord.status === "pending" || askRecord.status === "submitting")) {
+                askRecord.status = "cancelled";
+                renderAskCard(askRecord);
+              }
+            });
             renderReviewList();
           }
         }
@@ -1172,7 +1309,11 @@
         renderStatus("task_status", { text: data.text || data.detail || "收到未识别事件" });
         break;
       case "permission_request":
-        var approval = data.approval || data.ask || {};
+        if (data.kind === "ask_request" && data.ask) {
+          renderAskRequest(data.ask);
+          break;
+        }
+        var approval = data.approval || {};
         if (approval.id) {
           workflow.approvals[String(approval.id)] = { approval: approval, status: "pending" };
           renderReviewList();

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -1428,19 +1428,6 @@
     fillList(el.effortMenu, rows, pickEffort);
   }
 
-  function loadModels() {
-    setState(el.model, "loading");
-    return getJSON("/models").then(function (data) {
-      renderEffort(String(data.effort || "").toLowerCase(), !!data.current);
-      var models = Array.isArray(data.models) ? data.models : [];
-      if (!models.length) {
-        // #405 acceptance: an explicit, visible unavailable-model signal.
-        setValue(el.modelName, "模型不可用");
-        setState(el.model, "empty");
-        el.model.title = "没有任何已配置的可用模型；请在 provider 设置中添加后刷新";
-        fillList(el.modelMenu, [{ label: "模型不可用：未配置任何模型", disabled: true }]);
-        showNotice("模型不可用：未发现已配置的聊天模型，请检查 provider 配置。", "warn");
-        return;
   function initSessionFilters() {
     [el.sessionSearch, el.sessionProject, el.sessionStatus].forEach(function (control) {
       if (!control) return;
@@ -1454,6 +1441,19 @@
     });
   }
 
+  function loadModels() {
+    setState(el.model, "loading");
+    return getJSON("/models").then(function (data) {
+      renderEffort(String(data.effort || "").toLowerCase(), !!data.current);
+      var models = Array.isArray(data.models) ? data.models : [];
+      if (!models.length) {
+        // #405 acceptance: an explicit, visible unavailable-model signal.
+        setValue(el.modelName, "模型不可用");
+        setState(el.model, "empty");
+        el.model.title = "没有任何已配置的可用模型；请在 provider 设置中添加后刷新";
+        fillList(el.modelMenu, [{ label: "模型不可用：未配置任何模型", disabled: true }]);
+        showNotice("模型不可用：未发现已配置的聊天模型，请检查 provider 配置。", "warn");
+        return;
       }
       var activeRef = null;
       fillList(el.modelMenu, models.map(function (m) {
@@ -1518,6 +1518,7 @@
 
   initContextTabs();
   initComposer();
+  initSessionFilters();
   initSelectors();
   connectWorkspaceEvents();
 
@@ -1548,4 +1549,3 @@
   window.addEventListener("resize", function () { setSideOpen(document.body.classList.contains("ws-side-open")); });
   setSideOpen(false);
 })();
-  initSessionFilters();

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -280,6 +280,35 @@ func TestServeWorkspaceWorkbenchContract(t *testing.T) {
 	}
 }
 
+// TestServeWorkspaceInteractivePromptContract pins the live decision boundary:
+// structured ask requests render as choices in the timeline and are answered
+// through the existing /answer route, while approval requests remain separate.
+func TestServeWorkspaceInteractivePromptContract(t *testing.T) {
+	js := string(workspaceShellJS)
+	for _, want := range []string{
+		`workflow.asks`, `function renderAskRequest`, `function renderAskCard`,
+		`data.kind === "ask_request"`, `postJSON("/answer"`,
+		`ws-ask__option`, `aria-pressed`, `record.status === "cancelled"`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("workspace interactive prompt behavior missing %q", want)
+		}
+	}
+	if strings.Contains(js, `var approval = data.approval || data.ask || {};`) {
+		t.Error("workspace permission handling must not treat ask payloads as approvals")
+	}
+	if strings.HasSuffix(strings.TrimSpace(js), "initSessionFilters();") {
+		t.Error("workspace session filter initialization must stay inside the shell IIFE")
+	}
+
+	css := string(workspaceLayoutCSS)
+	for _, want := range []string{`.ws-event--ask`, `.ws-ask__options`, `.ws-ask__option.is-selected`, `.ws-ask__submit`} {
+		if !strings.Contains(css, want) {
+			t.Errorf("workspace interactive prompt styles missing %q", want)
+		}
+	}
+}
+
 // TestServeWorkspaceComposerContract pins GUI-8's composer boundary: browser
 // actions use the existing HTTP routes and never alter permission mode locally.
 func TestServeWorkspaceComposerContract(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix workspace session filter initialization so search and Ctrl/Cmd+K remain available
- render structured `ask_request` events as workspace-native choice cards and answer through the existing `/answer` endpoint
- keep approval requests on the existing Review `/approve` flow
- add workspace styling and regression contracts for interactive prompts

## Verification
- `go test ./harness/serve/... -count=1`
- `node --check harness/serve/workspace/shell.js`
- `git diff --check`
- local workspace smoke check at `http://127.0.0.1:64901/workspace` (resource hooks present, session filtering works, no browser console errors)

## Scope
This PR changes only the new workspace UI assets and their contract tests. The legacy root UI and backend event protocol are unchanged.