### PR TITLE
test(judge): deflake TestWarmPopulatesCacheInBackground under -race

### DIFF
--- a/kernel/judge/cache_test.go
+++ b/kernel/judge/cache_test.go
@@ -87,7 +87,12 @@ func TestWarmPopulatesCacheInBackground(t *testing.T) {
 		t.Fatal("expected error while inner failing")
 	}
 	fail.Store(false)
-	deadline := time.Now().Add(2 * time.Second)
+	// The warm goroutine only needs one scheduling slot, but CI runs the
+	// whole suite under -race, where 2s of wall clock proved not to be a
+	// safe margin (flaked on #444). Wait generously, then tell apart
+	// "goroutine never ran" (scheduling) from "ran but cached nothing"
+	// (a real warm-path bug).
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		// Primary-rubric warm lands under the "p" namespace.
 		if confirm, ok := cj.Cache.Get("p" + VerdictKey("q", "s")); ok {
@@ -97,6 +102,9 @@ func TestWarmPopulatesCacheInBackground(t *testing.T) {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if inner.callCount() < 2 {
+		t.Fatal("background warm goroutine never ran")
 	}
 	t.Fatal("background warm did not populate the cache in time")
 }


### PR DESCRIPTION
## 问题

CI 以 `go test ./... -race` 运行全量测试。在 -race + 并行包调度的负载下，`TestWarmPopulatesCacheInBackground` 给后台 warm goroutine 的 **2 秒墙钟窗口**不够：goroutine 尚未被调度，轮询就超时了（PR #444 的 Go checks 挂在 `cache_test.go:101`，耗时 2.01s）。

## 修复

- 等待窗口 2s → **10s**（wall-clock，给 -race CI 足够调度余量）
- 超时后区分两种失败：**goroutine 从未运行**（`inner.callCount() < 2`，调度问题）与 **运行了但没写入缓存**（真正的 warm 路径 bug），避免把调度抖动误报为逻辑错误

不改任何生产代码，语义与原作者意图一致（事件等待 + 宽裕上限）。

## 验证

```
go test ./kernel/judge -run TestWarmPopulatesCacheInBackground -race -count=30
ok  semantix/kernel/judge  4.325s
```

合并后 PR #444 rebase 或合入 main 即可解锁其 Go checks。