### PR TITLE
feat(swebench): attribute model calls by source

### DIFF
--- a/docs/specs/swebench-memory-arm.md
+++ b/docs/specs/swebench-memory-arm.md
@@ -37,6 +37,18 @@
 - 新 Notice 码 `semantix_inject`（Detail `{"bytes":n}`），每用户轮注入块非空时发一次。
 - `RunMetrics` 新增：`semantix_inject_turns` / `semantix_inject_bytes` / `semantix_reuse_hits` / `semantix_reuse_savings_usd`（omitempty，旧读者无感）。metricsSink 消费 `semantix_inject` 与既有 `semantix_reuse` Notice。
 
+### P0 调用来源归因（Issue #447）
+
+`RunMetrics.steps` 已包含 executor、planner、subagent、compaction 和其他辅助模型调用，不能直接当作主循环步数。Go 侧 `usage_by_source` 保持权威来源；SWE-bench runner 将其规范化为：
+
+- 完整 `model_calls_by_source` 映射，未知来源不丢弃；
+- `executor_calls`、`planner_calls`、`subagent_calls`、`compaction_calls` 四个便捷字段；
+- `other_model_calls`，汇总 classifier/title/capability-router/recovery-reviewer/goal-evaluator 与未来来源；
+- `source_call_total` 和 `source_call_delta = steps - source_call_total`，用于发现漏归因；
+- `provider_retries`、`compactions`、`subagent_runs`、`tool_failures` 和 `tool_calls_by_name`，用于区分模型调用、传输重试、压缩尝试、委派与工具行为。
+
+旧 metrics 缺少这些字段时全部按 0 读取；`source_call_delta` 保留其 `steps`，明确表示无法追溯，而不是错误归入 executor。该变更只扩展观测 JSON 和报告，不修改 agent、provider request 或记忆注入行为。
+
 ## 3. 实验臂协议（替代旧 §4「--ablate all 隔离记忆内核」的错误设想）
 
 - **记忆对照 = `--semantix-memory on` vs `off` 两臂**（同子集、同模型、同 preset）。`--ablate` 不用于记忆对照（它只关 harness 侧 planner/subagent/evidence/harness-memory/compaction）。

--- a/docs/superpowers/plans/2026-09-02-issue-447-p0-metrics-attribution.md
+++ b/docs/superpowers/plans/2026-09-02-issue-447-p0-metrics-attribution.md
@@ -1,0 +1,304 @@
+# Issue #447 P0 Metrics Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Expose Semantix executor, planner, subagent, compaction, other-model, retry, and per-tool call counts in every normalized SWE-bench instance record and aggregate report so memory ON/OFF step deltas are attributable.
+
+**Architecture:** Keep `harness/cli/run_metrics.go` as the authoritative producer: it already emits `steps`, `usage_by_source`, `retries`, `compactions`, and `tool_calls_by_name`. Add a narrow normalization layer in the Semantix SWE-bench adapter, store both the complete source map and stable convenience counters, then aggregate those fields in `report.py`. This package does not alter the agent loop, retrieval, injection, or model requests.
+
+**Tech Stack:** Python 3 standard library (`dataclasses`, `unittest`, `tempfile`, `json`); existing Go metrics JSON contract.
+
+**Spec:** `docs/specs/semantix-memory-negative-transfer.md` §5.1 (PR #448) and parent tracking issue #447 §6 P0.1.
+
+## Global Constraints
+
+- Preserve existing `steps` semantics: every billed model call, regardless of source.
+- Preserve backward compatibility with metrics JSON that lacks `usage_by_source`, retry, compaction, or per-tool maps.
+- Keep unknown/future usage sources instead of dropping them.
+- Never infer executor calls by subtracting named auxiliary sources; use the producer's explicit `executor` bucket.
+- Report reconciliation explicitly: `source_call_total` and `source_call_delta = steps - source_call_total`.
+- Add no runtime dependencies.
+- This package is observability-only and must not change provider request bytes or agent behavior.
+
+---
+
+### Task 1: Normalize Semantix call-source telemetry per instance
+
+**Files:**
+- Modify: `scripts/swebench/common.py:58-78`
+- Modify: `scripts/swebench/run_bench.py:271-279`
+- Create: `scripts/swebench/test_metrics_attribution.py`
+
+**Interfaces:**
+- Consumes: raw `run --metrics` keys `steps`, `usage_by_source`, `retries`, `compactions`, `subagent_runs`, `tool_failures`, and `tool_calls_by_name`.
+- Produces: `InstanceMetrics.model_calls_by_source: dict[str, int]`, `executor_calls`, `planner_calls`, `subagent_calls`, `compaction_calls`, `other_model_calls`, `source_call_total`, `source_call_delta`, `provider_retries`, `compactions`, `subagent_runs`, `tool_failures`, and `tool_calls_by_name`.
+
+- [x] **Step 1: Write failing normalization tests**
+
+Create `scripts/swebench/test_metrics_attribution.py` using `unittest`. Insert the script directory into `sys.path`, import `InstanceMetrics` and `SemantixAdapter`, instantiate the adapter without running `prepare`, and cover:
+
+```python
+def test_semantix_fill_metrics_attributes_every_model_call(self):
+    raw = {
+        "steps": 11,
+        "usage_by_source": {
+            "executor": {"calls": 5},
+            "planner": {"calls": 1},
+            "subagent": {"calls": 2},
+            "compaction": {"calls": 1},
+            "classifier": {"calls": 2},
+        },
+        "retries": 3,
+        "compactions": 1,
+        "subagent_runs": 2,
+        "tool_calls": 8,
+        "tool_failures": 1,
+        "tool_calls_by_name": {"read_file": 4, "grep": 3, "bash": 1},
+    }
+    metrics = self.new_metrics()
+    self.adapter.fill_metrics(metrics, raw)
+    self.assertEqual(metrics.executor_calls, 5)
+    self.assertEqual(metrics.planner_calls, 1)
+    self.assertEqual(metrics.subagent_calls, 2)
+    self.assertEqual(metrics.compaction_calls, 1)
+    self.assertEqual(metrics.other_model_calls, 2)
+    self.assertEqual(metrics.source_call_total, 11)
+    self.assertEqual(metrics.source_call_delta, 0)
+```
+
+Also cover an old record without `usage_by_source` (`source_call_total == 0`, `source_call_delta == steps`) and malformed/negative source buckets being ignored rather than crashing.
+
+- [x] **Step 2: Run the test and confirm RED**
+
+Run:
+
+```powershell
+python scripts/swebench/test_metrics_attribution.py -v
+```
+
+Expected: FAIL because the new `InstanceMetrics` fields do not exist.
+
+- [x] **Step 3: Extend the normalized metrics schema**
+
+Add these defaulted fields to `InstanceMetrics` after `tool_calls`:
+
+```python
+model_calls_by_source: dict[str, int] = field(default_factory=dict)
+executor_calls: int = 0
+planner_calls: int = 0
+subagent_calls: int = 0
+compaction_calls: int = 0
+other_model_calls: int = 0
+source_call_total: int = 0
+source_call_delta: int = 0
+provider_retries: int = 0
+compactions: int = 0
+subagent_runs: int = 0
+tool_failures: int = 0
+tool_calls_by_name: dict[str, int] = field(default_factory=dict)
+```
+
+Keep the existing defaults so old adapters remain source-compatible.
+
+- [x] **Step 4: Add defensive call-map normalization**
+
+In `run_bench.py`, add a private helper near `sum_ledger`:
+
+```python
+def normalize_call_counts(value: object) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    out = {}
+    for source, bucket in value.items():
+        if not isinstance(source, str) or not isinstance(bucket, dict):
+            continue
+        calls = bucket.get("calls")
+        if isinstance(calls, bool) or not isinstance(calls, int) or calls < 0:
+            continue
+        out[source] = calls
+    return out
+```
+
+Use the same non-negative integer rule for `tool_calls_by_name` values; preserve unknown names.
+
+- [x] **Step 5: Populate source and trajectory counters**
+
+In `SemantixAdapter.fill_metrics`, retain existing token/cost assignments, then populate the new fields. Define the named set as `{executor, planner, subagent, compaction}`; sum every other source into `other_model_calls`. Set:
+
+```python
+m.source_call_total = sum(m.model_calls_by_source.values())
+m.source_call_delta = m.steps - m.source_call_total
+```
+
+Copy `retries` to `provider_retries`; do not rename or mutate the raw payload stored under `m.raw`.
+
+- [x] **Step 6: Run the normalization tests and confirm GREEN**
+
+Run:
+
+```powershell
+python scripts/swebench/test_metrics_attribution.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit the normalized per-instance metrics**
+
+```powershell
+git add scripts/swebench/common.py scripts/swebench/run_bench.py scripts/swebench/test_metrics_attribution.py
+git commit -m "feat(swebench): attribute semantix model calls by source"
+```
+
+---
+
+### Task 2: Aggregate attribution fields in benchmark reports
+
+**Files:**
+- Modify: `scripts/swebench/report.py:18-75`
+- Modify: `scripts/swebench/test_metrics_attribution.py`
+
+**Interfaces:**
+- Consumes: normalized JSONL fields produced by Task 1.
+- Produces: aggregate totals for named model-call sources, unknown sources, retries, compactions, subagent runs, tool failures, and tool names; Markdown includes a compact call-source column.
+
+- [x] **Step 1: Write failing report aggregation tests**
+
+Use `tempfile.TemporaryDirectory` to create a run directory with two `metrics.jsonl` rows. Assert:
+
+```python
+self.assertEqual(aggregate["executor_calls"], 8)
+self.assertEqual(aggregate["planner_calls"], 2)
+self.assertEqual(aggregate["subagent_calls"], 3)
+self.assertEqual(aggregate["compaction_calls"], 2)
+self.assertEqual(aggregate["other_model_calls"], 4)
+self.assertEqual(aggregate["provider_retries"], 3)
+self.assertEqual(aggregate["tool_calls_by_name"], {"bash": 2, "grep": 4})
+```
+
+Add one backward-compatibility row with no new keys and assert `load_run` treats them as zero.
+
+- [x] **Step 2: Run the report tests and confirm RED**
+
+Run:
+
+```powershell
+python scripts/swebench/test_metrics_attribution.py -v
+```
+
+Expected: FAIL because `report.load_run` omits attribution totals.
+
+- [x] **Step 3: Add backward-compatible aggregators**
+
+Add small helpers in `report.py`:
+
+```python
+def sum_int(metrics: list[dict], key: str) -> int:
+    return sum(m.get(key, 0) for m in metrics)
+
+def sum_count_maps(metrics: list[dict], key: str) -> dict[str, int]:
+    out = {}
+    for row in metrics:
+        for name, count in row.get(key, {}).items():
+            out[name] = out.get(name, 0) + count
+    return dict(sorted(out.items()))
+```
+
+Use them in `load_run` for every new counter and `model_calls_by_source`/`tool_calls_by_name`.
+
+- [x] **Step 4: Add a compact Markdown call breakdown**
+
+Add one column named `calls E/P/S/C/O` formatted as `executor/planner/subagent/compaction/other`, plus `tools` and `retry`. Keep JSON output fully structured.
+
+- [x] **Step 5: Run report tests and confirm GREEN**
+
+Run:
+
+```powershell
+python scripts/swebench/test_metrics_attribution.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit report aggregation**
+
+```powershell
+git add scripts/swebench/report.py scripts/swebench/test_metrics_attribution.py
+git commit -m "feat(swebench): report model call attribution"
+```
+
+---
+
+### Task 3: Document and verify the attribution contract
+
+**Files:**
+- Modify: `scripts/swebench/README.md:68-90`
+- Modify: `docs/specs/swebench-memory-arm.md`
+
+**Interfaces:**
+- Consumes: Task 1/2 field names and semantics.
+- Produces: operator-facing documentation that distinguishes total steps, source-attributed calls, compaction attempts, retries, and tool calls.
+
+- [x] **Step 1: Document the JSON contract**
+
+Add a table defining:
+
+- `steps`: total billed model calls;
+- `model_calls_by_source`: authoritative complete source map;
+- `executor_calls`, `planner_calls`, `subagent_calls`, `compaction_calls`: convenience counters;
+- `other_model_calls`: sum of classifier/title/capability-router/recovery-reviewer/goal-evaluator and future sources;
+- `source_call_delta`: `steps - source_call_total`, expected zero for current complete metrics;
+- `provider_retries`: transport retry events, not billed calls unless a usage event exists;
+- `compactions`: compaction attempts, distinct from `compaction_calls`;
+- `tool_calls_by_name`: completed tool calls by canonical name.
+
+- [x] **Step 2: Run formatting and focused tests**
+
+Run:
+
+```powershell
+python -m py_compile scripts/swebench/common.py scripts/swebench/run_bench.py scripts/swebench/report.py scripts/swebench/test_metrics_attribution.py
+python scripts/swebench/test_metrics_attribution.py -v
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [x] **Step 3: Run relevant Go producer tests**
+
+Run:
+
+```powershell
+go test ./harness/cli -run 'TestUsageBySource|TestMetrics|TestRunMetrics' -count=1
+```
+
+Expected: PASS. This confirms the producer contract consumed by Python still works.
+
+- [x] **Step 4: Record the unrelated baseline failure**
+
+Run:
+
+```powershell
+go test ./cmd/semantix -run '^TestDispatchExitCodeContract$' -count=1
+```
+
+Expected on baseline `eceb763`: FAIL at `main_test.go:291` because `run(nil, ...)` returns 0 instead of the test's expected usage code 2. This package does not touch `cmd/semantix`; do not claim a clean full-suite baseline.
+
+- [ ] **Step 5: Commit documentation**
+
+```powershell
+git add scripts/swebench/README.md docs/specs/swebench-memory-arm.md
+git commit -m "docs(swebench): define call attribution metrics"
+```
+
+- [ ] **Step 6: Final branch verification**
+
+Run:
+
+```powershell
+git diff --check upstream/main...HEAD
+python scripts/swebench/test_metrics_attribution.py -v
+go test ./harness/cli -run 'TestUsageBySource|TestMetrics|TestRunMetrics' -count=1
+git status --short
+```
+
+Expected: no diff errors, Python tests PASS, focused Go tests PASS, and only planned files are modified/committed.

--- a/docs/superpowers/plans/2026-09-02-issue-447-p0-metrics-attribution.md
+++ b/docs/superpowers/plans/2026-09-02-issue-447-p0-metrics-attribution.md
@@ -142,7 +142,7 @@ python scripts/swebench/test_metrics_attribution.py -v
 
 Expected: all tests PASS.
 
-- [ ] **Step 7: Commit the normalized per-instance metrics**
+- [x] **Step 7: Commit the normalized per-instance metrics**
 
 ```powershell
 git add scripts/swebench/common.py scripts/swebench/run_bench.py scripts/swebench/test_metrics_attribution.py
@@ -219,7 +219,7 @@ python scripts/swebench/test_metrics_attribution.py -v
 
 Expected: all tests PASS.
 
-- [ ] **Step 6: Commit report aggregation**
+- [x] **Step 6: Commit report aggregation**
 
 ```powershell
 git add scripts/swebench/report.py scripts/swebench/test_metrics_attribution.py
@@ -283,14 +283,14 @@ go test ./cmd/semantix -run '^TestDispatchExitCodeContract$' -count=1
 
 Expected on baseline `eceb763`: FAIL at `main_test.go:291` because `run(nil, ...)` returns 0 instead of the test's expected usage code 2. This package does not touch `cmd/semantix`; do not claim a clean full-suite baseline.
 
-- [ ] **Step 5: Commit documentation**
+- [x] **Step 5: Commit documentation**
 
 ```powershell
 git add scripts/swebench/README.md docs/specs/swebench-memory-arm.md
 git commit -m "docs(swebench): define call attribution metrics"
 ```
 
-- [ ] **Step 6: Final branch verification**
+- [x] **Step 6: Final branch verification**
 
 Run:
 

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -77,6 +77,26 @@ harness 侧模块，不触碰内核）。判读字段（metrics `raw`）：
 `semantix_inject_turns` / `semantix_inject_bytes` / `semantix_reuse_hits` /
 `raw.extract`（每实例入库量）。设计与根因：`docs/specs/swebench-memory-arm.md`。
 
+#### 调用来源归因字段
+
+Semantix 的 `steps` 是所有已计费模型调用总数，不等同于 executor 主循环轮数。
+runner 会把原生 `usage_by_source` 规范化进每实例 `metrics.jsonl`：
+
+| 字段 | 含义 |
+|---|---|
+| `steps` | 所有来源的已计费模型调用总数 |
+| `model_calls_by_source` | 原生完整来源表；未知的新来源原样保留 |
+| `executor_calls` / `planner_calls` / `subagent_calls` / `compaction_calls` | 四个主要来源的稳定便捷计数 |
+| `other_model_calls` | classifier、title、capability-router、recovery-reviewer、goal-evaluator 及未来来源之和 |
+| `source_call_total` | `model_calls_by_source` 的调用数总和 |
+| `source_call_delta` | `steps - source_call_total`；当前完整 metrics 预期为 0，旧记录可能非 0 |
+| `provider_retries` | provider 传输重试事件数；没有 Usage 事件时不计入 `steps` |
+| `compactions` | compaction 尝试次数；与实际产生 Usage 的 `compaction_calls` 不同 |
+| `tool_calls_by_name` | 已完成工具调用按 canonical tool name 汇总 |
+
+`report.py` 的 Markdown 表用 `calls E/P/S/C/O` 显示
+executor/planner/subagent/compaction/other；JSON 输出保留完整来源表和工具表。
+
 ## 方法学要点（对比公平性）
 
 - **同一 prompt 模板**（`common.PROMPT_TEMPLATE`）喂给所有 harness；system prompt 保持各 harness 原生（那正是 harness 差异的一部分）。

--- a/scripts/swebench/common.py
+++ b/scripts/swebench/common.py
@@ -68,6 +68,19 @@ class InstanceMetrics:
     cache_miss_tokens: int = 0
     steps: int = 0                   # model calls
     tool_calls: int = 0
+    model_calls_by_source: dict[str, int] = field(default_factory=dict)
+    executor_calls: int = 0
+    planner_calls: int = 0
+    subagent_calls: int = 0
+    compaction_calls: int = 0
+    other_model_calls: int = 0
+    source_call_total: int = 0
+    source_call_delta: int = 0
+    provider_retries: int = 0
+    compactions: int = 0
+    subagent_runs: int = 0
+    tool_failures: int = 0
+    tool_calls_by_name: dict[str, int] = field(default_factory=dict)
     cost_usd: float | None = None    # computed from DeepSeek prices when possible
     cost_native: float | None = None # what the harness itself reported
     cost_native_currency: str = ""

--- a/scripts/swebench/report.py
+++ b/scripts/swebench/report.py
@@ -16,6 +16,31 @@ import json
 from pathlib import Path
 
 
+def sum_int(metrics: list[dict], key: str) -> int:
+    """Sum one optional integer field while tolerating legacy records."""
+    return sum(
+        value
+        for row in metrics
+        if isinstance((value := row.get(key, 0)), int)
+        and not isinstance(value, bool)
+    )
+
+
+def sum_count_maps(metrics: list[dict], key: str) -> dict[str, int]:
+    """Merge optional non-negative string-to-int counter maps."""
+    out = {}
+    for row in metrics:
+        counts = row.get(key, {})
+        if not isinstance(counts, dict):
+            continue
+        for name, count in counts.items():
+            if (not isinstance(name, str) or not isinstance(count, int)
+                    or isinstance(count, bool) or count < 0):
+                continue
+            out[name] = out.get(name, 0) + count
+    return dict(sorted(out.items()))
+
+
 def load_run(run_dir: Path) -> dict:
     metrics = []
     mpath = run_dir / "metrics.jsonl"
@@ -41,6 +66,21 @@ def load_run(run_dir: Path) -> dict:
         "cache_hit_tokens": sum(m["cache_hit_tokens"] for m in metrics),
         "cache_miss_tokens": sum(m["cache_miss_tokens"] for m in metrics),
         "cache_hit_rate": None,
+        "steps": sum_int(metrics, "steps"),
+        "executor_calls": sum_int(metrics, "executor_calls"),
+        "planner_calls": sum_int(metrics, "planner_calls"),
+        "subagent_calls": sum_int(metrics, "subagent_calls"),
+        "compaction_calls": sum_int(metrics, "compaction_calls"),
+        "other_model_calls": sum_int(metrics, "other_model_calls"),
+        "source_call_total": sum_int(metrics, "source_call_total"),
+        "source_call_delta": sum_int(metrics, "source_call_delta"),
+        "model_calls_by_source": sum_count_maps(metrics, "model_calls_by_source"),
+        "provider_retries": sum_int(metrics, "provider_retries"),
+        "compactions": sum_int(metrics, "compactions"),
+        "subagent_runs": sum_int(metrics, "subagent_runs"),
+        "tool_calls": sum_int(metrics, "tool_calls"),
+        "tool_failures": sum_int(metrics, "tool_failures"),
+        "tool_calls_by_name": sum_count_maps(metrics, "tool_calls_by_name"),
         "cost_usd": sum(m["cost_usd"] or 0 for m in metrics),
         "empty_patches": sum(1 for m in metrics if m["empty_patch"]),
         "errors": sum(1 for m in metrics if m["error"]),
@@ -79,7 +119,8 @@ def main() -> None:
         return
 
     headers = ["harness", "model", "n", "resolved", "resolve %", "mean wall",
-               "input tok", "output tok", "cache hit %", "cost (USD)", "empty", "err"]
+               "input tok", "output tok", "cache hit %", "cost (USD)",
+               "calls E/P/S/C/O", "tools", "retry", "empty", "err"]
     print("| " + " | ".join(headers) + " |")
     print("|" + "---|" * len(headers))
     for r in rows:
@@ -89,6 +130,10 @@ def main() -> None:
             fmt(r["resolve_rate"], "pct"), fmt(r["wall_s_mean"], "s"),
             fmt(r["input_tokens"], "k"), fmt(r["output_tokens"], "k"),
             fmt(r["cache_hit_rate"], "pct"), fmt(r["cost_usd"], "usd"),
+            "/".join(str(r[key]) for key in (
+                "executor_calls", "planner_calls", "subagent_calls",
+                "compaction_calls", "other_model_calls")),
+            str(r["tool_calls"]), str(r["provider_retries"]),
             str(r["empty_patches"]), str(r["errors"]),
         ]) + " |")
 

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -95,6 +95,35 @@ def sum_ledger(rows: list[dict]) -> dict:
     return total
 
 
+def normalize_call_counts(value: object) -> dict[str, int]:
+    """Return valid non-negative call counts from a usage-by-source object."""
+    if not isinstance(value, dict):
+        return {}
+    out = {}
+    for source, bucket in value.items():
+        if not isinstance(source, str) or not isinstance(bucket, dict):
+            continue
+        calls = bucket.get("calls")
+        if isinstance(calls, bool) or not isinstance(calls, int) or calls < 0:
+            continue
+        out[source] = calls
+    return out
+
+
+def normalize_count_map(value: object) -> dict[str, int]:
+    """Return valid non-negative counters from a flat string-to-int object."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        name: count
+        for name, count in value.items()
+        if isinstance(name, str)
+        and isinstance(count, int)
+        and not isinstance(count, bool)
+        and count >= 0
+    }
+
+
 def clean_env(*, drop_prefixes=(), drop=()) -> dict:
     env = {}
     for k, v in os.environ.items():
@@ -275,6 +304,23 @@ context_window = 128000
         m.cache_miss_tokens = raw.get("cache_miss_tokens", 0)
         m.steps = raw.get("steps", 0)
         m.tool_calls = raw.get("tool_calls", 0)
+        m.model_calls_by_source = normalize_call_counts(raw.get("usage_by_source"))
+        m.executor_calls = m.model_calls_by_source.get("executor", 0)
+        m.planner_calls = m.model_calls_by_source.get("planner", 0)
+        m.subagent_calls = m.model_calls_by_source.get("subagent", 0)
+        m.compaction_calls = m.model_calls_by_source.get("compaction", 0)
+        named_sources = {"executor", "planner", "subagent", "compaction"}
+        m.other_model_calls = sum(
+            calls for source, calls in m.model_calls_by_source.items()
+            if source not in named_sources
+        )
+        m.source_call_total = sum(m.model_calls_by_source.values())
+        m.source_call_delta = m.steps - m.source_call_total
+        m.provider_retries = raw.get("retries", 0)
+        m.compactions = raw.get("compactions", 0)
+        m.subagent_runs = raw.get("subagent_runs", 0)
+        m.tool_failures = raw.get("tool_failures", 0)
+        m.tool_calls_by_name = normalize_count_map(raw.get("tool_calls_by_name"))
         m.cost_native = raw.get("cost")
         m.cost_native_currency = raw.get("currency", "")
 

--- a/scripts/swebench/test_metrics_attribution.py
+++ b/scripts/swebench/test_metrics_attribution.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Regression tests for Issue #447 call-source attribution."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from common import InstanceMetrics  # noqa: E402
+from report import load_run  # noqa: E402
+from run_bench import SemantixAdapter  # noqa: E402
+
+
+class SemantixMetricAttributionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.adapter = SemantixAdapter(SimpleNamespace(), HERE)
+
+    def new_metrics(self) -> InstanceMetrics:
+        return InstanceMetrics(
+            run_id="test-run",
+            harness="semantix",
+            model="test-model",
+            instance_id="test-instance",
+        )
+
+    def test_fill_metrics_attributes_every_model_call(self) -> None:
+        raw = {
+            "prompt_tokens": 1000,
+            "completion_tokens": 100,
+            "steps": 11,
+            "usage_by_source": {
+                "executor": {"calls": 5},
+                "planner": {"calls": 1},
+                "subagent": {"calls": 2},
+                "compaction": {"calls": 1},
+                "classifier": {"calls": 2},
+            },
+            "retries": 3,
+            "compactions": 1,
+            "subagent_runs": 2,
+            "tool_calls": 8,
+            "tool_failures": 1,
+            "tool_calls_by_name": {"read_file": 4, "grep": 3, "bash": 1},
+        }
+
+        metrics = self.new_metrics()
+        self.adapter.fill_metrics(metrics, raw)
+
+        self.assertEqual(metrics.model_calls_by_source, {
+            "executor": 5,
+            "planner": 1,
+            "subagent": 2,
+            "compaction": 1,
+            "classifier": 2,
+        })
+        self.assertEqual(metrics.executor_calls, 5)
+        self.assertEqual(metrics.planner_calls, 1)
+        self.assertEqual(metrics.subagent_calls, 2)
+        self.assertEqual(metrics.compaction_calls, 1)
+        self.assertEqual(metrics.other_model_calls, 2)
+        self.assertEqual(metrics.source_call_total, 11)
+        self.assertEqual(metrics.source_call_delta, 0)
+        self.assertEqual(metrics.provider_retries, 3)
+        self.assertEqual(metrics.compactions, 1)
+        self.assertEqual(metrics.subagent_runs, 2)
+        self.assertEqual(metrics.tool_failures, 1)
+        self.assertEqual(metrics.tool_calls_by_name, {
+            "read_file": 4,
+            "grep": 3,
+            "bash": 1,
+        })
+
+    def test_fill_metrics_keeps_old_records_explicitly_unattributed(self) -> None:
+        metrics = self.new_metrics()
+
+        self.adapter.fill_metrics(metrics, {"steps": 7, "tool_calls": 2})
+
+        self.assertEqual(metrics.model_calls_by_source, {})
+        self.assertEqual(metrics.source_call_total, 0)
+        self.assertEqual(metrics.source_call_delta, 7)
+        self.assertEqual(metrics.executor_calls, 0)
+        self.assertEqual(metrics.other_model_calls, 0)
+
+    def test_fill_metrics_ignores_malformed_or_negative_counts(self) -> None:
+        raw = {
+            "steps": 4,
+            "usage_by_source": {
+                "executor": {"calls": 3},
+                "negative": {"calls": -1},
+                "boolean": {"calls": True},
+                "string": {"calls": "9"},
+                "not-a-bucket": 2,
+                42: {"calls": 1},
+            },
+            "tool_calls_by_name": {
+                "grep": 2,
+                "negative": -2,
+                "boolean": False,
+                "string": "4",
+            },
+        }
+
+        metrics = self.new_metrics()
+        self.adapter.fill_metrics(metrics, raw)
+
+        self.assertEqual(metrics.model_calls_by_source, {"executor": 3})
+        self.assertEqual(metrics.tool_calls_by_name, {"grep": 2})
+        self.assertEqual(metrics.source_call_total, 3)
+        self.assertEqual(metrics.source_call_delta, 1)
+
+
+class AttributionReportTest(unittest.TestCase):
+    @staticmethod
+    def metric_row(**overrides: object) -> dict:
+        row = {
+            "harness": "semantix",
+            "model": "test-model",
+            "wall_ms": 1000,
+            "input_tokens": 100,
+            "output_tokens": 10,
+            "cache_hit_tokens": 80,
+            "cache_miss_tokens": 20,
+            "cost_usd": 0.01,
+            "empty_patch": False,
+            "error": "",
+        }
+        row.update(overrides)
+        return row
+
+    def write_run(self, rows: list[dict]) -> tuple[tempfile.TemporaryDirectory, Path]:
+        tmp = tempfile.TemporaryDirectory()
+        run_dir = Path(tmp.name) / "test-run"
+        run_dir.mkdir()
+        payload = "".join(json.dumps(row) + "\n" for row in rows)
+        (run_dir / "metrics.jsonl").write_text(payload, encoding="utf-8")
+        return tmp, run_dir
+
+    def test_load_run_aggregates_call_sources_retries_and_tools(self) -> None:
+        rows = [
+            self.metric_row(
+                executor_calls=5,
+                planner_calls=1,
+                subagent_calls=2,
+                compaction_calls=1,
+                other_model_calls=2,
+                source_call_total=11,
+                source_call_delta=0,
+                provider_retries=1,
+                compactions=1,
+                subagent_runs=2,
+                tool_calls=4,
+                tool_failures=1,
+                model_calls_by_source={"executor": 5, "classifier": 2},
+                tool_calls_by_name={"grep": 3, "bash": 1},
+            ),
+            self.metric_row(
+                executor_calls=3,
+                planner_calls=1,
+                subagent_calls=1,
+                compaction_calls=1,
+                other_model_calls=2,
+                source_call_total=8,
+                source_call_delta=0,
+                provider_retries=2,
+                compactions=1,
+                subagent_runs=1,
+                tool_calls=2,
+                tool_failures=0,
+                model_calls_by_source={"executor": 3, "goal-evaluator": 2},
+                tool_calls_by_name={"grep": 1, "bash": 1},
+            ),
+        ]
+        tmp, run_dir = self.write_run(rows)
+        self.addCleanup(tmp.cleanup)
+
+        aggregate = load_run(run_dir)
+
+        self.assertEqual(aggregate["executor_calls"], 8)
+        self.assertEqual(aggregate["planner_calls"], 2)
+        self.assertEqual(aggregate["subagent_calls"], 3)
+        self.assertEqual(aggregate["compaction_calls"], 2)
+        self.assertEqual(aggregate["other_model_calls"], 4)
+        self.assertEqual(aggregate["source_call_total"], 19)
+        self.assertEqual(aggregate["source_call_delta"], 0)
+        self.assertEqual(aggregate["provider_retries"], 3)
+        self.assertEqual(aggregate["compactions"], 2)
+        self.assertEqual(aggregate["subagent_runs"], 3)
+        self.assertEqual(aggregate["tool_calls"], 6)
+        self.assertEqual(aggregate["tool_failures"], 1)
+        self.assertEqual(aggregate["model_calls_by_source"], {
+            "classifier": 2,
+            "executor": 8,
+            "goal-evaluator": 2,
+        })
+        self.assertEqual(aggregate["tool_calls_by_name"], {"bash": 2, "grep": 4})
+
+    def test_load_run_treats_legacy_attribution_fields_as_zero(self) -> None:
+        tmp, run_dir = self.write_run([self.metric_row()])
+        self.addCleanup(tmp.cleanup)
+
+        aggregate = load_run(run_dir)
+
+        self.assertEqual(aggregate["executor_calls"], 0)
+        self.assertEqual(aggregate["source_call_total"], 0)
+        self.assertEqual(aggregate["provider_retries"], 0)
+        self.assertEqual(aggregate["model_calls_by_source"], {})
+        self.assertEqual(aggregate["tool_calls_by_name"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize Semantix `usage_by_source` into explicit executor/planner/subagent/compaction/other counters
- expose retries, compactions, subagent runs, tool failures, per-tool counts, and source reconciliation delta
- aggregate attribution in `report.py` and document the metrics contract
- add five regression tests and a P0.1 implementation plan

## Validation
- `python -m py_compile scripts/swebench/common.py scripts/swebench/run_bench.py scripts/swebench/report.py scripts/swebench/test_metrics_attribution.py`
- `python -u scripts/swebench/test_metrics_attribution.py -v` (5 passed)
- `go test ./harness/cli -run 'TestUsageBySource|TestMetrics|TestRunMetrics' -count=1`
- `git diff --check upstream/main...HEAD`

## Full-suite note
`go test ./...` is not green on this Windows host. Failures include the baseline-reproducible `cmd/semantix` exit-code test, symlink privilege errors, test executable access denials, temp-directory cleanup races, MCP startup timeouts, and a boot-test timeout. This PR changes only Python benchmark normalization/reporting and documentation; focused producer/consumer tests pass.

Refs #447