### PR TITLE
feat(semantix): add shadow retrieval diagnostics

### DIFF
--- a/docs/specs/issue-447-shadow-retrieval.md
+++ b/docs/specs/issue-447-shadow-retrieval.md
@@ -1,0 +1,49 @@
+# Issue #447 — P0.2 Shadow Retrieval
+
+## Purpose
+
+Shadow retrieval measures what the L2 memory path *would* inject without changing the provider request. It is the calibration step before adding small-library, slice-type, coverage, margin, and verification gates.
+
+## Configuration
+
+```toml
+[semantix]
+enabled = true
+mode = "shadow" # off | shadow | strict
+```
+
+| Mode | Retrieves | Emits diagnostics | Adds `[semantix-reuse]` to provider messages |
+|---|---:|---:|---:|
+| `off` | no | no | no |
+| `shadow` | yes | yes | no |
+| `strict` | yes | yes | yes, when candidates are admitted |
+
+Compatibility: when `mode` is absent, the existing `inject` boolean remains authoritative (`true` maps to `strict`; `false` maps to `off`). An invalid explicit value fails closed to `off`.
+
+## Per-turn record
+
+The existing `kernel_cache` event carries a `retrieval` object with:
+
+- effective mode, Project-scope library size, repository directory, and HEAD commit;
+- SHA-256/byte/token summaries for the pre/post-cleaning query (currently identical because no query cleaner is enabled);
+- top-1 minus top-2 BM25 margin;
+- score-ordered candidates with slice ID/type, source session, project, origin, verification status, absolute BM25 score, query coverage, zone, admission boolean, and exact reason;
+- canonical final slice order, actual injection byte count, message role, and terminal decision.
+
+Candidate reasons are stable replay inputs: `admitted`, `below_min_score`, `zone_grey`, `zone_miss`, `sanitized_empty`, `origin_below_floor`, `budget`, and `nil_slice`.
+
+`verified` is deliberately `unknown` in this phase. Existing slice provenance is not a successful-evaluation marker and must not be relabelled as verification.
+
+## Provider-byte invariant
+
+The agent request builder only inserts Semantix content when `InjectResult.Text` is non-empty. Shadow executes the same search, zone, sanitization, provenance, and budget path as strict, but returns empty `Text`, does not increment injection statistics, does not emit `SliceInject`, and disables speculative injection warm-up. A regression test serializes the resulting provider message projection and requires byte equality between `off` and `shadow`.
+
+## What this phase does not change
+
+- BM25 parameters or zone thresholds;
+- allowed slice types;
+- library-size, coverage, or margin admission thresholds;
+- Result-slice verification policy;
+- provider prompt content in legacy `inject=true` (`strict`) mode.
+
+Those controls follow after shadow traces establish score and failure distributions.

--- a/docs/superpowers/plans/2026-09-02-issue-447-p0-shadow-retrieval.md
+++ b/docs/superpowers/plans/2026-09-02-issue-447-p0-shadow-retrieval.md
@@ -1,0 +1,46 @@
+# Issue #447 P0.2 Shadow Retrieval Implementation Plan
+
+> Scope: make L2 retrieval observable before tightening admission. This change does not tune thresholds or add new slice allowlists.
+
+## Goal
+
+Add `off | shadow | strict` retrieval modes. `shadow` must execute the same retrieval and admission path as `strict`, emit replayable diagnostics, and return no injection text so provider-visible request bytes remain identical to `off`.
+
+## Compatibility
+
+- `mode = ""` preserves the legacy `inject` boolean (`inject=true` => `strict`, otherwise `off`).
+- An explicit mode takes precedence over `inject`.
+- `Enabled=false` always resolves to `off`.
+- Unknown explicit values fail closed to `off`.
+
+## Work packages
+
+1. **Exact admission trace in `kernel/inject`**
+   - Split retrieval from assembly so the bridge can inspect the exact top-k hits without running BM25 twice.
+   - Record every candidate's score, query coverage, zone, admission outcome, and exact rejection reason.
+   - Keep the existing deterministic block and budget behavior unchanged.
+
+2. **Mode and per-turn diagnostics in `harness/semantix`**
+   - Resolve the effective mode once in `NewBridge`.
+   - Attach library size, repository identity, HEAD commit, redacted query summaries, top-1/top-2 margin, candidate provenance, final order, role, bytes, and decision.
+   - In `shadow`, run the same retrieval/build path but suppress text, injection stats, and `SliceInject` events.
+
+3. **Wire and configuration contract**
+   - Add `semantix.mode` to config rendering and boot wiring.
+   - Carry retrieval diagnostics through the existing `kernel_cache` event wire shape.
+
+4. **Regression proof**
+   - RED tests first for exact rejection reasons, mode compatibility, shadow/no-injection behavior, strict behavior, and JSON wire fields.
+   - Verify focused packages and `git diff --check`.
+
+## Acceptance commands
+
+```powershell
+go test ./kernel/inject ./harness/semantix ./harness/eventwire ./harness/config ./harness/boot -count=1
+go test ./harness/agent -run 'TestPrependSystemBlock|TestSampling' -count=1
+git diff --check upstream/main...HEAD
+```
+
+## Provider-byte invariant
+
+The only Semantix input to provider request assembly is `turn.injectBlock`. `off` returns an empty `InjectResult`; `shadow` returns the same empty `Text` after recording diagnostics. Therefore both modes leave the message list untouched. A regression test compares the serialized provider-visible projection for `off` and `shadow` while confirming that only shadow emits retrieval diagnostics.

--- a/harness/agent/shadow_retrieval_test.go
+++ b/harness/agent/shadow_retrieval_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"semantix/harness/provider"
+	semantixbridge "semantix/harness/semantix"
+	"semantix/kernel/slice"
+)
+
+func TestShadowRetrievalKeepsProviderMessagesByteIdenticalToOff(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".semantix"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(&slice.Slice{ID: "ctx-1", Type: slice.Context, Scope: slice.Project, Content: []byte("修复 go 测试失败")}); err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := store.(interface{ Close() error }); ok {
+		_ = closer.Close()
+	}
+
+	off := semantixbridge.NewBridge(semantixbridge.Config{Enabled: true, Mode: "off", ProjectDir: dir})
+	shadow := semantixbridge.NewBridge(semantixbridge.Config{Enabled: true, Mode: "shadow", ProjectDir: dir})
+	offResult := off.InjectDetailed(context.Background(), "修复 go 测试")
+	shadowResult := shadow.InjectDetailed(context.Background(), "修复 go 测试")
+	if shadowResult.Diagnostics == nil || len(shadowResult.Diagnostics.Candidates) == 0 {
+		t.Fatalf("shadow retrieval did not run: %+v", shadowResult.Diagnostics)
+	}
+
+	base := []provider.Message{{Role: provider.RoleSystem, Content: "system"}, {Role: provider.RoleUser, Content: "修复 go 测试"}}
+	assemble := func(block string) []provider.Message {
+		if block == "" {
+			return append([]provider.Message(nil), base...)
+		}
+		return prependSystemBlock(base, block)
+	}
+	offJSON, err := json.Marshal(assemble(offResult.Text))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shadowJSON, err := json.Marshal(assemble(shadowResult.Text))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(offJSON) != string(shadowJSON) {
+		t.Fatalf("provider messages differ\noff:    %s\nshadow: %s", offJSON, shadowJSON)
+	}
+}

--- a/harness/boot/boot.go
+++ b/harness/boot/boot.go
@@ -300,6 +300,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		Enabled:     cfg.Semantix.Enabled && !opts.Ablation.Off(ablation.Kernel),
 		Binary:      cfg.Semantix.Binary,
 		Inject:      cfg.Semantix.Inject,
+		Mode:        cfg.Semantix.Mode,
 		Budget:      cfg.Semantix.Budget,
 		SessionsDir: cfg.Semantix.SessionsDir,
 		ProjectDir:  cfg.Semantix.ProjectDir,

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -959,6 +959,9 @@ type SemantixConfig struct {
 	Binary string `toml:"binary"`
 	// Inject appends the [semantix-reuse] block to the system prompt region.
 	Inject bool `toml:"inject"`
+	// Mode controls L2 retrieval: off | shadow | strict. Empty preserves the
+	// legacy Inject boolean; an explicit value takes precedence.
+	Mode string `toml:"mode"`
 	// Budget caps the L2 injection block size in bytes (default 4096).
 	Budget int `toml:"budget"`
 	// SessionsDir is where the session JSONL mirror is written; empty uses

--- a/harness/config/render.go
+++ b/harness/config/render.go
@@ -522,6 +522,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	b.WriteString("# inject the [semantix-reuse] block on similar tasks (inject).\n")
 	fmt.Fprintf(&b, "enabled = %v\n", c.Semantix.Enabled)
 	fmt.Fprintf(&b, "inject  = %v\n", c.Semantix.Inject)
+	if c.Semantix.Mode != "" {
+		fmt.Fprintf(&b, "mode    = %q   # off | shadow | strict\n", c.Semantix.Mode)
+	} else {
+		b.WriteString("# mode    = \"shadow\"   # observe retrieval without provider injection\n")
+	}
 	if c.Semantix.Binary != "" {
 		fmt.Fprintf(&b, "binary  = %q\n", c.Semantix.Binary)
 	} else {

--- a/harness/config/render_test.go
+++ b/harness/config/render_test.go
@@ -210,6 +210,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Desktop.CheckUpdates = boolPtr(false)
 	orig.Desktop.UpdateChannel = "preview"
 	orig.Desktop.Telemetry = boolPtr(false)
+	orig.Semantix.Mode = "shadow"
 	orig.Notifications.Enabled = true
 	orig.Notifications.TurnDone = true
 	orig.Notifications.ApprovalRequest = true
@@ -328,6 +329,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.ConfigVersion != Default().ConfigVersion {
 		t.Errorf("config_version = %d, want %d", got.ConfigVersion, Default().ConfigVersion)
+	}
+	if got.Semantix.Mode != "shadow" {
+		t.Errorf("semantix.mode = %q, want shadow", got.Semantix.Mode)
 	}
 	if got.Language != "zh" {
 		t.Errorf("language = %q, want zh", got.Language)

--- a/harness/event/event.go
+++ b/harness/event/event.go
@@ -532,11 +532,59 @@ type CacheDiagnostics struct {
 // "degraded"; Layer is "L2" or "L3". It carries observations only, never
 // unmeasured cost or performance claims.
 type KernelCachePayload struct {
-	Op       string   `json:"op,omitempty"`
-	Layer    string   `json:"layer,omitempty"`
-	SliceIDs []string `json:"sliceIds,omitempty"`
-	Bytes    int      `json:"bytes,omitempty"`
-	Reason   string   `json:"reason,omitempty"`
+	Op        string                `json:"op,omitempty"`
+	Layer     string                `json:"layer,omitempty"`
+	SliceIDs  []string              `json:"sliceIds,omitempty"`
+	Bytes     int                   `json:"bytes,omitempty"`
+	Reason    string                `json:"reason,omitempty"`
+	Retrieval *RetrievalDiagnostics `json:"retrieval,omitempty"`
+}
+
+// QuerySummary identifies retrieval input without copying user text into the
+// telemetry stream. SHA256 plus byte/token counts is sufficient to correlate
+// the before/after cleaning stages and detect whether cleaning changed bytes.
+type QuerySummary struct {
+	SHA256 string `json:"sha256,omitempty"`
+	Bytes  int    `json:"bytes,omitempty"`
+	Tokens int    `json:"tokens,omitempty"`
+}
+
+// RetrievalCandidate records one score-ordered top-k result and the exact
+// production admission outcome. Verified is "unknown" until slice metadata
+// gains a distinct successful-evaluation marker; provenance must not be
+// misreported as verification.
+type RetrievalCandidate struct {
+	ID            string  `json:"id,omitempty"`
+	Type          string  `json:"type,omitempty"`
+	SourceSession string  `json:"sourceSession,omitempty"`
+	Project       string  `json:"project,omitempty"`
+	Origin        string  `json:"origin,omitempty"`
+	Verified      string  `json:"verified,omitempty"`
+	Score         float64 `json:"score,omitempty"`
+	Coverage      float64 `json:"coverage,omitempty"`
+	Zone          string  `json:"zone,omitempty"`
+	Admitted      bool    `json:"admitted,omitempty"`
+	Reason        string  `json:"reason,omitempty"`
+}
+
+// RetrievalDiagnostics is the replayable per-turn L2 retrieval record. In
+// shadow mode Candidates and the counterfactual FinalOrder are populated but
+// Injected/Bytes/MessageRole remain zero because provider input is untouched.
+type RetrievalDiagnostics struct {
+	Mode           string               `json:"mode,omitempty"`
+	LibrarySize    int                  `json:"librarySize,omitempty"`
+	Repo           string               `json:"repo,omitempty"`
+	BaseCommit     string               `json:"baseCommit,omitempty"`
+	QueryBefore    QuerySummary         `json:"queryBefore,omitempty"`
+	QueryAfter     QuerySummary         `json:"queryAfter,omitempty"`
+	TopMargin      float64              `json:"topMargin,omitempty"`
+	Candidates     []RetrievalCandidate `json:"candidates,omitempty"`
+	Injected       bool                 `json:"injected,omitempty"`
+	Bytes          int                  `json:"bytes,omitempty"`
+	MessageRole    string               `json:"messageRole,omitempty"`
+	FinalOrder     []string             `json:"finalOrder,omitempty"`
+	Decision       string               `json:"decision,omitempty"`
+	DecisionReason string               `json:"decisionReason,omitempty"`
 }
 
 // FinalReadiness carries machine-readable recovery requirements on TurnDone.

--- a/harness/eventwire/wire.go
+++ b/harness/eventwire/wire.go
@@ -53,11 +53,49 @@ type Event struct {
 
 // KernelCache is the JSON form of event.KernelCachePayload.
 type KernelCache struct {
-	Op       string   `json:"op,omitempty"`
-	Layer    string   `json:"layer,omitempty"`
-	SliceIDs []string `json:"sliceIds,omitempty"`
-	Bytes    int      `json:"bytes,omitempty"`
-	Reason   string   `json:"reason,omitempty"`
+	Op        string                `json:"op,omitempty"`
+	Layer     string                `json:"layer,omitempty"`
+	SliceIDs  []string              `json:"sliceIds,omitempty"`
+	Bytes     int                   `json:"bytes,omitempty"`
+	Reason    string                `json:"reason,omitempty"`
+	Retrieval *RetrievalDiagnostics `json:"retrieval,omitempty"`
+}
+
+type QuerySummary struct {
+	SHA256 string `json:"sha256,omitempty"`
+	Bytes  int    `json:"bytes,omitempty"`
+	Tokens int    `json:"tokens,omitempty"`
+}
+
+type RetrievalCandidate struct {
+	ID            string  `json:"id,omitempty"`
+	Type          string  `json:"type,omitempty"`
+	SourceSession string  `json:"sourceSession,omitempty"`
+	Project       string  `json:"project,omitempty"`
+	Origin        string  `json:"origin,omitempty"`
+	Verified      string  `json:"verified,omitempty"`
+	Score         float64 `json:"score,omitempty"`
+	Coverage      float64 `json:"coverage,omitempty"`
+	Zone          string  `json:"zone,omitempty"`
+	Admitted      bool    `json:"admitted,omitempty"`
+	Reason        string  `json:"reason,omitempty"`
+}
+
+type RetrievalDiagnostics struct {
+	Mode           string               `json:"mode,omitempty"`
+	LibrarySize    int                  `json:"librarySize,omitempty"`
+	Repo           string               `json:"repo,omitempty"`
+	BaseCommit     string               `json:"baseCommit,omitempty"`
+	QueryBefore    QuerySummary         `json:"queryBefore,omitempty"`
+	QueryAfter     QuerySummary         `json:"queryAfter,omitempty"`
+	TopMargin      float64              `json:"topMargin,omitempty"`
+	Candidates     []RetrievalCandidate `json:"candidates,omitempty"`
+	Injected       bool                 `json:"injected,omitempty"`
+	Bytes          int                  `json:"bytes,omitempty"`
+	MessageRole    string               `json:"messageRole,omitempty"`
+	FinalOrder     []string             `json:"finalOrder,omitempty"`
+	Decision       string               `json:"decision,omitempty"`
+	DecisionReason string               `json:"decisionReason,omitempty"`
 }
 
 // CompletionSummary is the JSON form of event.CompletionSummaryInfo.
@@ -247,10 +285,31 @@ func ToWire(e event.Event) Event {
 		}
 	case event.KernelCache:
 		if c := e.KernelCache; c != nil {
-			w.KernelCache = &KernelCache{Op: c.Op, Layer: c.Layer, SliceIDs: append([]string(nil), c.SliceIDs...), Bytes: c.Bytes, Reason: c.Reason}
+			w.KernelCache = &KernelCache{Op: c.Op, Layer: c.Layer, SliceIDs: append([]string(nil), c.SliceIDs...), Bytes: c.Bytes, Reason: c.Reason, Retrieval: toWireRetrieval(c.Retrieval)}
 		}
 	}
 	return w
+}
+
+func toWireRetrieval(in *event.RetrievalDiagnostics) *RetrievalDiagnostics {
+	if in == nil {
+		return nil
+	}
+	out := &RetrievalDiagnostics{
+		Mode: in.Mode, LibrarySize: in.LibrarySize, Repo: in.Repo, BaseCommit: in.BaseCommit,
+		QueryBefore: QuerySummary{SHA256: in.QueryBefore.SHA256, Bytes: in.QueryBefore.Bytes, Tokens: in.QueryBefore.Tokens},
+		QueryAfter:  QuerySummary{SHA256: in.QueryAfter.SHA256, Bytes: in.QueryAfter.Bytes, Tokens: in.QueryAfter.Tokens},
+		TopMargin:   in.TopMargin, Injected: in.Injected, Bytes: in.Bytes, MessageRole: in.MessageRole,
+		FinalOrder: append([]string(nil), in.FinalOrder...), Decision: in.Decision, DecisionReason: in.DecisionReason,
+	}
+	for _, c := range in.Candidates {
+		out.Candidates = append(out.Candidates, RetrievalCandidate{
+			ID: c.ID, Type: c.Type, SourceSession: c.SourceSession, Project: c.Project,
+			Origin: c.Origin, Verified: c.Verified, Score: c.Score, Coverage: c.Coverage,
+			Zone: c.Zone, Admitted: c.Admitted, Reason: c.Reason,
+		})
+	}
+	return out
 }
 
 func toWireUsage(e event.Event) *Usage {

--- a/harness/eventwire/wire_test.go
+++ b/harness/eventwire/wire_test.go
@@ -81,6 +81,8 @@ func TestToWireContextMaintenanceJSON(t *testing.T) {
 func TestToWireKernelCacheJSON(t *testing.T) {
 	w := ToWire(event.Event{Kind: event.KernelCache, KernelCache: &event.KernelCachePayload{
 		Op: "degraded", Layer: "L2", SliceIDs: []string{"b", "a"}, Bytes: 128, Reason: "budget",
+		Retrieval: &event.RetrievalDiagnostics{Mode: "shadow", LibrarySize: 3, TopMargin: 1.25,
+			Candidates: []event.RetrievalCandidate{{ID: "b", Type: "context", Score: 2.5, Coverage: 0.75, Zone: "hit", Admitted: true, Reason: "admitted"}}},
 	}})
 	if w.Kind != "kernel_cache" || w.KernelCache == nil {
 		t.Fatalf("kernel cache wire = %+v", w)
@@ -89,7 +91,7 @@ func TestToWireKernelCacheJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`"kind":"kernel_cache"`, `"op":"degraded"`, `"layer":"L2"`, `"sliceIds":["b","a"]`, `"reason":"budget"`} {
+	for _, want := range []string{`"kind":"kernel_cache"`, `"op":"degraded"`, `"layer":"L2"`, `"sliceIds":["b","a"]`, `"reason":"budget"`, `"mode":"shadow"`, `"librarySize":3`, `"coverage":0.75`, `"reason":"admitted"`} {
 		if !strings.Contains(string(b), want) {
 			t.Fatalf("kernel cache JSON = %s, missing %s", b, want)
 		}

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -5,10 +5,13 @@ package semantix
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +37,9 @@ type Config struct {
 	Binary string
 	// Inject appends the [semantix-reuse] block to the system prompt region.
 	Inject bool
+	// Mode controls L2 retrieval: off | shadow | strict. Empty preserves the
+	// legacy Inject boolean; an explicit value takes precedence.
+	Mode string
 	// Budget caps the L2 injection block size in bytes (default 4096).
 	Budget int
 	// GreyMode controls the grey-zone injection policy: "" / "drop" keeps
@@ -62,6 +68,7 @@ type Config struct {
 // the agent main loop.
 type Bridge struct {
 	cfg    Config
+	mode   RetrievalMode
 	events *kernelevent.SyncBus
 
 	mu    sync.Mutex
@@ -77,16 +84,47 @@ type Bridge struct {
 	closing     bool
 }
 
+// RetrievalMode controls whether L2 retrieval is disabled, observed only, or
+// allowed to contribute a provider-visible system block.
+type RetrievalMode string
+
+const (
+	RetrievalOff    RetrievalMode = "off"
+	RetrievalShadow RetrievalMode = "shadow"
+	RetrievalStrict RetrievalMode = "strict"
+)
+
 // NewBridge builds a Bridge from cfg.
 func NewBridge(cfg Config) *Bridge {
 	if cfg.Budget <= 0 {
 		cfg.Budget = 4096
 	}
 	bus := kernelevent.NewSyncBus()
-	b := &Bridge{cfg: cfg, events: bus}
+	b := &Bridge{cfg: cfg, mode: resolveRetrievalMode(cfg), events: bus}
 	bus.Subscribe(b.mirrorKernel)
 	b.evolution = NewEvolutionLoop(bus, evolve.New(evolve.Config{}))
 	return b
+}
+
+func resolveRetrievalMode(cfg Config) RetrievalMode {
+	if !cfg.Enabled {
+		return RetrievalOff
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Mode)) {
+	case "":
+		if cfg.Inject {
+			return RetrievalStrict
+		}
+		return RetrievalOff
+	case string(RetrievalOff):
+		return RetrievalOff
+	case string(RetrievalShadow):
+		return RetrievalShadow
+	case string(RetrievalStrict):
+		return RetrievalStrict
+	default:
+		return RetrievalOff
+	}
 }
 
 // AttachEvolution connects the live scheduler and prefetcher to the online loop.
@@ -99,8 +137,9 @@ func (b *Bridge) AttachEvolution(scheduler, prefetcher EvolutionTuner) {
 // InjectResult carries the stable block and the canonical slice identities it
 // represents, allowing prefetch feedback to retain the existing targets wire.
 type InjectResult struct {
-	Text    string
-	Targets []string
+	Text        string
+	Targets     []string
+	Diagnostics *event.RetrievalDiagnostics
 }
 
 // Events is the in-process kernel event bus shared by the harness and kernel
@@ -120,9 +159,19 @@ func (b *Bridge) Events() kernelevent.Bus {
 // Enabled reports whether the kernel is wired in.
 func (b *Bridge) Enabled() bool { return b != nil && b.cfg.Enabled }
 
+// RetrievalMode reports the fail-closed effective L2 mode.
+func (b *Bridge) RetrievalMode() RetrievalMode {
+	if b == nil {
+		return RetrievalOff
+	}
+	return b.mode
+}
+
 // InjectEnabled reports whether L2 injection is wired on (used to decide
 // whether speculative prefetch warm-up is worth starting).
-func (b *Bridge) InjectEnabled() bool { return b != nil && b.cfg.Enabled && b.cfg.Inject }
+func (b *Bridge) InjectEnabled() bool {
+	return b != nil && b.Enabled() && b.mode == RetrievalStrict
+}
 
 // Sink wraps inner so every event is also mirrored into the kernel session
 // JSONL. Returns inner unchanged when the kernel is not enabled (zero-cost
@@ -177,7 +226,7 @@ func (b *Bridge) InjectDetailed(ctx context.Context, query string) InjectResult 
 }
 
 func (b *Bridge) injectResult(ctx context.Context, query string, budget int) InjectResult {
-	if !b.Enabled() || !b.cfg.Inject {
+	if !b.Enabled() || b.mode == RetrievalOff {
 		return InjectResult{}
 	}
 	store, idx, err := b.kernelIndex()
@@ -185,7 +234,17 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		b.emitKernelCache("miss", "L2", nil, 0, "slice store unavailable")
 		return InjectResult{}
 	}
-	closeSliceStore(store)
+	defer closeSliceStore(store)
+	projectSlices, err := store.List(slice.Project)
+	if err != nil {
+		b.emitKernelCache("miss", "L2", nil, 0, "slice library unavailable")
+		return InjectResult{}
+	}
+	hits, err := idx.Search(query, 5, slice.Project)
+	if err != nil {
+		b.emitKernelCache("miss", "L2", nil, 0, err.Error())
+		return InjectResult{}
+	}
 	z := zone.Default()
 	inj, err := (&inject.Injector{
 		Index:     idx,
@@ -194,7 +253,7 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		Budget:    budget,
 		Zones:     &z,
 		AllowGrey: b.cfg.GreyMode == "audit",
-	}).Build(query)
+	}).BuildHits(query, hits)
 	if err != nil {
 		op := "miss"
 		if budget < b.cfg.Budget {
@@ -203,13 +262,22 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		b.emitKernelCache(op, "L2", nil, 0, err.Error())
 		return InjectResult{}
 	}
+	diagnostics := b.retrievalDiagnostics(query, projectSlices, hits, inj)
+	if b.mode == RetrievalShadow {
+		diagnostics.Decision = "withheld"
+		diagnostics.DecisionReason = "shadow_mode"
+		b.emitKernelCacheDetailed("shadow", "L2", diagnostics.FinalOrder, 0, "shadow_mode", diagnostics)
+		return InjectResult{Targets: append([]string(nil), diagnostics.FinalOrder...), Diagnostics: diagnostics}
+	}
 	if inj == nil || len(inj.Slices) == 0 {
 		op := "miss"
 		if budget < b.cfg.Budget {
 			op = "degraded"
 		}
-		b.emitKernelCache(op, "L2", nil, 0, "no matching slices")
-		return InjectResult{}
+		diagnostics.Decision = "rejected"
+		diagnostics.DecisionReason = "no_admitted_slices"
+		b.emitKernelCacheDetailed(op, "L2", nil, 0, "no matching slices", diagnostics)
+		return InjectResult{Diagnostics: diagnostics}
 	}
 	targets := make([]string, 0, len(inj.Slices))
 	for _, sl := range inj.Slices {
@@ -219,12 +287,87 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 	}
 	sort.Strings(targets)
 	b.recordInjection(targets, inj.Bytes)
+	diagnostics.Injected = true
+	diagnostics.Bytes = inj.Bytes
+	diagnostics.MessageRole = "system"
+	diagnostics.Decision = "injected"
+	diagnostics.DecisionReason = "admitted"
 	op := "inject"
 	if budget < b.cfg.Budget {
 		op = "degraded"
 	}
-	b.emitKernelCache(op, "L2", targets, inj.Bytes, "")
-	return InjectResult{Text: inj.Text, Targets: targets}
+	b.emitKernelCacheDetailed(op, "L2", targets, inj.Bytes, "", diagnostics)
+	return InjectResult{Text: inj.Text, Targets: targets, Diagnostics: diagnostics}
+}
+
+func (b *Bridge) retrievalDiagnostics(query string, library []*slice.Slice, hits []slice.Hit, inj *inject.Injection) *event.RetrievalDiagnostics {
+	projectDir := b.projectDir()
+	d := &event.RetrievalDiagnostics{
+		Mode: string(b.mode), LibrarySize: len(library), Repo: filepath.Base(filepath.Clean(projectDir)),
+		BaseCommit: readGitHead(projectDir), QueryBefore: summarizeQuery(query), QueryAfter: summarizeQuery(query),
+	}
+	if len(hits) > 0 {
+		d.TopMargin = hits[0].Score
+		if len(hits) > 1 {
+			d.TopMargin -= hits[1].Score
+		}
+	}
+	if inj == nil {
+		return d
+	}
+	for i, decision := range inj.Decisions {
+		candidate := event.RetrievalCandidate{
+			ID: decision.ID, Score: decision.Score, Coverage: decision.Coverage,
+			Zone: decision.Zone, Admitted: decision.Admitted, Reason: decision.Reason, Verified: "unknown",
+		}
+		if i < len(hits) && hits[i].Slice != nil {
+			sl := hits[i].Slice
+			candidate.Type = sl.Type.String()
+			candidate.SourceSession = sl.Meta.SourceSession
+			candidate.Project = sl.Meta.ProjectSlug
+			candidate.Origin = string(sl.Meta.Origin)
+		}
+		d.Candidates = append(d.Candidates, candidate)
+	}
+	for _, sl := range inj.Slices {
+		if sl != nil {
+			d.FinalOrder = append(d.FinalOrder, sl.ID)
+		}
+	}
+	return d
+}
+
+func summarizeQuery(query string) event.QuerySummary {
+	sum := sha256.Sum256([]byte(query))
+	return event.QuerySummary{SHA256: fmt.Sprintf("%x", sum[:]), Bytes: len(query), Tokens: len(bm25.Tokenize(query))}
+}
+
+func readGitHead(root string) string {
+	gitDir := filepath.Join(root, ".git")
+	if raw, err := os.ReadFile(gitDir); err == nil {
+		line := strings.TrimSpace(string(raw))
+		if strings.HasPrefix(line, "gitdir:") {
+			gitDir = strings.TrimSpace(strings.TrimPrefix(line, "gitdir:"))
+			if !filepath.IsAbs(gitDir) {
+				gitDir = filepath.Join(root, gitDir)
+			}
+		}
+	}
+	head, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return ""
+	}
+	value := strings.TrimSpace(string(head))
+	if !strings.HasPrefix(value, "ref:") {
+		return value
+	}
+	ref := strings.TrimSpace(strings.TrimPrefix(value, "ref:"))
+	for _, base := range []string{gitDir, filepath.Clean(filepath.Join(gitDir, "..", ".."))} {
+		if raw, err := os.ReadFile(filepath.Join(base, filepath.FromSlash(ref))); err == nil {
+			return strings.TrimSpace(string(raw))
+		}
+	}
+	return ""
 }
 
 // emitKernelCache forwards an observed kernel cache operation to the live
@@ -232,6 +375,10 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 // mirror; this small projection is only for the workspace SSE/UI and is
 // fail-open when no frontend sink is attached.
 func (b *Bridge) emitKernelCache(op, layer string, ids []string, bytes int, reason string) {
+	b.emitKernelCacheDetailed(op, layer, ids, bytes, reason, nil)
+}
+
+func (b *Bridge) emitKernelCacheDetailed(op, layer string, ids []string, bytes int, reason string, retrieval *event.RetrievalDiagnostics) {
 	if b == nil || !b.Enabled() {
 		return
 	}
@@ -244,7 +391,7 @@ func (b *Bridge) emitKernelCache(op, layer string, ids []string, bytes int, reas
 		return
 	}
 	sink.Emit(event.Event{Kind: event.KernelCache, Text: op, Source: label,
-		KernelCache: &event.KernelCachePayload{Op: op, Layer: layer, SliceIDs: ids, Bytes: bytes, Reason: reason}})
+		KernelCache: &event.KernelCachePayload{Op: op, Layer: layer, SliceIDs: ids, Bytes: bytes, Reason: reason, Retrieval: retrieval}})
 }
 
 func (b *Bridge) recordInjection(ids []string, bytes int) {

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -227,6 +227,68 @@ func TestBridgeInjectRecordsStatsAndEvent(t *testing.T) {
 	}
 }
 
+func TestBridgeShadowRetrievalEmitsDiagnosticsWithoutInjection(t *testing.T) {
+	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
+	var events []event.Event
+	b := NewBridge(Config{Enabled: true, Mode: "shadow", Inject: true, ProjectDir: dir, Budget: 4096})
+	b.SetLabel("shadow-observation")
+	b.Sink(event.FuncSink(func(e event.Event) { events = append(events, e) }))
+
+	result := b.InjectDetailed(context.Background(), "修复 go 测试")
+	if result.Text != "" {
+		t.Fatalf("shadow Text = %q, want empty provider-visible injection", result.Text)
+	}
+	if result.Diagnostics == nil || result.Diagnostics.Mode != "shadow" || len(result.Diagnostics.Candidates) == 0 {
+		t.Fatalf("shadow diagnostics = %+v", result.Diagnostics)
+	}
+	if result.Diagnostics.LibrarySize != 3 || result.Diagnostics.QueryBefore.SHA256 == "" || result.Diagnostics.QueryAfter.SHA256 == "" {
+		t.Fatalf("shadow diagnostics missing replay context: %+v", result.Diagnostics)
+	}
+	if result.Diagnostics.Injected || result.Diagnostics.Bytes != 0 || result.Diagnostics.MessageRole != "" {
+		t.Fatalf("shadow reported provider injection: %+v", result.Diagnostics)
+	}
+	if len(events) != 1 || events[0].KernelCache == nil || events[0].KernelCache.Op != "shadow" || events[0].KernelCache.Retrieval == nil {
+		t.Fatalf("shadow events = %+v", events)
+	}
+
+	store, err := slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSliceStore(store)
+	for _, candidate := range result.Diagnostics.Candidates {
+		got, err := store.Get(candidate.ID)
+		if err != nil || got == nil {
+			t.Fatalf("Get(%q) = %v, %v", candidate.ID, got, err)
+		}
+		if got.Stats.Injected != 0 {
+			t.Fatalf("shadow mutated injection stats for %q: %+v", candidate.ID, got.Stats)
+		}
+	}
+}
+
+func TestBridgeRetrievalModeCompatibilityAndFailClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want RetrievalMode
+	}{
+		{"legacy strict", Config{Enabled: true, Inject: true}, RetrievalStrict},
+		{"legacy off", Config{Enabled: true}, RetrievalOff},
+		{"explicit shadow", Config{Enabled: true, Inject: true, Mode: "shadow"}, RetrievalShadow},
+		{"explicit strict", Config{Enabled: true, Mode: "strict"}, RetrievalStrict},
+		{"disabled", Config{Enabled: false, Inject: true, Mode: "strict"}, RetrievalOff},
+		{"unknown", Config{Enabled: true, Inject: true, Mode: "typo"}, RetrievalOff},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NewBridge(tc.cfg).RetrievalMode(); got != tc.want {
+				t.Fatalf("RetrievalMode() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestBridgeReuseSavingsDelta: the usage side attributes only the growth
 // between snapshots; the first snapshot takes the full cumulative value.
 func TestBridgeReuseSavingsDelta(t *testing.T) {

--- a/kernel/inject/inject.go
+++ b/kernel/inject/inject.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"unicode"
 
+	"semantix/kernel/bm25"
 	"semantix/kernel/sanitize"
 	"semantix/kernel/slice"
 	"semantix/kernel/zone"
@@ -112,6 +113,22 @@ type Injection struct {
 	// mode). Zero in the default drop mode; a persistent non-zero value is
 	// the signal to recalibrate zone thresholds (W3 of the efficiency plan).
 	GreyIncluded int
+	// Decisions preserves the score-order admission trace for every retrieved
+	// candidate. It is observation-only: replaying Admitted from Reason must
+	// yield the same slice set that produced Text.
+	Decisions []CandidateDecision
+}
+
+// CandidateDecision is the replayable admission outcome for one retrieved
+// slice. Reason is a stable enum: admitted, below_min_score, zone_grey,
+// zone_miss, sanitized_empty, origin_below_floor, budget, or nil_slice.
+type CandidateDecision struct {
+	ID       string
+	Score    float64
+	Coverage float64
+	Zone     string
+	Admitted bool
+	Reason   string
 }
 
 const (
@@ -126,14 +143,20 @@ func (in *Injector) Build(query string) (*Injection, error) {
 	if k <= 0 {
 		k = 5
 	}
-	budget := in.Budget
-	if budget <= 0 {
-		budget = DefaultBudget
-	}
-
 	hits, err := in.Index.Search(query, k, in.Scope)
 	if err != nil {
 		return nil, fmt.Errorf("inject: search: %w", err)
+	}
+	return in.BuildHits(query, hits)
+}
+
+// BuildHits applies the exact production admission and assembly path to an
+// already-retrieved score-ordered hit list. It lets callers record the same
+// candidates that produced the block without running retrieval twice.
+func (in *Injector) BuildHits(query string, hits []slice.Hit) (*Injection, error) {
+	budget := in.Budget
+	if budget <= 0 {
+		budget = DefaultBudget
 	}
 	top1 := 0.0
 	if len(hits) > 0 {
@@ -154,30 +177,48 @@ func (in *Injector) Build(query string) (*Injection, error) {
 		grey    bool   // audit-mode admission under the unverified header
 	}
 	var cands []candidate
+	decisions := make([]CandidateDecision, 0, len(hits))
 	size := len(blockOpen)
 	for _, h := range hits {
+		d := CandidateDecision{Score: h.Score, Zone: zone.Miss.String(), Reason: "nil_slice"}
+		if h.Slice == nil {
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
+		d.ID = h.Slice.ID
+		d.Coverage = bm25.QueryCoverage(query, string(h.Slice.Content))
 		if in.MinScore > 0 && h.Score < in.MinScore {
+			d.Reason = "below_min_score"
+			decisions = append(decisions, d)
+			dropped++
 			continue
 		}
 		isGrey := false
 		if in.Zones != nil {
 			z := *in.Zones
-			if h.Slice != nil {
-				z = z.ForType(h.Slice.Type.String()) // Issue #259 阶段 2
-			}
-			switch z.Classify(h.Score, top1) {
+			z = z.ForType(h.Slice.Type.String()) // Issue #259 阶段 2
+			classified := z.Classify(h.Score, top1)
+			d.Zone = classified.String()
+			switch classified {
 			case zone.Hit:
 				// verified: admitted below
 			case zone.Grey:
 				if !in.AllowGrey {
+					d.Reason = "zone_grey"
+					decisions = append(decisions, d)
 					dropped++
 					continue
 				}
 				isGrey = true // admitted below under the unverified header
 			default: // miss
+				d.Reason = "zone_miss"
+				decisions = append(decisions, d)
 				dropped++
 				continue
 			}
+		} else {
+			d.Zone = "unclassified"
 		}
 		// Inject-side sanitization (Issue #278, Security §3.1): the block
 		// carries the deterministically cleaned content — escape stripping,
@@ -188,6 +229,8 @@ func (in *Injector) Build(query string) (*Injection, error) {
 		// dropped entirely (nothing useful to inject).
 		content := sanitize.Sanitize(string(h.Slice.Content))
 		if content == "" {
+			d.Reason = "sanitized_empty"
+			decisions = append(decisions, d)
 			dropped++
 			continue
 		}
@@ -196,6 +239,8 @@ func (in *Injector) Build(query string) (*Injection, error) {
 		// (import and legacy are level 1; session-auto/prefetch 2;
 		// user-curated 3).
 		if h.Slice != nil && in.MinOrigin.Level() > h.Slice.Meta.Origin.Level() {
+			d.Reason = "origin_below_floor"
+			decisions = append(decisions, d)
 			dropped++
 			continue
 		}
@@ -209,10 +254,15 @@ func (in *Injector) Build(query string) (*Injection, error) {
 		}
 		item := len(fmt.Sprintf(header, h.Slice.ID, content))
 		if size+item+len(blockClose)+64 > budget && len(cands) > 0 {
+			d.Reason = "budget"
+			decisions = append(decisions, d)
 			dropped++
 			continue
 		}
 		size += item
+		d.Admitted = true
+		d.Reason = "admitted"
+		decisions = append(decisions, d)
 		cands = append(cands, candidate{sl: h.Slice, content: content, grey: isGrey})
 	}
 
@@ -246,5 +296,6 @@ func (in *Injector) Build(query string) (*Injection, error) {
 		Bytes:        buf.Len(),
 		Dropped:      dropped,
 		GreyIncluded: greyIncluded,
+		Decisions:    decisions,
 	}, nil
 }

--- a/kernel/inject/inject_test.go
+++ b/kernel/inject/inject_test.go
@@ -183,6 +183,34 @@ func TestInjectorZoneFilterDropsGrey(t *testing.T) {
 	}
 }
 
+func TestInjectorAdmissionTraceReplaysDecision(t *testing.T) {
+	idx := bm25.New()
+	store := newTestStore(t, filepath.Join(t.TempDir(), "db.jsonl"))
+	seed(t, idx, store, "修复 go 测试失败", "修复 go 发布流程")
+
+	hits, err := idx.Search("修复 go 测试失败", 5, slice.Project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	z := zone.Default()
+	in := &Injector{Index: idx, Scope: slice.Project, K: 5, Zones: &z}
+	inj, err := in.BuildHits("修复 go 测试失败", hits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inj.Decisions) != len(hits) {
+		t.Fatalf("decisions = %d, want one per hit (%d)", len(inj.Decisions), len(hits))
+	}
+	for _, d := range inj.Decisions {
+		if d.ID == "" || d.Score <= 0 || d.Coverage <= 0 || d.Zone == "" || d.Reason == "" {
+			t.Fatalf("incomplete decision: %+v", d)
+		}
+		if d.Admitted != (d.Reason == "admitted") {
+			t.Fatalf("decision cannot be replayed from reason: %+v", d)
+		}
+	}
+}
+
 // TestInjectorEscapesBlockMarkers is the HIGH-fix regression: a stored slice
 // containing block markers must not break the [semantix-reuse] structure.
 func TestInjectorEscapesBlockMarkers(t *testing.T) {

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -97,6 +97,13 @@ runner 会把原生 `usage_by_source` 规范化进每实例 `metrics.jsonl`：
 `report.py` 的 Markdown 表用 `calls E/P/S/C/O` 显示
 executor/planner/subagent/compaction/other；JSON 输出保留完整来源表和工具表。
 
+#### Shadow retrieval 实验臂
+
+`--semantix-retrieval-mode off|shadow|strict`（默认 `strict`）控制开启内核后的
+L2 路径。`shadow` 会检索、执行相同的 zone/清洗/预算判定并记录 `kernel_cache`
+诊断，但不向 provider 消息添加复用块；因此可作为 A/B 臂 B，与
+`--semantix-memory off` 做请求字节不变量检查，再用其分数分布标定后续门禁。
+
 ## 方法学要点（对比公平性）
 
 - **同一 prompt 模板**（`common.PROMPT_TEMPLATE`）喂给所有 harness；system prompt 保持各 harness 原生（那正是 harness 差异的一部分）。

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -207,6 +207,7 @@ class SemantixAdapter(Adapter):
 [semantix]
 enabled      = true
 inject       = true
+mode         = "{self.args.semantix_retrieval_mode}"
 budget       = 4096
 project_dir  = "{self.kernel_dir}"
 sessions_dir = "{sessions_dir}"
@@ -777,6 +778,10 @@ def main() -> None:
     ap.add_argument("--semantix-memory", default="on", choices=("on", "off"),
                     help="semantix memory-kernel arm: on = [semantix] enabled+inject, shared slice "
                     "library across instances, per-instance extract; off = kernel disabled (ablation twin)")
+    ap.add_argument("--semantix-retrieval-mode", default="strict",
+                    choices=("off", "shadow", "strict"),
+                    help="L2 retrieval mode when --semantix-memory=on; shadow records the same "
+                    "candidates and admission decisions as strict but leaves provider messages unchanged")
     ap.add_argument("--semantix-bin", default="")
     ap.add_argument("--semantix-kernel-bin", default="",
                     help="path to the semantix kernel CLI (default: bin/semantix) used for slice extraction")

--- a/scripts/swebench/test_shadow_config.py
+++ b/scripts/swebench/test_shadow_config.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from run_bench import SemantixAdapter
+
+
+class ShadowConfigTests(unittest.TestCase):
+    def test_write_home_emits_explicit_shadow_mode(self):
+        adapter = SemantixAdapter.__new__(SemantixAdapter)
+        adapter.args = SimpleNamespace(
+            openai_base="http://127.0.0.1:8139/v1",
+            effort="",
+            model="deepseek-v4-flash",
+            semantix_retrieval_mode="shadow",
+        )
+        adapter.memory_on = True
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            adapter.kernel_dir = root / "kernel"
+            adapter._write_home(root / "home", root / "sessions")
+            config = (root / "home" / "config.toml").read_text()
+        self.assertIn('mode         = "shadow"', config)
+        self.assertIn("enabled      = true", config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add fail-closed `off | shadow | strict` L2 retrieval modes while preserving legacy `inject` behavior
- make shadow execute the exact BM25, zone, sanitization, provenance, and budget path without changing provider messages or injection statistics
- emit replayable per-turn diagnostics: library/repo/commit, redacted query summaries, scores, coverage, top margin, provenance, zone, admission outcome, rejection reason, and canonical final order
- carry diagnostics through `kernel_cache` eventwire and expose `--semantix-retrieval-mode` in the SWE-bench runner
- document the P0.2 contract and add provider-byte, mode, admission-trace, config, and wire regressions

## Compatibility
- absent `mode`: `inject=true` maps to `strict`; otherwise `off`
- explicit mode takes precedence
- disabled or unknown mode fails closed to `off`
- `shadow` returns empty injection text, emits no `SliceInject`, and disables injection prefetch

## Validation
- `go test ./harness/semantix ./harness/eventwire ./harness/config -count=1`
- `go test ./harness/agent -run TestShadowRetrievalKeepsProviderMessagesByteIdenticalToOff -count=1`
- `go test -c -o .testbin/kernel-inject-check.exe ./kernel/inject` followed by the compiled package test binary (`PASS`)
- `go test -c -o .testbin/harness-boot-check.exe ./harness/boot`
- `python -m py_compile scripts/swebench/run_bench.py scripts/swebench/test_shadow_config.py`
- `python -u scripts/swebench/test_shadow_config.py -v`
- `git diff --check upstream/main...HEAD`

## Host note
Direct `go test ./kernel/inject` intermittently cannot open the generated test executable on this Windows host (`Access is denied`); compiling to a stable workspace path and executing that exact test binary passes. The boot package compiles; its no-test launch can hang in existing startup initialization on this host.

Refs #447