### PR TITLE
fix(swebench): isolate memory stores by repo

### DIFF
--- a/docs/specs/swebench-memory-arm.md
+++ b/docs/specs/swebench-memory-arm.md
@@ -15,12 +15,13 @@
 
 ## 2. 修复设计
 
-### R1/切片库共享（runner）
+### R1/切片库按 repo 共享（runner）
 
 - 新 flag `--semantix-memory on|off`（默认 **on**）。on 时 config.toml 写入
   `[semantix] enabled/inject/budget=4096/project_dir/sessions_dir`；off 为消融孪生臂（不写段）。
-- **每实例独立 `SEMANTIX_HOME`**（`semantix-home/inst/<iid>/`）：会话镜像、stats、projects 天然按实例隔离，`--workers` 并发下归属无竞态；**只有切片库共享**——所有实例的 `project_dir` 指向同一 `semantix-home/kernel/`（库文件 `kernel/.semantix/project.db`）。
-- 每实例结束后 runner 以 `semantix extract --input <mirror> --scope project --project-db <shared>` 收割切片（`threading.Lock` 串行化：库的 append journal 是单写者）；extract 结果尾部写入该实例 metrics 的 `raw.extract`。
+- **每实例独立 `SEMANTIX_HOME`**（`semantix-home/inst/<iid>/`）：会话镜像、stats、projects 天然按实例隔离。Project 库只在同 repo 内共享：`project_dir` 指向 `semantix-home/kernel/<owner>__<repo>/`（库文件 `<owner>__<repo>/.semantix/project.db`），杜绝跨 repo 检索污染。
+- 每实例结束后 runner 以 `semantix extract --input <mirror> --scope project --project-db <repo-store> --project <owner/repo>` 收割切片；extract 结果尾部写入该实例 metrics 的 `raw.extract`，实际 repo/store 写入 `raw.semantix_repo` / `raw.semantix_project_dir`。
+- memory-on 调度按 repo 分批：同 repo 保持冻结子集选中顺序、在一个 worker 内串行，因此 append journal 始终单写；不同 repo 的独立 store 可并行。缺失或不安全的 repo 标识直接失败，不共享 fallback 库。memory-off 与其他 adapter 保持既有实例级并行。
 - 新 flag `--semantix-kernel-bin`（默认 `bin/semantix`）。
 
 ### R2（config 渲染往返）
@@ -52,8 +53,8 @@
 ## 3. 实验臂协议（替代旧 §4「--ablate all 隔离记忆内核」的错误设想）
 
 - **记忆对照 = `--semantix-memory on` vs `off` 两臂**（同子集、同模型、同 preset）。`--ablate` 不用于记忆对照（它只关 harness 侧 planner/subagent/evidence/harness-memory/compaction）。
-- on 臂按 preds.jsonl 处理序天然形成课程：判读时报告 (a) 全臂 resolve；(b) 注入覆盖率 `semantix_inject_turns>0` 的实例占比；(c) 处理序前/后半 resolve 与步数差（学习曲线）；(d) 每注入字节的边际成本。
-- 由于处理序影响 on 臂（先跑的题喂后跑的题），跨臂公平性以「同 50 题整体」比较；更严谨的顺序敏感性留待多 seed 重复。
+- on 臂在每个 repo 内按固定选中顺序形成课程：判读时报告 (a) 全臂 resolve；(b) 注入覆盖率 `semantix_inject_turns>0` 的实例占比；(c) repo 内处理序与 resolve/步数差；(d) 每注入字节的边际成本。
+- `--workers` 只改变不同 repo 的完成交错，不改变任何 repo 内课程顺序。跨臂必须复用同一冻结子集与 repo 内顺序；更严谨的顺序敏感性留待多 seed 重复。
 
 ## 4. 实现与验证
 

--- a/docs/superpowers/plans/2026-09-02-issue-447-p0-repo-isolation.md
+++ b/docs/superpowers/plans/2026-09-02-issue-447-p0-repo-isolation.md
@@ -1,0 +1,39 @@
+# Issue #447 P0.3 Repo-Isolated Store Plan
+
+## Goal
+
+Stop cross-repository memory contamination in the standard SWE-bench runner while retaining parallel throughput:
+
+```text
+semantix-home/kernel/<owner>__<repo>/.semantix/project.db
+```
+
+Instances from the same repository must execute in their existing selected order. Different repositories may execute concurrently up to `--workers`.
+
+## Design
+
+1. Validate the dataset `repo` field as exactly `owner/repo` using path-safe GitHub components. Invalid/missing identities fail before execution instead of sharing an `unknown` store.
+2. Resolve one kernel directory per instance from that canonical identity and pass it to both agent configuration and post-instance extraction.
+3. Stamp extracted slices with the real `owner/repo` project identity instead of the constant `swebench`.
+4. Add an adapter scheduling contract:
+   - ordinary adapters return one instance per batch, preserving existing parallel behavior;
+   - Semantix memory-off does the same;
+   - Semantix memory-on groups instances by repo in first-seen repo order and preserves selected order inside each batch.
+5. Submit batches—not individual same-repo instances—to the worker pool. Each batch executes synchronously in its worker; repositories remain parallel.
+
+## Tests first
+
+- canonical repo key and fail-closed invalid identities;
+- distinct repos resolve distinct Project stores;
+- same-repo interleaved instances become one ordered batch;
+- memory-off keeps per-instance batches;
+- generated config and extraction command use the same repo-specific directory and project identity.
+
+## Acceptance
+
+```powershell
+python -m py_compile scripts/swebench/run_bench.py scripts/swebench/test_repo_isolation.py
+python -u scripts/swebench/test_repo_isolation.py -v
+python -u scripts/swebench/test_metrics_attribution.py -v
+git diff --check upstream/main...HEAD
+```

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -69,8 +69,9 @@ python3 run_bench.py --harness semantix --model deepseek-v4-flash \
 
 `--semantix-memory on`（默认）把记忆内核真正接入基准：config 写入 `[semantix]`
 enabled/inject；**每实例独立 `SEMANTIX_HOME`**（并发归属无竞态），所有实例的
-`project_dir` 指向**同一共享切片库**（`semantix-home/kernel/`）；每实例结束后
-runner 跑 `semantix extract` 把该会话蒸馏进库，后续实例即可检索注入（跨实例
+`project_dir` 指向**真实 repo 独立切片库**
+（`semantix-home/kernel/<owner>__<repo>/`）；每实例结束后 runner 跑
+`semantix extract` 把该会话蒸馏进库，后续同 repo 实例即可检索注入（跨实例
 记忆闭环，需 `go build -o bin/semantix ./cmd/semantix`）。`off` 为消融孪生臂
 （内核关闭，等价旧行为）。记忆对照请用这对臂，**不要用 `--ablate`**（它只关
 harness 侧模块，不触碰内核）。判读字段（metrics `raw`）：
@@ -104,12 +105,19 @@ L2 路径。`shadow` 会检索、执行相同的 zone/清洗/预算判定并记�
 诊断，但不向 provider 消息添加复用块；因此可作为 A/B 臂 B，与
 `--semantix-memory off` 做请求字节不变量检查，再用其分数分布标定后续门禁。
 
+#### Repo 隔离与调度
+
+memory-on 时 runner 按数据集 `repo=owner/repo` 分组。同 repo 实例严格保持冻结
+子集中的选中顺序并在同一 worker 内串行；不同 repo 才使用 `--workers` 并行。
+非法或缺失 repo 标识会在调度前失败，不会落入共享的 unknown 库。每实例
+`raw.semantix_repo` / `raw.semantix_project_dir` 记录实际归属，便于审计。
+
 ## 方法学要点（对比公平性）
 
 - **同一 prompt 模板**（`common.PROMPT_TEMPLATE`）喂给所有 harness；system prompt 保持各 harness 原生（那正是 harness 差异的一部分）。
 - **同一冻结子集**（`--sample N --seed S` 或 `--ids` 文件），同一模型、同一时段（DeepSeek 2026-08-16 起分峰谷计价，跨时段跑会引入成本噪声；成本按 off-peak 表折算，峰时 ×2）。
 - patch 提取统一为 `git add -A && git diff --cached`（工作区全部改动，含新文件）。
-- 切片库（`project_dir`）在 run 内跨实例共享——跨实例记忆/缓存正是被测对象；如需无记忆对照，用 `--semantix-memory off`，或换 `--run-id` 清空 state。
+- 切片库（`project_dir`）仅在同 repo 实例间共享；repo 之间物理隔离。如需无记忆对照，用 `--semantix-memory off`，或换 `--run-id` 清空 state。
 - 单实例 exit code 不作成败信号（semantix 有已知的非零退出怪癖），以 diff 非空 + 官方评测为准。
 - 每实例默认 2400s 超时；超时/崩溃记为 error，patch 照常提取（可能为空）。
 

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -27,7 +27,6 @@ import re
 import shutil
 import subprocess
 import sys
-import threading
 from pathlib import Path
 
 from common import (
@@ -47,6 +46,30 @@ from common import (
 
 DEEPSEEK_OPENAI_BASE = "https://api.deepseek.com"
 DEEPSEEK_ANTHROPIC_BASE = "https://api.deepseek.com/anthropic"
+
+REPO_OWNER = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+REPO_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def repo_identity(inst: dict) -> str:
+    """Return the canonical owner/repo identity or fail closed.
+
+    A shared fallback would recreate the contamination this guard prevents, so
+    malformed dataset rows stop scheduling instead of entering an unknown db.
+    """
+    raw = inst.get("repo")
+    if not isinstance(raw, str):
+        raise ValueError(f"instance {inst.get('instance_id', '<unknown>')} has no repo identity")
+    parts = raw.split("/")
+    if (len(parts) != 2 or parts[1] in {"", ".", ".."}
+            or not REPO_OWNER.fullmatch(parts[0] or "")
+            or not REPO_NAME.fullmatch(parts[1] or "")):
+        raise ValueError(f"invalid SWE-bench repo identity: {raw!r}")
+    return f"{parts[0].lower()}/{parts[1].lower()}"
+
+
+def repo_store_key(inst: dict) -> str:
+    return repo_identity(inst).replace("/", "__", 1)
 
 
 class CountProxy:
@@ -143,6 +166,14 @@ class Adapter:
     def prepare(self) -> None:  # once per run
         pass
 
+    def execution_batches(self, instances: list[dict]) -> list[list[dict]]:
+        """Independent batches that may run concurrently.
+
+        The default keeps historical per-instance parallelism. Stateful
+        adapters override this to serialize instances that share state.
+        """
+        return [[inst] for inst in instances]
+
     def run_instance(self, ws: Path, prompt: str, inst: dict) -> tuple[int | None, dict, str]:
         """Return (exit_code, raw_metrics, error_string)."""
         raise NotImplementedError
@@ -164,16 +195,15 @@ class SemantixAdapter(Adapter):
         # [semantix] section, so SemantixConfig.Enabled defaulted to false and
         # the whole kernel was off). With --semantix-memory on (the default)
         # every instance gets its OWN home (so session mirrors are attributed
-        # race-free under --workers), while [semantix].project_dir points all
-        # of them at ONE shared slice library; after each instance the runner
-        # runs `semantix extract` so later instances can retrieve its slices.
+        # race-free under --workers), while each real repo gets its OWN Project
+        # store. Same-repo instances are scheduled as one ordered batch; repos
+        # remain parallel.
         self.home = self.args.state_path / "semantix-home"
         self.home.mkdir(parents=True, exist_ok=True)
         self.memory_on = self.args.semantix_memory == "on"
-        self.kernel_dir = self.home / "kernel"
-        self.extract_lock = threading.Lock()
+        self.kernel_root = self.home / "kernel"
         if self.memory_on:
-            (self.kernel_dir / ".semantix").mkdir(parents=True, exist_ok=True)
+            self.kernel_root.mkdir(parents=True, exist_ok=True)
             self.kernel_bin = self.args.semantix_kernel_bin or shutil.which("semantix") or str(
                 HERE.parent.parent / "bin" / "semantix")
             if not Path(self.kernel_bin).exists():
@@ -190,7 +220,18 @@ class SemantixAdapter(Adapter):
                 "`go build -o bin/semantix-agent ./cmd/semantix-agent` or pass --semantix-bin"
             )
 
-    def _write_home(self, home: Path, sessions_dir: Path) -> None:
+    def execution_batches(self, instances: list[dict]) -> list[list[dict]]:
+        if not self.memory_on:
+            return super().execution_batches(instances)
+        by_repo: dict[str, list[dict]] = {}
+        for inst in instances:
+            by_repo.setdefault(repo_identity(inst), []).append(inst)
+        return list(by_repo.values())
+
+    def kernel_dir_for(self, inst: dict) -> Path:
+        return self.kernel_root / repo_store_key(inst)
+
+    def _write_home(self, home: Path, sessions_dir: Path, kernel_dir: Path | None) -> None:
         home.mkdir(parents=True, exist_ok=True)
         # Provider keys resolve ONLY from Semantix's global .env (never the
         # process environment) — see ProviderEntry.APIKey in harness/config.
@@ -202,6 +243,9 @@ class SemantixAdapter(Adapter):
         effort = f'effort      = "{self.args.effort}"\n' if self.args.effort else ""
         memory_section = ""
         if self.memory_on:
+            if kernel_dir is None:
+                raise ValueError("memory-on instance requires a repo-specific kernel directory")
+            (kernel_dir / ".semantix").mkdir(parents=True, exist_ok=True)
             sessions_dir.mkdir(parents=True, exist_ok=True)
             memory_section = f'''
 [semantix]
@@ -209,7 +253,7 @@ enabled      = true
 inject       = true
 mode         = "{self.args.semantix_retrieval_mode}"
 budget       = 4096
-project_dir  = "{self.kernel_dir}"
+project_dir  = "{kernel_dir}"
 sessions_dir = "{sessions_dir}"
 '''
         (home / "config.toml").write_text(
@@ -239,7 +283,9 @@ context_window = 128000
         mfile.parent.mkdir(parents=True, exist_ok=True)
         home = self.home / "inst" / inst["instance_id"]
         sessions_dir = home / "kernel-sessions"
-        self._write_home(home, sessions_dir)
+        repo = repo_identity(inst) if self.memory_on else ""
+        kernel_dir = self.kernel_dir_for(inst) if self.memory_on else None
+        self._write_home(home, sessions_dir, kernel_dir)
         env = clean_env()
         env.update({
             "SEMANTIX_HOME": str(home),
@@ -269,29 +315,33 @@ context_window = 128000
                 raw = json.loads(candidate.read_text())
                 break
         if self.memory_on:
-            raw["extract"] = self._extract_slices(sessions_dir, inst["instance_id"])
+            raw["semantix_repo"] = repo
+            raw["semantix_project_dir"] = str(kernel_dir)
+            raw["extract"] = self._extract_slices(
+                sessions_dir, inst["instance_id"], kernel_dir, repo)
         return exit_code, raw, err
 
-    def _extract_slices(self, sessions_dir: Path, instance_id: str) -> dict:
+    def _extract_slices(self, sessions_dir: Path, instance_id: str,
+                        kernel_dir: Path, repo: str) -> dict:
         """Close the memory loop: distill this instance's session mirrors into
-        the shared slice library so later instances can retrieve them. The
+        the repo-isolated slice library so later same-repo instances can retrieve them. The
         agent never extracts on its own (extraction is `semantix extract` /
         gateway-side by design), so the runner does it here. The sessions dir
         is per-instance, so every mirror in it belongs to this instance; the
-        lock serializes store writes (the append journal is single-writer)."""
+        scheduler serializes every same-repo batch, so each append journal has
+        exactly one writer while different repo stores remain parallel."""
         mirrors = sorted(sessions_dir.glob("*.jsonl"))
         out = {"mirrors": len(mirrors), "runs": []}
-        db = self.kernel_dir / ".semantix" / "project.db"
+        db = kernel_dir / ".semantix" / "project.db"
         for mirror in mirrors:
             ecmd = [self.kernel_bin, "extract",
                     "--input", str(mirror),
                     "--scope", "project",
                     "--project-db", str(db),
                     "--session", instance_id,
-                    "--project", "swebench"]
+                    "--project", repo]
             try:
-                with self.extract_lock:
-                    ep = subprocess.run(ecmd, capture_output=True, text=True, timeout=120)
+                ep = subprocess.run(ecmd, capture_output=True, text=True, timeout=120)
                 out["runs"].append({"mirror": mirror.name, "exit": ep.returncode,
                                     "out": (ep.stdout or ep.stderr).strip()[-300:]})
             except Exception as exc:  # extraction is best-effort, never fails the instance
@@ -755,6 +805,13 @@ def process_instance(adapter: Adapter, args, run_dir: Path, prices: dict, inst: 
         shutil.rmtree(ws, ignore_errors=True)
 
 
+def process_batch(adapter: Adapter, args, run_dir: Path, prices: dict,
+                  batch: list[dict]) -> None:
+    """Run one state-sharing batch sequentially inside a worker."""
+    for inst in batch:
+        process_instance(adapter, args, run_dir, prices, inst)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -768,7 +825,9 @@ def main() -> None:
     ap.add_argument("--run-id", default=None)
     ap.add_argument("--results-dir", default=str(HERE / "results"))
     ap.add_argument("--work-dir", default=str(HERE / "work"))
-    ap.add_argument("--workers", type=int, default=1)
+    ap.add_argument("--workers", type=int, default=1,
+                    help="parallel workers; semantix memory-on parallelizes repos while "
+                    "serializing the selected order within each repo")
     ap.add_argument("--timeout", type=int, default=2400, help="per-instance seconds")
     ap.add_argument("--max-turns", type=int, default=120, help="claude-code turn cap")
     ap.add_argument("--preset", default="balanced", help="semantix preset")
@@ -818,17 +877,18 @@ def main() -> None:
 
     adapter = ADAPTERS[args.harness](args, run_dir)
     adapter.prepare()
+    batches = adapter.execution_batches(todo)
     prices = load_prices(args.prices or None)
 
     (run_dir / "run_config.json").write_text(json.dumps(vars(args), indent=2, default=str))
 
     if args.workers <= 1:
-        for inst in todo:
-            process_instance(adapter, args, run_dir, prices, inst)
+        for batch in batches:
+            process_batch(adapter, args, run_dir, prices, batch)
     else:
         with cf.ThreadPoolExecutor(max_workers=args.workers) as pool:
-            futs = [pool.submit(process_instance, adapter, args, run_dir, prices, inst)
-                    for inst in todo]
+            futs = [pool.submit(process_batch, adapter, args, run_dir, prices, batch)
+                    for batch in batches]
             for fut in cf.as_completed(futs):
                 exc = fut.exception()
                 if exc:

--- a/scripts/swebench/test_repo_isolation.py
+++ b/scripts/swebench/test_repo_isolation.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from run_bench import Adapter, SemantixAdapter, process_batch, repo_store_key
+
+
+def inst(iid: str, repo: str) -> dict:
+    return {"instance_id": iid, "repo": repo}
+
+
+class RepoIdentityTests(unittest.TestCase):
+    def test_repo_store_key_is_canonical_and_path_safe(self):
+        self.assertEqual(repo_store_key(inst("a", "django/django")), "django__django")
+        self.assertEqual(repo_store_key(inst("b", "PyData/XArray")), "pydata__xarray")
+
+    def test_repo_store_key_rejects_missing_or_unsafe_identity(self):
+        for bad in ({}, {"repo": "django"}, {"repo": "../django"}, {"repo": "bad_owner/repo"},
+                    {"repo": "a/b/c"}, {"repo": "a\\b"}):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    repo_store_key(bad)
+
+
+class RepoSchedulingTests(unittest.TestCase):
+    def test_memory_on_groups_by_repo_and_preserves_selected_order(self):
+        adapter = SemantixAdapter(SimpleNamespace(), Path("run"))
+        adapter.memory_on = True
+        chosen = [
+            inst("django-1", "django/django"),
+            inst("flask-1", "pallets/flask"),
+            inst("django-2", "django/django"),
+            inst("flask-2", "pallets/flask"),
+        ]
+        batches = adapter.execution_batches(chosen)
+        self.assertEqual([[x["instance_id"] for x in batch] for batch in batches],
+                         [["django-1", "django-2"], ["flask-1", "flask-2"]])
+
+    def test_memory_off_and_other_adapters_keep_instance_parallelism(self):
+        chosen = [inst("a", "django/django"), inst("b", "django/django")]
+        semantix = SemantixAdapter(SimpleNamespace(), Path("run"))
+        semantix.memory_on = False
+        self.assertEqual([len(x) for x in semantix.execution_batches(chosen)], [1, 1])
+        self.assertEqual([len(x) for x in Adapter(SimpleNamespace(), Path("run")).execution_batches(chosen)], [1, 1])
+
+    def test_process_batch_runs_instances_sequentially_in_batch_order(self):
+        chosen = [inst("a", "django/django"), inst("b", "django/django")]
+        observed = []
+        with mock.patch("run_bench.process_instance",
+                        side_effect=lambda _a, _args, _run, _prices, item: observed.append(item["instance_id"])):
+            process_batch(Adapter(SimpleNamespace(), Path("run")), SimpleNamespace(),
+                          Path("run"), {}, chosen)
+        self.assertEqual(observed, ["a", "b"])
+
+
+class RepoStoreTests(unittest.TestCase):
+    def adapter(self, root: Path) -> SemantixAdapter:
+        args = SimpleNamespace(openai_base="http://127.0.0.1:8139/v1", effort="",
+                               model="deepseek-v4-flash", semantix_retrieval_mode="strict")
+        adapter = SemantixAdapter(args, root / "run")
+        adapter.memory_on = True
+        adapter.kernel_root = root / "semantix-home" / "kernel"
+        adapter.kernel_bin = str(root / "semantix")
+        return adapter
+
+    def test_distinct_repos_generate_distinct_project_dirs_and_config(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            adapter = self.adapter(root)
+            django_dir = adapter.kernel_dir_for(inst("d", "django/django"))
+            flask_dir = adapter.kernel_dir_for(inst("f", "pallets/flask"))
+            self.assertNotEqual(django_dir, flask_dir)
+            self.assertEqual(django_dir.name, "django__django")
+            self.assertEqual(flask_dir.name, "pallets__flask")
+
+            home = root / "home"
+            adapter._write_home(home, root / "sessions", django_dir)
+            config = (home / "config.toml").read_text()
+            self.assertIn(f'project_dir  = "{django_dir}"', config)
+            self.assertNotIn(str(flask_dir), config)
+
+    def test_extraction_uses_same_repo_store_and_real_project_identity(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            adapter = self.adapter(root)
+            sessions = root / "sessions"
+            sessions.mkdir()
+            (sessions / "turn.jsonl").write_text("{}\n")
+            kernel_dir = adapter.kernel_dir_for(inst("d", "django/django"))
+            completed = SimpleNamespace(returncode=0, stdout="stored=1", stderr="")
+            with mock.patch("run_bench.subprocess.run", return_value=completed) as run:
+                result = adapter._extract_slices(sessions, "d", kernel_dir, "django/django")
+            self.assertEqual(result["mirrors"], 1)
+            command = run.call_args.args[0]
+            self.assertEqual(command[command.index("--project") + 1], "django/django")
+            self.assertEqual(Path(command[command.index("--project-db") + 1]),
+                             kernel_dir / ".semantix" / "project.db")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/swebench/test_shadow_config.py
+++ b/scripts/swebench/test_shadow_config.py
@@ -19,10 +19,13 @@ class ShadowConfigTests(unittest.TestCase):
         adapter.memory_on = True
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
-            adapter.kernel_dir = root / "kernel"
-            adapter._write_home(root / "home", root / "sessions")
+            adapter.kernel_root = root / "kernel"
+            kernel_dir = adapter.kernel_dir_for(
+                {"instance_id": "django-1", "repo": "django/django"})
+            adapter._write_home(root / "home", root / "sessions", kernel_dir)
             config = (root / "home" / "config.toml").read_text()
         self.assertIn('mode         = "shadow"', config)
+        self.assertIn(f'project_dir  = "{kernel_dir}"', config)
         self.assertIn("enabled      = true", config)
 
 


### PR DESCRIPTION
## Summary
- isolate Semantix Project stores by canonical SWE-bench repository under `kernel/<owner>__<repo>/.semantix/project.db`
- fail closed on missing or unsafe repo identities instead of routing them into a shared fallback store
- preserve the frozen selected order within each repo by scheduling one sequential batch per repo
- retain `--workers` parallelism across independent repositories and preserve existing instance-level parallelism for memory-off and other adapters
- stamp extraction with the real `owner/repo` identity and record the resolved repo/store in raw metrics
- update the memory-arm methodology and add seven repo identity, store, extraction, and scheduling regressions

## Validation
- `python -m py_compile scripts/swebench/run_bench.py scripts/swebench/test_repo_isolation.py scripts/swebench/test_shadow_config.py scripts/swebench/test_metrics_attribution.py`
- `python -u scripts/swebench/test_repo_isolation.py -v` (7 passed)
- `python -u scripts/swebench/test_shadow_config.py -v` (1 passed)
- `python -u scripts/swebench/test_metrics_attribution.py -v` (5 passed)
- `python scripts/swebench/run_bench.py --help`
- `git diff --check upstream/main...HEAD`

## Sequencing
Rebased onto the merge of P0.2 PR #450. The combined runner now keeps both explicit `off|shadow|strict` retrieval mode selection and repo-isolated stores with deterministic repo-local scheduling.

Refs #447