### PR TITLE
fix(semantix): add strict L2 admission guards

### DIFF
--- a/docs/specs/semantix-l2-admission-policy.md
+++ b/docs/specs/semantix-l2-admission-policy.md
@@ -1,0 +1,122 @@
+# Semantix L2 严格准入策略
+
+> 状态：P0 基线（2026-09-02）  
+> 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)  
+> 适用路径：`harness/semantix` → `kernel/inject`
+
+## 1. 目标与边界
+
+本策略用于阻止弱相关历史在证据不足时进入 agent 上下文。它解决的是“是否允许注入”，不是用 BM25 分数证明历史一定正确。
+
+严格模式遵循四条规则：
+
+1. 检索命中不等于允许注入；
+2. 小库、单一来源或排序不稳定时宁可 miss；
+3. 仅允许语义强度较高的 `Context` 和 `Memory`；
+4. 每个拒绝都返回稳定 reason code，shadow 与 strict 使用同一套判断。
+
+`off` 不检索、不注入；`shadow` 运行完整清洗、检索和准入判断，但不改变 provider request；`strict` 只注入通过全部门禁的候选。
+
+## 2. 查询处理
+
+Bridge 不再直接把完整 benchmark prompt 交给 BM25，而是生成确定性的低权威 token 投影：
+
+1. 删除 `<execution-policy ...>...</execution-policy>`；
+2. 存在 `<issue>...</issue>` 时只使用 issue 正文；
+3. 删除少量英文 benchmark/仓库外壳词；
+4. 保留代码符号、测试名、错误信息、依赖名和 CJK token；
+5. 清洗后为空时 fail closed，reason 为 `empty_query_after_cleaning`。
+
+事件只保存原 query 与清洗后 query 的 SHA-256、字节数和 token 数，不记录原文。
+
+## 3. 生产默认值
+
+| 门禁 | 默认值 | 作用 |
+|---|---:|---|
+| 可注入类型 | `Context`, `Memory` | Prompt、ToolPattern、Result 仅诊断 |
+| Project 最小切片数 | 5 | 避免冷启动小库强制产生胜者 |
+| 候选类型最小来源会话数 | 2 | 避免单次会话自我强化 |
+| 最低 BM25 绝对分 | 0.70 | 排除只有相对排名、没有绝对相关性的候选 |
+| 最低 query coverage | 0.25 | 要求候选覆盖足够多的当前任务 token |
+| 最低 eligible top-1/top-2 margin | 0.15 | 排除两个候选难以区分的情况 |
+| runner-up | 必须存在 | 单个 eligible 候选不能自动通过 |
+
+Margin 只在 allowlist 内的候选之间计算，避免一个不可注入的高分 Prompt 改变 Context/Memory 的准入结论。
+
+## 4. 判断顺序和 reason code
+
+每个候选按下列顺序评估；先命中的拒绝条件成为该候选的稳定 reason：
+
+| Reason | 含义 | 运维动作 |
+|---|---|---|
+| `type_not_allowed` | 类型不在生产 allowlist | 保持 shadow；先提升切片质量/验证状态 |
+| `library_too_small` | Project 库小于 5 | 等待积累，不通过降低 score 绕过 |
+| `type_sources_too_few` | 该类型不足 2 个独立来源会话 | 增加独立成功样本 |
+| `score_low` | BM25 绝对分低于 0.70 | 检查 query 清洗或历史是否真正相关 |
+| `coverage_low` | query coverage 低于 0.25 | 检查是否只命中了通用词 |
+| `runner_up_missing` | allowlist 内没有第二候选 | 保持 miss，避免单候选强制胜者 |
+| `top_margin_low` | eligible top-1 与 top-2 差小于 0.15 | 候选歧义过高，等待更多证据 |
+| `grey_disabled` | 候选只进入 grey 且未启用 audit | 保持拒绝 |
+| `budget_exhausted` | 当前预算无法容纳候选 | 缩小或压缩切片，不突破预算 |
+
+通过全部门禁后，事件记录 `admitted`；shadow 模式随后将最终 decision 标为 `withheld` / `shadow_mode`，strict 模式才生成注入正文。
+
+## 5. 示例
+
+### 5.1 小库中的高分 Prompt
+
+即使 Prompt 与当前任务共享大量 `fix/test/repository` 词，它仍先被 `type_not_allowed` 拒绝；若库总量不足 5，其他候选还会得到 `library_too_small`。这避免“第一名”被误解为“足够相关”。
+
+### 5.2 两个接近的 Context
+
+两个允许类型候选分别为 1.10 和 1.02，margin 为 0.08。即使二者都超过绝对分和 coverage，top-1 仍以 `top_margin_low` 拒绝，因为当前证据不能稳定区分它们。
+
+### 5.3 强证据 Context
+
+Project 至少有 5 个切片，Context 来自至少 2 个独立 session；top-1 为 1.40、top-2 为 0.80，coverage 为 0.50。该候选通过默认门禁；strict 注入，shadow 仅记录。
+
+## 6. 校准流程
+
+默认阈值是保守止损线，不应直接按“注入率太低”下调。阈值调整必须基于冻结样本的配对实验：
+
+1. 使用同一 manifest、模型、prompt、repo 内顺序和运行环境；
+2. 比较 memory off、shadow、strict BM25 和旧宽松策略；
+3. 按 reason code 输出候选分布；
+4. 同时检查 resolved、executor calls、重复 read/grep/test、输入 token 和成本；
+5. 只有 pass@1 非劣且中位调用数/P75-P90 工具轮数不增加时才扩大准入；
+6. 每次只改一个阈值并保留上一组事件用于离线重放。
+
+覆盖率不是成功指标。大量 `library_too_small` 或 `runner_up_missing` 是冷启动期的预期行为。
+
+## 7. 观测与回放
+
+`RetrievalDiagnostics` 提供：
+
+- mode、library size、repo、base commit；
+- query before/after 摘要；
+- candidate ID/type/source session；
+- score、coverage、eligible top margin；
+- admitted/rejected/withheld 与 reason；
+- strict 模式的 injected bytes、message role 和最终顺序。
+
+离线回放必须使用事件中的原始数值与策略版本，不能用新的阈值反推旧 decision 后覆盖历史记录。
+
+## 8. 回滚
+
+出现回归时按影响面从小到大回滚：
+
+1. 单次实验改为 `shadow`，保持诊断而不改变模型输入；
+2. 单次运行改为 `off`，回到无记忆基线；
+3. 保留 reason 分布、provider request hash 和逐实例调用指标，用于定位是 query、候选质量还是阈值问题。
+
+不要通过重新开放 Prompt/ToolPattern/未验证 Result 或允许单候选自动通过来恢复注入率。
+
+## 9. 验证命令
+
+```powershell
+go test ./kernel/inject -count=1
+go test ./harness/semantix ./harness/eventwire -count=1
+go test ./harness/config -run TestRenderTOMLRoundTrips -count=1
+go test ./harness/agent -run TestShadowRetrievalKeepsProviderMessagesByteIdenticalToOff -count=1
+git diff --check upstream/main...HEAD
+```

--- a/docs/specs/semantix-l2-admission-policy.md
+++ b/docs/specs/semantix-l2-admission-policy.md
@@ -1,8 +1,6 @@
 # Semantix L2 严格准入策略
 
-> 状态：P0 基线（2026-09-02）  
-> 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)  
-> 适用路径：`harness/semantix` → `kernel/inject`
+> 状态：P0 基线（2026-09-02）`r`n> 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)`r`n> 适用路径：`harness/semantix` → `kernel/inject`
 
 ## 1. 目标与边界
 

--- a/docs/specs/semantix-l2-admission-policy.md
+++ b/docs/specs/semantix-l2-admission-policy.md
@@ -1,6 +1,10 @@
 # Semantix L2 严格准入策略
 
-> 状态：P0 基线（2026-09-02）`r`n> 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)`r`n> 适用路径：`harness/semantix` → `kernel/inject`
+> 状态：P0 基线（2026-09-02）
+>
+> 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)
+>
+> 适用路径：`harness/semantix` → `kernel/inject`
 
 ## 1. 目标与边界
 

--- a/docs/specs/semantix-memory-negative-transfer.md
+++ b/docs/specs/semantix-memory-negative-transfer.md
@@ -1,6 +1,6 @@
 # Semantix 记忆注入负迁移：多步、意图偏移与重复探索修复方案
 
-> 状态：提案（2026-09-02）
+> 状态：实施中（2026-09-02）
 >
 > 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)
 >
@@ -184,7 +184,17 @@ Result 初始为 probation；只有验证命令通过、无回滚，或外部评
 7. 接入成功提升和负迁移熔断；
 8. 最后验证 hybrid/model embedding 的增量收益。
 
-## 9. 相关材料
+## 9. 实施进度
+
+- P0.1 指标归因：已完成，调用来源与重复工具指标已进入逐实例记录；
+- P0.2 Shadow retrieval：已完成，`off | shadow | strict` 及 provider-byte 不变性测试已落地；
+- P0.3 Repo 隔离：PR 已提交，采用真实 repo 独立 store 和 repo 内确定性串行；
+- P0.4 严格准入：已实现 C/M allowlist、小库/来源会话/绝对分/coverage/margin/runner-up 门禁和 query 清洗；
+- 后续：历史正文降权、严格预算、A-D 配对实验、成功提升与负迁移熔断。
+
+P0.4 的具体默认值、reason code、校准和回滚合同见 `docs/specs/semantix-l2-admission-policy.md`。
+
+## 10. 相关材料
 
 - `docs/reports/swe-pilot-two-arm.md`
 - `docs/reports/swebench-harness-comparison.md`

--- a/docs/superpowers/plans/2026-09-02-issue-447-p0-admission-guards.md
+++ b/docs/superpowers/plans/2026-09-02-issue-447-p0-admission-guards.md
@@ -1,0 +1,47 @@
+# Issue #447 P0.4 Admission Guards Plan
+
+## Goal
+
+Turn the P0.2 shadow trace into a conservative production admission policy that blocks the two observed negative-transfer paths: wrong-type semantic matches and weak/ambiguous matches from small libraries.
+
+## Production defaults
+
+- injectable types: `Context`, `Memory`;
+- `Prompt` and `ToolPattern`: retrieved and diagnosed, never injected;
+- `Result`: retrieved and diagnosed, never injected until a distinct successful-evaluation marker exists;
+- minimum Project library size: 5 slices;
+- minimum distinct non-empty source sessions for the candidate type: 2;
+- minimum absolute BM25 score: 0.70;
+- minimum cleaned-query coverage: 0.25;
+- minimum eligible top-1 minus top-2 margin: 0.15;
+- a single eligible candidate is rejected (`runner_up_missing`).
+
+These values are intentionally conservative initial stops. Shadow diagnostics retain exact scores/reasons so later calibration can change constants without changing the event contract.
+
+## Query cleaning
+
+Retrieval uses a deterministic low-authority query projection:
+
+1. remove the transient `<execution-policy>` block;
+2. when a SWE-bench `<issue>...</issue>` block exists, use its body and discard the fixed benchmark frame/requirements;
+3. remove a small English-only set of framing stopwords while preserving code symbols, CJK terms, test names, and domain terms.
+
+Telemetry records hashes/counts for both original and cleaned query; it does not log raw user text.
+
+## Commit sequence
+
+1. `feat(inject): add replayable admission policy guards`
+   - generic injector fields, exact rejection reasons, eligible margin.
+2. `fix(semantix): enforce conservative L2 admission defaults`
+   - query cleaner, C/M policy, library/session evidence, bridge tests.
+3. `docs(semantix): document negative-transfer admission gates`
+   - operator contract and verification evidence.
+
+## Acceptance
+
+```powershell
+go test ./kernel/inject -count=1
+go test ./harness/semantix ./harness/eventwire ./harness/config -count=1
+go test ./harness/agent -run TestShadowRetrievalKeepsProviderMessagesByteIdenticalToOff -count=1
+git diff --check upstream/main...HEAD
+```

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -92,7 +92,18 @@ const (
 	RetrievalOff    RetrievalMode = "off"
 	RetrievalShadow RetrievalMode = "shadow"
 	RetrievalStrict RetrievalMode = "strict"
+
+	strictMinLibrarySize    = 5
+	strictMinSourceSessions = 2
+	strictMinScore          = 0.70
+	strictMinCoverage       = 0.25
+	strictMinTopMargin      = 0.15
 )
+
+var strictAllowedTypes = map[slice.SliceType]bool{
+	slice.Context: true,
+	slice.Memory:  true,
+}
 
 // NewBridge builds a Bridge from cfg.
 func NewBridge(cfg Config) *Bridge {
@@ -240,20 +251,37 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		b.emitKernelCache("miss", "L2", nil, 0, "slice library unavailable")
 		return InjectResult{}
 	}
-	hits, err := idx.Search(query, 5, slice.Project)
+	cleanedQuery := cleanRetrievalQuery(query)
+	if cleanedQuery == "" {
+		diagnostics := b.retrievalDiagnostics(query, cleanedQuery, projectSlices, nil, nil)
+		diagnostics.Decision = "rejected"
+		diagnostics.DecisionReason = "empty_query_after_cleaning"
+		b.emitKernelCacheDetailed("miss", "L2", nil, 0, diagnostics.DecisionReason, diagnostics)
+		return InjectResult{Diagnostics: diagnostics}
+	}
+	hits, err := idx.Search(cleanedQuery, 5, slice.Project)
 	if err != nil {
 		b.emitKernelCache("miss", "L2", nil, 0, err.Error())
 		return InjectResult{}
 	}
 	z := zone.Default()
 	inj, err := (&inject.Injector{
-		Index:     idx,
-		Scope:     slice.Project,
-		K:         5,
-		Budget:    budget,
-		Zones:     &z,
-		AllowGrey: b.cfg.GreyMode == "audit",
-	}).BuildHits(query, hits)
+		Index:                idx,
+		Scope:                slice.Project,
+		K:                    5,
+		Budget:               budget,
+		AllowedTypes:         strictAllowedTypes,
+		LibrarySize:          len(projectSlices),
+		MinLibrarySize:       strictMinLibrarySize,
+		SourceSessionsByType: sourceSessionCounts(projectSlices),
+		MinSourceSessions:    strictMinSourceSessions,
+		MinScore:             strictMinScore,
+		MinCoverage:          strictMinCoverage,
+		MinTopMargin:         strictMinTopMargin,
+		RequireRunnerUp:      true,
+		Zones:                &z,
+		AllowGrey:            b.cfg.GreyMode == "audit",
+	}).BuildHits(cleanedQuery, hits)
 	if err != nil {
 		op := "miss"
 		if budget < b.cfg.Budget {
@@ -262,7 +290,7 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		b.emitKernelCache(op, "L2", nil, 0, err.Error())
 		return InjectResult{}
 	}
-	diagnostics := b.retrievalDiagnostics(query, projectSlices, hits, inj)
+	diagnostics := b.retrievalDiagnostics(query, cleanedQuery, projectSlices, hits, inj)
 	if b.mode == RetrievalShadow {
 		diagnostics.Decision = "withheld"
 		diagnostics.DecisionReason = "shadow_mode"
@@ -300,21 +328,16 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 	return InjectResult{Text: inj.Text, Targets: targets, Diagnostics: diagnostics}
 }
 
-func (b *Bridge) retrievalDiagnostics(query string, library []*slice.Slice, hits []slice.Hit, inj *inject.Injection) *event.RetrievalDiagnostics {
+func (b *Bridge) retrievalDiagnostics(query, cleanedQuery string, library []*slice.Slice, hits []slice.Hit, inj *inject.Injection) *event.RetrievalDiagnostics {
 	projectDir := b.projectDir()
 	d := &event.RetrievalDiagnostics{
 		Mode: string(b.mode), LibrarySize: len(library), Repo: filepath.Base(filepath.Clean(projectDir)),
-		BaseCommit: readGitHead(projectDir), QueryBefore: summarizeQuery(query), QueryAfter: summarizeQuery(query),
-	}
-	if len(hits) > 0 {
-		d.TopMargin = hits[0].Score
-		if len(hits) > 1 {
-			d.TopMargin -= hits[1].Score
-		}
+		BaseCommit: readGitHead(projectDir), QueryBefore: summarizeQuery(query), QueryAfter: summarizeQuery(cleanedQuery),
 	}
 	if inj == nil {
 		return d
 	}
+	d.TopMargin = inj.TopMargin
 	for i, decision := range inj.Decisions {
 		candidate := event.RetrievalCandidate{
 			ID: decision.ID, Score: decision.Score, Coverage: decision.Coverage,
@@ -335,6 +358,24 @@ func (b *Bridge) retrievalDiagnostics(query string, library []*slice.Slice, hits
 		}
 	}
 	return d
+}
+
+func sourceSessionCounts(library []*slice.Slice) map[slice.SliceType]int {
+	sets := make(map[slice.SliceType]map[string]struct{})
+	for _, sl := range library {
+		if sl == nil || sl.Meta.SourceSession == "" {
+			continue
+		}
+		if sets[sl.Type] == nil {
+			sets[sl.Type] = make(map[string]struct{})
+		}
+		sets[sl.Type][sl.Meta.SourceSession] = struct{}{}
+	}
+	counts := make(map[slice.SliceType]int, len(sets))
+	for typ, sessions := range sets {
+		counts[typ] = len(sessions)
+	}
+	return counts
 }
 
 func summarizeQuery(query string) event.QuerySummary {

--- a/harness/semantix/query.go
+++ b/harness/semantix/query.go
@@ -1,0 +1,69 @@
+package semantix
+
+import (
+	"strings"
+
+	"semantix/kernel/bm25"
+)
+
+var retrievalStopwords = map[string]struct{}{
+	"a": {}, "at": {}, "below": {}, "checkout": {}, "commit": {},
+	"git": {}, "github": {}, "in": {}, "issue": {}, "of": {},
+	"please": {}, "repository": {}, "requirements": {}, "resolve": {},
+	"task": {}, "the": {}, "working": {}, "you": {}, "are": {},
+}
+
+// cleanRetrievalQuery removes host/benchmark framing before lexical search.
+// It intentionally returns a token projection rather than natural prose: BM25
+// and QueryCoverage consume the same tokenizer, so punctuation loss cannot
+// change the lexical evidence while boilerplate cannot dominate it.
+func cleanRetrievalQuery(raw string) string {
+	query := stripTaggedBlock(raw, "execution-policy")
+	if issue, ok := taggedBody(query, "issue"); ok {
+		query = issue
+	}
+	tokens := bm25.Tokenize(query)
+	kept := tokens[:0]
+	for _, token := range tokens {
+		if _, drop := retrievalStopwords[token]; !drop {
+			kept = append(kept, token)
+		}
+	}
+	return strings.Join(kept, " ")
+}
+
+func stripTaggedBlock(text, tag string) string {
+	for {
+		lower := strings.ToLower(text)
+		start := strings.Index(lower, "<"+tag)
+		if start < 0 {
+			return text
+		}
+		openEndRel := strings.Index(lower[start:], ">")
+		if openEndRel < 0 {
+			return text[:start]
+		}
+		closeStartRel := strings.Index(lower[start+openEndRel+1:], "</"+tag+">")
+		if closeStartRel < 0 {
+			return text[:start]
+		}
+		end := start + openEndRel + 1 + closeStartRel + len(tag) + 3
+		text = text[:start] + " " + text[end:]
+	}
+}
+
+func taggedBody(text, tag string) (string, bool) {
+	lower := strings.ToLower(text)
+	open := "<" + tag + ">"
+	close := "</" + tag + ">"
+	start := strings.Index(lower, open)
+	if start < 0 {
+		return "", false
+	}
+	start += len(open)
+	endRel := strings.Index(lower[start:], close)
+	if endRel < 0 {
+		return "", false
+	}
+	return text[start : start+endRel], true
+}

--- a/harness/semantix/query_test.go
+++ b/harness/semantix/query_test.go
@@ -1,0 +1,40 @@
+package semantix
+
+import (
+	"reflect"
+	"testing"
+
+	"semantix/kernel/bm25"
+)
+
+func TestCleanRetrievalQueryExtractsIssueAndDropsExecutionPolicy(t *testing.T) {
+	raw := `You are working in a git checkout of the org/repo repository at commit abc. Resolve the GitHub issue below.
+<issue>
+Cache invalidation fails in RedisStore
+</issue>
+Requirements:
+- implement a complete fix
+
+<execution-policy preset="balanced">
+route=direct risk=low verify=targeted review=conditional
+</execution-policy>`
+	got := bm25.Tokenize(cleanRetrievalQuery(raw))
+	want := []string{"cache", "invalidation", "fails", "redisstore"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cleaned tokens = %v, want %v", got, want)
+	}
+}
+
+func TestCleanRetrievalQueryKeepsDomainAndCJKTerms(t *testing.T) {
+	got := bm25.Tokenize(cleanRetrievalQuery("Please fix CacheKey 测试失败 issue"))
+	want := []string{"fix", "cachekey", "测", "试", "失", "败"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cleaned tokens = %v, want %v", got, want)
+	}
+}
+
+func TestCleanRetrievalQueryFailsClosedWhenOnlyFramingRemains(t *testing.T) {
+	if got := cleanRetrievalQuery("Please resolve the GitHub issue below"); got != "" {
+		t.Fatalf("cleaned query = %q, want empty", got)
+	}
+}

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -142,6 +142,16 @@ func reuseFixtureSlices() []*slice.Slice {
 	}
 }
 
+func admissionFixtureSlices() []*slice.Slice {
+	return []*slice.Slice{
+		{ID: "ctx-strong", Type: slice.Context, Scope: slice.Project, Content: []byte("修复 go 测试失败"), Meta: slice.SliceMeta{SourceSession: "boot-1"}},
+		{ID: "ctx-runner", Type: slice.Context, Scope: slice.Project, Content: []byte("修复 release process"), Meta: slice.SliceMeta{SourceSession: "boot-2"}},
+		{ID: "memory-other", Type: slice.Memory, Scope: slice.Project, Content: []byte("部署 kubernetes 服务"), Meta: slice.SliceMeta{SourceSession: "boot-1"}},
+		{ID: "prompt-blocked", Type: slice.Prompt, Scope: slice.Project, Content: []byte("修复 go 测试失败"), Meta: slice.SliceMeta{SourceSession: "boot-3"}},
+		{ID: "result-blocked", Type: slice.Result, Scope: slice.Project, Content: []byte("修复 go 测试失败"), Meta: slice.SliceMeta{SourceSession: "boot-4"}},
+	}
+}
+
 // usageL3Event is a usage-log line fully served by L3 reuse: billed cost is
 // zero and the entire would-be cost counts as savings (0.27 USD/1M tokens ×
 // 20000 tokens = 0.0054).
@@ -184,7 +194,7 @@ func TestBridgeReuseForwardsKernelCacheObservation(t *testing.T) {
 }
 
 func TestBridgeInjectRecordsStatsAndEvent(t *testing.T) {
-	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
+	dir := writeKernelDir(t, admissionFixtureSlices(), nil)
 	sessionsDir := t.TempDir()
 	b := NewBridge(Config{Enabled: true, Inject: true, ProjectDir: dir, SessionsDir: sessionsDir, Budget: 4096})
 	b.SetLabel("inject-stats")
@@ -224,6 +234,37 @@ func TestBridgeInjectRecordsStatsAndEvent(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("session JSONL missing SliceInject: %s", raw)
+	}
+}
+
+func TestBridgeStrictAdmissionRejectsWrongTypesAndSmallLibrary(t *testing.T) {
+	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
+	b := NewBridge(Config{Enabled: true, Mode: "strict", ProjectDir: dir})
+	result := b.InjectDetailed(context.Background(), "修复 go 测试")
+	if result.Text != "" || result.Diagnostics == nil {
+		t.Fatalf("strict small-library result = %+v", result)
+	}
+	reasons := map[string]bool{}
+	for _, candidate := range result.Diagnostics.Candidates {
+		reasons[candidate.Reason] = true
+	}
+	if !reasons["type_not_allowed"] || !reasons["library_too_small"] {
+		t.Fatalf("candidate reasons = %v, want type and library guards", reasons)
+	}
+}
+
+func TestBridgeStrictAdmissionInjectsOnlyContextWithStrongEvidence(t *testing.T) {
+	dir := writeKernelDir(t, admissionFixtureSlices(), nil)
+	b := NewBridge(Config{Enabled: true, Mode: "strict", ProjectDir: dir})
+	result := b.InjectDetailed(context.Background(), "修复 go 测试")
+	if result.Text == "" || result.Diagnostics == nil || !result.Diagnostics.Injected {
+		t.Fatalf("strict strong-evidence result = %+v", result)
+	}
+	if len(result.Targets) != 1 || result.Targets[0] != "ctx-strong" {
+		t.Fatalf("targets = %v, want only ctx-strong", result.Targets)
+	}
+	if strings.Contains(result.Text, "prompt-blocked") || strings.Contains(result.Text, "result-blocked") {
+		t.Fatalf("wrong-type slice leaked into injection:\n%s", result.Text)
 	}
 }
 
@@ -362,7 +403,7 @@ func TestBridgeReuseEmptySources(t *testing.T) {
 // in budget), so a tight window still gets reuse context without the
 // full injection cost.
 func TestBridgeInjectDegradedShrinksBlock(t *testing.T) {
-	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
+	dir := writeKernelDir(t, admissionFixtureSlices(), nil)
 	b := NewBridge(Config{Enabled: true, Inject: true, ProjectDir: dir, Budget: 4096})
 	defer b.Close()
 	full := b.InjectDetailed(context.Background(), "修复 go 测试")

--- a/kernel/inject/inject.go
+++ b/kernel/inject/inject.go
@@ -82,6 +82,22 @@ type Injector struct {
 	Budget int
 	// MinScore drops slices below this BM25 score (0 disables).
 	MinScore float64
+	// AllowedTypes, when non-nil, is a fail-closed injection allowlist. Search
+	// results outside it remain in Decisions for shadow analysis.
+	AllowedTypes map[slice.SliceType]bool
+	// LibrarySize and MinLibrarySize gate immature Project libraries.
+	LibrarySize    int
+	MinLibrarySize int
+	// SourceSessionsByType counts distinct non-empty source sessions in the
+	// library. MinSourceSessions prevents one session from self-confirming.
+	SourceSessionsByType map[slice.SliceType]int
+	MinSourceSessions    int
+	// MinCoverage is the cleaned-query token coverage floor.
+	MinCoverage float64
+	// MinTopMargin is the absolute score gap between the two best candidates
+	// that pass AllowedTypes. RequireRunnerUp rejects a singleton eligible set.
+	MinTopMargin    float64
+	RequireRunnerUp bool
 	// Zones, when non-nil, applies the grey-zone classifier: only clearly
 	// reusable slices (zone.Hit) enter the block; grey/miss candidates are
 	// skipped (Krites §3.1 — the grey zone must be verified, not injected).
@@ -117,11 +133,16 @@ type Injection struct {
 	// candidate. It is observation-only: replaying Admitted from Reason must
 	// yield the same slice set that produced Text.
 	Decisions []CandidateDecision
+	// TopMargin is top1-top2 over type-eligible candidates. Zero means fewer
+	// than two eligible candidates or equal scores.
+	TopMargin float64
 }
 
 // CandidateDecision is the replayable admission outcome for one retrieved
 // slice. Reason is a stable enum: admitted, below_min_score, zone_grey,
-// zone_miss, sanitized_empty, origin_below_floor, budget, or nil_slice.
+// zone_miss, sanitized_empty, origin_below_floor, budget, nil_slice,
+// type_not_allowed, library_too_small, type_sources_too_few,
+// runner_up_missing, top_margin_low, or coverage_low.
 type CandidateDecision struct {
 	ID       string
 	Score    float64
@@ -158,9 +179,19 @@ func (in *Injector) BuildHits(query string, hits []slice.Hit) (*Injection, error
 	if budget <= 0 {
 		budget = DefaultBudget
 	}
+	eligibleScores := make([]float64, 0, len(hits))
+	for _, h := range hits {
+		if h.Slice != nil && in.typeAllowed(h.Slice.Type) {
+			eligibleScores = append(eligibleScores, h.Score)
+		}
+	}
 	top1 := 0.0
-	if len(hits) > 0 {
-		top1 = hits[0].Score
+	topMargin := 0.0
+	if len(eligibleScores) > 0 {
+		top1 = eligibleScores[0]
+	}
+	if len(eligibleScores) > 1 {
+		topMargin = eligibleScores[0] - eligibleScores[1]
 	}
 
 	var kept []*slice.Slice
@@ -188,8 +219,44 @@ func (in *Injector) BuildHits(query string, hits []slice.Hit) (*Injection, error
 		}
 		d.ID = h.Slice.ID
 		d.Coverage = bm25.QueryCoverage(query, string(h.Slice.Content))
+		if !in.typeAllowed(h.Slice.Type) {
+			d.Reason = "type_not_allowed"
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
+		if in.MinLibrarySize > 0 && in.LibrarySize < in.MinLibrarySize {
+			d.Reason = "library_too_small"
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
+		if in.MinSourceSessions > 0 && in.SourceSessionsByType[h.Slice.Type] < in.MinSourceSessions {
+			d.Reason = "type_sources_too_few"
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
+		if in.RequireRunnerUp && len(eligibleScores) < 2 {
+			d.Reason = "runner_up_missing"
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
+		if in.MinTopMargin > 0 && topMargin < in.MinTopMargin {
+			d.Reason = "top_margin_low"
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
 		if in.MinScore > 0 && h.Score < in.MinScore {
 			d.Reason = "below_min_score"
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
+		if in.MinCoverage > 0 && d.Coverage < in.MinCoverage {
+			d.Reason = "coverage_low"
 			decisions = append(decisions, d)
 			dropped++
 			continue
@@ -297,5 +364,10 @@ func (in *Injector) BuildHits(query string, hits []slice.Hit) (*Injection, error
 		Dropped:      dropped,
 		GreyIncluded: greyIncluded,
 		Decisions:    decisions,
+		TopMargin:    topMargin,
 	}, nil
+}
+
+func (in *Injector) typeAllowed(t slice.SliceType) bool {
+	return in.AllowedTypes == nil || in.AllowedTypes[t]
 }

--- a/kernel/inject/inject_test.go
+++ b/kernel/inject/inject_test.go
@@ -211,6 +211,93 @@ func TestInjectorAdmissionTraceReplaysDecision(t *testing.T) {
 	}
 }
 
+func TestInjectorPolicyRejectsWithReplayableReasons(t *testing.T) {
+	contextHit := func(id, content, session string, score float64) slice.Hit {
+		return slice.Hit{Score: score, Slice: &slice.Slice{
+			ID: id, Type: slice.Context, Scope: slice.Project, Content: []byte(content),
+			Meta: slice.SliceMeta{SourceSession: session},
+		}}
+	}
+	promptHit := slice.Hit{Score: 3, Slice: &slice.Slice{
+		ID: "prompt", Type: slice.Prompt, Scope: slice.Project, Content: []byte("cache failure repair"),
+	}}
+	baseHits := []slice.Hit{
+		contextHit("ctx-a", "cache failure repair", "s1", 3),
+		contextHit("ctx-b", "cache failure diagnosis", "s2", 2),
+	}
+	base := func() *Injector {
+		return &Injector{
+			AllowedTypes:         map[slice.SliceType]bool{slice.Context: true, slice.Memory: true},
+			LibrarySize:          8,
+			MinLibrarySize:       5,
+			SourceSessionsByType: map[slice.SliceType]int{slice.Context: 2},
+			MinSourceSessions:    2,
+			MinScore:             0.7,
+			MinCoverage:          0.25,
+			MinTopMargin:         0.15,
+			RequireRunnerUp:      true,
+			Budget:               4096,
+		}
+	}
+	cases := []struct {
+		name   string
+		mutate func(*Injector) []slice.Hit
+		reason string
+	}{
+		{"type", func(in *Injector) []slice.Hit { return []slice.Hit{promptHit, baseHits[0], baseHits[1]} }, "type_not_allowed"},
+		{"library", func(in *Injector) []slice.Hit { in.LibrarySize = 4; return baseHits }, "library_too_small"},
+		{"sessions", func(in *Injector) []slice.Hit { in.SourceSessionsByType[slice.Context] = 1; return baseHits }, "type_sources_too_few"},
+		{"runner up", func(in *Injector) []slice.Hit { return baseHits[:1] }, "runner_up_missing"},
+		{"margin", func(in *Injector) []slice.Hit {
+			return []slice.Hit{baseHits[0], contextHit("ctx-b", "cache failure diagnosis", "s2", 2.9)}
+		}, "top_margin_low"},
+		{"score", func(in *Injector) []slice.Hit { in.MinScore = 4; return baseHits }, "below_min_score"},
+		{"coverage", func(in *Injector) []slice.Hit { in.MinCoverage = 0.9; return baseHits }, "coverage_low"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := base()
+			inj, err := in.BuildHits("cache failure repair", tc.mutate(in))
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, d := range inj.Decisions {
+				if d.Reason == tc.reason {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("decisions = %+v, want reason %q", inj.Decisions, tc.reason)
+			}
+		})
+	}
+}
+
+func TestInjectorPolicyAdmitsContextWithStrongEvidence(t *testing.T) {
+	hits := []slice.Hit{
+		{Score: 3, Slice: &slice.Slice{ID: "a", Type: slice.Context, Scope: slice.Project, Content: []byte("cache failure repair")}},
+		{Score: 2, Slice: &slice.Slice{ID: "b", Type: slice.Context, Scope: slice.Project, Content: []byte("cache failure diagnosis")}},
+	}
+	in := &Injector{
+		AllowedTypes: map[slice.SliceType]bool{slice.Context: true, slice.Memory: true},
+		LibrarySize:  8, MinLibrarySize: 5,
+		SourceSessionsByType: map[slice.SliceType]int{slice.Context: 2}, MinSourceSessions: 2,
+		MinScore: 0.7, MinCoverage: 0.25, MinTopMargin: 0.15, RequireRunnerUp: true,
+		Budget: 4096,
+	}
+	inj, err := in.BuildHits("cache failure repair", hits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inj.Slices) == 0 || inj.TopMargin != 1 {
+		t.Fatalf("injection = %+v, want admitted context and margin 1", inj)
+	}
+	if inj.Decisions[0].Reason != "admitted" {
+		t.Fatalf("top decision = %+v", inj.Decisions[0])
+	}
+}
+
 // TestInjectorEscapesBlockMarkers is the HIGH-fix regression: a stored slice
 // containing block markers must not break the [semantix-reuse] structure.
 func TestInjectorEscapesBlockMarkers(t *testing.T) {


### PR DESCRIPTION
## Summary

- add replayable admission guards with stable rejection reasons for type, library size, source diversity, absolute score, query coverage, runner-up presence, and top-margin ambiguity
- clean benchmark/host framing before BM25 retrieval and record before/after query summaries without raw prompt text
- make strict L2 injection conservative by default: only Context/Memory, at least 5 project slices, 2 source sessions, score >= 0.70, coverage >= 0.25, and eligible top-1/top-2 margin >= 0.15
- document the production defaults, calibration contract, reason codes, observability, and rollback procedure

## Why

Issue #447 shows that the current memory path can create a forced winner in small libraries, match benchmark boilerplate rather than task intent, and admit weak slice types into high-authority context. This PR implements the P0.4 stop-loss policy. A miss is the expected fallback whenever evidence is insufficient.

## Decision semantics

- `off`: no retrieval or injection
- `shadow`: run the same cleaner and admission policy, emit replayable diagnostics, withhold content
- `strict`: inject only candidates that pass every guard
- disallowed candidates still appear in diagnostics with exact reason codes
- top margin is calculated only among eligible Context/Memory candidates

## Verification

- `go test ./kernel/inject -count=1`
- `go test ./harness/semantix ./harness/eventwire -count=1`
- `go test ./harness/config -run TestRenderTOMLRoundTrips -count=1`
- `go test ./harness/agent -run TestShadowRetrievalKeepsProviderMessagesByteIdenticalToOff -count=1`
- `git diff --check upstream/main...HEAD`

All commands above pass locally on Windows. A repository-wide `go test ./... -count=1` also exposed unrelated existing Windows failures in `cmd/semantix` (`TestDispatchExitCodeContract`) and concurrent ACP/access-denied tests; the changed packages and cross-layer contract tests pass.

Refs #447