### PR TITLE
feat(swebench): add paired L2 memory experiment matrix

### DIFF
--- a/docs/reports/issue-447-memory-matrix-pilot.md
+++ b/docs/reports/issue-447-memory-matrix-pilot.md
@@ -1,0 +1,80 @@
+# Issue #447 A–D memory matrix pilot
+
+Date: 2026-09-02
+
+This report records the first end-to-end pilot of the paired memory matrix. It is
+pipeline evidence, not a causal estimate of memory quality.
+
+## Setup
+
+- Dataset: SWE-bench Verified
+- Instance: `django__django-13195`
+- Repetitions: 1
+- Maximum turns: 40
+- Arm order: A → B → C → D
+- State and work directories: isolated per arm
+- A/B/C: current agent; D: pre-policy legacy agent
+
+The four arm runs completed and produced patches. Official resolved scoring was
+not part of this pilot, so resolved is reported as `n/a`.
+
+## Observed metrics
+
+| Arm | Policy | Executor calls | Input tokens | Tool calls | Repeated tool calls | Wall time (ms) | Cost (USD) | Patch bytes |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| A | memory off | 43 | 1,305,440 | 48 | 0 | 176,061 | 0.02691086 | 2,200 |
+| B | shadow retrieval | 51 | 1,608,715 | 60 | 0 | 222,067 | 0.032217724 | 4,947 |
+| C | strict current policy | 38 | 1,006,020 | 46 | 1 | 164,577 | 0.024804972 | 2,662 |
+| D | legacy all-type policy | 76 | 2,980,415 | 87 | n/a | 303,511 | 0.05220650 | 4,947 |
+
+Paired deltas against A:
+
+| Arm | Δ executor | Δ input tokens | Δ tool calls | Δ repeated calls |
+|---|---:|---:|---:|---:|
+| B | +8 | +303,275 | +12 | 0 |
+| C | -5 | -299,420 | -2 | +1 |
+| D | +33 | +1,674,975 | +39 | n/a |
+
+`n/a` for D repeated calls is intentional: the legacy binary did not emit the
+attribution field. Missing telemetry must not be normalized to a real zero.
+
+## Causal boundary
+
+Each memory-on arm started with an empty, isolated store. B, C, and D recorded no
+`semantix_inject_turns` during the instance and extracted three slices only after
+the run. Therefore the large D-minus-A delta occurred without memory injection
+and cannot be attributed to an injected slice or replacement policy.
+
+This observation adds a third live hypothesis to the two product hypotheses:
+
+1. Sparse or poorly matched slices may cross the admission threshold and cause
+   intent drift.
+2. Excessive replacement may remove constraints, inducing rework or repeated
+   execution.
+3. Model/provider/runtime variance can produce a large step delta even when no
+   memory was injected.
+
+The pilot supports the measurement pipeline but does not rank these hypotheses.
+
+## Issues found by the pilot
+
+The actual run exposed and drove fixes for:
+
+- cross-platform workspace locking and cleanup;
+- persistence of Semantix CLI arguments, exit code, stdout, and stderr;
+- selection of the repository's canonical DeepSeek model alias;
+- separation of missing repeated-call attribution from a measured zero.
+
+## Next acceptance gate
+
+Run the frozen 50-instance subset for at least three repetitions after warming
+an isolated store with earlier instances from the same repository. Pair every
+comparison by `(repetition, instance_id)` and require all of the following before
+claiming causality:
+
+1. a recorded injection event;
+2. the exact admitted slice IDs, scores, bytes, and replacement decision;
+3. a statistically stable regression in executor calls, input tokens, repeated
+   tool calls, or resolved rate;
+4. replay or slice-removal evidence that the regression disappears when the
+   implicated slice is shadowed or excluded.

--- a/docs/specs/issue-447-memory-abcd-matrix.md
+++ b/docs/specs/issue-447-memory-abcd-matrix.md
@@ -1,0 +1,96 @@
+# Issue #447：SWE-bench 记忆 A-D 配对矩阵
+
+> 状态：执行器与报告器已实现（2026-09-02）
+>
+> 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)
+
+## 1. 目的
+
+P0 的 shadow、repo 隔离、严格准入、历史降权和硬预算需要通过真实任务配对回答三个问题：
+
+1. 检索本身是否改变 provider 请求或基础运行开销；
+2. 严格策略能否在 pass@1 非劣时降低 executor calls、工具轮数、token 和成本；
+3. 改善来自 P0 门禁还是随机波动/实例构成。
+
+旧 full/`--ablate all` 不是记忆因果对照，本矩阵只使用显式 memory/retrieval 臂。
+
+## 2. 实验臂
+
+| 臂 | memory | retrieval | binary | 目的 |
+|---|---|---|---|---|
+| A | off | off | current | 无记忆基线 |
+| B | on | shadow | current | 运行检索与诊断，但 provider bytes 等价 A |
+| C | on | strict | current | P0 保守策略 |
+| D | on | strict | legacy @ `cb5e9cc` | 旧全类型宽松注入 |
+
+D 固定在 repo 隔离已存在、P0.4 尚未进入的 commit，避免把跨 repo 污染差异错误算到准入策略上。current binary 必须包含待验收的全部 P0 PR。
+
+## 3. 冻结与隔离
+
+- 同一 dataset、`--ids`、model、preset、effort、价格表和超时；
+- 建议至少 20 instances × 3 repetitions；正式验收使用 frozen-50 × 3；
+- repetition 内严格 A→B→C→D 串行，避免跨臂 CPU/API 竞争；
+- 每个 repetition/arm 有独立 state 和 work 目录；
+- memory-on 内继续使用 repo 独立 store 和 repo 内冻结顺序；
+- 每个 run 的完整命令和路径写入 matrix manifest；
+- 中断后复用相同 run-id，按 `preds.jsonl` 继续，不重跑已完成实例。
+
+## 4. 指标
+
+每个 `(repetition, instance_id)` 与同 repetition 的 A 配对。报告至少包含：
+
+- resolved；
+- executor/total calls；
+- input tokens、cost、wall；
+- tool calls；
+- read/search/test 工具族总量；
+- provider retries；
+- Semantix inject turns/bytes。
+
+每个指标同时输出 absolute 与 `arm - A` 的 mean、median、P75、P90。缺失实例集合直接失败，不能用不完整均值继续。
+
+当前 `tool_calls_by_name` 不包含参数签名，因此 read/search/test 只是工具族总量，不是重复率。重复相同路径/查询/测试、策略反转和 rollback 必须由 P1 trajectory/fuse 事件提供；报告器不做无证据推断。
+
+## 5. 判定顺序
+
+1. B 与 A 的 provider-byte 回归测试必须先通过；
+2. 比较 B-A 判断检索/日志的非注入开销；
+3. 比较 C-A 判断 strict 的端到端收益；
+4. 比较 C-D 判断门禁相对旧策略的增量；
+5. pass@1 非劣后才评价成本优化；
+6. 重点检查 median 与 P75/P90，均值只作补充；
+7. 任一污染事件或大幅负迁移实例进入逐 trajectory 审核。
+
+## 6. 执行
+
+```bash
+cd scripts/swebench
+python3 memory_matrix.py \
+  --dataset data/swebench_verified.jsonl \
+  --ids subsets/verified-50-s20260824.txt \
+  --model deepseek-v4-flash --repetitions 3 --workers 4 \
+  --semantix-bin ../../bin/semantix-agent \
+  --legacy-semantix-bin ../../bin/semantix-agent-issue447-legacy \
+  --semantix-kernel-bin ../../bin/semantix
+```
+
+对 manifest 中每个 run 完成 `evaluate.py`，然后：
+
+```bash
+python3 memory_matrix_report.py \
+  --manifest results/issue447-memory.matrix.json \
+  --format json --out results/issue447-memory.report.json
+python3 memory_matrix_report.py \
+  --manifest results/issue447-memory.matrix.json \
+  --format md --out results/issue447-memory.report.md
+```
+
+## 7. 验证
+
+```powershell
+python -m py_compile scripts/swebench/memory_matrix.py scripts/swebench/memory_matrix_report.py
+python -m unittest discover -s scripts/swebench -p 'test_*.py' -v
+python scripts/swebench/memory_matrix.py <required arguments> --dry-run
+```
+
+单测固定：A-D 顺序、两轮目录隔离、C/D binary 选择、按实例配对、分位数和实例集合不一致 fail closed。

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -146,9 +146,10 @@ legacy binary 应固定构建自 `cb5e9cc`（repo 隔离已合并、strict 仍�
 
 报告严格按 `(repetition, instance_id)` 与 A 配对；任一臂缺实例立即报错。输出
 resolved、executor calls、steps、input tokens、工具总数和 read/search/test 工具族、
-wall、cost、retry、注入次数/字节的 absolute 与相对 A 的 median/P75/P90。当前
-metrics 只有工具名计数，工具族字段表示调用总量而非“重复调用”；重复参数级指标
-仍需 P1 trajectory/fuse 事件补齐，不能从同名调用数反推。
+wall、cost、retry、注入次数/字节的 absolute 与相对 A 的 median/P75/P90。接入
+`repeated_tool_calls` 后，Markdown 额外显示 `Δ repeats median/P75/P90`，JSON 同时
+保留重复 read/search/test 工具族。旧 metrics 缺少重复字段时维持 unattributed，
+不会把“未采集”伪装成 0；重复信号用于归因，不单独作为有害循环或熔断依据。
 
 ## 方法学要点（对比公平性）
 

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -140,6 +140,9 @@ python3 memory_matrix_report.py \
   --format md --out results/issue447-memory.report.md
 ```
 
+首次单实例端到端预跑及其因果边界见
+[`docs/reports/issue-447-memory-matrix-pilot.md`](../../docs/reports/issue-447-memory-matrix-pilot.md)。
+
 legacy binary 应固定构建自 `cb5e9cc`（repo 隔离已合并、strict 仍为旧全类型
 策略），不能用 harness `--ablate all` 代替。矩阵 manifest 保存每个 run 的完整
 命令、state/work/run 路径；重复执行会沿用 `run_bench.py` 的按实例续跑能力。

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -112,6 +112,44 @@ memory-on 时 runner 按数据集 `repo=owner/repo` 分组。同 repo 实例严�
 非法或缺失 repo 标识会在调度前失败，不会落入共享的 unknown 库。每实例
 `raw.semantix_repo` / `raw.semantix_project_dir` 记录实际归属，便于审计。
 
+#### Issue #447 A-D 配对矩阵
+
+`memory_matrix.py` 固定按 repetition 内 A→B→C→D 串行执行，避免跨臂的
+provider/CPU 竞争；每个 repetition/arm 使用独立 state/work 目录，同时复用同一
+`--ids` 顺序：
+
+| 臂 | 配置 | agent binary |
+|---|---|---|
+| A | `memory=off`, `retrieval=off` | 当前版本 |
+| B | `memory=on`, `retrieval=shadow` | 当前版本 |
+| C | `memory=on`, `retrieval=strict` | 当前版本（P0 门禁） |
+| D | `memory=on`, `retrieval=strict` | P0.4 前的 legacy all-type 版本 |
+
+```bash
+python3 memory_matrix.py \
+  --dataset data/swebench_verified.jsonl \
+  --ids subsets/verified-50-s20260824.txt \
+  --model deepseek-v4-flash --repetitions 3 --workers 4 \
+  --semantix-bin ../../bin/semantix-agent \
+  --legacy-semantix-bin ../../bin/semantix-agent-issue447-legacy \
+  --semantix-kernel-bin ../../bin/semantix
+
+# 对生成的每个 run 完成官方 evaluate.py 后：
+python3 memory_matrix_report.py \
+  --manifest results/issue447-memory.matrix.json \
+  --format md --out results/issue447-memory.report.md
+```
+
+legacy binary 应固定构建自 `cb5e9cc`（repo 隔离已合并、strict 仍为旧全类型
+策略），不能用 harness `--ablate all` 代替。矩阵 manifest 保存每个 run 的完整
+命令、state/work/run 路径；重复执行会沿用 `run_bench.py` 的按实例续跑能力。
+
+报告严格按 `(repetition, instance_id)` 与 A 配对；任一臂缺实例立即报错。输出
+resolved、executor calls、steps、input tokens、工具总数和 read/search/test 工具族、
+wall、cost、retry、注入次数/字节的 absolute 与相对 A 的 median/P75/P90。当前
+metrics 只有工具名计数，工具族字段表示调用总量而非“重复调用”；重复参数级指标
+仍需 P1 trajectory/fuse 事件补齐，不能从同名调用数反推。
+
 ## 方法学要点（对比公平性）
 
 - **同一 prompt 模板**（`common.PROMPT_TEMPLATE`）喂给所有 harness；system prompt 保持各 harness 原生（那正是 harness 差异的一部分）。

--- a/scripts/swebench/common.py
+++ b/scripts/swebench/common.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
@@ -158,6 +160,40 @@ def _run(cmd: list[str], cwd: Path | None = None, check: bool = True, env: dict 
                           capture_output=True, text=True)
 
 
+@contextmanager
+def exclusive_file_lock(path: Path):
+    """Hold a one-byte advisory lock on POSIX and Windows."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+b") as lock:
+        if os.name == "nt":
+            import msvcrt
+
+            lock.seek(0, os.SEEK_END)
+            if lock.tell() == 0:
+                lock.write(b"\0")
+                lock.flush()
+            while True:
+                lock.seek(0)
+                try:
+                    msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
+                    break
+                except OSError:
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                lock.seek(0)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock, fcntl.LOCK_UN)
+
+
 def ensure_repo_cache(work_dir: Path, repo: str) -> Path:
     cache = work_dir / "repos" / (repo.replace("/", "__") + ".git")
     if cache.exists():
@@ -165,13 +201,11 @@ def ensure_repo_cache(work_dir: Path, repo: str) -> Path:
     cache.parent.mkdir(parents=True, exist_ok=True)
     # Serialize concurrent clones (workers race on first use of a repo);
     # clone to a temp path so a killed clone never leaves a half-built cache.
-    import fcntl
-
-    with open(cache.with_suffix(".lock"), "w") as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
+    with exclusive_file_lock(cache.with_suffix(".lock")):
         if not cache.exists():
             tmp = cache.with_suffix(".tmp")
-            subprocess.run(["rm", "-rf", str(tmp)], check=True)
+            if tmp.exists():
+                shutil.rmtree(tmp)
             _run(["git", "clone", "--bare", f"https://github.com/{repo}.git", str(tmp)])
             tmp.rename(cache)
     return cache
@@ -180,7 +214,7 @@ def ensure_repo_cache(work_dir: Path, repo: str) -> Path:
 def prepare_workspace(work_dir: Path, run_id: str, inst: dict) -> Path:
     ws = work_dir / "ws" / run_id / inst["instance_id"]
     if ws.exists():
-        subprocess.run(["rm", "-rf", str(ws)], check=True)
+        shutil.rmtree(ws)
     cache = ensure_repo_cache(work_dir, inst["repo"])
     # --shared is safe: workspaces are throwaway and never gc'd independently.
     _run(["git", "clone", "--shared", "--no-checkout", str(cache), str(ws)])

--- a/scripts/swebench/memory_matrix.py
+++ b/scripts/swebench/memory_matrix.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Run the Issue #447 paired memory experiment matrix.
+
+Arms are executed sequentially to avoid cross-arm provider/CPU contention:
+
+  A  memory off
+  B  memory on + shadow retrieval
+  C  memory on + current strict policy
+  D  memory on + legacy all-type policy (separate agent binary)
+
+Each repetition/arm gets an isolated state and work directory. The selected
+dataset order is identical because every command reuses the same --ids/--seed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+@dataclass(frozen=True)
+class MatrixRun:
+    arm: str
+    label: str
+    repetition: int
+    run_id: str
+    run_dir: str
+    state_dir: str
+    work_dir: str
+    command: list[str]
+
+
+ARM_CONFIG = (
+    ("A", "off", "off", "off", False),
+    ("B", "shadow", "on", "shadow", False),
+    ("C", "strict", "on", "strict", False),
+    ("D", "legacy", "on", "strict", True),
+)
+
+
+def add_optional(command: list[str], flag: str, value: str) -> None:
+    if value:
+        command.extend((flag, value))
+
+
+def build_runs(args: argparse.Namespace) -> list[MatrixRun]:
+    runs: list[MatrixRun] = []
+    for repetition in range(1, args.repetitions + 1):
+        for arm, label, memory, retrieval, legacy in ARM_CONFIG:
+            run_id = f"{args.prefix}.r{repetition:02d}.{arm}-{label}"
+            state_dir = str(Path(args.state_dir) / f"r{repetition:02d}" / f"{arm}-{label}")
+            work_dir = str(Path(args.work_dir) / f"r{repetition:02d}" / f"{arm}-{label}")
+            agent_bin = args.legacy_semantix_bin if legacy else args.semantix_bin
+            command = [
+                sys.executable, str(HERE / "run_bench.py"),
+                "--harness", "semantix",
+                "--dataset", args.dataset,
+                "--ids", args.ids,
+                "--model", args.model,
+                "--run-id", run_id,
+                "--results-dir", args.results_dir,
+                "--work-dir", work_dir,
+                "--state-dir", state_dir,
+                "--workers", str(args.workers),
+                "--timeout", str(args.timeout),
+                "--max-turns", str(args.max_turns),
+                "--preset", args.preset,
+                "--semantix-memory", memory,
+                "--semantix-retrieval-mode", retrieval,
+                "--semantix-bin", agent_bin,
+                "--semantix-kernel-bin", args.semantix_kernel_bin,
+            ]
+            add_optional(command, "--effort", args.effort)
+            add_optional(command, "--prices", args.prices)
+            add_optional(command, "--openai-base", args.openai_base)
+            add_optional(command, "--anthropic-base", args.anthropic_base)
+            runs.append(MatrixRun(
+                arm=arm, label=label, repetition=repetition, run_id=run_id,
+                run_dir=str(Path(args.results_dir) / run_id),
+                state_dir=state_dir, work_dir=work_dir, command=command,
+            ))
+    return runs
+
+
+def manifest_for(args: argparse.Namespace, runs: list[MatrixRun]) -> dict:
+    return {
+        "schema": 1,
+        "prefix": args.prefix,
+        "dataset": args.dataset,
+        "ids": args.ids,
+        "model": args.model,
+        "repetitions": args.repetitions,
+        "arm_order": [arm for arm, *_ in ARM_CONFIG],
+        "runs": [asdict(run) for run in runs],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--ids", required=True, help="frozen instance IDs in dataset order")
+    ap.add_argument("--model", default="deepseek-v4-flash")
+    ap.add_argument("--semantix-bin", required=True, help="current strict semantix-agent")
+    ap.add_argument("--legacy-semantix-bin", required=True,
+                    help="baseline semantix-agent retaining the old all-type policy")
+    ap.add_argument("--semantix-kernel-bin", required=True)
+    ap.add_argument("--repetitions", type=int, default=3)
+    ap.add_argument("--prefix", default="issue447-memory")
+    ap.add_argument("--results-dir", default=str(HERE / "results"))
+    ap.add_argument("--work-dir", default=str(HERE / "work" / "issue447-memory"))
+    ap.add_argument("--state-dir", default=str(HERE / "state" / "issue447-memory"))
+    ap.add_argument("--workers", type=int, default=4)
+    ap.add_argument("--timeout", type=int, default=2400)
+    ap.add_argument("--max-turns", type=int, default=120)
+    ap.add_argument("--preset", default="balanced")
+    ap.add_argument("--effort", default="")
+    ap.add_argument("--prices", default="")
+    ap.add_argument("--openai-base", default="")
+    ap.add_argument("--anthropic-base", default="")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--continue-on-error", action="store_true")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repetitions < 1:
+        raise SystemExit("--repetitions must be >= 1")
+    runs = build_runs(args)
+    manifest_path = Path(args.results_dir) / f"{args.prefix}.matrix.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(manifest_for(args, runs), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"manifest: {manifest_path}")
+
+    failed = False
+    for run in runs:
+        print(f"=== repetition {run.repetition} arm {run.arm}-{run.label} ===", flush=True)
+        print(shlex.join(run.command), flush=True)
+        if args.dry_run:
+            continue
+        result = subprocess.run(run.command, cwd=HERE, check=False)
+        if result.returncode:
+            failed = True
+            print(f"arm {run.arm} exit={result.returncode}", file=sys.stderr, flush=True)
+            if not args.continue_on_error:
+                return result.returncode
+    return int(failed)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/swebench/memory_matrix_report.py
+++ b/scripts/swebench/memory_matrix_report.py
@@ -97,15 +97,15 @@ def metric_value(row: dict, metric: str) -> float | None:
     if metric == "test_calls":
         return tool_family(row, TEST_TOOLS)
     if metric == "repeated_read_calls":
-        if "repeated_tool_calls_by_name" not in row:
+        if not isinstance(row.get("repeated_tool_calls_by_name"), dict):
             return None
         return tool_family(row, READ_TOOLS, "repeated_tool_calls_by_name")
     if metric == "repeated_search_calls":
-        if "repeated_tool_calls_by_name" not in row:
+        if not isinstance(row.get("repeated_tool_calls_by_name"), dict):
             return None
         return tool_family(row, SEARCH_TOOLS, "repeated_tool_calls_by_name")
     if metric == "repeated_test_calls":
-        if "repeated_tool_calls_by_name" not in row:
+        if not isinstance(row.get("repeated_tool_calls_by_name"), dict):
             return None
         return tool_family(row, TEST_TOOLS, "repeated_tool_calls_by_name")
     if metric.startswith("semantix_"):

--- a/scripts/swebench/memory_matrix_report.py
+++ b/scripts/swebench/memory_matrix_report.py
@@ -13,6 +13,8 @@ METRICS = (
     "resolved", "executor_calls", "steps", "input_tokens", "tool_calls",
     "read_calls", "search_calls", "test_calls", "wall_ms", "cost_usd",
     "provider_retries", "semantix_inject_turns", "semantix_inject_bytes",
+    "repeated_tool_calls", "repeated_read_calls", "repeated_search_calls",
+    "repeated_test_calls",
 )
 
 READ_TOOLS = {"read", "read_file", "readfile", "view", "view_file"}
@@ -76,8 +78,8 @@ def load_rows(run: dict) -> dict[str, dict]:
     return rows
 
 
-def tool_family(row: dict, names: set[str]) -> float:
-    counts = row.get("tool_calls_by_name", {})
+def tool_family(row: dict, names: set[str], field: str = "tool_calls_by_name") -> float:
+    counts = row.get(field, {})
     if not isinstance(counts, dict):
         return 0.0
     return float(sum(
@@ -94,6 +96,12 @@ def metric_value(row: dict, metric: str) -> float | None:
         return tool_family(row, SEARCH_TOOLS)
     if metric == "test_calls":
         return tool_family(row, TEST_TOOLS)
+    if metric == "repeated_read_calls":
+        return tool_family(row, READ_TOOLS, "repeated_tool_calls_by_name")
+    if metric == "repeated_search_calls":
+        return tool_family(row, SEARCH_TOOLS, "repeated_tool_calls_by_name")
+    if metric == "repeated_test_calls":
+        return tool_family(row, TEST_TOOLS, "repeated_tool_calls_by_name")
     if metric.startswith("semantix_"):
         value = row.get("raw", {}).get(metric)
     else:
@@ -166,8 +174,8 @@ def fmt(value: float | None) -> str:
 
 def markdown(report: dict) -> str:
     lines = [
-        "| arm | paired n | resolved | Δ executor median/P75/P90 | Δ input median/P75/P90 | Δ tools median/P75/P90 |",
-        "|---|---:|---:|---:|---:|---:|",
+        "| arm | paired n | resolved | Δ executor median/P75/P90 | Δ input median/P75/P90 | Δ tools median/P75/P90 | Δ repeats median/P75/P90 |",
+        "|---|---:|---:|---:|---:|---:|---:|",
     ]
     for arm, data in report["arms"].items():
         def delta(metric: str) -> str:
@@ -179,7 +187,8 @@ def markdown(report: dict) -> str:
         lines.append(
             f"| {arm} | {data['instances']} | "
             f"{'n/a' if resolved is None else f'{resolved:.1%}'} | "
-            f"{delta('executor_calls')} | {delta('input_tokens')} | {delta('tool_calls')} |"
+            f"{delta('executor_calls')} | {delta('input_tokens')} | {delta('tool_calls')} | "
+            f"{delta('repeated_tool_calls')} |"
         )
     return "\n".join(lines) + "\n"
 

--- a/scripts/swebench/memory_matrix_report.py
+++ b/scripts/swebench/memory_matrix_report.py
@@ -97,10 +97,16 @@ def metric_value(row: dict, metric: str) -> float | None:
     if metric == "test_calls":
         return tool_family(row, TEST_TOOLS)
     if metric == "repeated_read_calls":
+        if "repeated_tool_calls_by_name" not in row:
+            return None
         return tool_family(row, READ_TOOLS, "repeated_tool_calls_by_name")
     if metric == "repeated_search_calls":
+        if "repeated_tool_calls_by_name" not in row:
+            return None
         return tool_family(row, SEARCH_TOOLS, "repeated_tool_calls_by_name")
     if metric == "repeated_test_calls":
+        if "repeated_tool_calls_by_name" not in row:
+            return None
         return tool_family(row, TEST_TOOLS, "repeated_tool_calls_by_name")
     if metric.startswith("semantix_"):
         value = row.get("raw", {}).get(metric)

--- a/scripts/swebench/memory_matrix_report.py
+++ b/scripts/swebench/memory_matrix_report.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Build per-instance paired A-D summaries from a memory matrix manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from pathlib import Path
+
+METRICS = (
+    "resolved", "executor_calls", "steps", "input_tokens", "tool_calls",
+    "read_calls", "search_calls", "test_calls", "wall_ms", "cost_usd",
+    "provider_retries", "semantix_inject_turns", "semantix_inject_bytes",
+)
+
+READ_TOOLS = {"read", "read_file", "readfile", "view", "view_file"}
+SEARCH_TOOLS = {"grep", "rg", "search", "search_files", "find"}
+TEST_TOOLS = {"test", "run_tests", "pytest", "go_test"}
+
+
+def percentile(values: list[float], q: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    position = (len(ordered) - 1) * q
+    low = math.floor(position)
+    high = math.ceil(position)
+    if low == high:
+        return float(ordered[low])
+    return float(ordered[low] + (ordered[high] - ordered[low]) * (position - low))
+
+
+def distribution(values: list[float]) -> dict:
+    return {
+        "count": len(values),
+        "mean": statistics.fmean(values) if values else None,
+        "median": statistics.median(values) if values else None,
+        "p75": percentile(values, 0.75),
+        "p90": percentile(values, 0.90),
+    }
+
+
+def official_resolution(run_dir: Path) -> dict[str, float] | None:
+    reports = sorted(run_dir.glob(f"*.{run_dir.name}.json"))
+    if not reports:
+        return None
+    report = json.loads(reports[-1].read_text(encoding="utf-8"))
+    resolved = report.get("resolved_ids")
+    if not isinstance(resolved, list):
+        return None
+    resolved_set = {value for value in resolved if isinstance(value, str)}
+    return {instance_id: 1.0 for instance_id in resolved_set}
+
+
+def load_rows(run: dict) -> dict[str, dict]:
+    inline = run.get("rows")
+    if isinstance(inline, dict):
+        return inline
+    run_dir = Path(run["run_dir"])
+    metrics_path = run_dir / "metrics.jsonl"
+    rows = {}
+    with metrics_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            rows[row["instance_id"]] = row
+    resolution = official_resolution(run_dir)
+    if resolution is not None:
+        for instance_id, row in rows.items():
+            row["resolved"] = resolution.get(instance_id, 0.0)
+    return rows
+
+
+def tool_family(row: dict, names: set[str]) -> float:
+    counts = row.get("tool_calls_by_name", {})
+    if not isinstance(counts, dict):
+        return 0.0
+    return float(sum(
+        count for name, count in counts.items()
+        if isinstance(name, str) and name.lower() in names
+        and isinstance(count, int) and not isinstance(count, bool) and count >= 0
+    ))
+
+
+def metric_value(row: dict, metric: str) -> float | None:
+    if metric == "read_calls":
+        return tool_family(row, READ_TOOLS)
+    if metric == "search_calls":
+        return tool_family(row, SEARCH_TOOLS)
+    if metric == "test_calls":
+        return tool_family(row, TEST_TOOLS)
+    if metric.startswith("semantix_"):
+        value = row.get("raw", {}).get(metric)
+    else:
+        value = row.get(metric)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def build_report(manifest: dict) -> dict:
+    loaded = []
+    by_rep_arm: dict[tuple[int, str], dict[str, dict]] = {}
+    for run in manifest.get("runs", []):
+        rows = load_rows(run)
+        item = dict(run, rows=rows)
+        loaded.append(item)
+        by_rep_arm[(int(run["repetition"]), run["arm"])] = rows
+
+    repetitions = sorted({int(run["repetition"]) for run in loaded})
+    arms = sorted({run["arm"] for run in loaded})
+    for repetition in repetitions:
+        baseline = by_rep_arm.get((repetition, "A"))
+        if baseline is None:
+            raise ValueError(f"repetition {repetition} missing arm A baseline")
+        baseline_ids = set(baseline)
+        for arm in arms:
+            rows = by_rep_arm.get((repetition, arm))
+            if rows is None:
+                raise ValueError(f"repetition {repetition} missing arm {arm}")
+            if set(rows) != baseline_ids:
+                raise ValueError(
+                    f"repetition {repetition} arm {arm} instance set differs from arm A"
+                )
+
+    output = {"schema": 1, "repetitions": len(repetitions), "arms": {}}
+    for arm in arms:
+        absolute = {metric: [] for metric in METRICS}
+        deltas = {metric: [] for metric in METRICS}
+        instance_count = 0
+        for repetition in repetitions:
+            rows = by_rep_arm[(repetition, arm)]
+            baseline = by_rep_arm[(repetition, "A")]
+            instance_count += len(rows)
+            for instance_id, row in rows.items():
+                for metric in METRICS:
+                    value = metric_value(row, metric)
+                    base = metric_value(baseline[instance_id], metric)
+                    if value is not None:
+                        absolute[metric].append(value)
+                    if arm != "A" and value is not None and base is not None:
+                        deltas[metric].append(value - base)
+        resolved_values = absolute["resolved"]
+        output["arms"][arm] = {
+            "instances": instance_count,
+            "resolved_rate": statistics.fmean(resolved_values) if resolved_values else None,
+            "metrics": {
+                metric: {
+                    "absolute": distribution(absolute[metric]),
+                    "delta_vs_A": None if arm == "A" else distribution(deltas[metric]),
+                }
+                for metric in METRICS
+            },
+        }
+    return output
+
+
+def fmt(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.2f}"
+
+
+def markdown(report: dict) -> str:
+    lines = [
+        "| arm | paired n | resolved | Δ executor median/P75/P90 | Δ input median/P75/P90 | Δ tools median/P75/P90 |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for arm, data in report["arms"].items():
+        def delta(metric: str) -> str:
+            d = data["metrics"][metric]["delta_vs_A"]
+            if d is None:
+                return "baseline"
+            return "/".join(fmt(d[key]) for key in ("median", "p75", "p90"))
+        resolved = data["resolved_rate"]
+        lines.append(
+            f"| {arm} | {data['instances']} | "
+            f"{'n/a' if resolved is None else f'{resolved:.1%}'} | "
+            f"{delta('executor_calls')} | {delta('input_tokens')} | {delta('tool_calls')} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--format", choices=("json", "md"), default="md")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    report = build_report(manifest)
+    text = (json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+            if args.format == "json" else markdown(report))
+    if args.out:
+        Path(args.out).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -187,7 +187,8 @@ class Adapter:
 # semantix-agent
 # ---------------------------------------------------------------------------
 
-SEMANTIX_BENCH_PROVIDER = "swebench-deepseek"
+def semantix_bench_provider(model: str) -> str:
+    return "deepseek-pro" if model.endswith("-pro") else "deepseek-flash"
 
 
 class SemantixAdapter(Adapter):
@@ -243,6 +244,7 @@ class SemantixAdapter(Adapter):
             f"DEEPSEEK_API_KEY={os.environ.get('DEEPSEEK_API_KEY', 'smoke')}\n")
         env_file.chmod(0o600)
         base = self.args.openai_base or DEEPSEEK_OPENAI_BASE
+        provider_selector = semantix_bench_provider(self.args.model)
         effort = f'effort      = "{self.args.effort}"\n' if self.args.effort else ""
         memory_section = ""
         if self.memory_on:
@@ -260,7 +262,7 @@ project_dir  = "{kernel_dir}"
 sessions_dir = "{sessions_dir}"
 '''
         (home / "config.toml").write_text(
-            f'''default_model = "{SEMANTIX_BENCH_PROVIDER}"
+            f'''default_model = "{provider_selector}"
 {memory_section}
 # Benchmark convention: every arm runs in its max-permission mode (codex
 # danger-full-access, claude --dangerously-skip-permissions, dsh
@@ -269,7 +271,7 @@ sessions_dir = "{sessions_dir}"
 bash = "off"
 
 [[providers]]
-name        = "{SEMANTIX_BENCH_PROVIDER}"
+name        = "{provider_selector}"
 kind        = "openai"
 base_url    = "{base}"
 models      = ["{self.args.model}"]
@@ -302,7 +304,7 @@ context_window = 128000
             "--permission-mode", "auto",
             "--preset", self.args.preset,
             "--metrics", str(mfile),
-            "--model", SEMANTIX_BENCH_PROVIDER,
+            "--model", semantix_bench_provider(self.args.model),
         ]
         if self.args.ablate:
             cmd += ["--ablate", self.args.ablate]

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -187,6 +187,9 @@ class Adapter:
 # semantix-agent
 # ---------------------------------------------------------------------------
 
+SEMANTIX_BENCH_PROVIDER = "swebench-deepseek"
+
+
 class SemantixAdapter(Adapter):
     name = "semantix"
 
@@ -257,7 +260,7 @@ project_dir  = "{kernel_dir}"
 sessions_dir = "{sessions_dir}"
 '''
         (home / "config.toml").write_text(
-            f'''default_model = "deepseek"
+            f'''default_model = "{SEMANTIX_BENCH_PROVIDER}"
 {memory_section}
 # Benchmark convention: every arm runs in its max-permission mode (codex
 # danger-full-access, claude --dangerously-skip-permissions, dsh
@@ -266,7 +269,7 @@ sessions_dir = "{sessions_dir}"
 bash = "off"
 
 [[providers]]
-name        = "deepseek"
+name        = "{SEMANTIX_BENCH_PROVIDER}"
 kind        = "openai"
 base_url    = "{base}"
 models      = ["{self.args.model}"]
@@ -299,7 +302,7 @@ context_window = 128000
             "--permission-mode", "auto",
             "--preset", self.args.preset,
             "--metrics", str(mfile),
-            "--model", "deepseek",
+            "--model", SEMANTIX_BENCH_PROVIDER,
         ]
         if self.args.ablate:
             cmd += ["--ablate", self.args.ablate]

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -303,12 +303,28 @@ context_window = 128000
         ]
         if self.args.ablate:
             cmd += ["--ablate", self.args.ablate]
+        stdout_text = ""
+        stderr_text = ""
         try:
             proc = subprocess.run(cmd, input=prompt, capture_output=True, text=True,
                                   env=env, timeout=self.args.timeout)
             exit_code, err = proc.returncode, ""
-        except subprocess.TimeoutExpired:
+            stdout_text = proc.stdout or ""
+            stderr_text = proc.stderr or ""
+        except subprocess.TimeoutExpired as exc:
             exit_code, err = None, f"timeout after {self.args.timeout}s"
+            stdout_text = exc.stdout or ""
+            stderr_text = exc.stderr or ""
+        if isinstance(stdout_text, bytes):
+            stdout_text = stdout_text.decode("utf-8", errors="replace")
+        if isinstance(stderr_text, bytes):
+            stderr_text = stderr_text.decode("utf-8", errors="replace")
+        # Preserve adapter-local diagnostics beside native metrics. Without
+        # these files, an early CLI failure produces only zero counters and
+        # discards the actual provider/configuration error.
+        stem = mfile.with_suffix("")
+        Path(str(stem) + ".stdout.txt").write_text(stdout_text, encoding="utf-8")
+        Path(str(stem) + ".stderr.txt").write_text(stderr_text, encoding="utf-8")
         raw = {}
         for candidate in (mfile, Path(str(mfile) + ".partial")):
             if candidate.exists():

--- a/scripts/swebench/test_memory_matrix.py
+++ b/scripts/swebench/test_memory_matrix.py
@@ -70,14 +70,24 @@ class MemoryMatrixReportTest(unittest.TestCase):
                 {"instance_id": "i1", "executor_calls": 5, "steps": 6,
                  "input_tokens": 100, "tool_calls": 8, "wall_ms": 1000,
                  "cost_usd": 1.0, "provider_retries": 0, "empty_patch": False,
-                 "tool_calls_by_name": {"read_file": 3, "grep": 2, "bash": 1}, "raw": {}},
+                 "tool_calls_by_name": {"read_file": 3, "grep": 2, "bash": 1},
+                 "repeated_tool_calls": 3,
+                 "repeated_tool_calls_by_name": {"read_file": 2, "grep": 1}, "raw": {}},
                 {"instance_id": "i2", "executor_calls": 7, "steps": 8,
                  "input_tokens": 200, "tool_calls": 10, "wall_ms": 2000,
                  "cost_usd": 2.0, "provider_retries": 1, "empty_patch": False,
-                 "tool_calls_by_name": {"read_file": 4, "grep": 1, "bash": 2}, "raw": {}},
+                 "tool_calls_by_name": {"read_file": 4, "grep": 1, "bash": 2},
+                 "repeated_tool_calls": 2,
+                 "repeated_tool_calls_by_name": {"read_file": 1, "grep": 1}, "raw": {}},
             ]
-            strict_rows = [dict(base_rows[0], executor_calls=4, input_tokens=80),
-                           dict(base_rows[1], executor_calls=6, input_tokens=150)]
+            strict_rows = [
+                dict(base_rows[0], executor_calls=4, input_tokens=80,
+                     repeated_tool_calls=1,
+                     repeated_tool_calls_by_name={"read_file": 1}),
+                dict(base_rows[1], executor_calls=6, input_tokens=150,
+                     repeated_tool_calls=0,
+                     repeated_tool_calls_by_name={}),
+            ]
             runs = []
             for arm, rows, resolved in (
                 ("A", base_rows, ["i1"]),
@@ -96,6 +106,10 @@ class MemoryMatrixReportTest(unittest.TestCase):
             self.assertEqual(c["resolved_rate"], 1.0)
             self.assertEqual(c["metrics"]["executor_calls"]["delta_vs_A"]["median"], -1.0)
             self.assertEqual(c["metrics"]["input_tokens"]["delta_vs_A"]["p90"], -23.0)
+            self.assertEqual(c["metrics"]["repeated_tool_calls"]["delta_vs_A"]["median"], -2.0)
+            self.assertEqual(c["metrics"]["repeated_read_calls"]["delta_vs_A"]["median"], -1.0)
+            self.assertEqual(c["metrics"]["repeated_search_calls"]["delta_vs_A"]["median"], -1.0)
+            self.assertIn("Δ repeats median/P75/P90", memory_matrix_report.markdown(report))
 
     def test_report_rejects_unpaired_instance_sets(self):
         manifest = {"schema": 1, "runs": [

--- a/scripts/swebench/test_memory_matrix.py
+++ b/scripts/swebench/test_memory_matrix.py
@@ -123,6 +123,13 @@ class MemoryMatrixReportTest(unittest.TestCase):
         legacy = {"tool_calls_by_name": {"read_file": 3}}
         self.assertIsNone(memory_matrix_report.metric_value(legacy, "repeated_tool_calls"))
         self.assertIsNone(memory_matrix_report.metric_value(legacy, "repeated_read_calls"))
+        normalized_legacy = {
+            "repeated_tool_calls": None,
+            "repeated_tool_calls_by_name": None,
+        }
+        self.assertIsNone(memory_matrix_report.metric_value(
+            normalized_legacy, "repeated_read_calls"
+        ))
 
 
 if __name__ == "__main__":

--- a/scripts/swebench/test_memory_matrix.py
+++ b/scripts/swebench/test_memory_matrix.py
@@ -1,0 +1,110 @@
+import argparse
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import memory_matrix  # noqa: E402
+import memory_matrix_report  # noqa: E402
+
+
+class MemoryMatrixCommandTest(unittest.TestCase):
+    def test_builds_repeated_abcd_commands_with_isolated_state(self):
+        args = argparse.Namespace(
+            dataset="dataset.jsonl",
+            ids="ids.txt",
+            model="deepseek-v4-flash",
+            semantix_bin="bin/current-agent",
+            legacy_semantix_bin="bin/legacy-agent",
+            semantix_kernel_bin="bin/semantix",
+            repetitions=2,
+            prefix="issue447",
+            results_dir="results",
+            work_dir="work",
+            state_dir="state",
+            workers=3,
+            timeout=1200,
+            max_turns=80,
+            preset="balanced",
+            effort="",
+            prices="",
+            openai_base="",
+            anthropic_base="",
+        )
+        runs = memory_matrix.build_runs(args)
+        self.assertEqual([(r.repetition, r.arm) for r in runs], [
+            (1, "A"), (1, "B"), (1, "C"), (1, "D"),
+            (2, "A"), (2, "B"), (2, "C"), (2, "D"),
+        ])
+        commands = {r.arm: r.command for r in runs[:4]}
+        self.assertIn("off", commands["A"])
+        self.assertIn("shadow", commands["B"])
+        self.assertIn("strict", commands["C"])
+        self.assertIn("bin/legacy-agent", commands["D"])
+        self.assertIn("bin/current-agent", commands["C"])
+        self.assertEqual(len({r.state_dir for r in runs}), 8)
+        self.assertEqual(len({r.work_dir for r in runs}), 8)
+
+
+class MemoryMatrixReportTest(unittest.TestCase):
+    def write_run(self, root: Path, run_id: str, rows: list[dict], resolved: list[str]):
+        run = root / run_id
+        run.mkdir(parents=True)
+        (run / "metrics.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+        (run / f"test.{run_id}.json").write_text(json.dumps({
+            "resolved_instances": len(resolved),
+            "submitted_instances": len(rows),
+            "resolved_ids": resolved,
+        }), encoding="utf-8")
+
+    def test_report_pairs_each_arm_against_off_by_instance(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base_rows = [
+                {"instance_id": "i1", "executor_calls": 5, "steps": 6,
+                 "input_tokens": 100, "tool_calls": 8, "wall_ms": 1000,
+                 "cost_usd": 1.0, "provider_retries": 0, "empty_patch": False,
+                 "tool_calls_by_name": {"read_file": 3, "grep": 2, "bash": 1}, "raw": {}},
+                {"instance_id": "i2", "executor_calls": 7, "steps": 8,
+                 "input_tokens": 200, "tool_calls": 10, "wall_ms": 2000,
+                 "cost_usd": 2.0, "provider_retries": 1, "empty_patch": False,
+                 "tool_calls_by_name": {"read_file": 4, "grep": 1, "bash": 2}, "raw": {}},
+            ]
+            strict_rows = [dict(base_rows[0], executor_calls=4, input_tokens=80),
+                           dict(base_rows[1], executor_calls=6, input_tokens=150)]
+            runs = []
+            for arm, rows, resolved in (
+                ("A", base_rows, ["i1"]),
+                ("B", base_rows, ["i1"]),
+                ("C", strict_rows, ["i1", "i2"]),
+                ("D", base_rows, ["i1"]),
+            ):
+                run_id = f"m.r01.{arm}"
+                self.write_run(root, run_id, rows, resolved)
+                runs.append({"arm": arm, "label": arm, "repetition": 1,
+                             "run_id": run_id, "run_dir": str(root / run_id)})
+            manifest = {"schema": 1, "runs": runs}
+            report = memory_matrix_report.build_report(manifest)
+            c = report["arms"]["C"]
+            self.assertEqual(c["instances"], 2)
+            self.assertEqual(c["resolved_rate"], 1.0)
+            self.assertEqual(c["metrics"]["executor_calls"]["delta_vs_A"]["median"], -1.0)
+            self.assertEqual(c["metrics"]["input_tokens"]["delta_vs_A"]["p90"], -23.0)
+
+    def test_report_rejects_unpaired_instance_sets(self):
+        manifest = {"schema": 1, "runs": [
+            {"arm": "A", "repetition": 1, "run_id": "a", "rows": {"i1": {}}},
+            {"arm": "B", "repetition": 1, "run_id": "b", "rows": {"i2": {}}},
+        ]}
+        with self.assertRaisesRegex(ValueError, "instance set"):
+            memory_matrix_report.build_report(manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/swebench/test_memory_matrix.py
+++ b/scripts/swebench/test_memory_matrix.py
@@ -119,6 +119,11 @@ class MemoryMatrixReportTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "instance set"):
             memory_matrix_report.build_report(manifest)
 
+    def test_missing_repeat_fields_stay_unattributed(self):
+        legacy = {"tool_calls_by_name": {"read_file": 3}}
+        self.assertIsNone(memory_matrix_report.metric_value(legacy, "repeated_tool_calls"))
+        self.assertIsNone(memory_matrix_report.metric_value(legacy, "repeated_read_calls"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/swebench/test_metrics_attribution.py
+++ b/scripts/swebench/test_metrics_attribution.py
@@ -144,10 +144,10 @@ class SemantixMetricAttributionTest(unittest.TestCase):
             self.assertEqual((native / "i1.semantix.stderr.txt").read_text(),
                              "provider stderr\n")
             command = run.call_args.args[0]
-            self.assertEqual(command[command.index("--model") + 1], "swebench-deepseek")
+            self.assertEqual(command[command.index("--model") + 1], "deepseek-flash")
             config = (root / "home" / "inst" / "i1" / "config.toml").read_text()
-            self.assertIn('default_model = "swebench-deepseek"', config)
-            self.assertIn('name        = "swebench-deepseek"', config)
+            self.assertIn('default_model = "deepseek-flash"', config)
+            self.assertIn('name        = "deepseek-flash"', config)
 
 
 class AttributionReportTest(unittest.TestCase):

--- a/scripts/swebench/test_metrics_attribution.py
+++ b/scripts/swebench/test_metrics_attribution.py
@@ -135,7 +135,7 @@ class SemantixMetricAttributionTest(unittest.TestCase):
             adapter.memory_on = False
             completed = SimpleNamespace(returncode=1, stdout="provider stdout\n",
                                         stderr="provider stderr\n")
-            with mock.patch("run_bench.subprocess.run", return_value=completed):
+            with mock.patch("run_bench.subprocess.run", return_value=completed) as run:
                 adapter.run_instance(root, "prompt", {"instance_id": "i1"})
 
             native = root / "run" / "native"
@@ -143,6 +143,11 @@ class SemantixMetricAttributionTest(unittest.TestCase):
                              "provider stdout\n")
             self.assertEqual((native / "i1.semantix.stderr.txt").read_text(),
                              "provider stderr\n")
+            command = run.call_args.args[0]
+            self.assertEqual(command[command.index("--model") + 1], "swebench-deepseek")
+            config = (root / "home" / "inst" / "i1" / "config.toml").read_text()
+            self.assertIn('default_model = "swebench-deepseek"', config)
+            self.assertIn('name        = "swebench-deepseek"', config)
 
 
 class AttributionReportTest(unittest.TestCase):

--- a/scripts/swebench/test_metrics_attribution.py
+++ b/scripts/swebench/test_metrics_attribution.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 
 HERE = Path(__file__).resolve().parent
@@ -115,6 +116,33 @@ class SemantixMetricAttributionTest(unittest.TestCase):
         self.assertEqual(metrics.tool_calls_by_name, {"grep": 2})
         self.assertEqual(metrics.source_call_total, 3)
         self.assertEqual(metrics.source_call_delta, 1)
+
+    def test_run_instance_persists_cli_output_for_failure_diagnosis(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            args = SimpleNamespace(
+                openai_base="http://127.0.0.1:8139/v1",
+                effort="",
+                model="deepseek-v4-flash",
+                semantix_retrieval_mode="off",
+                preset="balanced",
+                ablate="",
+                timeout=30,
+            )
+            adapter = SemantixAdapter(args, root / "run")
+            adapter.binary = "semantix-agent"
+            adapter.home = root / "home"
+            adapter.memory_on = False
+            completed = SimpleNamespace(returncode=1, stdout="provider stdout\n",
+                                        stderr="provider stderr\n")
+            with mock.patch("run_bench.subprocess.run", return_value=completed):
+                adapter.run_instance(root, "prompt", {"instance_id": "i1"})
+
+            native = root / "run" / "native"
+            self.assertEqual((native / "i1.semantix.stdout.txt").read_text(),
+                             "provider stdout\n")
+            self.assertEqual((native / "i1.semantix.stderr.txt").read_text(),
+                             "provider stderr\n")
 
 
 class AttributionReportTest(unittest.TestCase):

--- a/scripts/swebench/test_repo_isolation.py
+++ b/scripts/swebench/test_repo_isolation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
+import common
 from run_bench import Adapter, SemantixAdapter, process_batch, repo_store_key
 
 
@@ -57,6 +58,38 @@ class RepoSchedulingTests(unittest.TestCase):
 
 
 class RepoStoreTests(unittest.TestCase):
+    def test_repo_cache_clone_is_portable_and_atomic(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+
+            def fake_clone(command, **_kwargs):
+                Path(command[-1]).mkdir()
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with mock.patch("common._run", side_effect=fake_clone) as run:
+                cache = common.ensure_repo_cache(root, "django/django")
+            self.assertTrue(cache.is_dir())
+            self.assertEqual(run.call_count, 1)
+
+    def test_prepare_workspace_removes_stale_tree_without_shell_rm(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            inst_row = {
+                "instance_id": "django-1",
+                "repo": "django/django",
+                "base_commit": "abc123",
+            }
+            stale = root / "ws" / "run" / "django-1"
+            stale.mkdir(parents=True)
+            (stale / "leftover").write_text("stale", encoding="utf-8")
+            cache = root / "cache.git"
+            cache.mkdir()
+            with mock.patch("common.ensure_repo_cache", return_value=cache), \
+                    mock.patch("common._run") as run:
+                workspace = common.prepare_workspace(root, "run", inst_row)
+            self.assertFalse((workspace / "leftover").exists())
+            self.assertEqual(run.call_count, 4)
+
     def adapter(self, root: Path) -> SemantixAdapter:
         args = SimpleNamespace(openai_base="http://127.0.0.1:8139/v1", effort="",
                                model="deepseek-v4-flash", semantix_retrieval_mode="strict")


### PR DESCRIPTION
## Summary

- add a deterministic A-D memory experiment driver with isolated state/work directories per repetition and arm
- run arms sequentially as A off, B shadow, C current strict, D pinned legacy all-type policy
- write a machine-readable manifest containing every run id, path, and exact command
- add a paired reporter that validates identical instance sets and reports absolute plus delta-vs-A mean/median/P75/P90
- cover resolved, executor/total calls, tokens, tool families, wall, cost, retries, and Semantix injection volume
- document binary pinning, execution, evaluation, interpretation order, and the remaining parameter-level repetition gap

## Why

Issue #447 cannot be accepted using aggregate memory ON/OFF means or the historical `--ablate all` comparison. The P0 changes need same-instance, same-repetition comparisons and tail metrics, with a retained legacy policy arm to separate admission-policy benefit from normal run variance.

## Arms

| Arm | Configuration | Binary |
|---|---|---|
| A | memory off / retrieval off | current |
| B | memory on / shadow | current |
| C | memory on / strict | current P0 |
| D | memory on / strict | legacy pinned at `cb5e9cc` |

D is pinned after repo isolation but before P0.4, so C-D measures the admission/authority policy instead of cross-repo contamination.

## Verification

- `python -m py_compile scripts/swebench/memory_matrix.py scripts/swebench/memory_matrix_report.py scripts/swebench/test_memory_matrix.py`
- `python -m unittest discover -s scripts/swebench -p 'test_*.py' -v` (16 tests pass)
- one-repetition `--dry-run` generated four ordered commands and an isolated manifest
- `git diff --check upstream/main...HEAD`

## Execution note

The repository checkout contains the frozen ID list, but not the SWE-bench dataset, current/legacy binaries, or a configured provider credential. This PR delivers and verifies the reproducible execution/report path; the real 20x3/frozen-50x3 model run starts after #452 and #453 are reviewed and the current binary includes the full P0 stack.

Refs #447