### PR TITLE
feat(metrics): attribute repeated tool calls for memory experiments

### DIFF
--- a/docs/specs/issue-447-repeated-tool-attribution.md
+++ b/docs/specs/issue-447-repeated-tool-attribution.md
@@ -1,0 +1,67 @@
+# Issue #447：重复工具调用归因合同
+
+> 状态：P1 测量基线（2026-09-02）
+>
+> 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)
+
+## 1. 定义
+
+一次已完成工具调用的签名为：
+
+```text
+SHA-256(provider-visible tool name + NUL + canonical JSON arguments)
+```
+
+同一 run 中第一个已完成签名不是重复；之后每个相同签名计一次 `repeated_tool_calls`，并按工具名计入 `repeated_tool_calls_by_name`。
+
+参数 JSON 会先解析并重新序列化，因此对象 key 顺序不同不制造假差异。解析失败时使用 trim 后原始字节做摘要。工具名属于签名的一部分，相同参数但不同工具不是重复。
+
+## 2. 数据流
+
+1. 完整 `ToolDispatch` 提供 ID、provider-visible name 和 args；partial dispatch 不参与；
+2. metrics sink 只保存 ID → `(name, digest)`；
+3. 对应 `ToolResult` 到达后，签名才进入 completed 集合；
+4. 已完成集合中已有该签名时累计 repeat；
+5. result 后删除 pending ID；未完成/取消的 dispatch 不计调用或重复。
+
+原始参数不进入 metrics JSON，也不长期保存在重复计数器。现有 `tool_calls_by_name` 继续统计所有已完成调用；新字段只统计首次之后的同参重复。
+
+## 3. 解释边界
+
+`repeated_tool_calls` 是轨迹信号，不自动等价“有害”：
+
+- 同一测试在修改前后各跑一次可能是必要验证；
+- 同一路径在内容变化后重读可能是有效确认；
+- 相同命令在外部状态变化后重试可能合理。
+
+因此该字段用于 A-D 配对、异常实例筛选和后续 fuse 输入。熔断必须再结合新证据增量、工具结果、修改/回滚、时间顺序与注入 slice ID，不能仅凭 repeat > 0 拒绝历史。
+
+## 4. 输出
+
+`run --metrics`：
+
+```json
+{
+  "tool_calls": 12,
+  "tool_calls_by_name": {"read_file": 5, "grep": 4, "bash": 3},
+  "repeated_tool_calls": 3,
+  "repeated_tool_calls_by_name": {"read_file": 2, "grep": 1}
+}
+```
+
+SWE runner 将两个字段原样规范化到每实例 `metrics.jsonl`；`report.py` 聚合 total 和 per-name map，Markdown 显示 `tools/repeat`。
+
+## 5. 验证
+
+- canonical JSON key 顺序得到同一签名；
+- 相同工具/参数第二次完成计 1；
+- 不同参数不计重复；
+- 不同工具名不计同签名；
+- dispatch 本身不计完成或重复；
+- legacy metrics 缺字段时聚合为 0/空 map；
+- malformed/negative per-name counters继续 fail closed。
+
+```powershell
+go test ./harness/cli -run 'TestMetricsSinkAttributesRepeatedToolArguments|TestMetricsSinkAccountsToolCallsAndRetries' -count=1
+python -m unittest scripts/swebench/test_metrics_attribution.py -v
+```

--- a/harness/cli/run_metrics.go
+++ b/harness/cli/run_metrics.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"maps"
 	"os"
@@ -143,6 +144,16 @@ type RunMetrics struct {
 	Retries            int                    `json:"retries"`
 	ToolCallsByName    map[string]int         `json:"tool_calls_by_name,omitempty"`
 	ToolFailuresByName map[string]int         `json:"tool_failures_by_name,omitempty"`
+	// RepeatedToolCalls counts completed calls after the first occurrence of
+	// the same provider-visible tool name + canonical JSON arguments. Only a
+	// digest is retained; raw arguments never enter metrics.
+	RepeatedToolCalls       int            `json:"repeated_tool_calls,omitempty"`
+	RepeatedToolCallsByName map[string]int `json:"repeated_tool_calls_by_name,omitempty"`
+}
+
+type pendingToolCall struct {
+	signature string
+	name      string
 }
 
 // metricsSink forwards every event to the real sink and accumulates the per-call
@@ -159,6 +170,10 @@ type metricsSink struct {
 	// childMutations counts how many distinct children mutated each path, so
 	// two children racing on one file is measurable rather than anecdotal.
 	childMutations map[string]int
+	// pendingTools joins full dispatch arguments to the later result by ID;
+	// seenToolSignatures counts completed calls only.
+	pendingTools       map[string]pendingToolCall
+	seenToolSignatures map[string]int
 
 	// partialPath receives throttled in-flight snapshots, so a run killed by a
 	// timeout still leaves accounting behind instead of nothing. Empty disables
@@ -189,6 +204,7 @@ func (m RunMetrics) clone() RunMetrics {
 	out.UsageBySource = cloneSourceUsage(m.UsageBySource)
 	out.ToolCallsByName = cloneCounts(m.ToolCallsByName)
 	out.ToolFailuresByName = cloneCounts(m.ToolFailuresByName)
+	out.RepeatedToolCallsByName = cloneCounts(m.RepeatedToolCallsByName)
 	out.OriginalCosts = cloneFloatMap(m.OriginalCosts)
 	out.OriginalTotals = append([]billing.Money(nil), m.OriginalTotals...)
 	if len(m.CostQuotes) > 0 {
@@ -367,11 +383,64 @@ func (s *metricsSink) record(e event.Event) {
 		}
 	}
 	if e.Kind == event.ToolResult {
+		s.recordToolRepeat(e.Tool)
 		s.recordToolResult(e.Tool)
+	}
+	if e.Kind == event.ToolDispatch && !e.Tool.Partial {
+		s.recordToolDispatch(e.Tool)
 	}
 	if e.Kind == event.Retrying {
 		s.m.Retries++
 	}
+}
+
+func (s *metricsSink) recordToolDispatch(t event.Tool) {
+	if strings.TrimSpace(t.ID) == "" {
+		return
+	}
+	name := strings.TrimSpace(t.Name)
+	if name == "" {
+		name = "unknown"
+	}
+	if s.pendingTools == nil {
+		s.pendingTools = make(map[string]pendingToolCall)
+	}
+	s.pendingTools[t.ID] = pendingToolCall{signature: toolCallSignature(name, t.Args), name: name}
+}
+
+func (s *metricsSink) recordToolRepeat(t event.Tool) {
+	call, ok := s.pendingTools[t.ID]
+	if !ok {
+		return
+	}
+	delete(s.pendingTools, t.ID)
+	if s.seenToolSignatures == nil {
+		s.seenToolSignatures = make(map[string]int)
+	}
+	if s.seenToolSignatures[call.signature] > 0 {
+		s.m.RepeatedToolCalls++
+		if s.m.RepeatedToolCallsByName == nil {
+			s.m.RepeatedToolCallsByName = make(map[string]int)
+		}
+		s.m.RepeatedToolCallsByName[call.name]++
+	}
+	s.seenToolSignatures[call.signature]++
+}
+
+func toolCallSignature(name, args string) string {
+	normalized := []byte(strings.TrimSpace(args))
+	var decoded any
+	if json.Unmarshal(normalized, &decoded) == nil {
+		if canonical, err := json.Marshal(decoded); err == nil {
+			normalized = canonical
+		}
+	}
+	payload := make([]byte, 0, len(name)+1+len(normalized))
+	payload = append(payload, name...)
+	payload = append(payload, 0)
+	payload = append(payload, normalized...)
+	sum := sha256.Sum256(payload)
+	return string(sum[:])
 }
 
 func originalTotalsFromFloatMap(totals map[string]float64) []billing.Money {

--- a/harness/cli/run_metrics.go
+++ b/harness/cli/run_metrics.go
@@ -147,7 +147,7 @@ type RunMetrics struct {
 	// RepeatedToolCalls counts completed calls after the first occurrence of
 	// the same provider-visible tool name + canonical JSON arguments. Only a
 	// digest is retained; raw arguments never enter metrics.
-	RepeatedToolCalls       int            `json:"repeated_tool_calls,omitempty"`
+	RepeatedToolCalls       int            `json:"repeated_tool_calls"`
 	RepeatedToolCallsByName map[string]int `json:"repeated_tool_calls_by_name,omitempty"`
 }
 

--- a/harness/cli/run_metrics_test.go
+++ b/harness/cli/run_metrics_test.go
@@ -199,6 +199,7 @@ func TestWriteMetricsIncludesReadinessFields(t *testing.T) {
 		t.Fatalf("Unmarshal: %v", err)
 	}
 	for _, key := range []string{
+		"repeated_tool_calls",
 		"readiness_checks",
 		"readiness_allowed",
 		"readiness_blocks",

--- a/harness/cli/run_metrics_test.go
+++ b/harness/cli/run_metrics_test.go
@@ -145,6 +145,25 @@ func TestMetricsSinkAccountsToolCallsAndRetries(t *testing.T) {
 	}
 }
 
+func TestMetricsSinkAttributesRepeatedToolArguments(t *testing.T) {
+	s := &metricsSink{inner: event.Discard}
+	call := func(id, name, args string) {
+		s.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: id, Name: name, Args: args}})
+		s.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: id, Name: name}})
+	}
+	call("r1", "read_file", `{"path":"a.go","line":1}`)
+	call("r2", "read_file", `{"line":1,"path":"a.go"}`) // same canonical JSON
+	call("r3", "read_file", `{"path":"b.go","line":1}`)
+	call("g1", "grep", `{"path":"a.go","line":1}`) // tool name is part of signature
+
+	if s.m.RepeatedToolCalls != 1 {
+		t.Fatalf("repeated tool calls = %d, want 1", s.m.RepeatedToolCalls)
+	}
+	if s.m.RepeatedToolCallsByName["read_file"] != 1 || len(s.m.RepeatedToolCallsByName) != 1 {
+		t.Fatalf("repeated calls by name = %v, want read_file=1", s.m.RepeatedToolCallsByName)
+	}
+}
+
 func TestWriteMetricsIncludesReadinessFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "metrics.json")
 	if err := writeMetrics(path, RunMetrics{

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -94,6 +94,8 @@ runner 会把原生 `usage_by_source` 规范化进每实例 `metrics.jsonl`：
 | `provider_retries` | provider 传输重试事件数；没有 Usage 事件时不计入 `steps` |
 | `compactions` | compaction 尝试次数；与实际产生 Usage 的 `compaction_calls` 不同 |
 | `tool_calls_by_name` | 已完成工具调用按 canonical tool name 汇总 |
+| `repeated_tool_calls` | 同一 provider-visible 工具名 + canonical JSON 参数在首次完成后的重复次数 |
+| `repeated_tool_calls_by_name` | 上述重复按工具名拆分；只保留参数摘要，不写原始参数 |
 
 `report.py` 的 Markdown 表用 `calls E/P/S/C/O` 显示
 executor/planner/subagent/compaction/other；JSON 输出保留完整来源表和工具表。

--- a/scripts/swebench/common.py
+++ b/scripts/swebench/common.py
@@ -81,6 +81,8 @@ class InstanceMetrics:
     subagent_runs: int = 0
     tool_failures: int = 0
     tool_calls_by_name: dict[str, int] = field(default_factory=dict)
+    repeated_tool_calls: int = 0
+    repeated_tool_calls_by_name: dict[str, int] = field(default_factory=dict)
     cost_usd: float | None = None    # computed from DeepSeek prices when possible
     cost_native: float | None = None # what the harness itself reported
     cost_native_currency: str = ""

--- a/scripts/swebench/common.py
+++ b/scripts/swebench/common.py
@@ -81,8 +81,10 @@ class InstanceMetrics:
     subagent_runs: int = 0
     tool_failures: int = 0
     tool_calls_by_name: dict[str, int] = field(default_factory=dict)
-    repeated_tool_calls: int = 0
-    repeated_tool_calls_by_name: dict[str, int] = field(default_factory=dict)
+    # None means the selected harness/binary predates repeat attribution;
+    # zero means attribution ran and observed no repeated signature.
+    repeated_tool_calls: int | None = None
+    repeated_tool_calls_by_name: dict[str, int] | None = None
     cost_usd: float | None = None    # computed from DeepSeek prices when possible
     cost_native: float | None = None # what the harness itself reported
     cost_native_currency: str = ""

--- a/scripts/swebench/report.py
+++ b/scripts/swebench/report.py
@@ -81,6 +81,8 @@ def load_run(run_dir: Path) -> dict:
         "tool_calls": sum_int(metrics, "tool_calls"),
         "tool_failures": sum_int(metrics, "tool_failures"),
         "tool_calls_by_name": sum_count_maps(metrics, "tool_calls_by_name"),
+        "repeated_tool_calls": sum_int(metrics, "repeated_tool_calls"),
+        "repeated_tool_calls_by_name": sum_count_maps(metrics, "repeated_tool_calls_by_name"),
         "cost_usd": sum(m["cost_usd"] or 0 for m in metrics),
         "empty_patches": sum(1 for m in metrics if m["empty_patch"]),
         "errors": sum(1 for m in metrics if m["error"]),
@@ -120,7 +122,7 @@ def main() -> None:
 
     headers = ["harness", "model", "n", "resolved", "resolve %", "mean wall",
                "input tok", "output tok", "cache hit %", "cost (USD)",
-               "calls E/P/S/C/O", "tools", "retry", "empty", "err"]
+               "calls E/P/S/C/O", "tools/repeat", "retry", "empty", "err"]
     print("| " + " | ".join(headers) + " |")
     print("|" + "---|" * len(headers))
     for r in rows:
@@ -133,7 +135,7 @@ def main() -> None:
             "/".join(str(r[key]) for key in (
                 "executor_calls", "planner_calls", "subagent_calls",
                 "compaction_calls", "other_model_calls")),
-            str(r["tool_calls"]), str(r["provider_retries"]),
+            f"{r['tool_calls']}/{r['repeated_tool_calls']}", str(r["provider_retries"]),
             str(r["empty_patches"]), str(r["errors"]),
         ]) + " |")
 

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -372,6 +372,10 @@ context_window = 128000
         m.subagent_runs = raw.get("subagent_runs", 0)
         m.tool_failures = raw.get("tool_failures", 0)
         m.tool_calls_by_name = normalize_count_map(raw.get("tool_calls_by_name"))
+        m.repeated_tool_calls = raw.get("repeated_tool_calls", 0)
+        m.repeated_tool_calls_by_name = normalize_count_map(
+            raw.get("repeated_tool_calls_by_name")
+        )
         m.cost_native = raw.get("cost")
         m.cost_native_currency = raw.get("currency", "")
 

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -372,10 +372,12 @@ context_window = 128000
         m.subagent_runs = raw.get("subagent_runs", 0)
         m.tool_failures = raw.get("tool_failures", 0)
         m.tool_calls_by_name = normalize_count_map(raw.get("tool_calls_by_name"))
-        m.repeated_tool_calls = raw.get("repeated_tool_calls", 0)
-        m.repeated_tool_calls_by_name = normalize_count_map(
-            raw.get("repeated_tool_calls_by_name")
-        )
+        if "repeated_tool_calls" in raw:
+            m.repeated_tool_calls = raw.get("repeated_tool_calls")
+        if "repeated_tool_calls_by_name" in raw:
+            m.repeated_tool_calls_by_name = normalize_count_map(
+                raw.get("repeated_tool_calls_by_name")
+            )
         m.cost_native = raw.get("cost")
         m.cost_native_currency = raw.get("currency", "")
 

--- a/scripts/swebench/test_metrics_attribution.py
+++ b/scripts/swebench/test_metrics_attribution.py
@@ -49,6 +49,8 @@ class SemantixMetricAttributionTest(unittest.TestCase):
             "tool_calls": 8,
             "tool_failures": 1,
             "tool_calls_by_name": {"read_file": 4, "grep": 3, "bash": 1},
+            "repeated_tool_calls": 3,
+            "repeated_tool_calls_by_name": {"read_file": 2, "grep": 1},
         }
 
         metrics = self.new_metrics()
@@ -77,6 +79,8 @@ class SemantixMetricAttributionTest(unittest.TestCase):
             "grep": 3,
             "bash": 1,
         })
+        self.assertEqual(metrics.repeated_tool_calls, 3)
+        self.assertEqual(metrics.repeated_tool_calls_by_name, {"read_file": 2, "grep": 1})
 
     def test_fill_metrics_keeps_old_records_explicitly_unattributed(self) -> None:
         metrics = self.new_metrics()
@@ -160,6 +164,8 @@ class AttributionReportTest(unittest.TestCase):
                 tool_failures=1,
                 model_calls_by_source={"executor": 5, "classifier": 2},
                 tool_calls_by_name={"grep": 3, "bash": 1},
+                repeated_tool_calls=2,
+                repeated_tool_calls_by_name={"grep": 2},
             ),
             self.metric_row(
                 executor_calls=3,
@@ -176,6 +182,8 @@ class AttributionReportTest(unittest.TestCase):
                 tool_failures=0,
                 model_calls_by_source={"executor": 3, "goal-evaluator": 2},
                 tool_calls_by_name={"grep": 1, "bash": 1},
+                repeated_tool_calls=1,
+                repeated_tool_calls_by_name={"grep": 1},
             ),
         ]
         tmp, run_dir = self.write_run(rows)
@@ -201,6 +209,8 @@ class AttributionReportTest(unittest.TestCase):
             "goal-evaluator": 2,
         })
         self.assertEqual(aggregate["tool_calls_by_name"], {"bash": 2, "grep": 4})
+        self.assertEqual(aggregate["repeated_tool_calls"], 3)
+        self.assertEqual(aggregate["repeated_tool_calls_by_name"], {"grep": 3})
 
     def test_load_run_treats_legacy_attribution_fields_as_zero(self) -> None:
         tmp, run_dir = self.write_run([self.metric_row()])
@@ -213,6 +223,8 @@ class AttributionReportTest(unittest.TestCase):
         self.assertEqual(aggregate["provider_retries"], 0)
         self.assertEqual(aggregate["model_calls_by_source"], {})
         self.assertEqual(aggregate["tool_calls_by_name"], {})
+        self.assertEqual(aggregate["repeated_tool_calls"], 0)
+        self.assertEqual(aggregate["repeated_tool_calls_by_name"], {})
 
 
 if __name__ == "__main__":

--- a/scripts/swebench/test_metrics_attribution.py
+++ b/scripts/swebench/test_metrics_attribution.py
@@ -92,6 +92,8 @@ class SemantixMetricAttributionTest(unittest.TestCase):
         self.assertEqual(metrics.source_call_delta, 7)
         self.assertEqual(metrics.executor_calls, 0)
         self.assertEqual(metrics.other_model_calls, 0)
+        self.assertIsNone(metrics.repeated_tool_calls)
+        self.assertIsNone(metrics.repeated_tool_calls_by_name)
 
     def test_fill_metrics_ignores_malformed_or_negative_counts(self) -> None:
         raw = {


### PR DESCRIPTION
## Summary

Add an observable, privacy-preserving signal for exact repeated tool calls so issue #447's paired memory experiments can distinguish step growth from repeated execution rather than inferring it from total steps alone.

A completed call is considered repeated only after the first occurrence of the same provider-visible tool name plus canonical JSON arguments in one run. Dispatch/result events are joined by tool-call ID; incomplete calls do not count.

## Scope

- `harness/cli`: add `repeated_tool_calls` and `repeated_tool_calls_by_name` to run metrics.
- Canonicalize JSON arguments before hashing so key order does not create false differences.
- Retain only SHA-256 digests in the in-memory attribution state; raw arguments are not persisted to metrics.
- `scripts/swebench`: propagate, aggregate, and display the new fields as `tools/repeat`.
- Document the attribution contract, interpretation limits, and follow-up fuse boundary.

This PR intentionally adds measurement, not a fuse. A repeated call can be valid when state changed; later policy work must combine this signal with evidence/result deltas, ordering, and injected slice provenance.

## Validation

- [ ] `go vet ./...`
- [ ] `go test ./... -race`
- [x] `git diff --check upstream/main...HEAD`
- [x] `go test ./harness/cli -run 'TestMetricsSinkAttributesRepeatedToolArguments|TestMetricsSinkAccountsToolCallsAndRetries' -count=1`
- [x] `python -m unittest discover -s scripts/swebench -p 'test_*.py' -v` (13 tests)

A full `go test ./harness/cli -count=1` was also run. The changed focused tests passed, while the package run hit existing Windows timing/TempDir failures in `TestLoadResumableSessionRejectsCleanupPending`, `TestMCPRemoveCLIClearsSemantixOAuthState`, and `TestModelSwitchRefreshesCustomStatusline`; none touches the changed metrics path.

## Compatibility and data impact

The metrics JSON change is additive. Legacy records without the fields aggregate to zero and an empty per-tool map. No configuration or runtime decision changes in this PR.

## Security and privacy

Raw tool arguments are not emitted or retained in run metrics. The sink stores only tool name and an argument digest until the corresponding result, then deletes the pending entry.

## Evidence

The test covers canonical JSON key order, a second identical completed call, distinct arguments, and tool-name separation. The SWE tests cover propagation, aggregation, legacy records, and malformed/negative per-name counters.

## Related issues

Contributes to #447.

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Tests or documentation cover the changed behavior.
- [x] User-facing behavior and examples are updated where needed.
- [x] No credentials, private source code, personal data, or sensitive local paths are included.
- [x] Wire-contract changes are additive and synchronized with the relevant metrics documentation; `docs/events.md` is not changed because no event shape changed.
