### PR TITLE
feat(swebench): Issue #326 Track A/B 基建——protocol 开关、cost.jsonl、注入审计+…

### DIFF
--- a/harness/boot/boot.go
+++ b/harness/boot/boot.go
@@ -304,6 +304,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		Budget:      cfg.Semantix.Budget,
 		SessionsDir: cfg.Semantix.SessionsDir,
 		ProjectDir:  cfg.Semantix.ProjectDir,
+		AuditDir:    cfg.Semantix.AuditDir,
 		CostMissUSD: cfg.Semantix.CostInputPriceUSD,
 		CostHitUSD:  cfg.Semantix.CostCachePriceUSD,
 	})

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -973,6 +973,13 @@ type SemantixConfig struct {
 	// directory to share a slice library across workspaces (e.g. benchmark
 	// arms measuring cross-session reuse).
 	ProjectDir string `toml:"project_dir"`
+	// AuditDir is where the kernel appends one JSON line per admitted L2
+	// injection (full [semantix-reuse] block + query + admitted slice IDs).
+	// It is the raw material for the SWE-bench Track B leakage scan (Issue
+	// #326): dumped blocks are scanned for a later instance's gold patch or
+	// FAIL_TO_PASS test names to rule out "the cache leaked the answer".
+	// Empty disables the journal — zero file I/O.
+	AuditDir string `toml:"audit_dir"`
 	// CostInputPriceUSD / CostCachePriceUSD override the usage cost model
 	// prices (USD per 1M tokens at cache miss / hit) used by the reuse panel
 	// savings delta. Zero keeps the kernel defaults — mirror semantix.toml

--- a/harness/config/render.go
+++ b/harness/config/render.go
@@ -543,6 +543,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	if c.Semantix.ProjectDir != "" {
 		fmt.Fprintf(&b, "project_dir = %q   # shared slice library root (<dir>/.semantix/...)\n", c.Semantix.ProjectDir)
 	}
+	if c.Semantix.AuditDir != "" {
+		fmt.Fprintf(&b, "audit_dir = %q    # per-admitted-injection JSONL journal (Track B leakage scan)\n", c.Semantix.AuditDir)
+	}
 	if c.Semantix.CostInputPriceUSD != 0 {
 		fmt.Fprintf(&b, "cost_input_price_usd = %s\n", formatFloat(c.Semantix.CostInputPriceUSD))
 	}

--- a/harness/config/semantix_render_test.go
+++ b/harness/config/semantix_render_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// TestRenderTOMLRoundTripsSemantixAuditDir guards the Issue #326 injection
+// audit_dir key: once the semantix section renders, a later config save
+// (RenderTOML is used by every setup/migration/editor write) must not drop
+// the audit journal location the benchmark runner configured.
+func TestRenderTOMLRoundTripsSemantixAuditDir(t *testing.T) {
+	cfg := Default()
+	cfg.Semantix.Enabled = true
+	cfg.Semantix.Inject = true
+	cfg.Semantix.SessionsDir = "/run/sessions"
+	cfg.Semantix.AuditDir = "/run/audit"
+
+	rendered := RenderTOML(cfg)
+	if !strings.Contains(rendered, `audit_dir = "/run/audit"`) {
+		t.Fatalf("render missing audit_dir:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `sessions_dir = "/run/sessions"`) {
+		t.Fatalf("render missing sessions_dir:\n%s", rendered)
+	}
+
+	back := Default()
+	if _, err := toml.Decode(rendered, back); err != nil {
+		t.Fatalf("round-trip decode: %v", err)
+	}
+	if !back.Semantix.Enabled || !back.Semantix.Inject {
+		t.Fatalf("round-trip lost semantix enabled/inject: %+v", back.Semantix)
+	}
+	if back.Semantix.AuditDir != "/run/audit" || back.Semantix.SessionsDir != "/run/sessions" {
+		t.Fatalf("round-trip lost semantix dirs: %+v", back.Semantix)
+	}
+}

--- a/harness/semantix/audit.go
+++ b/harness/semantix/audit.go
@@ -1,0 +1,121 @@
+package semantix
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// auditEntry is one line of the injection audit journal: every admitted L2
+// injection exactly as it becomes provider-visible (the full [semantix-reuse]
+// block), plus the query it was assembled for and the admitted slice targets.
+// The runner copies the journal into run_dir/audit/<instance>.jsonl and the
+// SWE-bench Track B leakage scan (Issue #326 §六 #4) checks each block against
+// the instance being solved's gold patch and FAIL_TO_PASS test names — if a
+// slice library distilled from earlier same-repo instances ever carried the
+// answer, the scan flags it.
+type auditEntry struct {
+	Seq       int64    `json:"seq"`
+	At        int64    `json:"at"` // unix ms (UTC)
+	Session   string   `json:"session,omitempty"`
+	Query     string   `json:"query"`        // truncated to maxAuditQueryRunes
+	QueryHash string   `json:"query_sha256"` // full query hash (untruncated)
+	Degraded  bool     `json:"degraded"`
+	Budget    int      `json:"budget"`
+	Bytes     int      `json:"bytes"`
+	Targets   []string `json:"targets"`
+	Text      string   `json:"text"`
+}
+
+// maxAuditQueryRunes bounds the stored query copy; the injected block itself
+// is already budget-capped by the kernel injector.
+const maxAuditQueryRunes = 4096
+
+// auditInjection appends one journal line for an admitted injection. It is a
+// no-op when AuditDir is unset (the common case: zero file I/O on the hot
+// path) and degrades fail-open — a journal write error drops the entry and
+// closes the journal rather than ever blocking or failing the agent loop.
+func (b *Bridge) auditInjection(query string, budget int, degraded bool,
+	targets []string, bytes int, text string) {
+	if b == nil || b.cfg.AuditDir == "" || text == "" {
+		return
+	}
+	targets = append([]string(nil), targets...)
+	// Capture the label before taking auditMu: sessionLabel locks b.mu, and
+	// Close locks b.mu then auditMu — taking auditMu first would invert that
+	// order. Label assignment happens once per process, so this read is
+	// stable for the lifetime of a run.
+	session := b.sessionLabel()
+	q := []rune(query)
+	if len(q) > maxAuditQueryRunes {
+		q = q[:maxAuditQueryRunes]
+	}
+	sum := sha256.Sum256([]byte(query))
+	entry := auditEntry{
+		Seq:       0, // assigned under auditMu below
+		At:        time.Now().UTC().UnixMilli(),
+		Session:   session,
+		Query:     string(q),
+		QueryHash: hex.EncodeToString(sum[:]),
+		Degraded:  degraded,
+		Budget:    budget,
+		Bytes:     bytes,
+		Targets:   targets,
+		Text:      text,
+	}
+	b.auditMu.Lock()
+	defer b.auditMu.Unlock()
+	if b.auditF == nil {
+		f, err := openAuditJournal(b.cfg.AuditDir)
+		if err != nil {
+			return
+		}
+		b.auditF = f
+	}
+	b.auditSeq++
+	entry.Seq = b.auditSeq
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	if _, err := b.auditF.Write(append(data, '\n')); err != nil {
+		_ = b.auditF.Close()
+		b.auditF = nil
+		return
+	}
+	_ = b.auditF.Sync()
+}
+
+// closeAudit closes the journal, if open, and returns its error. Callers hold
+// auditMu.
+func (b *Bridge) closeAudit() error {
+	if b.auditF == nil {
+		return nil
+	}
+	err := b.auditF.Close()
+	b.auditF = nil
+	return err
+}
+
+func (b *Bridge) sessionLabel() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.label
+}
+
+// openAuditJournal opens <AuditDir>/inject-audit.jsonl for append, creating
+// the directory 0700 and refusing a pre-placed symlink (same tamper guard as
+// the session sink).
+func openAuditJournal(dir string) (*os.File, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, "inject-audit.jsonl")
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrPermission}
+	}
+	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+}

--- a/harness/semantix/audit_test.go
+++ b/harness/semantix/audit_test.go
@@ -1,0 +1,118 @@
+package semantix
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBridgeAuditJournalDumpsAdmittedInjections verifies the Issue #326
+// injection audit journal: every admitted L2 injection is appended verbatim
+// (query + targets + bytes + full [semantix-reuse] block), and a shadow/off
+// retrieval mode — which never admits — writes nothing.
+func TestBridgeAuditJournalDumpsAdmittedInjections(t *testing.T) {
+	dir := writeKernelDir(t, admissionFixtureSlices(), nil)
+	auditDir := t.TempDir()
+	b := NewBridge(Config{Enabled: true, Inject: true, ProjectDir: dir,
+		SessionsDir: t.TempDir(), Budget: 4096, AuditDir: auditDir})
+	b.SetLabel("audit-session")
+	res := b.InjectDetailed(context.Background(), "修复 go 测试")
+	if res.Text == "" || len(res.Targets) == 0 {
+		t.Fatalf("InjectDetailed() = %+v, want admitted slices", res)
+	}
+	// A second, distinct query either misses or injects; either way the
+	// journal must contain the first entry already and Close must stay clean.
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries := readAuditJournal(t, auditDir)
+	if len(entries) != 1 {
+		t.Fatalf("audit journal entries = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Text != res.Text {
+		t.Fatalf("journal text != injected text (%d vs %d bytes)", len(e.Text), len(res.Text))
+	}
+	if e.Bytes == 0 || e.Bytes != len(res.Text) {
+		t.Fatalf("journal bytes = %d, text len = %d", e.Bytes, len(res.Text))
+	}
+	if len(e.Targets) != len(res.Targets) {
+		t.Fatalf("journal targets = %v, want %v", e.Targets, res.Targets)
+	}
+	if e.Query == "" || e.QueryHash == "" {
+		t.Fatalf("journal query fields empty: %+v", e)
+	}
+	if e.Seq != 1 || e.At == 0 {
+		t.Fatalf("journal seq/at = %d/%d", e.Seq, e.At)
+	}
+	if e.Session != "audit-session" {
+		t.Fatalf("journal session = %q", e.Session)
+	}
+}
+
+func TestBridgeAuditJournalSilentWhenNoDirOrShadow(t *testing.T) {
+	t.Run("no audit dir config", func(t *testing.T) {
+		dir := writeKernelDir(t, admissionFixtureSlices(), nil)
+		b := NewBridge(Config{Enabled: true, Inject: true, ProjectDir: dir})
+		if res := b.InjectDetailed(context.Background(), "修复 go 测试"); res.Text == "" {
+			t.Fatal("expected an admitted injection")
+		}
+		_ = b.Close()
+		// No AuditDir configured: the runner must not see a journal anywhere.
+		if entries, err := os.ReadDir(filepath.Join(dir, "..")); err == nil {
+			for _, entry := range entries {
+				if entry.Name() == "inject-audit.jsonl" {
+					t.Fatal("journal created without AuditDir configured")
+				}
+			}
+		}
+	})
+	t.Run("shadow mode writes nothing", func(t *testing.T) {
+		dir := writeKernelDir(t, admissionFixtureSlices(), nil)
+		auditDir := t.TempDir()
+		b := NewBridge(Config{Enabled: true, Mode: "shadow", Inject: true,
+			ProjectDir: dir, AuditDir: auditDir})
+		res := b.InjectDetailed(context.Background(), "修复 go 测试")
+		if res.Text != "" {
+			t.Fatalf("shadow mode must not inject, got %d bytes", len(res.Text))
+		}
+		_ = b.Close()
+		if entries := readAuditJournal(t, auditDir); len(entries) != 0 {
+			t.Fatalf("shadow mode wrote %d audit entries", len(entries))
+		}
+	})
+}
+
+// readAuditJournal returns the decoded entries of the journal, tolerating an
+// absent file (len 0).
+func readAuditJournal(t *testing.T, auditDir string) []auditEntry {
+	t.Helper()
+	f, err := os.Open(filepath.Join(auditDir, "inject-audit.jsonl"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var out []auditEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if len(sc.Bytes()) == 0 {
+			continue
+		}
+		var e auditEntry
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			t.Fatalf("journal line: %v", err)
+		}
+		out = append(out, e)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -55,6 +55,15 @@ type Config struct {
 	// log resolve against (kernel CLI semantics: <dir>/.semantix/...).
 	// Empty uses the process working directory.
 	ProjectDir string
+	// AuditDir, when set, appends one JSON line per admitted L2 injection —
+	// the full provider-visible [semantix-reuse] block plus the query it was
+	// assembled for and the admitted slice targets. This is the raw material
+	// for the Issue #326 Track B leakage scan (dumped blocks are scanned for
+	// a later instance's gold patch or FAIL_TO_PASS test names to rule out
+	// "the cache leaked the answer"). Empty disables the journal: zero file
+	// I/O and zero overhead on the hot path. Shadow/off retrieval never
+	// admits blocks, so it never writes an entry.
+	AuditDir string
 	// CostMissUSD / CostHitUSD are the usage cost model prices (USD per 1M
 	// tokens at cache miss / hit) for the reuse panel savings delta.
 	// Zero keeps the kernel defaults (usage.DefaultCost*PerMTok).
@@ -82,6 +91,12 @@ type Bridge struct {
 	evolution   *EvolutionLoop
 	statsWG     sync.WaitGroup
 	closing     bool
+
+	// auditMu guards the injection audit journal (audit.go). Separate from mu
+	// so an admitted injection never blocks the mirror/session state.
+	auditMu  sync.Mutex
+	auditF   *os.File
+	auditSeq int64
 }
 
 // RetrievalMode controls whether L2 retrieval is disabled, observed only, or
@@ -325,6 +340,7 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		op = "degraded"
 	}
 	b.emitKernelCacheDetailed(op, "L2", targets, inj.Bytes, "", diagnostics)
+	b.auditInjection(query, budget, op == "degraded", targets, inj.Bytes, inj.Text)
 	return InjectResult{Text: inj.Text, Targets: targets, Diagnostics: diagnostics}
 }
 
@@ -706,10 +722,20 @@ func (b *Bridge) Close() error {
 	b.hs = nil
 	b.sink = nil
 	b.mu.Unlock()
-	if hs == nil {
+	var auditErr error
+	b.auditMu.Lock()
+	auditErr = b.closeAudit()
+	b.auditMu.Unlock()
+	if hs == nil && auditErr == nil {
 		return nil
 	}
-	return hs.Close()
+	if hs == nil {
+		return auditErr
+	}
+	if err := hs.Close(); err != nil {
+		return err
+	}
+	return auditErr
 }
 
 // dirOrFallback returns dir, falling back to a per-build default when empty.

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -73,8 +73,9 @@ enabled/inject；**每实例独立 `SEMANTIX_HOME`**（并发归属无竞态）�
 （`semantix-home/kernel/<owner>__<repo>/`）；每实例结束后 runner 跑
 `semantix extract` 把该会话蒸馏进库，后续同 repo 实例即可检索注入（跨实例
 记忆闭环，需 `go build -o bin/semantix ./cmd/semantix`）。`off` 为消融孪生臂
-（内核关闭，等价旧行为）。记忆对照请用这对臂，**不要用 `--ablate`**（它只关
-harness 侧模块，不触碰内核）。判读字段（metrics `raw`）：
+（内核关闭，等价旧行为）。记忆对照请用这对臂；`--ablate kernel/all` 也能经
+boot 门禁关内核（arm 同记 `no-kernel`），但 runner 层面记忆对照统一走
+`--semantix-memory`。判读字段（metrics `raw`）：
 `semantix_inject_turns` / `semantix_inject_bytes` / `semantix_reuse_hits` /
 `raw.extract`（每实例入库量）。设计与根因：`docs/specs/swebench-memory-arm.md`。
 
@@ -106,6 +107,57 @@ executor/planner/subagent/compaction/other；JSON 输出保留完整来源表和
 L2 路径。`shadow` 会检索、执行相同的 zone/清洗/预算判定并记录 `kernel_cache`
 诊断，但不向 provider 消息添加复用块；因此可作为 A/B 臂 B，与
 `--semantix-memory off` 做请求字节不变量检查，再用其分数分布标定后续门禁。
+
+#### Issue #326：双协议开关 `--protocol grouped|standard` + `cost.jsonl`
+
+`--semantix-memory on` 下的跨实例 store 策略由 `--protocol` 控制（Issue #326
+§二）：
+
+| protocol | 含义 | 对应 Track | store 布局 |
+|---|---|---|---|
+| `grouped`（默认） | 同 repo 实例共享一个切片库、按选中顺序成课程（跨实例复用） | **B（性价比，非标准协议）** | `kernel/<owner>__<repo>/` |
+| `standard` | 每实例一个**全新 per-instance store**，跨实例复用恒为零（= SWE-bench 官方协议） | **A（能力，可比 leaderboard）** | `kernel/std/<instance_id>/` |
+
+发布口径按 Issue #326 铁律执行：arm 名（`full` / `no-kernel` 等）随
+`run_config.json`、`metrics.jsonl`、`cost.jsonl` 每行落盘，
+**Track A 与 Track B 数据永不混表**（报告见下）。`--ablate` 只影响 harness 侧
+模块命名；`--semantix-memory off` 追加 `no-kernel`。
+
+每实例额外产出 `run_dir/cost.jsonl`（一行一实例，含 `arm`/`protocol`/USD 成本/
+kernel 可观测字段），与 `preds.jsonl` 同级，作为报告的成本数据源。
+
+#### Track B 注入审计 + 泄漏扫描（Issue #326 §六 #4 / §五）
+
+记忆臂每次**实际注入**的 L2 块（完整 provider-visible `[semantix-reuse]`
+文本 + query + 命中切片 ID）由 agent 按 `[semantix] audit_dir` 落盘，runner
+收进 `run_dir/audit/<instance_id>.jsonl`（+ `.txt` 人类可读版）。反作弊扫描：
+
+```bash
+python3 scan_leaks.py --run-dir results/<run_id> --dataset data/swebench_verified.jsonl
+```
+
+对每个被求解实例，检查其注入块是否含**该实例自己的** gold patch / gold 新增行
+（≥ `--min-added-len`）/ FAIL_TO_PASS 测试名。命中即「泄漏候选（人工复核）」
+——同 repo issue 与共享测试文件本来就会重叠，故候选非定论，正是 Issue #326
+要求「dump + 扫 + 随报告发布扫描脚本」的原因。默认命中即 exit 1（`--no-fail`
+放开），`--report-json` 导出结构化结果。
+
+#### Track A/B 报告合并生成（不判分）
+
+```bash
+python3 report_tracks.py --runs results/full.std.* results/nokernel.std.* \
+    --dataset data/swebench_verified.jsonl --out-dir docs/reports/data/issue-326
+```
+
+只做 join：官方 `swebench.harness.run_evaluation` 报告的 `resolved_ids`
+（`evaluate.py` 产物）+ `cost.jsonl`。产出：
+- **Track A**：每 run 一格的 能力×成本 表（resolve rate、cost/instance 均值
+  与 seed 固定的 percentile-bootstrap 95% CI、总成本、墙钟、缓存命中率）；
+- **Track B**：grouped 记忆臂按 repo 内 ordinal 的成本曲线（前后半段均值差、
+  逐实例表、`track_b.csv`），并在输出中显式标注「非标准协议，不与 leaderboard
+  并列」。
+判分永远不自研：仍是 `python -m swebench.harness.run_evaluation`。
+
 
 #### Repo 隔离与调度
 

--- a/scripts/swebench/common.py
+++ b/scripts/swebench/common.py
@@ -63,6 +63,12 @@ class InstanceMetrics:
     harness: str
     model: str
     instance_id: str
+    # Protocol/arm are the Issue #326 experiment axes: protocol is the
+    # cross-instance store policy (grouped | standard) and arm the published
+    # configuration name (full | no-... | +no-kernel). Both land in every
+    # metrics/cost row so Track A/B tables group by them without a join.
+    protocol: str = ""
+    arm: str = ""
     wall_ms: int = 0
     input_tokens: int = 0            # prompt tokens, cache hits included
     output_tokens: int = 0

--- a/scripts/swebench/report_tracks.py
+++ b/scripts/swebench/report_tracks.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Merge official SWE-bench verdicts with cost.jsonl into Track A/B reports.
+
+Issue #326 splits the authority claim into two tracks that must never be
+co-reported in one table:
+
+  * Track A — capability (standard protocol, comparable to leaderboards).
+    Every instance solves in isolation: arm `full` (product default) vs
+    `no-kernel` (ablation twin proving kernel overhead ≈ 0). Each run directory
+    is one agent × model × arm cell; verdicts come from the official
+    `swebench.harness.run_evaluation` report (never self-judged).
+  * Track B — cost-effectiveness (grouped protocol, explicitly non-standard).
+    Same-repo instances run in a fixed course and share a slice store, so
+    later instances reuse earlier ones; the signal is the within-repo cost
+    curve slope with no resolve-rate regression.
+
+This script never judges patches. It joins `cost.jsonl` (per-instance USD,
+written by run_bench.py) with the official report's `resolved_ids` and prints
+the two tables separately, plus per-repo Track B curves.
+
+Examples:
+  python report_tracks.py --runs results/full.std.20260824 results/nokernel.std.20260824 \\
+      --dataset data/swebench_verified.jsonl
+  python report_tracks.py --runs results/full.grp.20260824 \\
+      --dataset data/swebench_verified.jsonl --out-dir docs/reports/data/issue-326
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import sys
+from pathlib import Path
+
+from common import select_instances
+
+DEFAULT_SEED = 20260824
+
+
+# ---------------------------------------------------------------------------
+# loaders
+# ---------------------------------------------------------------------------
+
+
+def load_costs(run_dir: Path) -> list[dict]:
+    """cost.jsonl when present (run_bench >= Issue #326), else derive a lean
+    row from metrics.jsonl so older runs still report."""
+    costs = run_dir / "cost.jsonl"
+    if costs.exists():
+        with open(costs, encoding="utf-8") as handle:
+            return [json.loads(line) for line in handle if line.strip()]
+    rows = []
+    metrics = run_dir / "metrics.jsonl"
+    if metrics.exists():
+        with open(metrics, encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                m = json.loads(line)
+                rows.append({
+                    "instance_id": m["instance_id"],
+                    "arm": m.get("arm", ""),
+                    "protocol": m.get("protocol", ""),
+                    "wall_ms": m.get("wall_ms", 0),
+                    "steps": m.get("steps", 0),
+                    "input_tokens": m.get("input_tokens", 0),
+                    "output_tokens": m.get("output_tokens", 0),
+                    "cache_hit_tokens": m.get("cache_hit_tokens", 0),
+                    "cache_miss_tokens": m.get("cache_miss_tokens", 0),
+                    "cost_usd": m.get("cost_usd"),
+                    "cost_native": m.get("cost_native"),
+                    "empty_patch": m.get("empty_patch", True),
+                    "error": m.get("error", ""),
+                    "semantix_inject_turns": m.get("semantix_inject_turns"),
+                    "semantix_inject_bytes": m.get("semantix_inject_bytes"),
+                    "semantix_reuse_hits": m.get("semantix_reuse_hits"),
+                })
+    return rows
+
+
+def load_config(run_dir: Path) -> dict:
+    path = run_dir / "run_config.json"
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {}
+
+
+def official_resolution(run_dir: Path) -> dict[str, float] | None:
+    """Parse the report left by `python -m swebench.harness.run_evaluation`
+    (via evaluate.py). Returns {instance_id: 1.0} for resolved ids or None.
+    The newest report wins (re-evaluations overwrite with the same run_id)."""
+    candidates = sorted(run_dir.glob(f"*.{run_dir.name}.json"),
+                        key=lambda p: (p.stat().st_mtime, p.name))
+    if not candidates:
+        return None
+    try:
+        report = json.loads(candidates[-1].read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    resolved = report.get("resolved_ids")
+    if not isinstance(resolved, list):
+        return None
+    return {iid: 1.0 for iid in resolved if isinstance(iid, str)}
+
+
+# ---------------------------------------------------------------------------
+# Track A: per-run capability × cost cell
+# ---------------------------------------------------------------------------
+
+
+def percentile(values, q):
+    ordered = sorted(values)
+    if not ordered:
+        return None
+    position = (len(ordered) - 1) * q
+    low = int(position)
+    high = min(low + 1, len(ordered) - 1)
+    weight = position - low
+    return ordered[low] * (1 - weight) + ordered[high] * weight
+
+
+def bootstrap_ci(values, seed: int, resamples: int = 2000) -> dict:
+    """Deterministic percentile bootstrap 95% CI; None-safe."""
+    vals = [v for v in values if v is not None]
+    if not vals:
+        return {"mean": None, "ci95": [None, None]}
+    rng = random.Random(seed)
+    means = []
+    for _ in range(resamples):
+        sample = [vals[rng.randrange(len(vals))] for _ in range(len(vals))]
+        means.append(statistics.fmean(sample))
+    means.sort()
+    lo = means[int(0.025 * len(means))]
+    hi = means[int(0.975 * len(means))]
+    return {"mean": statistics.fmean(vals), "ci95": [round(lo, 6), round(hi, 6)]}
+
+
+def track_a_row(run_dir: Path) -> dict:
+    cfg = load_config(run_dir)
+    rows = load_costs(run_dir)
+    resolution = official_resolution(run_dir)
+    by_id = {r["instance_id"]: r for r in rows}
+    ordered = list(by_id.values())
+    n = len(ordered)
+    resolved = None
+    if resolution is not None:
+        resolved = sum(1 for iid in by_id if resolution.get(iid) == 1.0)
+    costs = [r.get("cost_usd") for r in ordered]
+    walls = [r.get("wall_ms") for r in ordered]
+    hit_rates = []
+    for r in ordered:
+        hit, miss = r.get("cache_hit_tokens", 0), r.get("cache_miss_tokens", 0)
+        if hit + miss > 0:
+            hit_rates.append(hit / (hit + miss))
+    inject_bytes = [r.get("semantix_inject_bytes") for r in ordered
+                    if r.get("semantix_inject_bytes") is not None]
+    seed = int(cfg.get("seed", DEFAULT_SEED))
+    return {
+        "run_id": run_dir.name,
+        "harness": cfg.get("harness", ""),
+        "model": cfg.get("model", ""),
+        "arm": cfg.get("arm", "") or (rows[0].get("arm") if rows else ""),
+        "protocol": cfg.get("protocol", "") or (rows[0].get("protocol") if rows else ""),
+        "n": n,
+        "resolved": resolved,
+        "resolve_rate": round(resolved / n, 4) if resolved is not None and n else None,
+        "resolution": resolution is not None,
+        "cost": bootstrap_ci(costs, seed),
+        "cost_total_usd": round(sum(c for c in costs if c is not None), 6),
+        "wall_s_mean": round(statistics.fmean(walls) / 1000, 1) if walls else None,
+        "steps_mean": round(statistics.fmean([r.get("steps", 0) for r in ordered]), 2) if ordered else None,
+        "cache_hit_rate_mean": round(statistics.fmean(hit_rates), 4) if hit_rates else None,
+        "inject_bytes_total": sum(inject_bytes) if inject_bytes else None,
+        "empty_patch": sum(1 for r in ordered if r.get("empty_patch")),
+        "errors": sum(1 for r in ordered if r.get("error")),
+    }
+
+
+def format_track_a(rows: list[dict]) -> str:
+    if not rows:
+        return "_no runs_"
+    header = ("| run_id | harness+model | arm | protocol | n | resolved | "
+              "resolve | cost/inst USD (95% CI) | total USD | wall s | cache hit |")
+    sep = "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+    lines = [header, sep]
+    for r in rows:
+        ci = r["cost"]["ci95"]
+        cost = f"{r['cost']['mean']:.4f} [{ci[0]}, {ci[1]}]" if r["cost"]["mean"] is not None else "—"
+        rate = f"{r['resolve_rate']:.2%}" if r["resolve_rate"] is not None else "no verdict"
+        ch = f"{r['cache_hit_rate_mean']:.1%}" if r["cache_hit_rate_mean"] is not None else "—"
+        wall = f"{r['wall_s_mean']}" if r["wall_s_mean"] is not None else "—"
+        resolved = r["resolved"] if r["resolved"] is not None else "—"
+        lines.append(f"| {r['run_id']} | {r['harness']}+{r['model']} | {r['arm'] or '—'} "
+                     f"| {r['protocol'] or '—'} | {r['n']} | {resolved} | {rate} | "
+                     f"{cost} | {r['cost_total_usd']} | {wall} | {ch} |")
+    lines.append("")
+    lines.append("> resolve rate = official harness pass on FAIL_TO_PASS+PASS_TO_PASS; "
+                 "cost = model-price run (cost.jsonl); CI = seed-fixed percentile bootstrap.")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Track B: within-repo cost curve (grouped protocol only)
+# ---------------------------------------------------------------------------
+
+
+def solve_order(cfg: dict, dataset_rows: list[dict]) -> list[dict]:
+    """Recompute the runner's per-instance course from run_config so ordinals
+    are reproducible. Falls back to dataset order when the ids file is gone."""
+    ids = cfg.get("ids")
+    sample = int(cfg.get("sample", 0) or 0)
+    seed = int(cfg.get("seed", DEFAULT_SEED))
+    ids_file = Path(ids) if ids else None
+    if ids_file is not None and not ids_file.exists():
+        ids_file = None  # ids file no longer present: approximate
+    try:
+        return select_instances(dataset_rows, ids_file, sample, seed)
+    except SystemExit:
+        return dataset_rows
+
+
+def repo_ordinals(run_dir: Path, dataset_rows: list[dict]) -> dict[str, tuple[str, int]]:
+    """instance_id -> (repo, ordinal_within_repo) following the run's own
+    selection + repo-grouped course (grouped protocol only; standard protocol
+    has no cross-instance course)."""
+    cfg = load_config(run_dir)
+    if cfg.get("protocol", "grouped") != "grouped":
+        return {}
+    present = {r["instance_id"] for r in load_costs(run_dir)}
+    out: dict[str, tuple[str, int]] = {}
+    counter: dict[str, int] = {}
+    for row in solve_order(cfg, dataset_rows):
+        if row["instance_id"] not in present:
+            continue
+        repo = row.get("repo", "")
+        counter[repo] = counter.get(repo, 0) + 1
+        out[row["instance_id"]] = (repo, counter[repo])
+    return out
+
+
+def track_b_rows(run_dir: Path, dataset_rows: list[dict]) -> list[dict]:
+    """One row per solved instance of a grouped run, in course order, with the
+    within-repo ordinal, running cost and resolution — the material of the
+    cost-curve slope check."""
+    cfg = load_config(run_dir)
+    if cfg.get("protocol", "grouped") != "grouped":
+        return []
+    if cfg.get("harness") != "semantix" or cfg.get("semantix_memory") != "on":
+        return []
+    rows = {r["instance_id"]: r for r in load_costs(run_dir)}
+    ordinals = repo_ordinals(run_dir, dataset_rows)
+    resolution = official_resolution(run_dir) or {}
+    out = []
+    for iid, (repo, ordinal) in sorted(
+            ordinals.items(), key=lambda kv: (kv[1][0], kv[1][1])):
+        row = rows.get(iid, {})
+        out.append({
+            "run_id": run_dir.name, "repo": repo, "ordinal": ordinal,
+            "instance_id": iid,
+            "cost_usd": row.get("cost_usd"),
+            "wall_ms": row.get("wall_ms"),
+            "resolved": int(resolution.get(iid, 0.0)),
+            "resolution": iid in resolution,
+            "inject_bytes": row.get("semantix_inject_bytes"),
+        })
+    return out
+
+
+def format_track_b(per_run: list[tuple[Path, list[dict]]]) -> str:
+    non_empty = [(p, rows) for p, rows in per_run if rows]
+    if not non_empty:
+        return ("_no grouped memory-on runs with a per-repo course_ — Track B "
+                "needs `--semantix-memory on --protocol grouped` and ≥2 "
+                "same-repo instances per repo.")
+    chunks = []
+    for run_dir, rows in non_empty:
+        chunks.append(f"### {run_dir.name}")
+        by_repo: dict[str, list[dict]] = {}
+        for row in rows:
+            by_repo.setdefault(row["repo"], []).append(row)
+        for repo, items in by_repo.items():
+            first, second = items[:len(items) // 2], items[len(items) // 2:]
+            f_cost = statistics.fmean([x["cost_usd"] for x in first if x["cost_usd"] is not None]) if first else None
+            s_cost = statistics.fmean([x["cost_usd"] for x in second if x["cost_usd"] is not None]) if second else None
+            resolved = sum(x["resolved"] for x in items)
+            chunks.append(f"**{repo}** — n={len(items)} resolved={resolved} "
+                          f"mean cost 1st half={f_cost:.4f}$ 2nd half={s_cost:.4f}$")
+            header = "| # | instance_id | cost USD | resolved | inject bytes |"
+            sep = "| --- | --- | --- | --- | --- |"
+            chunks.append(header)
+            chunks.append(sep)
+            for row in items:
+                cost = f"{row['cost_usd']:.4f}" if row["cost_usd"] is not None else "—"
+                inj = row["inject_bytes"] if row["inject_bytes"] is not None else "—"
+                res = "y" if row["resolved"] else ("n" if row["resolution"] else "?")
+                chunks.append(f"| {row['ordinal']} | {row['instance_id']} | {cost} | {res} | {inj} |")
+        chunks.append("")
+    chunks.append("> Track B uses the grouped (non-standard) protocol: same-repo "
+                  "instances share a slice store in a fixed course. Never compare "
+                  "these numbers against leaderboards (Issue #326 §二).")
+    return "\n".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def collect(run_dirs: list[Path], dataset_rows: list[dict]) -> dict:
+    track_a = []
+    track_b_per_run = []
+    for run_dir in run_dirs:
+        track_a.append(track_a_row(run_dir))
+        b = track_b_rows(run_dir, dataset_rows)
+        if b:
+            track_b_per_run.append((run_dir, b))
+    return {"track_a": track_a, "track_b": track_b_per_run}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--runs", nargs="+", required=True)
+    ap.add_argument("--dataset", required=True, help="local SWE-bench Verified jsonl "
+                    "(needed to recompute Track B course ordinals)")
+    ap.add_argument("--format", default="md", choices=["md", "json"])
+    ap.add_argument("--out-dir", default="",
+                    help="write report.md/report.json/track_b.csv here instead of stdout")
+    args = ap.parse_args()
+
+    dataset_rows = []
+    with open(Path(args.dataset), encoding="utf-8") as handle:
+        dataset_rows = [json.loads(line) for line in handle if line.strip()]
+    result = collect([Path(p) for p in args.runs], dataset_rows)
+
+    if args.format == "json":
+        payload = json.dumps(result, indent=2, ensure_ascii=False, default=str)
+        if args.out_dir:
+            out = Path(args.out_dir)
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "report.json").write_text(payload, encoding="utf-8")
+        else:
+            print(payload)
+        return
+
+    md = "\n".join([
+        "# Issue #326 SWE-bench Track A / Track B",
+        "",
+        "## Track A — capability (standard protocol, official verdict)",
+        "",
+        format_track_a(result["track_a"]),
+        "",
+        "## Track B — cost curve (grouped protocol, non-standard)",
+        "",
+        format_track_b(result["track_b"]),
+        "",
+    ])
+    if args.out_dir:
+        out = Path(args.out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "report.md").write_text(md, encoding="utf-8")
+        (out / "report.json").write_text(
+            json.dumps(result, indent=2, ensure_ascii=False, default=str), encoding="utf-8")
+        rows = [r for _, rr in result["track_b"] for r in rr]
+        if rows:
+            import csv
+            with open(out / "track_b.csv", "w", newline="", encoding="utf-8") as fh:
+                writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(rows)
+        print(f"wrote {out}/report.md, report.json"
+              + (", track_b.csv" if rows else ""))
+    else:
+        print(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -72,6 +72,74 @@ def repo_store_key(inst: dict) -> str:
     return repo_identity(inst).replace("/", "__", 1)
 
 
+# Harness-side ablation modules in Go Modules() order. Kernel is handled
+# separately: boot gates the memory bridge on Ablation.Off(ablation.Kernel),
+# and the runner toggles it via --semantix-memory, so --ablate kernel/all
+# also switch the kernel off even with --semantix-memory on. Used to derive
+# the published arm name; the CLI stays the source of truth for what is
+# actually disabled.
+HARNESS_MODULES = ["evidence", "planner", "subagent", "retrieval", "compaction"]
+
+
+def _disabled_modules(spec: str) -> list[str]:
+    """Normalize an --ablate spec ("evidence,planner" | "all" | "") into the
+    ordered list of disabled modules (kernel accepted too). Harness modules are
+    ordered like Go Modules(); unknown names keep their input order last, so
+    the published arm name stays stable across machines."""
+    if not spec:
+        return []
+    spec = spec.strip().lower()
+    if spec in ("", "none"):
+        return []
+    if spec == "all":
+        # Go Parse("all") disables every ablation module, kernel included
+        # (boot gates the bridge on Ablation.Off(ablation.Kernel)), so the
+        # published arm must carry no-kernel as well.
+        return list(HARNESS_MODULES) + ["kernel"]
+    wanted = [f.strip() for f in re.split(r"[,\s]+", spec) if f.strip()]
+    rank = {m: i for i, m in enumerate(HARNESS_MODULES + ["kernel"])}
+    seen, unknown, out = set(), [], []
+    for m in wanted:
+        if m in seen:
+            continue
+        seen.add(m)
+        if m in rank:
+            out.append(m)
+        else:
+            unknown.append(m)
+    out.sort(key=lambda m: rank[m])
+    return out + unknown
+
+
+def arm_label(adapter_name: str, ablate: str, memory_on: bool) -> str:
+    """Published arm name (Issue #326): 'full' for the control arm, otherwise
+    'no-evidence+...', with '+no-kernel' when the memory kernel is disabled for
+    the semantix harness (either --semantix-memory off or --ablate kernel).
+    Only the semantix harness has a kernel, so the memory flag never changes
+    another harness's arm name."""
+    parts = [f"no-{m}" for m in _disabled_modules(ablate)]
+    if (adapter_name == "semantix" and not memory_on
+            and "no-kernel" not in parts):
+        parts.append("no-kernel")
+    return "+".join(parts) if parts else "full"
+
+
+def kernel_protocol_state(memory_on: bool, ablate: str, protocol: str) -> tuple[bool, str, bool]:
+    """Resolve what the run actually did with the kernel and the store policy.
+
+    The kernel is live only when --semantix-memory on AND the ablation spec
+    does not disable it (--ablate kernel/all — boot gates the bridge on
+    Ablation.Off(ablation.Kernel)). Only a live kernel forms a cross-instance
+    reuse course, so protocol (grouped|standard) is meaningful only then;
+    otherwise it is recorded "" so Track A/B joins never mistake a kernel-less
+    run for a Track B grouped run. Returns (kernel_on, effective_protocol,
+    standard)."""
+    disabled = set(_disabled_modules(ablate))
+    kernel_on = memory_on and "kernel" not in disabled
+    effective = protocol if kernel_on else ""
+    return kernel_on, effective, kernel_on and effective == "standard"
+
+
 class CountProxy:
     """Per-instance metering proxy (count_proxy.py) for harnesses whose own
     telemetry is unreliable. Records provider-reported usage to a ledger."""
@@ -205,6 +273,16 @@ class SemantixAdapter(Adapter):
         self.home = self.args.state_path / "semantix-home"
         self.home.mkdir(parents=True, exist_ok=True)
         self.memory_on = self.args.semantix_memory == "on"
+        # Issue #326 Track A/B protocol: grouped (default) keeps one slice
+        # store per repo across same-repo instances (cross-instance reuse =
+        # Track B); standard gives every instance a fresh, per-instance store
+        # so cross-instance reuse is exactly zero (= Track A, the leaderboard
+        # protocol). Protocol is recorded empty whenever the kernel is off —
+        # via --semantix-memory off or --ablate kernel/all — and Track A/B
+        # joins never conflate a kernel-less run with a Track B grouped run.
+        self.kernel_on, self.protocol, self.standard = kernel_protocol_state(
+            self.memory_on, self.args.ablate, getattr(self.args, "protocol", "grouped"))
+        self.arm = arm_label(self.name, self.args.ablate, self.memory_on)
         self.kernel_root = self.home / "kernel"
         if self.memory_on:
             self.kernel_root.mkdir(parents=True, exist_ok=True)
@@ -225,7 +303,12 @@ class SemantixAdapter(Adapter):
             )
 
     def execution_batches(self, instances: list[dict]) -> list[list[dict]]:
-        if not self.memory_on:
+        # A cross-instance reuse course exists only while the kernel is live
+        # and protocol is grouped. Kernel-less arms (--semantix-memory off or
+        # --ablate kernel/all) and the standard (fresh-store) protocol never
+        # share state: keep per-instance parallelism.
+        if (not self.memory_on or not getattr(self, "kernel_on", True)
+                or getattr(self, "standard", False)):
             return super().execution_batches(instances)
         by_repo: dict[str, list[dict]] = {}
         for inst in instances:
@@ -233,6 +316,13 @@ class SemantixAdapter(Adapter):
         return list(by_repo.values())
 
     def kernel_dir_for(self, inst: dict) -> Path:
+        # grouped: one store per repo shared across same-repo instances (the
+        # cross-session reuse course). standard: a fresh per-instance store so
+        # instance N can never retrieve slices distilled from instances run
+        # before it (cross-session reuse == 0 by construction).
+        if getattr(self, "standard", False):
+            iid = inst["instance_id"]
+            return self.kernel_root / "std" / iid
         return self.kernel_root / repo_store_key(inst)
 
     def _write_home(self, home: Path, sessions_dir: Path, kernel_dir: Path | None) -> None:
@@ -260,6 +350,7 @@ mode         = "{self.args.semantix_retrieval_mode}"
 budget       = 4096
 project_dir  = "{kernel_dir}"
 sessions_dir = "{sessions_dir}"
+audit_dir    = "{home / 'audit'}"
 '''
         (home / "config.toml").write_text(
             f'''default_model = "{provider_selector}"
@@ -340,7 +431,49 @@ context_window = 128000
             raw["semantix_project_dir"] = str(kernel_dir)
             raw["extract"] = self._extract_slices(
                 sessions_dir, inst["instance_id"], kernel_dir, repo)
+            raw["audit"] = self._collect_audit(home, inst["instance_id"])
         return exit_code, raw, err
+
+    def _collect_audit(self, home: Path, instance_id: str) -> dict:
+        """Copy this instance's L2 injection audit journal (written by the
+        agent's [semantix] audit_dir) into run_dir/audit/<iid>.{jsonl,txt} —
+        the raw material for the Track B leakage scan (Issue #326 §六 #4).
+        Shadow/off retrieval or an empty slice library writes no entries."""
+        out = {"entries": 0, "bytes": 0}
+        journal = home / "audit" / "inject-audit.jsonl"
+        if not journal.exists():
+            return out
+        entries = []
+        try:
+            lines = journal.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return out
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except ValueError:
+                continue
+            entries.append(entry)
+            out["bytes"] += int(entry.get("bytes", 0) or 0)
+        out["entries"] = len(entries)
+        if not entries:
+            return out
+        dest = self.run_dir / "audit"
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / f"{instance_id}.jsonl").write_text(
+            "".join(json.dumps(e, ensure_ascii=False) + "\n" for e in entries),
+            encoding="utf-8")
+        txt = []
+        for e in entries:
+            txt.append(
+                f"--- inject seq={e.get('seq')} at={e.get('at')} "
+                f"degraded={e.get('degraded', False)} bytes={e.get('bytes', 0)} "
+                f"targets={','.join(e.get('targets') or [])}")
+            txt.append(e.get("text", ""))
+        (dest / f"{instance_id}.txt").write_text("\n".join(txt) + "\n", encoding="utf-8")
+        return out
 
     def _extract_slices(self, sessions_dir: Path, instance_id: str,
                         kernel_dir: Path, repo: str) -> dict:
@@ -806,6 +939,8 @@ def process_instance(adapter: Adapter, args, run_dir: Path, prices: dict, inst: 
     m.agent_exit = exit_code
     m.error = err
     m.raw = raw
+    m.protocol = getattr(adapter, "protocol", "")
+    m.arm = getattr(adapter, "arm", "")
     try:
         adapter.fill_metrics(m, raw)
     except Exception as e:
@@ -822,6 +957,29 @@ def process_instance(adapter: Adapter, args, run_dir: Path, prices: dict, inst: 
     model_name = f"{adapter.name}+{args.model}"
     write_prediction(run_dir / "preds.jsonl", iid, model_name, patch)
     append_jsonl(run_dir / "metrics.jsonl", m.to_json())
+    # Issue #326 §三 cost / instance: a lean per-instance cost ledger so
+    # reports can price Track A/B without re-parsing the full metrics rows
+    # (which embed raw native telemetry). metrics.jsonl stays the source of
+    # truth; cost.jsonl is a projection of the same row plus the kernel
+    # observables the semantix harness reports.
+    cost_row = {
+        "run_id": m.run_id, "harness": m.harness, "model": m.model,
+        "instance_id": m.instance_id, "arm": m.arm, "protocol": m.protocol,
+        "agent_exit": m.agent_exit, "error": m.error,
+        "wall_ms": m.wall_ms, "steps": m.steps,
+        "input_tokens": m.input_tokens, "output_tokens": m.output_tokens,
+        "cache_hit_tokens": m.cache_hit_tokens,
+        "cache_miss_tokens": m.cache_miss_tokens,
+        "cache_hit_rate": m.cache_hit_rate,
+        "cost_usd": m.cost_usd, "cost_native": m.cost_native,
+        "cost_native_currency": m.cost_native_currency,
+        "patch_bytes": m.patch_bytes, "empty_patch": m.empty_patch,
+    }
+    for key in ("semantix_inject_turns", "semantix_inject_bytes",
+                "semantix_reuse_hits", "semantix_reuse_savings_usd", "audit"):
+        if key in m.raw:
+            cost_row[key] = m.raw[key]
+    append_jsonl(run_dir / "cost.jsonl", json.dumps(cost_row, ensure_ascii=False))
     rate = m.cache_hit_rate
     print(f"[{iid}] exit={exit_code} wall={m.wall_ms / 1000:.0f}s "
           f"in={m.input_tokens} out={m.output_tokens} "
@@ -859,11 +1017,19 @@ def main() -> None:
     ap.add_argument("--max-turns", type=int, default=120, help="claude-code turn cap")
     ap.add_argument("--preset", default="balanced", help="semantix preset")
     ap.add_argument("--effort", default="", help="semantix provider effort override")
-    ap.add_argument("--ablate", default="", help="semantix --ablate arm (harness-side modules only; "
-                    "it does NOT toggle the memory kernel — use --semantix-memory for that)")
+    ap.add_argument("--ablate", default="", help="semantix --ablate arm: harness-side modules "
+                    "(evidence/planner/subagent/retrieval/compaction), plus kernel/all which boot "
+                    "honors and gate the memory bridge off even with --semantix-memory on; "
+                    "the memory对照 arm is still --semantix-memory on/off")
     ap.add_argument("--semantix-memory", default="on", choices=("on", "off"),
                     help="semantix memory-kernel arm: on = [semantix] enabled+inject, shared slice "
                     "library across instances, per-instance extract; off = kernel disabled (ablation twin)")
+    ap.add_argument("--protocol", default="grouped", choices=("grouped", "standard"),
+                    help="Issue #326 cross-instance store policy for --semantix-memory on: "
+                    "grouped (default, Track B) keeps one slice store per repo across same-repo "
+                    "instances so later instances reuse earlier ones; standard (Track A) gives "
+                    "every instance a fresh per-instance store so cross-instance reuse is zero — "
+                    "the SWE-bench leaderboard protocol. Ignored when memory is off.")
     ap.add_argument("--semantix-retrieval-mode", default="strict",
                     choices=("off", "shadow", "strict"),
                     help="L2 retrieval mode when --semantix-memory=on; shadow records the same "
@@ -907,7 +1073,13 @@ def main() -> None:
     batches = adapter.execution_batches(todo)
     prices = load_prices(args.prices or None)
 
-    (run_dir / "run_config.json").write_text(json.dumps(vars(args), indent=2, default=str))
+    cfg = dict(vars(args))
+    cfg["arm"] = getattr(adapter, "arm", "")
+    # protocol is only meaningful when the memory kernel is on; record what
+    # the adapter actually ran ("" elsewhere) so tables never mislabel a
+    # no-kernel / non-semantix run as grouped (Issue #326 Track A/B split).
+    cfg["protocol"] = getattr(adapter, "protocol", "")
+    (run_dir / "run_config.json").write_text(json.dumps(cfg, indent=2, default=str))
 
     if args.workers <= 1:
         for batch in batches:

--- a/scripts/swebench/scan_leaks.py
+++ b/scripts/swebench/scan_leaks.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Scan a run's L2 injection audit journal for answer leakage (Issue #326).
+
+Issue #326 §五 requires the Track B (grouped, cross-instance reuse) run to dump
+every provider-visible injection block and prove it contains no leak of the
+instance being solved: not the gold patch, not its FAIL_TO_PASS test names.
+This script is that scan. It reads the journal the runner copied from each
+agent's [semantix] audit_dir into run_dir/audit/<instance>.jsonl and checks
+every block against the dataset row of the instance that was being solved.
+
+Semantics (documented, deliberate):
+
+  * A block injected while solving instance N may only contain slices distilled
+    from same-repo instances solved before N — the runner extracts slices only
+    after an instance finishes, and each repo store is written by one worker in
+    selection order. So checking N's own gold patch / FAIL_TO_PASS test names
+    is the leakage contract; there is no store that could contain N's answer
+    before N runs.
+  * Matching is substring-based on whitespace-normalized text: (a) the full
+    normalized gold patch, (b) any normalized gold-added line of length >=
+    --min-added-len (default 20), (c) any normalized FAIL_TO_PASS test id.
+    A hit is a *candidate* for manual review, not a verdict: same-repo issue
+    statements and shared test files legitimately overlap, which is exactly
+    why the issue mandates dumping + scanning instead of asserting by
+    construction.
+
+Examples:
+  python scan_leaks.py --run-dir results/semantix.deepseek-v4-flash.20260824 \
+      --dataset data/swebench_verified.jsonl
+  python scan_leaks.py --run-dir ... --dataset ... --report-json leaks.json --no-fail
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# library API (imported by report_tracks.py too)
+# ---------------------------------------------------------------------------
+
+
+def _norm(text: str) -> str:
+    return re.sub(r"\s+", "", text or "")
+
+
+def gold_added_lines(gold_patch: str, min_len: int = 20) -> list[str]:
+    """Content lines a gold patch *adds* (unified diff '+', minus the '+++'
+    file header), whitespace-normalized and length-filtered so trivial
+    additions (blank lines, one-word imports) do not flood the report."""
+    out = []
+    for line in (gold_patch or "").splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        content = line[1:].lstrip()
+        normalized = _norm(content)
+        if len(normalized) >= min_len:
+            out.append(normalized)
+    return out
+
+
+def scan_instance_entries(entries: list[dict], gold_patch: str,
+                          fail_to_pass: list[str], min_added_len: int = 20) -> list[dict]:
+    """Check every injected block in `entries` (audit lines recorded while one
+    instance was being solved) against that instance's gold patch and
+    FAIL_TO_PASS test ids. Returns one dict per distinct hit."""
+    needles: list[tuple[str, str]] = []  # (kind, normalized needle)
+    if gold_patch:
+        needles.append(("gold_patch", _norm(gold_patch)))
+        for line in gold_added_lines(gold_patch, min_added_len):
+            needles.append(("gold_line", line))
+    if fail_to_pass:
+        for test_id in fail_to_pass:
+            needles.append(("test_name", _norm(test_id)))
+    if not needles:
+        return []
+
+    flags: list[dict] = []
+    seen: set[tuple[int, str, str]] = set()
+    for entry in entries:
+        seq = entry.get("seq")
+        block = _norm(entry.get("text", ""))
+        if not block:
+            continue
+        for kind, needle in needles:
+            if not needle:
+                continue
+            if needle not in block:
+                continue
+            key = (seq, kind, needle)
+            if key in seen:
+                continue
+            seen.add(key)
+            # Recover a short human-readable excerpt from the original text.
+            raw_text = entry.get("text", "") or ""
+            excerpt = raw_text[:160].replace("\n", " ")
+            flags.append({
+                "instance_id": entry.get("_instance_id"),
+                "seq": seq,
+                "kind": kind,
+                "needle_chars": len(needle),
+                "targets": entry.get("targets") or [],
+                "excerpt": excerpt,
+            })
+    return flags
+
+
+def scan_run(run_dir: Path, rows_by_id: dict[str, dict], min_added_len: int = 20) -> dict:
+    """Scan every audit/<instance>.jsonl under run_dir. rows_by_id maps
+    instance_id -> dataset row (gold 'patch', FAIL_TO_PASS list)."""
+    audit_root = Path(run_dir) / "audit"
+    flagged: list[dict] = []
+    entries_total = 0
+    instances_audited = 0
+    if audit_root.is_dir():
+        for path in sorted(audit_root.glob("*.jsonl")):
+            iid = path.name[:-len(".jsonl")]
+            row = rows_by_id.get(iid)
+            try:
+                raw_entries = [json.loads(line) for line in
+                               path.read_text(encoding="utf-8").splitlines() if line.strip()]
+            except (OSError, ValueError):
+                continue
+            entries = []
+            for e in raw_entries:
+                e = dict(e)
+                e["_instance_id"] = iid
+                entries.append(e)
+            if not entries:
+                continue
+            instances_audited += 1
+            entries_total += len(entries)
+            gold = (row or {}).get("patch", "") if row else ""
+            tests = [str(x) for x in ((row or {}).get("FAIL_TO_PASS") or [])] if row else []
+            flagged.extend(scan_instance_entries(entries, gold, tests, min_added_len))
+    status = "no_audit" if instances_audited == 0 else (
+        "flagged" if flagged else "clean")
+    return {
+        "run_dir": str(run_dir),
+        "instances_audited": instances_audited,
+        "entries": entries_total,
+        "flagged": flagged,
+        "status": status,
+    }
+
+
+def format_report(result: dict) -> str:
+    lines = [f"# Leak scan: {result['run_dir']}",
+             "",
+             f"- status: **{result['status']}**",
+             f"- instances with injections audited: {result['instances_audited']}",
+             f"- injected blocks checked: {result['entries']}",
+             f"- leak candidates: {len(result['flagged'])}",
+             ""]
+    if result["flagged"]:
+        lines.append("| instance | seq | kind | needle chars | targets |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for flag in result["flagged"]:
+            targets = ",".join(flag["targets"])[:60]
+            lines.append(f"| {flag['instance_id']} | {flag['seq']} | {flag['kind']} "
+                         f"| {flag['needle_chars']} | {targets} |")
+        lines.append("")
+        lines.append("> Candidates need manual review: same-repo issues and shared "
+                     "test files legitimately overlap.")
+    elif result["status"] == "no_audit":
+        lines.append("No injection audit artifacts found (shadow/off retrieval, "
+                     "empty slice library, or pre-#326 run).")
+    return "\n".join(lines)
+
+
+def load_rows_by_id(dataset: Path) -> dict[str, dict]:
+    rows = {}
+    with open(dataset, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            rows[row["instance_id"]] = row
+    return rows
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--run-dir", required=True)
+    ap.add_argument("--dataset", required=True, help="local SWE-bench Verified jsonl")
+    ap.add_argument("--min-added-len", type=int, default=20,
+                    help="shortest gold-added line (normalized chars) to match (default 20)")
+    ap.add_argument("--report-json", default="", help="optional path to write the JSON result")
+    ap.add_argument("--no-fail", action="store_true",
+                    help="exit 0 even when candidates are flagged (default exit 1)")
+    args = ap.parse_args()
+
+    result = scan_run(Path(args.run_dir), load_rows_by_id(Path(args.dataset)),
+                      min_added_len=args.min_added_len)
+    print(format_report(result))
+    if args.report_json:
+        Path(args.report_json).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.report_json).write_text(
+            json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+    if result["flagged"] and not args.no_fail:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/swebench/test_protocol_arms.py
+++ b/scripts/swebench/test_protocol_arms.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from run_bench import SemantixAdapter, arm_label, kernel_protocol_state
+
+
+def args(protocol="grouped", semantix_memory="on", ablate=""):
+    return SimpleNamespace(protocol=protocol, semantix_memory=semantix_memory,
+                           ablate=ablate, openai_base="http://x/v1",
+                           semantix_retrieval_mode="strict")
+
+
+def inst(iid: str, repo: str) -> dict:
+    return {"instance_id": iid, "repo": repo}
+
+
+class ArmLabelTests(unittest.TestCase):
+    def test_full_and_no_kernel_arms(self):
+        self.assertEqual(arm_label("semantix", "", True), "full")
+        self.assertEqual(arm_label("semantix", "", False), "no-kernel")
+
+    def test_harness_modules_ordered_like_go_modules(self):
+        self.assertEqual(arm_label("semantix", "planner,evidence", True),
+                         "no-evidence+no-planner")
+        self.assertEqual(arm_label("semantix", "all", False),
+                         "no-evidence+no-planner+no-subagent+no-retrieval"
+                         "+no-compaction+no-kernel")
+
+    def test_memory_flag_only_affects_semantix(self):
+        self.assertEqual(arm_label("dsh", "", False), "full")
+
+
+class ProtocolTests(unittest.TestCase):
+    def adapter(self, a) -> SemantixAdapter:
+        adapter = SemantixAdapter(a, Path("run"))
+        adapter.memory_on = a.semantix_memory == "on"
+        # Reuse the production derivation (kernel_protocol_state) instead of
+        # re-implementing it, so the tests exercise the same gating lines the
+        # runner calls in prepare().
+        adapter.kernel_on, adapter.protocol, adapter.standard = kernel_protocol_state(
+            adapter.memory_on, a.ablate, a.protocol)
+        adapter.arm = arm_label("semantix", a.ablate, adapter.memory_on)
+        adapter.kernel_root = Path("/k")
+        return adapter
+
+    def test_grouped_keeps_repo_course(self):
+        adapter = self.adapter(args())
+        chosen = [inst("django-1", "django/django"), inst("flask-1", "pallets/flask"),
+                  inst("django-2", "django/django")]
+        batches = adapter.execution_batches(chosen)
+        self.assertEqual([[x["instance_id"] for x in b] for b in batches],
+                         [["django-1", "django-2"], ["flask-1"]])
+
+    def test_standard_protocol_isolates_instances(self):
+        adapter = self.adapter(args(protocol="standard"))
+        chosen = [inst("django-1", "django/django"), inst("django-2", "django/django")]
+        batches = adapter.execution_batches(chosen)
+        self.assertEqual([len(b) for b in batches], [1, 1])
+
+    def test_kernel_dir_isolation_standard_vs_grouped(self):
+        grouped = self.adapter(args())
+        standard = self.adapter(args(protocol="standard"))
+        self.assertEqual(grouped.kernel_dir_for(inst("d1", "django/django")),
+                         Path("/k/django__django"))
+        self.assertEqual(standard.kernel_dir_for(inst("d1", "django/django")),
+                         Path("/k/std/d1"))
+        self.assertNotEqual(standard.kernel_dir_for(inst("d1", "django/django")),
+                            standard.kernel_dir_for(inst("d2", "django/django")))
+
+    def test_memory_off_scheduling_unchanged(self):
+        adapter = self.adapter(args(semantix_memory="off"))
+        chosen = [inst("a", "django/django"), inst("b", "django/django")]
+        self.assertEqual([len(b) for b in adapter.execution_batches(chosen)], [1, 1])
+
+    def test_ablate_kernel_disables_reuse_course_and_protocol(self):
+        # boot gates the bridge on Ablation.Off(ablation.Kernel), so
+        # --ablate kernel (and --ablate all) with --semantix-memory on still
+        # means no live kernel: arm carries no-kernel, protocol must not say
+        # grouped, and scheduling must not form a same-repo course.
+        for spec in ("kernel", "all"):
+            with self.subTest(ablate=spec):
+                adapter = self.adapter(args(ablate=spec))
+                self.assertEqual(adapter.protocol, "")
+                self.assertTrue(adapter.arm.endswith("no-kernel"),
+                                adapter.arm)
+                if spec == "kernel":
+                    self.assertEqual(adapter.arm, "no-kernel")
+                chosen = [inst("django-1", "django/django"),
+                          inst("django-2", "django/django")]
+                batches = adapter.execution_batches(chosen)
+                self.assertEqual([len(b) for b in batches], [1, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/swebench/test_report_tracks.py
+++ b/scripts/swebench/test_report_tracks.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import report_tracks
+from report_tracks import (bootstrap_ci, official_resolution, repo_ordinals,
+                           track_a_row, track_b_rows)
+
+
+def dataset_rows():
+    return [
+        {"instance_id": "django-1", "repo": "django/django", "base_commit": "a"},
+        {"instance_id": "flask-1", "repo": "pallets/flask", "base_commit": "b"},
+        {"instance_id": "django-2", "repo": "django/django", "base_commit": "a"},
+        {"instance_id": "flask-2", "repo": "pallets/flask", "base_commit": "b"},
+    ]
+
+
+def write_run(root: Path, run_id: str, cfg: dict, costs: list[dict],
+              resolved_ids: list[str]):
+    run_dir = root / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    with open(run_dir / "cost.jsonl", "w", encoding="utf-8") as handle:
+        for row in costs:
+            handle.write(json.dumps(row) + "\n")
+    if resolved_ids is not None:
+        # swebench's run_evaluation writes <model>.<run_id>.json; official
+        # resolution globs *.<run_id>.json so the model prefix is required.
+        (run_dir / f"m.{run_id}.json").write_text(
+            json.dumps({"resolved_ids": resolved_ids}), encoding="utf-8")
+    return run_dir
+
+
+def cost(iid: str, cost_usd: float, **extra) -> dict:
+    row = {"run_id": "", "harness": "semantix", "model": "deepseek-v4-flash",
+           "instance_id": iid, "arm": "full", "protocol": "grouped",
+           "agent_exit": 0, "error": "", "wall_ms": 10_000, "steps": 10,
+           "input_tokens": 1000, "output_tokens": 200,
+           "cache_hit_tokens": 400, "cache_miss_tokens": 600,
+           "cache_hit_rate": 0.4, "cost_usd": cost_usd, "cost_native": None,
+           "cost_native_currency": "", "patch_bytes": 100,
+           "empty_patch": False, "semantix_inject_bytes": None}
+    row.update(extra)
+    return row
+
+
+class TrackACellTests(unittest.TestCase):
+    def test_track_a_row_joins_verdict_and_cost(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            run_dir = write_run(
+                root, "full.std", {"harness": "semantix", "model": "deepseek-v4-flash",
+                                   "arm": "full", "protocol": "standard", "seed": 7},
+                [cost("django-1", 0.5, protocol="standard"),
+                 cost("django-2", 1.5, protocol="standard")],
+                resolved_ids=["django-1"])
+            row = track_a_row(run_dir)
+            self.assertEqual(row["arm"], "full")
+            self.assertEqual(row["protocol"], "standard")
+            self.assertEqual(row["n"], 2)
+            self.assertEqual(row["resolved"], 1)
+            self.assertAlmostEqual(row["resolve_rate"], 0.5)
+            self.assertAlmostEqual(row["cost"]["mean"], 1.0)
+            self.assertAlmostEqual(row["cost_total_usd"], 2.0)
+
+    def test_bootstrap_ci_deterministic_and_bounded(self):
+        values = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        first = bootstrap_ci(values, 42)
+        second = bootstrap_ci(values, 42)
+        self.assertEqual(first, second)
+        self.assertLess(first["ci95"][0], first["mean"])
+        self.assertGreater(first["ci95"][1], first["mean"])
+
+
+class OfficialResolutionTests(unittest.TestCase):
+    def test_reads_evaluate_report(self):
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = Path(td) / "semantix.deepseek-v4-flash.7"
+            run_dir.mkdir()
+            (run_dir / "m.semantix.deepseek-v4-flash.7.json").write_text(
+                json.dumps({"resolved_ids": ["a"]}), encoding="utf-8")
+            self.assertEqual(official_resolution(run_dir), {"a": 1.0})
+
+    def test_absent_report_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(official_resolution(Path(td)))
+
+
+class TrackBTests(unittest.TestCase):
+    def test_repo_ordinals_follow_run_course(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cfg = {"harness": "semantix", "protocol": "grouped", "sample": 0,
+                   "seed": 3, "ids": None}
+            costs = [cost("django-1", 0.5), cost("flask-1", 0.5),
+                     cost("django-2", 0.3), cost("flask-2", 0.3)]
+            run_dir = write_run(root, "grp", cfg, costs, resolved_ids=[])
+            ordinals = repo_ordinals(run_dir, dataset_rows())
+            self.assertEqual(ordinals["django-1"], ("django/django", 1))
+            self.assertEqual(ordinals["django-2"], ("django/django", 2))
+            self.assertEqual(ordinals["flask-2"], ("pallets/flask", 2))
+
+    def test_track_b_rows_only_for_grouped_semantix_memory_on(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cfg = {"harness": "semantix", "protocol": "grouped",
+                   "semantix_memory": "on", "sample": 0, "seed": 3, "ids": None}
+            costs = [cost("django-1", 0.5), cost("django-2", 0.3)]
+            run_dir = write_run(root, "grp", cfg, costs, resolved_ids=["django-1"])
+            rows = track_b_rows(run_dir, dataset_rows())
+            self.assertEqual([(r["instance_id"], r["ordinal"]) for r in rows],
+                             [("django-1", 1), ("django-2", 2)])
+            # memory off => no course
+            cfg_off = dict(cfg, semantix_memory="off")
+            run_off = write_run(root, "grp-off", cfg_off,
+                                [cost("django-1", 0.5)], resolved_ids=[])
+            self.assertEqual(track_b_rows(run_off, dataset_rows()), [])
+
+    def test_track_a_without_verdict_keeps_rate_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            run_dir = write_run(root, "noverdict",
+                                {"harness": "semantix", "arm": "full", "protocol": "standard"},
+                                [cost("django-1", 0.5, protocol="standard")],
+                                resolved_ids=None)
+            row = track_a_row(run_dir)
+            self.assertIsNone(row["resolve_rate"])
+            self.assertFalse(row["resolution"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/swebench/test_scan_leaks.py
+++ b/scripts/swebench/test_scan_leaks.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import scan_leaks
+
+
+def entry(seq: int, text: str, targets=("ctx-strong",)) -> dict:
+    return {"seq": seq, "at": 1, "query": "q", "query_sha256": "x",
+            "degraded": False, "budget": 4096, "bytes": len(text),
+            "targets": list(targets), "text": text}
+
+
+GOLD = (
+    "diff --git a/tests/test_forms.py b/tests/test_forms.py\n"
+    "--- a/tests/test_forms.py\n+++ b/tests/test_forms.py\n"
+    "@@ -42,7 +42,7 @@\n"
+    " def test_render_required(self):\n"
+    "     form = self.build_form()\n"
+    "-    self.assertFalse(form.fields['name'].required)\n"
+    "+    self.assertTrue(form.fields['name'].required)\n"
+)
+
+
+class GoldAddedLineTests(unittest.TestCase):
+    def test_extracts_only_real_additions_above_min_len(self):
+        lines = scan_leaks.gold_added_lines(GOLD, min_len=20)
+        self.assertEqual(lines, ["self.assertTrue(form.fields['name'].required)"])
+
+    def test_ignores_trivial_additions(self):
+        patch = "+++ b/x\n+ \n+\n+def short():\n"
+        self.assertEqual(scan_leaks.gold_added_lines(patch, min_len=20), [])
+
+
+class ScanInstanceTests(unittest.TestCase):
+    def test_clean_block_injects_nothing(self):
+        entries = [entry(1, "[semantix-reuse] 修复 go 测试失败 go run ./...")]
+        flags = scan_leaks.scan_instance_entries(entries, GOLD, ["tests.test_forms::test_ok"])
+        self.assertEqual(flags, [])
+
+    def test_flags_leaked_test_name_and_gold_line(self):
+        block = ("[semantix-reuse] 部署生产表单："
+                 "tests.test_forms::test_render_required 需要 required=True，"
+                 "self.assertTrue(form.fields['name'].required)")
+        entries = [entry(1, block)]
+        flags = scan_leaks.scan_instance_entries(entries, GOLD, ["tests.test_forms::test_render_required"])
+        kinds = {f["kind"] for f in flags}
+        self.assertIn("test_name", kinds)
+        self.assertIn("gold_line", kinds)
+
+    def test_full_gold_patch_match(self):
+        entries = [entry(1, "prefix " + GOLD + " suffix")]
+        flags = scan_leaks.scan_instance_entries(entries, GOLD, [])
+        kinds = {f["kind"] for f in flags}
+        self.assertIn("gold_patch", kinds)
+        # The full patch match implies its added lines matched too.
+        self.assertIn("gold_line", kinds)
+
+    def test_dedupes_repeated_needles(self):
+        entries = [entry(1, "tests.test_forms::test_render_required again"),
+                   entry(2, "tests.test_forms::test_render_required again")]
+        flags = scan_leaks.scan_instance_entries(entries, "", ["tests.test_forms::test_render_required"])
+        self.assertEqual(len(flags), 2)  # one per distinct (seq, kind, needle)
+
+
+class ScanRunTests(unittest.TestCase):
+    def test_scan_run_end_to_end(self):
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = Path(td) / "run"
+            audit = run_dir / "audit"
+            audit.mkdir(parents=True)
+            (audit / "django-1.jsonl").write_text(
+                json.dumps(entry(1, "clean unrelated text"), ensure_ascii=False) + "\n",
+                encoding="utf-8")
+            (audit / "django-2.jsonl").write_text(
+                json.dumps(entry(1, "tests.test_forms::test_render_required leaked"),
+                           ensure_ascii=False) + "\n",
+                encoding="utf-8")
+            rows = {
+                "django-1": {"instance_id": "django-1", "repo": "django/django",
+                             "patch": GOLD, "FAIL_TO_PASS": ["tests.test_forms::test_render_required"]},
+                "django-2": {"instance_id": "django-2", "repo": "django/django",
+                             "patch": GOLD, "FAIL_TO_PASS": ["tests.test_forms::test_render_required"]},
+            }
+            result = scan_leaks.scan_run(run_dir, rows)
+            self.assertEqual(result["instances_audited"], 2)
+            self.assertEqual(result["entries"], 2)
+            self.assertEqual(result["status"], "flagged")
+            self.assertEqual(len(result["flagged"]), 1)
+            self.assertEqual(result["flagged"][0]["instance_id"], "django-2")
+
+    def test_scan_run_no_audit_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = scan_leaks.scan_run(Path(td), {})
+            self.assertEqual(result["status"], "no_audit")
+            self.assertEqual(result["flagged"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…泄漏扫描、报告合并生成

- run_bench: --protocol grouped|standard；standard 给每实例 fresh store（跨实例 复用恒零 = Track A），grouped 保留同 repo 课程（Track B）；arm 命名(full/ no-kernel 等)落 run_config 与每行 metrics/cost；新增 run_dir/cost.jsonl
- 注入审计链路：semantix Config.AuditDir → Bridge 每次 admitted L2 注入落盘 <audit_dir>/inject-audit.jsonl（seq/query/完整 [semantix-reuse] 块/命中切片）； runner 拷入 run_dir/audit/<iid>.{jsonl,txt}；scan_leaks.py 对每个被解实例扫 gold patch/新增行/FAIL_TO_PASS 测试名，命中即泄漏候选（人工复核）
- report_tracks.py：仅 join 官方 run_evaluation resolved_ids + cost.jsonl，输出 Track A 能力×成本表(均值+bootstrap CI)与 Track B repo 内成本曲线，显式标注 非标准协议；判分不自研
- 测试：Go audit/config 渲染单测 + python arm/protocol/scan/report 单测共 42 绿； go build ./... 与 vet 干净

## Summary

<!-- Explain what this pull request changes and why. -->

## Scope

<!-- List the affected packages, commands, integrations, documentation, or site areas. -->

## Validation

<!-- List the exact checks you ran and their results. -->

- [ ] `go vet ./...`
- [ ] `go test ./... -race`
- [ ] `git diff --check`
- [ ] Additional checks are documented below, or are not applicable.

## Compatibility and data impact

<!-- Describe changes to CLI behavior, configuration, event contracts, stored slices, indexes, or supported platforms. Write "None" when there is no impact. -->

## Security and privacy

<!-- Describe changes to trust boundaries, persisted data, sanitization, scopes, retention, external requests, or side effects. Write "None" when there is no impact. -->

## Evidence

<!-- Add sanitized logs, benchmark results, screenshots, or before/after examples when relevant. -->

## Related issues

<!-- Use "Closes #123" or link the relevant issue. -->

## Checklist

- [ ] The change is focused and does not include unrelated work.
- [ ] Tests or documentation cover the changed behavior.
- [ ] User-facing behavior and examples are updated where needed.
- [ ] No credentials, private source code, personal data, or sensitive local paths are included.
- [ ] Wire-contract changes are additive and synchronized with `docs/events.md`.
