### PR TITLE
fix(swebench): resolve runner paths before workspace changes

### DIFF
--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -120,6 +120,10 @@ memory-on 时 runner 按数据集 `repo=owner/repo` 分组。同 repo 实例严�
 provider/CPU 竞争；每个 repetition/arm 使用独立 state/work 目录，同时复用同一
 `--ids` 顺序：
 
+所有 CLI 路径会在 runner 启动时解析为绝对路径。这样 agent 切换到每个实例的
+workspace 后，仍会读取同一个 state/config/credential 目录并把 metrics 写回预期的
+results 目录；从 `scripts/swebench` 传入相对路径与绝对路径语义一致。
+
 | 臂 | 配置 | agent binary |
 |---|---|---|
 | A | `memory=off`, `retrieval=off` | 当前版本 |

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -147,6 +147,25 @@ def normalize_count_map(value: object) -> dict[str, int]:
     }
 
 
+CLI_PATH_FIELDS = (
+    "dataset", "ids", "results_dir", "work_dir", "state_dir", "prices",
+    "custom_spec", "semantix_bin", "semantix_kernel_bin", "codex_bin",
+)
+
+
+def resolve_cli_paths(args, base: Path | None = None) -> None:
+    """Pin CLI paths before adapters change the child process workspace."""
+    base = (base or Path.cwd()).resolve()
+    for name in CLI_PATH_FIELDS:
+        value = getattr(args, name, "")
+        if not value:
+            continue
+        path = Path(value).expanduser()
+        if not path.is_absolute():
+            path = base / path
+        setattr(args, name, str(path.resolve()))
+
+
 def clean_env(*, drop_prefixes=(), drop=()) -> dict:
     env = {}
     for k, v in os.environ.items():
@@ -881,6 +900,7 @@ def main() -> None:
     ap.add_argument("--anthropic-base", default="", help="override Anthropic-compatible base URL (mock)")
     ap.add_argument("--keep-ws", action="store_true")
     args = ap.parse_args()
+    resolve_cli_paths(args)
 
     if not args.run_id:
         args.run_id = f"{args.harness}.{args.model.replace('/', '-')}.{args.seed}"

--- a/scripts/swebench/test_repo_isolation.py
+++ b/scripts/swebench/test_repo_isolation.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import common
+import run_bench
 from run_bench import Adapter, SemantixAdapter, process_batch, repo_store_key
 
 
@@ -58,6 +59,33 @@ class RepoSchedulingTests(unittest.TestCase):
 
 
 class RepoStoreTests(unittest.TestCase):
+    def test_relative_cli_paths_are_resolved_before_workspace_chdir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            args = SimpleNamespace(
+                dataset="data/verified.jsonl",
+                ids="subsets/ids.txt",
+                results_dir="results",
+                work_dir="work",
+                state_dir="state",
+                prices="",
+                custom_spec="",
+                semantix_bin="bin/semantix-agent",
+                semantix_kernel_bin="bin/semantix",
+                codex_bin="",
+            )
+
+            run_bench.resolve_cli_paths(args, root)
+
+            for name in (
+                "dataset", "ids", "results_dir", "work_dir", "state_dir",
+                "semantix_bin", "semantix_kernel_bin",
+            ):
+                self.assertTrue(Path(getattr(args, name)).is_absolute(), name)
+            self.assertEqual(args.results_dir, str(root / "results"))
+            self.assertEqual(args.state_dir, str(root / "state"))
+            self.assertEqual(args.prices, "")
+
     def test_repo_cache_clone_is_portable_and_atomic(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## Summary

- resolve every path-like runner argument before the per-instance workspace changes cwd
- keep isolated `SEMANTIX_HOME`, credentials, metrics, workspaces, and dataset references stable when callers use relative paths
- document relative/absolute path equivalence

## Root cause

The matrix examples use relative `results/work/state` paths. `run_bench.py` passed those relative values into an agent whose cwd is the checked-out SWE-bench workspace, while it wrote config and credentials relative to `scripts/swebench`. The child therefore looked in a different `SEMANTIX_HOME` and failed with `provider "deepseek-flash": missing env DEEPSEEK_API_KEY` even though the isolated `.env` existed.

## Verification

- RED: `test_relative_cli_paths_are_resolved_before_workspace_chdir` failed because path normalization did not exist
- GREEN: 21 SWE-bench Python tests pass
- end-to-end offline A/B/C/D warm run with relative paths: all 12 agent invocations reached the mock provider and emitted non-zero usage

Relates to #447.
