### PR TITLE
feat(swebench): seed memory arms from one frozen store

### DIFF
--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -136,6 +136,7 @@ python3 memory_matrix.py \
   --dataset data/swebench_verified.jsonl \
   --ids subsets/verified-50-s20260824.txt \
   --model deepseek-v4-flash --repetitions 3 --workers 4 \
+  --semantix-seed-dir state/issue447-frozen-seed \
   --semantix-bin ../../bin/semantix-agent \
   --legacy-semantix-bin ../../bin/semantix-agent-issue447-legacy \
   --semantix-kernel-bin ../../bin/semantix
@@ -148,6 +149,13 @@ python3 memory_matrix_report.py \
 
 首次单实例端到端预跑及其因果边界见
 [`docs/reports/issue-447-memory-matrix-pilot.md`](../../docs/reports/issue-447-memory-matrix-pilot.md)。
+
+`--semantix-seed-dir` 接收一个冻结的 repo-store 根目录，内部结构与 runner 的
+`kernel/<owner>__<repo>/` 一致。矩阵会在 B/C/D 第一次启动时分别复制同一份 seed，
+A 不读取 seed；断点续跑通过 `.seed-source.json` 识别已经完成的复制，不会覆盖运行中
+新提取的切片。若目标 state 已有数据但没有 seed 标记，runner 会直接报错，避免把
+未知历史与冻结语料混在一起。发布实验结果时应同时保存 seed 生成命令、输入 session
+列表和 repo 顺序。
 
 legacy binary 应固定构建自 `cb5e9cc`（repo 隔离已合并、strict 仍为旧全类型
 策略），不能用 harness `--ablate all` 代替。矩阵 manifest 保存每个 run 的完整

--- a/scripts/swebench/memory_matrix.py
+++ b/scripts/swebench/memory_matrix.py
@@ -81,6 +81,9 @@ def build_runs(args: argparse.Namespace) -> list[MatrixRun]:
             add_optional(command, "--prices", args.prices)
             add_optional(command, "--openai-base", args.openai_base)
             add_optional(command, "--anthropic-base", args.anthropic_base)
+            if memory == "on":
+                add_optional(command, "--semantix-seed-dir",
+                             getattr(args, "semantix_seed_dir", ""))
             runs.append(MatrixRun(
                 arm=arm, label=label, repetition=repetition, run_id=run_id,
                 run_dir=str(Path(args.results_dir) / run_id),
@@ -97,6 +100,7 @@ def manifest_for(args: argparse.Namespace, runs: list[MatrixRun]) -> dict:
         "ids": args.ids,
         "model": args.model,
         "repetitions": args.repetitions,
+        "semantix_seed_dir": getattr(args, "semantix_seed_dir", ""),
         "arm_order": [arm for arm, *_ in ARM_CONFIG],
         "runs": [asdict(run) for run in runs],
     }
@@ -111,6 +115,8 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--legacy-semantix-bin", required=True,
                     help="baseline semantix-agent retaining the old all-type policy")
     ap.add_argument("--semantix-kernel-bin", required=True)
+    ap.add_argument("--semantix-seed-dir", default="",
+                    help="frozen owner__repo store root copied into B/C/D")
     ap.add_argument("--repetitions", type=int, default=3)
     ap.add_argument("--prefix", default="issue447-memory")
     ap.add_argument("--results-dir", default=str(HERE / "results"))

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -149,7 +149,8 @@ def normalize_count_map(value: object) -> dict[str, int]:
 
 CLI_PATH_FIELDS = (
     "dataset", "ids", "results_dir", "work_dir", "state_dir", "prices",
-    "custom_spec", "semantix_bin", "semantix_kernel_bin", "codex_bin",
+    "custom_spec", "semantix_bin", "semantix_kernel_bin", "semantix_seed_dir",
+    "codex_bin",
 )
 
 
@@ -227,6 +228,7 @@ class SemantixAdapter(Adapter):
         self.kernel_root = self.home / "kernel"
         if self.memory_on:
             self.kernel_root.mkdir(parents=True, exist_ok=True)
+            self._seed_kernel_root()
             self.kernel_bin = self.args.semantix_kernel_bin or shutil.which("semantix") or str(
                 HERE.parent.parent / "bin" / "semantix")
             if not Path(self.kernel_bin).exists():
@@ -242,6 +244,33 @@ class SemantixAdapter(Adapter):
                 f"semantix-agent binary not found ({self.binary}); build with "
                 "`go build -o bin/semantix-agent ./cmd/semantix-agent` or pass --semantix-bin"
             )
+
+    def _seed_kernel_root(self) -> None:
+        seed_value = getattr(self.args, "semantix_seed_dir", "")
+        if not seed_value:
+            return
+        source = Path(seed_value).resolve()
+        if not source.is_dir():
+            raise RuntimeError(f"Semantix seed store directory does not exist: {source}")
+        marker = self.kernel_root / ".seed-source.json"
+        source_text = str(source)
+        if marker.exists():
+            recorded = json.loads(marker.read_text(encoding="utf-8"))
+            if recorded.get("source") != source_text:
+                raise RuntimeError(
+                    f"Semantix state was seeded from {recorded.get('source')!r}, "
+                    f"not {source_text!r}"
+                )
+            return
+        if any(self.kernel_root.iterdir()):
+            raise RuntimeError(
+                f"Semantix kernel root already contains unseeded state: {self.kernel_root}"
+            )
+        shutil.copytree(source, self.kernel_root, dirs_exist_ok=True)
+        marker.write_text(
+            json.dumps({"schema": 1, "source": source_text}, indent=2) + "\n",
+            encoding="utf-8",
+        )
 
     def execution_batches(self, instances: list[dict]) -> list[list[dict]]:
         if not self.memory_on:
@@ -890,6 +919,8 @@ def main() -> None:
     ap.add_argument("--semantix-bin", default="")
     ap.add_argument("--semantix-kernel-bin", default="",
                     help="path to the semantix kernel CLI (default: bin/semantix) used for slice extraction")
+    ap.add_argument("--semantix-seed-dir", default="",
+                    help="frozen repo-store root copied once into each memory-on run")
     ap.add_argument("--codex-bin", default="", help="codex binary override (chat wire needs ≤0.80.0)")
     ap.add_argument("--codex-wire-api", default="responses", choices=["responses", "chat"])
     ap.add_argument("--state-dir", default=os.path.expanduser("~/.cache/semantix-swebench"),

--- a/scripts/swebench/test_memory_matrix.py
+++ b/scripts/swebench/test_memory_matrix.py
@@ -21,6 +21,7 @@ class MemoryMatrixCommandTest(unittest.TestCase):
             semantix_bin="bin/current-agent",
             legacy_semantix_bin="bin/legacy-agent",
             semantix_kernel_bin="bin/semantix",
+            semantix_seed_dir="seed",
             repetitions=2,
             prefix="issue447",
             results_dir="results",
@@ -46,6 +47,10 @@ class MemoryMatrixCommandTest(unittest.TestCase):
         self.assertIn("strict", commands["C"])
         self.assertIn("bin/legacy-agent", commands["D"])
         self.assertIn("bin/current-agent", commands["C"])
+        self.assertNotIn("--semantix-seed-dir", commands["A"])
+        for arm in ("B", "C", "D"):
+            self.assertIn("--semantix-seed-dir", commands[arm])
+            self.assertIn("seed", commands[arm])
         self.assertEqual(len({r.state_dir for r in runs}), 8)
         self.assertEqual(len({r.work_dir for r in runs}), 8)
 

--- a/scripts/swebench/test_repo_isolation.py
+++ b/scripts/swebench/test_repo_isolation.py
@@ -59,6 +59,40 @@ class RepoSchedulingTests(unittest.TestCase):
 
 
 class RepoStoreTests(unittest.TestCase):
+    def test_frozen_seed_store_is_copied_once_and_resume_keeps_new_slices(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            seed = root / "seed"
+            seed_db = seed / "django__django" / ".semantix" / "project.db.journal"
+            seed_db.parent.mkdir(parents=True)
+            seed_db.write_text("frozen seed\n", encoding="utf-8")
+            adapter = SemantixAdapter.__new__(SemantixAdapter)
+            adapter.args = SimpleNamespace(semantix_seed_dir=str(seed))
+            adapter.kernel_root = root / "kernel"
+            adapter.kernel_root.mkdir()
+
+            adapter._seed_kernel_root()
+            copied = adapter.kernel_root / "django__django" / ".semantix" / "project.db.journal"
+            self.assertEqual(copied.read_text(encoding="utf-8"), "frozen seed\n")
+
+            copied.write_text("frozen seed\nnew slice\n", encoding="utf-8")
+            adapter._seed_kernel_root()
+            self.assertEqual(copied.read_text(encoding="utf-8"), "frozen seed\nnew slice\n")
+
+    def test_frozen_seed_store_refuses_to_mix_with_unmarked_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            seed = root / "seed"
+            seed.mkdir()
+            adapter = SemantixAdapter.__new__(SemantixAdapter)
+            adapter.args = SimpleNamespace(semantix_seed_dir=str(seed))
+            adapter.kernel_root = root / "kernel"
+            adapter.kernel_root.mkdir()
+            (adapter.kernel_root / "existing").write_text("untracked state", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "already contains unseeded state"):
+                adapter._seed_kernel_root()
+
     def test_relative_cli_paths_are_resolved_before_workspace_chdir(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -72,6 +106,7 @@ class RepoStoreTests(unittest.TestCase):
                 custom_spec="",
                 semantix_bin="bin/semantix-agent",
                 semantix_kernel_bin="bin/semantix",
+                semantix_seed_dir="seed",
                 codex_bin="",
             )
 
@@ -79,7 +114,7 @@ class RepoStoreTests(unittest.TestCase):
 
             for name in (
                 "dataset", "ids", "results_dir", "work_dir", "state_dir",
-                "semantix_bin", "semantix_kernel_bin",
+                "semantix_bin", "semantix_kernel_bin", "semantix_seed_dir",
             ):
                 self.assertTrue(Path(getattr(args, name)).is_absolute(), name)
             self.assertEqual(args.results_dir, str(root / "results"))


### PR DESCRIPTION
## Summary
- add `--semantix-seed-dir` to initialize every memory-enabled matrix arm from the same frozen per-repository slice store
- keep arm A memory-off and unseeded, while B/C/D receive byte-identical initial kernel state
- make resume idempotent with a source marker; preserve slices learned after seeding and reject mixed/unmarked state
- record the seed directory in the matrix manifest and document the workflow

## Why
Issue #447 needs paired causal evidence. Previously each arm started from an empty store, so one-pass A/B/C/D runs could measure the wiring but could not reliably exercise strict admission. A frozen seed removes initial-memory drift between B/C/D without contaminating arm A.

## Verification
- `python -m unittest discover -s scripts/swebench -p 'test_*.py'` -> 23 tests, OK
- offline A/B/C/D smoke on `django__django-15731` with a six-Context, two-source frozen seed:
  - A-off: no reuse/injection fields
  - B-shadow: `semantix_reuse_hits=5`, no injection
  - C-strict: `semantix_reuse_hits=5`, `semantix_inject_turns=1`, `semantix_inject_bytes=2620`
  - D-legacy: `semantix_reuse_hits=5`, `semantix_inject_turns=1`, `semantix_inject_bytes=2368`
- all four agent invocations reached the provider; the mock intentionally returned no patch, so this smoke validates isolation/admission plumbing rather than task resolution

Closes part of #447 (experiment infrastructure; not the final statistical verdict).
