### PR TITLE
feat(memory): retrieve from structured task signals

### DIFF
--- a/docs/specs/semantix-l2-admission-policy.md
+++ b/docs/specs/semantix-l2-admission-policy.md
@@ -1,6 +1,6 @@
 # Semantix L2 严格准入策略
 
-> 状态：P0 基线（2026-09-02）
+> 状态：P0 基线 + P1.1 结构化 query（2026-09-03）
 >
 > 跟踪 Issue：[#447](https://github.com/Gnosil/semantix/issues/447)
 >
@@ -21,15 +21,17 @@
 
 ## 2. 查询处理
 
-Bridge 不再直接把完整 benchmark prompt 交给 BM25，而是生成确定性的低权威 token 投影：
+Bridge 不再直接把完整 benchmark prompt 交给 BM25，而是生成确定性的低权威 token 投影。P1.1 在 P0 模板清洗上继续提取：
 
 1. 删除 `<execution-policy ...>...</execution-policy>`；
 2. 存在 `<issue>...</issue>` 时只使用 issue 正文；
-3. 删除少量英文 benchmark/仓库外壳词；
-4. 保留代码符号、测试名、错误信息、依赖名和 CJK token；
-5. 清洗后为空时 fail closed，reason 为 `empty_query_after_cleaning`。
+3. 从 runner 外壳识别 repo，从 issue 标题识别 intent；
+4. 确定性提取 workspace path、代码 symbol、error code/exception、test name 和 import dependency；
+5. URL 本身不参与 path/symbol 提取，避免链接路径伪装成 workspace 证据；
+6. structured 模式只把 intent 和这些高信息字段投影给 BM25，正文叙述和固定 benchmark 外壳不参与检索；
+7. 没有结构化信号时保留原 P0 清洗结果，记录 `lexical_fallback/no_structured_signals`；清洗后为空仍 fail closed。
 
-事件只保存原 query 与清洗后 query 的 SHA-256、字节数和 token 数，不记录原文。
+事件继续只保存完整 query 与最终检索 query 的 SHA-256、字节数和 token 数，不复制完整 prompt；同时在 `queryStructure` 记录被选中的 intent/repo/path/symbol/error/test/dependency 及 fallback reason，使检索输入可解释。
 
 ## 3. 生产默认值
 
@@ -96,6 +98,7 @@ Project 至少有 5 个切片，Context 来自至少 2 个独立 session；top-1
 
 - mode、library size、repo、base commit；
 - query before/after 摘要；
+- query strategy、结构化字段和 fallback reason；
 - candidate ID/type/source session；
 - score、coverage、eligible top margin；
 - admitted/rejected/withheld 与 reason；

--- a/docs/specs/semantix-memory-negative-transfer.md
+++ b/docs/specs/semantix-memory-negative-transfer.md
@@ -124,7 +124,7 @@ Prompt、ToolPattern 默认 shadow-only；Result 只有在具有成功验证或�
 
 #### 5.7 查询结构化
 
-检索 query 从完整 prompt 改为任务意图、repo、路径、符号和错误码；固定 benchmark 外壳不参与检索。
+检索 query 从完整 prompt 改为任务意图、repo、路径、符号、错误码/异常、测试名和依赖；固定 benchmark 外壳与 URL 不参与检索。找不到结构化信号时回退到 P0 lexical cleaning，并记录稳定 fallback reason。
 
 #### 5.8 ToolPattern 升级
 
@@ -191,7 +191,9 @@ Result 初始为 probation；只有验证命令通过、无回滚，或外部评
 - P0.3 Repo 隔离：已完成，采用真实 repo 独立 store 和 repo 内确定性串行；
 - P0.4 严格准入：已实现 C/M allowlist、小库/来源会话/绝对分/coverage/margin/runner-up 门禁和 query 清洗；
 - P0.5 历史正文降权、provenance、严格预算和 score-first 稳定排序：已实现；
-- 后续：A-D 配对实验、Result 成功提升和负迁移熔断。
+- P1.1 结构化 query：已实现确定性 intent/repo/path/symbol/error/test/dependency 提取、lexical fallback 和 eventwire 观测；
+- A-D 执行器已支持冻结种子，离线 strict/shadow/legacy 注入管线已验证；
+- 后续：冻结样本正式配对实验、Result 成功提升和负迁移熔断。
 
 P0.4 的具体默认值、reason code、校准和回滚合同见 `docs/specs/semantix-l2-admission-policy.md`；
 P0.5 的 provider 消息合同、完整字节预算口径和回滚步骤见

--- a/harness/event/event.go
+++ b/harness/event/event.go
@@ -549,6 +549,22 @@ type QuerySummary struct {
 	Tokens int    `json:"tokens,omitempty"`
 }
 
+// RetrievalQueryStructure records the deterministic, high-information query
+// projection used for retrieval. It is intentionally fielded rather than a
+// copy of the complete user prompt so experiments can explain and replay the
+// selected lexical evidence without retaining benchmark framing.
+type RetrievalQueryStructure struct {
+	Strategy       string   `json:"strategy,omitempty"`
+	Intent         string   `json:"intent,omitempty"`
+	Repo           string   `json:"repo,omitempty"`
+	Paths          []string `json:"paths,omitempty"`
+	Symbols        []string `json:"symbols,omitempty"`
+	ErrorCodes     []string `json:"errorCodes,omitempty"`
+	TestNames      []string `json:"testNames,omitempty"`
+	Dependencies   []string `json:"dependencies,omitempty"`
+	FallbackReason string   `json:"fallbackReason,omitempty"`
+}
+
 // RetrievalCandidate records one score-ordered top-k result and the exact
 // production admission outcome. Verified is "unknown" until slice metadata
 // gains a distinct successful-evaluation marker; provenance must not be
@@ -571,20 +587,21 @@ type RetrievalCandidate struct {
 // shadow mode Candidates and the counterfactual FinalOrder are populated but
 // Injected/Bytes/MessageRole remain zero because provider input is untouched.
 type RetrievalDiagnostics struct {
-	Mode           string               `json:"mode,omitempty"`
-	LibrarySize    int                  `json:"librarySize,omitempty"`
-	Repo           string               `json:"repo,omitempty"`
-	BaseCommit     string               `json:"baseCommit,omitempty"`
-	QueryBefore    QuerySummary         `json:"queryBefore,omitempty"`
-	QueryAfter     QuerySummary         `json:"queryAfter,omitempty"`
-	TopMargin      float64              `json:"topMargin,omitempty"`
-	Candidates     []RetrievalCandidate `json:"candidates,omitempty"`
-	Injected       bool                 `json:"injected,omitempty"`
-	Bytes          int                  `json:"bytes,omitempty"`
-	MessageRole    string               `json:"messageRole,omitempty"`
-	FinalOrder     []string             `json:"finalOrder,omitempty"`
-	Decision       string               `json:"decision,omitempty"`
-	DecisionReason string               `json:"decisionReason,omitempty"`
+	Mode           string                  `json:"mode,omitempty"`
+	LibrarySize    int                     `json:"librarySize,omitempty"`
+	Repo           string                  `json:"repo,omitempty"`
+	BaseCommit     string                  `json:"baseCommit,omitempty"`
+	QueryBefore    QuerySummary            `json:"queryBefore,omitempty"`
+	QueryAfter     QuerySummary            `json:"queryAfter,omitempty"`
+	QueryStructure RetrievalQueryStructure `json:"queryStructure,omitempty"`
+	TopMargin      float64                 `json:"topMargin,omitempty"`
+	Candidates     []RetrievalCandidate    `json:"candidates,omitempty"`
+	Injected       bool                    `json:"injected,omitempty"`
+	Bytes          int                     `json:"bytes,omitempty"`
+	MessageRole    string                  `json:"messageRole,omitempty"`
+	FinalOrder     []string                `json:"finalOrder,omitempty"`
+	Decision       string                  `json:"decision,omitempty"`
+	DecisionReason string                  `json:"decisionReason,omitempty"`
 }
 
 // FinalReadiness carries machine-readable recovery requirements on TurnDone.

--- a/harness/eventwire/wire.go
+++ b/harness/eventwire/wire.go
@@ -67,6 +67,18 @@ type QuerySummary struct {
 	Tokens int    `json:"tokens,omitempty"`
 }
 
+type RetrievalQueryStructure struct {
+	Strategy       string   `json:"strategy,omitempty"`
+	Intent         string   `json:"intent,omitempty"`
+	Repo           string   `json:"repo,omitempty"`
+	Paths          []string `json:"paths,omitempty"`
+	Symbols        []string `json:"symbols,omitempty"`
+	ErrorCodes     []string `json:"errorCodes,omitempty"`
+	TestNames      []string `json:"testNames,omitempty"`
+	Dependencies   []string `json:"dependencies,omitempty"`
+	FallbackReason string   `json:"fallbackReason,omitempty"`
+}
+
 type RetrievalCandidate struct {
 	ID            string  `json:"id,omitempty"`
 	Type          string  `json:"type,omitempty"`
@@ -82,20 +94,21 @@ type RetrievalCandidate struct {
 }
 
 type RetrievalDiagnostics struct {
-	Mode           string               `json:"mode,omitempty"`
-	LibrarySize    int                  `json:"librarySize,omitempty"`
-	Repo           string               `json:"repo,omitempty"`
-	BaseCommit     string               `json:"baseCommit,omitempty"`
-	QueryBefore    QuerySummary         `json:"queryBefore,omitempty"`
-	QueryAfter     QuerySummary         `json:"queryAfter,omitempty"`
-	TopMargin      float64              `json:"topMargin,omitempty"`
-	Candidates     []RetrievalCandidate `json:"candidates,omitempty"`
-	Injected       bool                 `json:"injected,omitempty"`
-	Bytes          int                  `json:"bytes,omitempty"`
-	MessageRole    string               `json:"messageRole,omitempty"`
-	FinalOrder     []string             `json:"finalOrder,omitempty"`
-	Decision       string               `json:"decision,omitempty"`
-	DecisionReason string               `json:"decisionReason,omitempty"`
+	Mode           string                  `json:"mode,omitempty"`
+	LibrarySize    int                     `json:"librarySize,omitempty"`
+	Repo           string                  `json:"repo,omitempty"`
+	BaseCommit     string                  `json:"baseCommit,omitempty"`
+	QueryBefore    QuerySummary            `json:"queryBefore,omitempty"`
+	QueryAfter     QuerySummary            `json:"queryAfter,omitempty"`
+	QueryStructure RetrievalQueryStructure `json:"queryStructure,omitempty"`
+	TopMargin      float64                 `json:"topMargin,omitempty"`
+	Candidates     []RetrievalCandidate    `json:"candidates,omitempty"`
+	Injected       bool                    `json:"injected,omitempty"`
+	Bytes          int                     `json:"bytes,omitempty"`
+	MessageRole    string                  `json:"messageRole,omitempty"`
+	FinalOrder     []string                `json:"finalOrder,omitempty"`
+	Decision       string                  `json:"decision,omitempty"`
+	DecisionReason string                  `json:"decisionReason,omitempty"`
 }
 
 // CompletionSummary is the JSON form of event.CompletionSummaryInfo.
@@ -299,7 +312,13 @@ func toWireRetrieval(in *event.RetrievalDiagnostics) *RetrievalDiagnostics {
 		Mode: in.Mode, LibrarySize: in.LibrarySize, Repo: in.Repo, BaseCommit: in.BaseCommit,
 		QueryBefore: QuerySummary{SHA256: in.QueryBefore.SHA256, Bytes: in.QueryBefore.Bytes, Tokens: in.QueryBefore.Tokens},
 		QueryAfter:  QuerySummary{SHA256: in.QueryAfter.SHA256, Bytes: in.QueryAfter.Bytes, Tokens: in.QueryAfter.Tokens},
-		TopMargin:   in.TopMargin, Injected: in.Injected, Bytes: in.Bytes, MessageRole: in.MessageRole,
+		QueryStructure: RetrievalQueryStructure{
+			Strategy: in.QueryStructure.Strategy, Intent: in.QueryStructure.Intent, Repo: in.QueryStructure.Repo,
+			Paths: append([]string(nil), in.QueryStructure.Paths...), Symbols: append([]string(nil), in.QueryStructure.Symbols...),
+			ErrorCodes: append([]string(nil), in.QueryStructure.ErrorCodes...), TestNames: append([]string(nil), in.QueryStructure.TestNames...),
+			Dependencies: append([]string(nil), in.QueryStructure.Dependencies...), FallbackReason: in.QueryStructure.FallbackReason,
+		},
+		TopMargin: in.TopMargin, Injected: in.Injected, Bytes: in.Bytes, MessageRole: in.MessageRole,
 		FinalOrder: append([]string(nil), in.FinalOrder...), Decision: in.Decision, DecisionReason: in.DecisionReason,
 	}
 	for _, c := range in.Candidates {

--- a/harness/eventwire/wire_test.go
+++ b/harness/eventwire/wire_test.go
@@ -82,7 +82,8 @@ func TestToWireKernelCacheJSON(t *testing.T) {
 	w := ToWire(event.Event{Kind: event.KernelCache, KernelCache: &event.KernelCachePayload{
 		Op: "degraded", Layer: "L2", SliceIDs: []string{"b", "a"}, Bytes: 128, Reason: "budget",
 		Retrieval: &event.RetrievalDiagnostics{Mode: "shadow", LibrarySize: 3, TopMargin: 1.25,
-			Candidates: []event.RetrievalCandidate{{ID: "b", Type: "context", Score: 2.5, Coverage: 0.75, Zone: "hit", Admitted: true, Reason: "admitted"}}},
+			QueryStructure: event.RetrievalQueryStructure{Strategy: "structured", Intent: "repair cache", Repo: "owner/repo", Paths: []string{"cache/store.go"}, Symbols: []string{"cache.load"}},
+			Candidates:     []event.RetrievalCandidate{{ID: "b", Type: "context", Score: 2.5, Coverage: 0.75, Zone: "hit", Admitted: true, Reason: "admitted"}}},
 	}})
 	if w.Kind != "kernel_cache" || w.KernelCache == nil {
 		t.Fatalf("kernel cache wire = %+v", w)
@@ -91,7 +92,7 @@ func TestToWireKernelCacheJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`"kind":"kernel_cache"`, `"op":"degraded"`, `"layer":"L2"`, `"sliceIds":["b","a"]`, `"reason":"budget"`, `"mode":"shadow"`, `"librarySize":3`, `"coverage":0.75`, `"reason":"admitted"`} {
+	for _, want := range []string{`"kind":"kernel_cache"`, `"op":"degraded"`, `"layer":"L2"`, `"sliceIds":["b","a"]`, `"reason":"budget"`, `"mode":"shadow"`, `"librarySize":3`, `"coverage":0.75`, `"reason":"admitted"`, `"strategy":"structured"`, `"intent":"repair cache"`, `"repo":"owner/repo"`, `"paths":["cache/store.go"]`, `"symbols":["cache.load"]`} {
 		if !strings.Contains(string(b), want) {
 			t.Fatalf("kernel cache JSON = %s, missing %s", b, want)
 		}

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -251,9 +251,10 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		b.emitKernelCache("miss", "L2", nil, 0, "slice library unavailable")
 		return InjectResult{}
 	}
-	cleanedQuery := cleanRetrievalQuery(query)
+	retrievalQuery := buildRetrievalQuery(query)
+	cleanedQuery := retrievalQuery.Text
 	if cleanedQuery == "" {
-		diagnostics := b.retrievalDiagnostics(query, cleanedQuery, projectSlices, nil, nil)
+		diagnostics := b.retrievalDiagnostics(query, retrievalQuery, projectSlices, nil, nil)
 		diagnostics.Decision = "rejected"
 		diagnostics.DecisionReason = "empty_query_after_cleaning"
 		b.emitKernelCacheDetailed("miss", "L2", nil, 0, diagnostics.DecisionReason, diagnostics)
@@ -290,7 +291,7 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		b.emitKernelCache(op, "L2", nil, 0, err.Error())
 		return InjectResult{}
 	}
-	diagnostics := b.retrievalDiagnostics(query, cleanedQuery, projectSlices, hits, inj)
+	diagnostics := b.retrievalDiagnostics(query, retrievalQuery, projectSlices, hits, inj)
 	if b.mode == RetrievalShadow {
 		diagnostics.Decision = "withheld"
 		diagnostics.DecisionReason = "shadow_mode"
@@ -328,11 +329,17 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 	return InjectResult{Text: inj.Text, Targets: targets, Diagnostics: diagnostics}
 }
 
-func (b *Bridge) retrievalDiagnostics(query, cleanedQuery string, library []*slice.Slice, hits []slice.Hit, inj *inject.Injection) *event.RetrievalDiagnostics {
+func (b *Bridge) retrievalDiagnostics(query string, retrievalQuery RetrievalQuery, library []*slice.Slice, hits []slice.Hit, inj *inject.Injection) *event.RetrievalDiagnostics {
 	projectDir := b.projectDir()
 	d := &event.RetrievalDiagnostics{
 		Mode: string(b.mode), LibrarySize: len(library), Repo: filepath.Base(filepath.Clean(projectDir)),
-		BaseCommit: readGitHead(projectDir), QueryBefore: summarizeQuery(query), QueryAfter: summarizeQuery(cleanedQuery),
+		BaseCommit: readGitHead(projectDir), QueryBefore: summarizeQuery(query), QueryAfter: summarizeQuery(retrievalQuery.Text),
+		QueryStructure: event.RetrievalQueryStructure{
+			Strategy: retrievalQuery.Strategy, Intent: retrievalQuery.Intent, Repo: retrievalQuery.Repo,
+			Paths: append([]string(nil), retrievalQuery.Paths...), Symbols: append([]string(nil), retrievalQuery.Symbols...),
+			ErrorCodes: append([]string(nil), retrievalQuery.ErrorCodes...), TestNames: append([]string(nil), retrievalQuery.TestNames...),
+			Dependencies: append([]string(nil), retrievalQuery.Dependencies...), FallbackReason: retrievalQuery.FallbackReason,
+		},
 	}
 	if inj == nil {
 		return d

--- a/harness/semantix/query.go
+++ b/harness/semantix/query.go
@@ -1,10 +1,38 @@
 package semantix
 
 import (
+	"regexp"
+	"sort"
 	"strings"
 
 	"semantix/kernel/bm25"
 )
+
+var (
+	repoPattern   = regexp.MustCompile(`(?i)checkout\s+of\s+the\s+([a-z0-9_.-]+/[a-z0-9_.-]+)\s+repository`)
+	pathPattern   = regexp.MustCompile(`(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+`)
+	symbolPattern = regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b|\b_+[A-Za-z0-9_]+_+\b|\b[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]+\b`)
+	errorPattern  = regexp.MustCompile(`(?i)\b[a-z][a-z0-9]*error\b|\b[A-Z]{2,}(?:[_-][A-Z0-9]+)+\b`)
+	testPattern   = regexp.MustCompile(`(?i)\btest[A-Za-z0-9_]*\b`)
+	importPattern = regexp.MustCompile(`(?i)\bimports?\s+([a-z_][a-z0-9_.]*)|\bfrom\s+([a-z_][a-z0-9_.]*)\s+import\b`)
+	urlPattern    = regexp.MustCompile(`(?i)https?://\S+`)
+)
+
+// RetrievalQuery is the deterministic P1 query projection. Text is the only
+// value sent to BM25; the named fields explain which high-information signals
+// contributed to it and make fallback behavior observable.
+type RetrievalQuery struct {
+	Text           string
+	Strategy       string
+	Intent         string
+	Repo           string
+	Paths          []string
+	Symbols        []string
+	ErrorCodes     []string
+	TestNames      []string
+	Dependencies   []string
+	FallbackReason string
+}
 
 var retrievalStopwords = map[string]struct{}{
 	"a": {}, "at": {}, "below": {}, "checkout": {}, "commit": {},
@@ -30,6 +58,150 @@ func cleanRetrievalQuery(raw string) string {
 		}
 	}
 	return strings.Join(kept, " ")
+}
+
+// buildRetrievalQuery extracts stable high-information fields from a task. If
+// no such field exists it preserves the P0 lexical cleaning behavior rather
+// than pretending a generic sentence is structured evidence.
+func buildRetrievalQuery(raw string) RetrievalQuery {
+	body := stripTaggedBlock(raw, "execution-policy")
+	issue, hasIssue := taggedBody(body, "issue")
+	if hasIssue {
+		body = issue
+	}
+	signalBody := urlPattern.ReplaceAllString(body, " ")
+	q := RetrievalQuery{Intent: firstNonEmptyLine(body), Repo: firstCapture(repoPattern, raw)}
+	q.Paths = collectPaths(signalBody, q.Repo)
+	q.Symbols = collectMatches(symbolPattern, signalBody)
+	q.ErrorCodes = collectMatches(errorPattern, signalBody)
+	q.Dependencies = collectImports(signalBody)
+	for _, value := range append(append([]string(nil), q.Paths...), q.Symbols...) {
+		if strings.Contains(strings.ToLower(value), "test") {
+			q.TestNames = append(q.TestNames, strings.ToLower(value))
+		}
+	}
+	q.TestNames = append(q.TestNames, collectMatches(testPattern, signalBody)...)
+	q.TestNames = uniqueSorted(q.TestNames)
+
+	hasSignals := len(q.Paths)+len(q.Symbols)+len(q.ErrorCodes)+len(q.TestNames)+len(q.Dependencies) > 0
+	if !hasSignals {
+		q.Text = cleanRetrievalQuery(raw)
+		q.Strategy = "lexical_fallback"
+		q.FallbackReason = "no_structured_signals"
+		if q.Text == "" {
+			q.FallbackReason = "empty_after_cleaning"
+		}
+		return q
+	}
+
+	values := []string{q.Intent}
+	values = append(values, q.Paths...)
+	values = append(values, q.Symbols...)
+	values = append(values, q.ErrorCodes...)
+	values = append(values, q.TestNames...)
+	values = append(values, q.Dependencies...)
+	q.Text = joinRetrievalTokens(values...)
+	q.Strategy = "structured"
+	return q
+}
+
+func firstNonEmptyLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func firstCapture(re *regexp.Regexp, text string) string {
+	match := re.FindStringSubmatch(text)
+	if len(match) < 2 {
+		return ""
+	}
+	return strings.ToLower(match[1])
+}
+
+func collectPaths(text, repo string) []string {
+	var out []string
+	for _, match := range pathPattern.FindAllString(text, -1) {
+		value := strings.ToLower(strings.Trim(match, "./"))
+		if value == "" || value == repo || strings.Contains(value, "://") {
+			continue
+		}
+		// A single slash without a file-like suffix is normally an owner/repo
+		// slug, not a workspace path.
+		if strings.Count(value, "/") < 2 && !strings.Contains(pathBase(value), ".") {
+			continue
+		}
+		out = append(out, value)
+	}
+	return uniqueSorted(out)
+}
+
+func pathBase(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+func collectMatches(re *regexp.Regexp, text string) []string {
+	matches := re.FindAllString(text, -1)
+	for i := range matches {
+		matches[i] = strings.ToLower(matches[i])
+	}
+	return uniqueSorted(matches)
+}
+
+func collectImports(text string) []string {
+	var out []string
+	for _, match := range importPattern.FindAllStringSubmatch(text, -1) {
+		for _, value := range match[1:] {
+			if value == "" {
+				continue
+			}
+			root := strings.Split(strings.ToLower(value), ".")[0]
+			out = append(out, root)
+		}
+	}
+	return uniqueSorted(out)
+}
+
+func uniqueSorted(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func joinRetrievalTokens(values ...string) string {
+	var tokens []string
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		for _, token := range bm25.Tokenize(value) {
+			if _, drop := retrievalStopwords[token]; drop {
+				continue
+			}
+			if _, ok := seen[token]; ok {
+				continue
+			}
+			seen[token] = struct{}{}
+			tokens = append(tokens, token)
+		}
+	}
+	return strings.Join(tokens, " ")
 }
 
 func stripTaggedBlock(text, tag string) string {

--- a/harness/semantix/query_test.go
+++ b/harness/semantix/query_test.go
@@ -2,6 +2,7 @@ package semantix
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"semantix/kernel/bm25"
@@ -23,6 +24,89 @@ route=direct risk=low verify=targeted review=conditional
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cleaned tokens = %v, want %v", got, want)
 	}
+}
+
+func TestBuildRetrievalQueryExtractsStructuredSWEIssueSignals(t *testing.T) {
+	raw := `You are working in a git checkout of the django/django repository at commit abc. Resolve the GitHub issue below.
+<issue>
+inspect.signature() returns incorrect signature on manager methods.
+	The wrapper in django/db/models/manager.py exposes (*args, **kwargs) for
+	Person.objects.bulk_create. Use functools.wraps instead of assigning __name__
+	and __doc__. The example imports inspect and uses from django.db import models.
+	See https://github.com/django/django/blob/main/django/db/models/manager.py#L84.
+	If acknowledged, assign the ticket to me.
+</issue>
+Requirements:
+- implement a complete fix
+<execution-policy preset="balanced">route=full-plan</execution-policy>`
+
+	got := buildRetrievalQuery(raw)
+	if got.Strategy != "structured" || got.FallbackReason != "" {
+		t.Fatalf("strategy = %q fallback = %q", got.Strategy, got.FallbackReason)
+	}
+	if got.Intent != "inspect.signature() returns incorrect signature on manager methods." {
+		t.Fatalf("intent = %q", got.Intent)
+	}
+	if got.Repo != "django/django" {
+		t.Fatalf("repo = %q", got.Repo)
+	}
+	if !reflect.DeepEqual(got.Paths, []string{"django/db/models/manager.py"}) {
+		t.Fatalf("paths = %v", got.Paths)
+	}
+	for _, symbol := range []string{"__doc__", "__name__", "functools.wraps", "inspect.signature", "person.objects.bulk_create"} {
+		if !containsString(got.Symbols, symbol) {
+			t.Errorf("symbols = %v, missing %q", got.Symbols, symbol)
+		}
+	}
+	for _, dependency := range []string{"django", "inspect"} {
+		if !containsString(got.Dependencies, dependency) {
+			t.Errorf("dependencies = %v, missing %q", got.Dependencies, dependency)
+		}
+	}
+	for _, noise := range []string{"acknowledged", "assign", "ticket", "requirements", "full", "plan"} {
+		if containsString(bm25.Tokenize(got.Text), noise) {
+			t.Errorf("structured query leaked noise %q: %q", noise, got.Text)
+		}
+	}
+}
+
+func TestBuildRetrievalQueryExtractsErrorAndTestNames(t *testing.T) {
+	got := buildRetrievalQuery(`<issue>
+Fix HTTP_500 from TestCacheInvalidation in tests/cache/test_backend.py.
+Running test_redis_timeout raises ConnectionError in RedisStore.get_value.
+</issue>`)
+	if got.Strategy != "structured" {
+		t.Fatalf("strategy = %q", got.Strategy)
+	}
+	for _, code := range []string{"connectionerror", "http_500"} {
+		if !containsString(got.ErrorCodes, code) {
+			t.Errorf("error codes = %v, missing %q", got.ErrorCodes, code)
+		}
+	}
+	for _, name := range []string{"testcacheinvalidation", "test_redis_timeout", "tests/cache/test_backend.py"} {
+		if !containsString(got.TestNames, name) {
+			t.Errorf("test names = %v, missing %q", got.TestNames, name)
+		}
+	}
+}
+
+func TestBuildRetrievalQueryFallsBackToCleanLexicalQuery(t *testing.T) {
+	got := buildRetrievalQuery("Please fix cache invalidation bug")
+	if got.Strategy != "lexical_fallback" || got.FallbackReason != "no_structured_signals" {
+		t.Fatalf("strategy = %q fallback = %q", got.Strategy, got.FallbackReason)
+	}
+	if got.Text != cleanRetrievalQuery("Please fix cache invalidation bug") {
+		t.Fatalf("text = %q", got.Text)
+	}
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if strings.EqualFold(item, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCleanRetrievalQueryKeepsDomainAndCJKTerms(t *testing.T) {

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -271,6 +271,32 @@ func TestBridgeStrictAdmissionInjectsOnlyContextWithStrongEvidence(t *testing.T)
 	}
 }
 
+func TestBridgeRecordsAndUsesStructuredRetrievalQuery(t *testing.T) {
+	dir := writeKernelDir(t, admissionFixtureSlices(), nil)
+	b := NewBridge(Config{Enabled: true, Mode: "strict", ProjectDir: dir})
+	raw := `You are working in a git checkout of the owner/repo repository at commit abc.
+<issue>
+修复 go 测试
+The failure is in internal/cache/store.go and TestCacheLoad.
+</issue>
+Requirements: ignore this benchmark framing`
+	result := b.InjectDetailed(context.Background(), raw)
+	if result.Diagnostics == nil {
+		t.Fatal("missing diagnostics")
+	}
+	want := buildRetrievalQuery(raw)
+	if result.Diagnostics.QueryAfter.SHA256 != summarizeQuery(want.Text).SHA256 {
+		t.Fatalf("query after = %+v, want structured text %q", result.Diagnostics.QueryAfter, want.Text)
+	}
+	got := result.Diagnostics.QueryStructure
+	if got.Strategy != "structured" || got.Intent != "修复 go 测试" || got.Repo != "owner/repo" {
+		t.Fatalf("query structure = %+v", got)
+	}
+	if !containsString(got.Paths, "internal/cache/store.go") || !containsString(got.TestNames, "testcacheload") {
+		t.Fatalf("query structure signals = %+v", got)
+	}
+}
+
 func TestBridgeShadowRetrievalEmitsDiagnosticsWithoutInjection(t *testing.T) {
 	dir := writeKernelDir(t, reuseFixtureSlices(), nil)
 	var events []event.Event


### PR DESCRIPTION
## Summary
- replace full-body BM25 input with a deterministic structured projection when high-information task signals are available
- extract intent, repo, workspace paths, symbols, error/exception codes, test names, and imported dependencies
- strip URLs before path/symbol extraction and retain the previous lexical cleaner as an explicit fail-safe fallback
- carry the selected fields, strategy, and fallback reason through retrieval diagnostics and eventwire

## Why
Issue #447 identified that long benchmark narratives dilute query coverage and let generic prompt words compete with the actual symbol/path/error intent. This change makes the retrieval input smaller and explainable without changing repo/type/score/coverage/margin admission gates.

## Behavior
- `structured`: BM25 receives the stable union of intent + named high-information fields
- `lexical_fallback/no_structured_signals`: existing P0 cleaned query is preserved when deterministic extraction finds no field evidence
- complete prompt text is still represented only by before/after hashes and sizes; `queryStructure` contains only the selected evidence

## Verification
- TDD red: the new extractor tests initially failed with `undefined: buildRetrievalQuery`; URL regression then failed because a GitHub URL was classified as a workspace path
- `go test ./harness/semantix ./harness/eventwire -count=1` -> pass
- `go test ./harness/agent -run TestShadowRetrievalKeepsProviderMessagesByteIdenticalToOff -count=1` -> pass
- `python -m unittest discover -s scripts/swebench -p 'test_*.py'` -> 23 tests, OK
- `git diff --check upstream/main...HEAD` -> clean

Issue: #447 (P1.1)
