### PR TITLE
feat(memory): fuse injected history on loop guards

### DIFF
--- a/docs/specs/semantix-memory-negative-transfer.md
+++ b/docs/specs/semantix-memory-negative-transfer.md
@@ -136,7 +136,7 @@ Result 初始为 probation；只有验证命令通过、无回滚，或外部评
 
 #### 5.10 负迁移熔断
 
-将 slice ID 与后续工具行为关联。连续出现重复读取、重复搜索、重复测试、无效路径或回滚时，当前 turn 停止使用该 slice，并累计 reject/waste，而不是仅累计 injected。
+将 slice ID 与后续工具行为关联。第一阶段复用 harness 已有 loop/progress guard：只有该 guard 已确认连续调用没有新增证据时，才从后续 provider request 清除当前 turn 的历史块，并为关联 slice 发出 `SliceReject(reason=loop_guard)`、累计 `Rejected`。熔断在同一 turn 幂等，后台 prefetch 也不能重新注入。重复调用本身仍只是相关信号，不单独证明某 slice 有害。
 
 ### P2：检索升级
 
@@ -192,8 +192,9 @@ Result 初始为 probation；只有验证命令通过、无回滚，或外部评
 - P0.4 严格准入：已实现 C/M allowlist、小库/来源会话/绝对分/coverage/margin/runner-up 门禁和 query 清洗；
 - P0.5 历史正文降权、provenance、严格预算和 score-first 稳定排序：已实现；
 - P1.1 结构化 query：已实现确定性 intent/repo/path/symbol/error/test/dependency 提取、lexical fallback 和 eventwire 观测；
+- P1.4 第一阶段负迁移熔断：已接入 loop/progress guard、本轮移除、slice reject 反馈及 SWE metrics；
 - A-D 执行器已支持冻结种子，离线 strict/shadow/legacy 注入管线已验证；
-- 后续：冻结样本正式配对实验、Result 成功提升和负迁移熔断。
+- 后续：冻结样本正式配对实验、Result 成功提升，以及按无效路径/回滚/外部 unresolved 细分 fuse reason。
 
 P0.4 的具体默认值、reason code、校准和回滚合同见 `docs/specs/semantix-l2-admission-policy.md`；
 P0.5 的 provider 消息合同、完整字节预算口径和回滚步骤见

--- a/harness/agent/negative_transfer_fuse_test.go
+++ b/harness/agent/negative_transfer_fuse_test.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"semantix/harness/event"
+	"semantix/harness/semantix"
+	"semantix/harness/tool"
+	"semantix/kernel/slice"
+)
+
+func TestLoopGuardFusesInjectedSlicesOnce(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".semantix"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(&slice.Slice{ID: "ctx-a", Type: slice.Context, Scope: slice.Project, Content: []byte("cache repair")}); err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := store.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bridge := semantix.NewBridge(semantix.Config{Enabled: true, Mode: "strict", ProjectDir: dir})
+	defer bridge.Close()
+	var events []event.Event
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{Semantix: bridge}, event.FuncSink(func(e event.Event) {
+		events = append(events, e)
+	}))
+	a.turn.injectBlock = "[semantix-reuse]\ncache repair\n[/semantix-reuse]"
+	a.turn.injectTargets = []string{"ctx-a"}
+
+	a.armLoopGuardPass(0)
+	a.armLoopGuardPass(0)
+	if a.turn.injectBlock != "" || !a.turn.injectionFused {
+		t.Fatalf("turn injection not fused: %+v", a.turn)
+	}
+	fuseNotices := 0
+	for _, e := range events {
+		if e.Kind == event.Notice && e.Code == event.NoticeCodeSemantixFuse {
+			fuseNotices++
+		}
+	}
+	if fuseNotices != 1 {
+		t.Fatalf("fuse notices = %d, want 1", fuseNotices)
+	}
+	store, err = slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if closer, ok := store.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
+	got, err := store.Get("ctx-a")
+	if err != nil || got.Stats.Rejected != 1 {
+		t.Fatalf("slice after fuse = %+v, %v", got, err)
+	}
+	prepared, err := a.prepareSamplingRequest(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, msg := range prepared.req.Messages {
+		if strings.Contains(msg.Content, "cache repair") {
+			t.Fatalf("fused history remained provider-visible: %+v", prepared.req.Messages)
+		}
+	}
+}
+
+func TestPrefetchedInjectionBecomesFuseableTurnHistory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".semantix"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(&slice.Slice{ID: "ctx-prefetch", Type: slice.Context, Scope: slice.Project, Content: []byte("prefetched cache repair")}); err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := store.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bridge := semantix.NewBridge(semantix.Config{Enabled: true, Mode: "strict", ProjectDir: dir})
+	defer bridge.Close()
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{Semantix: bridge}, event.FuncSink(func(event.Event) {}))
+	a.storePrefetch(&prefetchedInjectResult{
+		Text:    "[semantix-reuse]\nprefetched cache repair\n[/semantix-reuse]",
+		Targets: []string{"ctx-prefetch"},
+		Turn:    a.semantixTurn.Load(),
+	})
+
+	prepared, err := a.prepareSamplingRequest(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.turn.injectBlock == "" || len(a.turn.injectTargets) != 1 {
+		t.Fatalf("prefetch was not retained as active turn history: %+v", a.turn)
+	}
+	seen := false
+	for _, msg := range prepared.req.Messages {
+		seen = seen || strings.Contains(msg.Content, "prefetched cache repair")
+	}
+	if !seen {
+		t.Fatalf("prefetched history was not provider-visible: %+v", prepared.req.Messages)
+	}
+
+	a.armLoopGuardPass(0)
+	prepared, err = a.prepareSamplingRequest(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, msg := range prepared.req.Messages {
+		if strings.Contains(msg.Content, "prefetched cache repair") {
+			t.Fatalf("fused prefetch remained provider-visible: %+v", prepared.req.Messages)
+		}
+	}
+}

--- a/harness/agent/progress_guard.go
+++ b/harness/agent/progress_guard.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"semantix/harness/event"
@@ -177,6 +178,20 @@ func progressGuardNoticeText() string {
 func (a *Agent) armLoopGuardPass(receiptMark int) {
 	a.turn.loopGuardArmed = true
 	a.turn.loopGuardReceiptMark = receiptMark
+	if a.turn.injectionFused || a.turn.injectBlock == "" || len(a.turn.injectTargets) == 0 {
+		return
+	}
+	targets := append([]string(nil), a.turn.injectTargets...)
+	a.turn.injectBlock = ""
+	a.turn.injectionFused = true
+	if a.semantix != nil {
+		a.semantix.RecordInjectionReject(targets, "loop_guard")
+	}
+	detail, _ := json.Marshal(map[string]any{"slices": len(targets), "reason": "loop_guard"})
+	a.svc.sink.Emit(event.Event{
+		Kind: event.Notice, Level: event.LevelWarn, Code: event.NoticeCodeSemantixFuse,
+		Text: "Semantix history was removed after a loop guard detected no progress.", Detail: string(detail),
+	})
 }
 
 // loopGuardAllowsFinal reports whether final readiness should stand down: a

--- a/harness/agent/run_loop.go
+++ b/harness/agent/run_loop.go
@@ -13,6 +13,7 @@ import (
 	"semantix/harness/evidence"
 	"semantix/harness/jobs"
 	"semantix/harness/provider"
+	"semantix/harness/semantix"
 	"semantix/harness/taskintent"
 	"semantix/harness/taskpolicy"
 	"semantix/harness/tool"
@@ -272,11 +273,14 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 		// Issue #270 step 2: the degrade_inject tier shrinks the injection
 		// (halved block budget) instead of dropping it, so tight budgets still
 		// get some reuse context. Any other action keeps the full injection.
+		var result semantix.InjectResult
 		if a.budgetCtrl != nil && a.budgetCtrl.Action() == sched.BudgetActionDegradeInject {
-			state.injectBlock = a.semantix.InjectDegraded(ctx, input)
+			result = a.semantix.InjectDegradedDetailed(ctx, input)
 		} else {
-			state.injectBlock = a.semantix.InjectDetailed(ctx, input).Text
+			result = a.semantix.InjectDetailed(ctx, input)
 		}
+		state.injectBlock = result.Text
+		state.injectTargets = append([]string(nil), result.Targets...)
 		// U33/H4a reuse panel: capture the kernel's per-turn reuse summary
 		// (hit slices + incremental cost savings + top source sessions)
 		// alongside the injection block. Same soft-degrade contract: a zero

--- a/harness/agent/sampling_request.go
+++ b/harness/agent/sampling_request.go
@@ -101,15 +101,21 @@ func (a *Agent) buildSamplingRequest(ctx context.Context, trigger string) (sampl
 	}
 	// L2 semantic injection (U8): keep only a fixed trust policy at system
 	// authority and place this turn's locked [semantix-reuse] body in ordinary
-	// user-role history. The block is assembled once per turn and is byte-stable,
-	// so the provider prefix cache keeps hitting across rounds.
+	// user-role history. The block is byte-stable until a loop/progress guard
+	// trips the negative-transfer fuse; after that it stays absent for the turn.
 	// When the synchronous injection missed (kernel timeout on turn start),
 	// fall back to the block warmed during LLM wait time (N12 prefetch).
 	if block := a.turn.injectBlock; block != "" {
 		a.wastePrefetch()
 		requestMessages = prependSemantixHistory(requestMessages, block)
-	} else if pb := a.takePrefetch(a.semantixTurn.Load()); pb != nil && pb.Text != "" {
-		requestMessages = prependSemantixHistory(requestMessages, pb.Text)
+	} else if !a.turn.injectionFused {
+		if pb := a.takePrefetch(a.semantixTurn.Load()); pb != nil && pb.Text != "" {
+			a.turn.injectBlock = pb.Text
+			a.turn.injectTargets = append([]string(nil), pb.Targets...)
+			requestMessages = prependSemantixHistory(requestMessages, pb.Text)
+		}
+	} else {
+		a.wastePrefetch()
 	}
 	// Injection can create an adjacent history/current-task user run. Apply
 	// provider compatibility after injection so strict providers receive one

--- a/harness/agent/turnruntime.go
+++ b/harness/agent/turnruntime.go
@@ -31,11 +31,15 @@ type turnRuntime struct {
 	input           string
 	workDurationMs  func() int64
 
-	// injectBlock is the locked [semantix-reuse] block for this turn,
-	// assembled on the first user message and reused across tool rounds so
-	// the injected prefix stays byte-stable (L1 cache friendly). Empty
-	// disables injection for the turn.
+	// injectBlock is assembled on the first user message and reused across tool
+	// rounds so the injected prefix stays byte-stable. A loop/progress guard may
+	// clear it once as the explicit negative-transfer fuse.
 	injectBlock string
+	// injectTargets are the canonical slice IDs represented by injectBlock.
+	// injectionFused prevents a loop guard from penalizing or announcing the
+	// same slices more than once in one user turn.
+	injectTargets  []string
+	injectionFused bool
 
 	// reuse is this turn's semantix reuse panel data (U33/H4a): hit slices,
 	// incremental cost savings, and top source sessions, gathered on the

--- a/harness/cli/run_metrics.go
+++ b/harness/cli/run_metrics.go
@@ -126,6 +126,8 @@ type RunMetrics struct {
 	SemantixInjectBytes     int     `json:"semantix_inject_bytes,omitempty"`
 	SemantixReuseHits       int     `json:"semantix_reuse_hits,omitempty"`
 	SemantixReuseSavingsUSD float64 `json:"semantix_reuse_savings_usd,omitempty"`
+	SemantixFuseTurns       int     `json:"semantix_fuse_turns,omitempty"`
+	SemantixRejectedSlices  int     `json:"semantix_rejected_slices,omitempty"`
 
 	// Run accounting: what a benchmark needs to price one solved task and name
 	// the guard that ended a failed one.
@@ -379,6 +381,14 @@ func (s *metricsSink) record(e event.Event) {
 			if json.Unmarshal([]byte(e.Detail), &d) == nil {
 				s.m.SemantixReuseHits += d.Hits
 				s.m.SemantixReuseSavingsUSD += d.SavingsUSD
+			}
+		case event.NoticeCodeSemantixFuse:
+			s.m.SemantixFuseTurns++
+			var d struct {
+				Slices int `json:"slices"`
+			}
+			if json.Unmarshal([]byte(e.Detail), &d) == nil {
+				s.m.SemantixRejectedSlices += d.Slices
 			}
 		}
 	}

--- a/harness/cli/run_metrics_test.go
+++ b/harness/cli/run_metrics_test.go
@@ -164,6 +164,14 @@ func TestMetricsSinkAttributesRepeatedToolArguments(t *testing.T) {
 	}
 }
 
+func TestMetricsSinkCountsSemantixFuses(t *testing.T) {
+	s := &metricsSink{inner: event.Discard}
+	s.Emit(event.Event{Kind: event.Notice, Code: event.NoticeCodeSemantixFuse, Detail: `{"slices":2,"reason":"loop_guard"}`})
+	if s.m.SemantixFuseTurns != 1 || s.m.SemantixRejectedSlices != 2 {
+		t.Fatalf("fuse metrics = %+v", s.m)
+	}
+}
+
 func TestWriteMetricsIncludesReadinessFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "metrics.json")
 	if err := writeMetrics(path, RunMetrics{

--- a/harness/event/event.go
+++ b/harness/event/event.go
@@ -659,6 +659,9 @@ const (
 	// once per user turn so metrics can count injection coverage without
 	// scraping the prompt.
 	NoticeCodeSemantixInject = "semantix_inject"
+	// NoticeCodeSemantixFuse reports that a loop/progress guard removed the
+	// active history block. Detail carries {"slices": n, "reason": string}.
+	NoticeCodeSemantixFuse = "semantix_fuse"
 )
 
 type Event struct {

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -220,11 +220,17 @@ func (b *Bridge) Inject(ctx context.Context, query string) string {
 // 2): the harness calls this when the window budget crosses the
 // degrade_inject tier — shrink the injection instead of dropping it.
 func (b *Bridge) InjectDegraded(ctx context.Context, query string) string {
+	return b.InjectDegradedDetailed(ctx, query).Text
+}
+
+// InjectDegradedDetailed is the target-preserving form used by the agent so a
+// later negative-transfer fuse can attribute the reduced block to its slices.
+func (b *Bridge) InjectDegradedDetailed(ctx context.Context, query string) InjectResult {
 	budget := b.cfg.Budget / 2
 	if budget <= 0 {
 		budget = 1 // never fall back to the full DefaultBudget via the <=0 path
 	}
-	return b.inject(ctx, query, budget)
+	return b.injectResult(ctx, query, budget)
 }
 
 // inject is the shared injection path with an explicit block budget.
@@ -475,6 +481,48 @@ func (b *Bridge) recordInjection(ids []string, bytes int) {
 		}
 		_ = slice.ApplyStats(store, deltas)
 	}()
+}
+
+// RecordInjectionReject attributes a conservative negative-transfer signal to
+// every injected slice that was active when the harness loop guard fired. IDs
+// are canonicalized so one fuse increments each slice exactly once.
+func (b *Bridge) RecordInjectionReject(ids []string, reason string) {
+	if b == nil || !b.Enabled() || len(ids) == 0 {
+		return
+	}
+	ids = append([]string(nil), ids...)
+	sort.Strings(ids)
+	unique := ids[:0]
+	for _, id := range ids {
+		if id != "" && (len(unique) == 0 || unique[len(unique)-1] != id) {
+			unique = append(unique, id)
+		}
+	}
+	if len(unique) == 0 {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "negative_transfer"
+	}
+	now := time.Now().UTC()
+	if store, err := slice.NewFileStore(filepath.Join(b.projectDir(), ".semantix", "project.db")); err == nil {
+		deltas := make(map[string]slice.SliceStats, len(unique))
+		for _, id := range unique {
+			deltas[id] = slice.SliceStats{Rejected: 1, LastUsed: now.Unix()}
+		}
+		_ = slice.ApplyStats(store, deltas)
+		closeSliceStore(store)
+	}
+	b.mu.Lock()
+	session := b.label
+	b.mu.Unlock()
+	for _, id := range unique {
+		data, err := json.Marshal(kernelevent.SliceRejectPayload{SliceID: id, Reason: reason})
+		if err == nil {
+			b.events.Emit(kernelevent.Event{Kind: kernelevent.SliceReject, SessionID: session, At: now, Data: data})
+		}
+	}
 }
 
 // RecordPrefetch emits one terminal outcome for a warmed result. lead is

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -2,6 +2,7 @@ package semantix
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,6 +269,37 @@ func TestBridgeStrictAdmissionInjectsOnlyContextWithStrongEvidence(t *testing.T)
 	}
 	if strings.Contains(result.Text, "prompt-blocked") || strings.Contains(result.Text, "result-blocked") {
 		t.Fatalf("wrong-type slice leaked into injection:\n%s", result.Text)
+	}
+}
+
+func TestBridgeRecordInjectionRejectUpdatesSlicesAndEmitsEvents(t *testing.T) {
+	dir := writeKernelDir(t, admissionFixtureSlices(), nil)
+	b := NewBridge(Config{Enabled: true, Mode: "strict", ProjectDir: dir})
+	defer b.Close()
+	var rejected []kernelevent.SliceRejectPayload
+	unsub := b.Events().Subscribe(func(e kernelevent.Event) {
+		if e.Kind != kernelevent.SliceReject {
+			return
+		}
+		var payload kernelevent.SliceRejectPayload
+		if json.Unmarshal(e.Data, &payload) == nil {
+			rejected = append(rejected, payload)
+		}
+	})
+	defer unsub()
+
+	b.RecordInjectionReject([]string{"ctx-strong", "ctx-strong"}, "repeat_tool_loop")
+	if len(rejected) != 1 || rejected[0].SliceID != "ctx-strong" || rejected[0].Reason != "repeat_tool_loop" {
+		t.Fatalf("reject events = %+v", rejected)
+	}
+	store, err := slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSliceStore(store)
+	got, err := store.Get("ctx-strong")
+	if err != nil || got.Stats.Rejected != 1 {
+		t.Fatalf("slice after reject = %+v, %v", got, err)
 	}
 }
 

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -76,7 +76,8 @@ enabled/inject；**每实例独立 `SEMANTIX_HOME`**（并发归属无竞态）�
 （内核关闭，等价旧行为）。记忆对照请用这对臂，**不要用 `--ablate`**（它只关
 harness 侧模块，不触碰内核）。判读字段（metrics `raw`）：
 `semantix_inject_turns` / `semantix_inject_bytes` / `semantix_reuse_hits` /
-`raw.extract`（每实例入库量）。设计与根因：`docs/specs/swebench-memory-arm.md`。
+`semantix_fuse_turns` / `semantix_rejected_slices` / `raw.extract`（每实例入库量）。
+设计与根因：`docs/specs/swebench-memory-arm.md`。
 
 #### 调用来源归因字段
 
@@ -96,6 +97,8 @@ runner 会把原生 `usage_by_source` 规范化进每实例 `metrics.jsonl`：
 | `tool_calls_by_name` | 已完成工具调用按 canonical tool name 汇总 |
 | `repeated_tool_calls` | 同一 provider-visible 工具名 + canonical JSON 参数在首次完成后的重复次数 |
 | `repeated_tool_calls_by_name` | 上述重复按工具名拆分；只保留参数摘要，不写原始参数 |
+| `semantix_fuse_turns` | 已有 loop/progress guard 清除本轮历史块的次数（每 user turn 最多一次） |
+| `semantix_rejected_slices` | 熔断时被关联并累计 `Rejected` 的注入 slice 数 |
 
 `report.py` 的 Markdown 表用 `calls E/P/S/C/O` 显示
 executor/planner/subagent/compaction/other；JSON 输出保留完整来源表和工具表。
@@ -164,9 +167,11 @@ legacy binary 应固定构建自 `cb5e9cc`（repo 隔离已合并、strict 仍�
 报告严格按 `(repetition, instance_id)` 与 A 配对；任一臂缺实例立即报错。输出
 resolved、executor calls、steps、input tokens、工具总数和 read/search/test 工具族、
 wall、cost、retry、注入次数/字节的 absolute 与相对 A 的 median/P75/P90。接入
-`repeated_tool_calls` 后，Markdown 额外显示 `Δ repeats median/P75/P90`，JSON 同时
-保留重复 read/search/test 工具族。旧 metrics 缺少重复字段时维持 unattributed，
-不会把“未采集”伪装成 0；重复信号用于归因，不单独作为有害循环或熔断依据。
+`repeated_tool_calls` 后，Markdown 显示 `Δ repeats median/P75/P90`；接入熔断后还显示
+`Δ fuses median/P75/P90`，JSON 同时保留 rejected slice 数和重复 read/search/test
+工具族。旧 metrics 缺少重复字段时维持 unattributed，不会把“未采集”伪装成 0。
+重复调用本身仍只是轨迹信号；只有 harness 已有 loop/progress guard 判断为持续无进展时，
+才移除当前 turn 的历史并记录 `SliceReject(reason=loop_guard)`。
 
 ## 方法学要点（对比公平性）
 

--- a/scripts/swebench/common.py
+++ b/scripts/swebench/common.py
@@ -87,6 +87,8 @@ class InstanceMetrics:
     # zero means attribution ran and observed no repeated signature.
     repeated_tool_calls: int | None = None
     repeated_tool_calls_by_name: dict[str, int] | None = None
+    semantix_fuse_turns: int = 0
+    semantix_rejected_slices: int = 0
     cost_usd: float | None = None    # computed from DeepSeek prices when possible
     cost_native: float | None = None # what the harness itself reported
     cost_native_currency: str = ""

--- a/scripts/swebench/memory_matrix_report.py
+++ b/scripts/swebench/memory_matrix_report.py
@@ -13,6 +13,7 @@ METRICS = (
     "resolved", "executor_calls", "steps", "input_tokens", "tool_calls",
     "read_calls", "search_calls", "test_calls", "wall_ms", "cost_usd",
     "provider_retries", "semantix_inject_turns", "semantix_inject_bytes",
+    "semantix_fuse_turns", "semantix_rejected_slices",
     "repeated_tool_calls", "repeated_read_calls", "repeated_search_calls",
     "repeated_test_calls",
 )
@@ -180,8 +181,8 @@ def fmt(value: float | None) -> str:
 
 def markdown(report: dict) -> str:
     lines = [
-        "| arm | paired n | resolved | Δ executor median/P75/P90 | Δ input median/P75/P90 | Δ tools median/P75/P90 | Δ repeats median/P75/P90 |",
-        "|---|---:|---:|---:|---:|---:|---:|",
+        "| arm | paired n | resolved | Δ executor median/P75/P90 | Δ input median/P75/P90 | Δ tools median/P75/P90 | Δ repeats median/P75/P90 | Δ fuses median/P75/P90 |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for arm, data in report["arms"].items():
         def delta(metric: str) -> str:
@@ -194,7 +195,7 @@ def markdown(report: dict) -> str:
             f"| {arm} | {data['instances']} | "
             f"{'n/a' if resolved is None else f'{resolved:.1%}'} | "
             f"{delta('executor_calls')} | {delta('input_tokens')} | {delta('tool_calls')} | "
-            f"{delta('repeated_tool_calls')} |"
+            f"{delta('repeated_tool_calls')} | {delta('semantix_fuse_turns')} |"
         )
     return "\n".join(lines) + "\n"
 

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -447,6 +447,8 @@ context_window = 128000
             m.repeated_tool_calls_by_name = normalize_count_map(
                 raw.get("repeated_tool_calls_by_name")
             )
+        m.semantix_fuse_turns = raw.get("semantix_fuse_turns", 0)
+        m.semantix_rejected_slices = raw.get("semantix_rejected_slices", 0)
         m.cost_native = raw.get("cost")
         m.cost_native_currency = raw.get("currency", "")
 

--- a/scripts/swebench/test_memory_matrix.py
+++ b/scripts/swebench/test_memory_matrix.py
@@ -115,6 +115,7 @@ class MemoryMatrixReportTest(unittest.TestCase):
             self.assertEqual(c["metrics"]["repeated_read_calls"]["delta_vs_A"]["median"], -1.0)
             self.assertEqual(c["metrics"]["repeated_search_calls"]["delta_vs_A"]["median"], -1.0)
             self.assertIn("Δ repeats median/P75/P90", memory_matrix_report.markdown(report))
+            self.assertIn("Δ fuses median/P75/P90", memory_matrix_report.markdown(report))
 
     def test_report_rejects_unpaired_instance_sets(self):
         manifest = {"schema": 1, "runs": [

--- a/scripts/swebench/test_metrics_attribution.py
+++ b/scripts/swebench/test_metrics_attribution.py
@@ -52,6 +52,8 @@ class SemantixMetricAttributionTest(unittest.TestCase):
             "tool_calls_by_name": {"read_file": 4, "grep": 3, "bash": 1},
             "repeated_tool_calls": 3,
             "repeated_tool_calls_by_name": {"read_file": 2, "grep": 1},
+            "semantix_fuse_turns": 1,
+            "semantix_rejected_slices": 2,
         }
 
         metrics = self.new_metrics()
@@ -82,6 +84,8 @@ class SemantixMetricAttributionTest(unittest.TestCase):
         })
         self.assertEqual(metrics.repeated_tool_calls, 3)
         self.assertEqual(metrics.repeated_tool_calls_by_name, {"read_file": 2, "grep": 1})
+        self.assertEqual(metrics.semantix_fuse_turns, 1)
+        self.assertEqual(metrics.semantix_rejected_slices, 2)
 
     def test_fill_metrics_keeps_old_records_explicitly_unattributed(self) -> None:
         metrics = self.new_metrics()


### PR DESCRIPTION
## Summary
- clear the active Semantix history block once the existing loop/progress guard confirms no progress
- retain prefetched fallback history as fuseable turn state and prevent reinjection after the fuse
- attribute the correlated negative-transfer signal with `SliceReject(reason=loop_guard)` and `SliceStats.Rejected`
- export `semantix_fuse_turns` / `semantix_rejected_slices` and include paired `Δ fuses` in the memory matrix report

This is deliberately conservative: repeated calls alone do not reject memory. The fuse only follows the harness's existing no-progress/storm guard and records correlation rather than claiming slice causality.

## Verification
- `go test ./harness/semantix -run 'TestBridgeRecordInjectionRejectUpdatesSlicesAndEmitsEvents' -count=1`
- `go test ./harness/agent -run 'TestLoopGuardFusesInjectedSlicesOnce|TestPrefetchedInjectionBecomesFuseableTurnHistory' -count=1`
- `go test ./harness/cli -run 'TestMetricsSinkCountsSemantixFuses' -count=1`
- `python -m unittest discover -s scripts/swebench -p 'test_*.py'` (23 tests)
- patch application and `ROLLBACK.sh` were verified on a separate clean `upstream/main@22f9546` worktree

## Full-suite note
The changed-package suite reached all relevant tests. Unrelated Windows tests showed pre-existing timing/TempDir cleanup failures; `TestModelSwitchRefreshesCustomStatusline` reproduces unchanged on clean `upstream/main@22f9546`, and the TempDir cleanup cases pass when rerun individually.

Closes part of #447.