### PR TITLE
fix(serve/gui): epic #403 核心可用性——composer 解锁、recovered pill、面板回放

### DIFF
--- a/harness/serve/broadcaster.go
+++ b/harness/serve/broadcaster.go
@@ -264,6 +264,25 @@ func (b *Broadcaster) SubscribeWebSince(lastSeq uint64, taskID string) (<-chan w
 	}
 }
 
+// ReplayWindow snapshots the broadcaster's retained workspace frames for a
+// client that attached after they were emitted (#403). It is the JSON sibling
+// of the SubscribeWebSince SSE path — the same bounded window, same ordering,
+// no live subscription. taskID is stamped onto every delivery exactly like a
+// fresh subscriber so the replay frames carry the same task attribution as the
+// live stream. Frames are immutable after publish, so sharing them is safe.
+func (b *Broadcaster) ReplayWindow(taskID string) []webDelivery {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	replay := make([]webDelivery, 0, len(b.webHistory))
+	for _, frame := range b.webHistory {
+		replay = append(replay, webDelivery{frame: frame, taskID: taskID})
+	}
+	return replay
+}
+
 // SubscribeWebLive registers a workspace subscriber without replaying retained
 // frames. The workspace uses this while it hydrates the durable /history
 // snapshot, buffering any events that arrive during that request.

--- a/harness/serve/serve.go
+++ b/harness/serve/serve.go
@@ -511,6 +511,7 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /workspace/shell.js", staticBytes("text/javascript; charset=utf-8", &workspaceShellJS))
 	mux.HandleFunc("GET /events", s.events)
 	mux.HandleFunc("GET /workspace/events", s.workspaceEvents)
+	mux.HandleFunc("GET /workspace/replay", s.workspaceReplay)
 	mux.HandleFunc("GET /history", s.history)
 	mux.HandleFunc("GET /context", s.context)
 	mux.HandleFunc("POST /submit", s.submit)

--- a/harness/serve/webproto.go
+++ b/harness/serve/webproto.go
@@ -252,17 +252,56 @@ func parseLastEventID(value string) uint64 {
 }
 
 func writeWebDelivery(w http.ResponseWriter, flusher http.Flusher, delivery webDelivery) {
-	payload, err := json.Marshal(WebEnvelope{
+	payload, err := json.Marshal(webEnvelopeFromDelivery(delivery))
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", delivery.frame.seq, delivery.frame.type_, payload)
+	flusher.Flush()
+}
+
+// webEnvelopeFromDelivery projects one broadcaster frame onto the stable
+// client envelope. Shared by the SSE writer and the JSON replay snapshot so
+// both transports expose byte-identical envelopes.
+func webEnvelopeFromDelivery(delivery webDelivery) WebEnvelope {
+	return WebEnvelope{
 		V:      1,
 		Seq:    delivery.frame.seq,
 		Type:   delivery.frame.type_,
 		TaskID: delivery.taskID,
 		TimeMS: delivery.frame.timeMS,
 		Data:   delivery.frame.data,
-	})
-	if err != nil {
-		return
 	}
-	fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", delivery.frame.seq, delivery.frame.type_, payload)
-	flusher.Flush()
+}
+
+// workspaceReplay returns the broadcaster's retained workspace frame window as
+// JSON so a freshly attached client can rebuild the live-only context panels
+// (Diff / Terminal / Review / cache status) after a page refresh or reconnect
+// without re-adding timeline cards that /history already owns (#403).
+//
+// The window is bounded (webHistoryLimit) and session-scoped: it reflects what
+// the broadcaster observed since the active session was (re)started. Frames
+// are the same versioned WebEnvelope objects the SSE stream carries — real
+// observed events, never fabricated — and clients deduplicate by seq before
+// newer live frames arrive.
+func (s *Server) workspaceReplay(w http.ResponseWriter, r *http.Request) {
+	taskID := filepath.Base(s.ctl().SessionPath())
+	if taskID == "" || taskID == "." || taskID == string(os.PathSeparator) {
+		taskID = "current"
+	}
+	frames := s.bc.ReplayWindow(taskID)
+	envs := make([]WebEnvelope, 0, len(frames))
+	for _, delivery := range frames {
+		envs = append(envs, webEnvelopeFromDelivery(delivery))
+	}
+	firstSeq, lastSeq := uint64(0), uint64(0)
+	if len(envs) > 0 {
+		firstSeq, lastSeq = envs[0].Seq, envs[len(envs)-1].Seq
+	}
+	writeJSON(w, struct {
+		TaskID   string        `json:"task_id"`
+		FirstSeq uint64        `json:"first_seq"`
+		LastSeq  uint64        `json:"last_seq"`
+		Frames   []WebEnvelope `json:"frames"`
+	}{TaskID: taskID, FirstSeq: firstSeq, LastSeq: lastSeq, Frames: envs})
 }

--- a/harness/serve/webproto_test.go
+++ b/harness/serve/webproto_test.go
@@ -424,3 +424,126 @@ func TestWorkspaceEventsReplaysAfterReconnect(t *testing.T) {
 		t.Fatalf("replay types = %q, %q", second.ssetype, third.ssetype)
 	}
 }
+
+// workspaceReplayJSON mirrors the GET /workspace/replay response shape.
+type workspaceReplayJSON struct {
+	TaskID   string        `json:"task_id"`
+	FirstSeq uint64        `json:"first_seq"`
+	LastSeq  uint64        `json:"last_seq"`
+	Frames   []WebEnvelope `json:"frames"`
+}
+
+// TestWorkspaceReplaySnapshotJSON exposes the retained workspace frame window
+// through GET /workspace/replay so a refreshed workspace page can rebuild its
+// Diff/Terminal/Review panels without a live subscription (#403). The window
+// must mirror the SSE stream exactly (versioned envelopes, stable increasing
+// seqs) and be cleared together with the session by ResetSession, exactly like
+// the SSE replay path.
+func TestWorkspaceReplaySnapshotJSON(t *testing.T) {
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc})
+	srv := New(ctrl, bc, config.ServeConfig{})
+	httpSrv := httptest.NewServer(srv.Handler())
+	defer httpSrv.Close()
+
+	fetch := func() workspaceReplayJSON {
+		t.Helper()
+		resp, err := http.Get(httpSrv.URL + "/workspace/replay")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /workspace/replay status = %d", resp.StatusCode)
+		}
+		var out workspaceReplayJSON
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+
+	expectedTaskID := filepath.Base(ctrl.SessionPath())
+	if expectedTaskID == "" || expectedTaskID == "." {
+		expectedTaskID = "current"
+	}
+
+	// No frames yet: an empty (non-null) window with matching task id.
+	empty := fetch()
+	if empty.TaskID != expectedTaskID {
+		t.Fatalf("empty replay task_id = %q, want %q", empty.TaskID, expectedTaskID)
+	}
+	if empty.Frames == nil || len(empty.Frames) != 0 {
+		t.Fatalf("empty replay frames = %#v, want []", empty.Frames)
+	}
+	if empty.FirstSeq != 0 || empty.LastSeq != 0 {
+		t.Fatalf("empty replay seqs = %d..%d, want 0..0", empty.FirstSeq, empty.LastSeq)
+	}
+
+	emitSeq := []event.Event{
+		{Kind: event.Message, Text: "完整回答"},
+		{Kind: event.ToolDispatch, Tool: event.Tool{ID: "t1", Name: "edit_file"}},
+		{Kind: event.ToolResult, Tool: event.Tool{ID: "t1", Output: "ok"}},
+		{Kind: event.Usage, Usage: &provider.Usage{CacheHitTokens: 9}},
+	}
+	for _, ev := range emitSeq {
+		bc.Emit(ev)
+	}
+
+	full := fetch()
+	wantTypes := []string{ProtoTypeAssistant, ProtoTypeToolStart, ProtoTypeToolResult, ProtoTypeCacheStatus}
+	if len(full.Frames) != len(wantTypes) {
+		t.Fatalf("replay frames = %d, want %d", len(full.Frames), len(wantTypes))
+	}
+	if full.FirstSeq != full.Frames[0].Seq || full.LastSeq != full.Frames[len(full.Frames)-1].Seq {
+		t.Fatalf("replay seq window %d..%d != frame seqs %d..%d",
+			full.FirstSeq, full.LastSeq, full.Frames[0].Seq, full.Frames[len(full.Frames)-1].Seq)
+	}
+	var last uint64
+	for i, env := range full.Frames {
+		if env.V != 1 {
+			t.Errorf("frame %d: v = %d, want 1", i, env.V)
+		}
+		if env.Seq <= last {
+			t.Errorf("frame %d: seq %d not increasing after %d", i, env.Seq, last)
+		}
+		last = env.Seq
+		if env.TaskID != expectedTaskID {
+			t.Errorf("frame %d: task_id = %q, want %q", i, env.TaskID, expectedTaskID)
+		}
+		if env.Type != wantTypes[i] {
+			t.Errorf("frame %d: type = %q, want %q", i, env.Type, wantTypes[i])
+		}
+	}
+	var inner struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(full.Frames[1].Data, &inner); err != nil {
+		t.Fatal(err)
+	}
+	if inner.Kind != "tool_dispatch" {
+		t.Errorf("replay tool frame inner kind = %q, want tool_dispatch", inner.Kind)
+	}
+
+	// The JSON snapshot obeys the same bounded window as the SSE replay path:
+	// once more than webHistoryLimit frames are retained, the oldest frames are
+	// evicted and the snapshot reports the surviving suffix.
+	for i := 0; i < webHistoryLimit+3; i++ {
+		bc.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo})
+	}
+	windowed := fetch()
+	if len(windowed.Frames) != webHistoryLimit {
+		t.Fatalf("bounded replay frames = %d, want %d", len(windowed.Frames), webHistoryLimit)
+	}
+	if windowed.FirstSeq == 0 || windowed.LastSeq <= windowed.FirstSeq {
+		t.Fatalf("bounded replay seqs %d..%d not strictly increasing", windowed.FirstSeq, windowed.LastSeq)
+	}
+
+	// Session (re)start clears the retained window for the next task, keeping
+	// the JSON snapshot consistent with the SSE replay path.
+	bc.ResetSession()
+	cleared := fetch()
+	if len(cleared.Frames) != 0 {
+		t.Fatalf("after ResetSession replay frames = %d, want 0", len(cleared.Frames))
+	}
+}

--- a/harness/serve/workspace/layout.css
+++ b/harness/serve/workspace/layout.css
@@ -482,6 +482,7 @@ body.ws-right-collapsed .ws-context { display: none; }
 }
 .ws-state-running { background: var(--sx-green-dim); color: var(--sx-green-strong); border: 1px solid var(--sx-green-border); }
 .ws-state-done { background: transparent; color: var(--sx-text-3); border: 1px solid var(--sx-border-strong); }
+.ws-state-recovered { background: var(--sx-orange-dim); color: var(--sx-orange); border: 1px solid var(--sx-orange-border); }
 .ws-state-empty { background: transparent; color: var(--sx-text-3); border: 1px dashed var(--sx-border-strong); }
 .ws-task-row[aria-current="true"] .ws-dot { flex: none; }
 .ws-tasks-note { padding: 8px 10px; font-size: 11.5px; line-height: 1.6; color: var(--sx-text-3); }

--- a/harness/serve/workspace/shell.js
+++ b/harness/serve/workspace/shell.js
@@ -151,11 +151,15 @@
   // running drives the 运行中 pill for the highlighted task row.
   var sessionRunning = false;
   var composerBusy = false;
+  var runningSyncSeq = 0;
   var EFFORT_LABELS = { low: "低", medium: "中", high: "高", max: "max" };
   var EFFORT_LEVELS = ["low", "medium", "high"];
   var TASK_PILLS = {
     running: ["运行中", "ws-state-running"],
     done: ["完成", "ws-state-done"],
+    // /sessions reports a branch whose last turn was interrupted as
+    // status:"recovered" (serve.go); the sidebar must render it, not crash.
+    recovered: ["待恢复", "ws-state-recovered"],
     empty: ["空会话", "ws-state-empty"]
   };
   var openMenu = null; // currently open dropdown element or null
@@ -1003,13 +1007,18 @@
     var record = workflow.tools[key];
     if (!record) {
       record = { args: "", output: "", err: "", truncated: false, progress: "", fileDiff: null, terminal: false, name: "" };
-      record.card = makeEvent("tool", toolLabel(tool.name), "⚙");
       workflow.tools[key] = record;
+    }
+    if (!record.card) {
+      // A record restored by /workspace/replay is panel-only (no timeline
+      // card yet, to avoid duplicating /history). The first live frame for
+      // the same tool id materializes its card.
+      record.card = makeEvent("tool", toolLabel(record.name || tool.name), "⚙");
     }
     if (tool.name) {
       record.name = String(tool.name);
       record.terminal = record.terminal || tool.name === "bash" || tool.name === "shell" || !!tool.execution;
-      record.card.label.textContent = toolLabel(tool.name) + " · " + tool.name;
+      if (record.card) record.card.label.textContent = toolLabel(tool.name) + " · " + tool.name;
     }
     if (tool.args) record.args = String(tool.args);
     if (tool.fileDiff) {
@@ -1134,6 +1143,22 @@
   function setComposerRunning(running) {
     composerBusy = !!running;
     updateComposerControls();
+  }
+
+  // #403: /status is the single source of truth for whether the active
+  // session is still running. turn_done/error frames only clear the optimistic
+  // composerBusy flag, but sessionRunning was latched by the last refreshTasks
+  // — without a re-sync the composer stayed disabled (and cancel stuck) until
+  // a manual refresh or task switch. Re-read /status so the composer and the
+  // current-row pill reflect the real backend state again.
+  function refreshRunningState() {
+    var requestSeq = ++runningSyncSeq;
+    return getJSON("/status").then(function (status) {
+      if (requestSeq !== runningSyncSeq) return; // a newer request superseded this one
+      sessionRunning = !!status.running;
+      updateComposerControls();
+      if (sessionRows.length) renderTasks(sessionRows);
+    }).catch(function () { /* transient /status failure: keep current latch */ });
   }
 
   function addOptimisticUserMessage(text) {
@@ -1270,6 +1295,7 @@
       case "error":
         composerBusy = false;
         updateComposerControls();
+        refreshRunningState(); // #403: turn aborted — release the running latch
         if (workflow.localUser) {
           setStatus(workflow.localUser.card, "未发送", "failed");
           workflow.localUser = null;
@@ -1284,6 +1310,7 @@
           var cancelled = !!data.cancelled || String(data.outcome || "").toLowerCase() === "cancelled";
           composerBusy = false;
           updateComposerControls();
+          refreshRunningState(); // #403: turn finished — re-sync the running latch
           if (workflow.localUser) {
             setStatus(workflow.localUser.card, cancelled ? "已取消" : "已发送", cancelled ? "cancelled" : "done");
             workflow.localUser = null;
@@ -1367,10 +1394,11 @@
     if (el.historyRetry) el.historyRetry.hidden = false;
   }
 
-  function hydrateHistory() {
+  function hydrateHistory(replayFrames) {
     historyHydrating = true;
     bufferedWorkspaceEvents = [];
     return getJSON("/history").then(renderHistory).then(function () {
+      if (Array.isArray(replayFrames) && replayFrames.length) applyReplayFrames(replayFrames);
       historyHydrating = false;
       var pending = bufferedWorkspaceEvents.splice(0);
       pending.forEach(handleWorkspaceEvent);
@@ -1379,6 +1407,101 @@
       bufferedWorkspaceEvents = [];
       showHistoryError(err);
     });
+  }
+
+  // #403: /workspace/replay is the JSON sibling of the SSE replay window. The
+  // live context panels (Diff / Terminal / Review / cache status) are pure
+  // projections of stream frames, so a fresh page (F5) or reconnect would
+  // otherwise lose every panel once a run's frames are no longer live. Loading
+  // the retained window lets the shell rebuild those panels from real observed
+  // frames — without re-adding timeline cards that /history already owns.
+  function loadWorkspaceReplay() {
+    return getJSON("/workspace/replay").then(function (snapshot) {
+      return Array.isArray(snapshot && snapshot.frames) ? snapshot.frames : [];
+    }).catch(function () {
+      // Older/standalone servers may not expose the endpoint: the shell still
+      // hydrates the conversation from /history and stays live-only.
+      return [];
+    });
+  }
+
+  // applyReplayFrames folds a retained-frame window back into the workflow
+  // projection. Unlike handleWorkspaceEvent it never touches the timeline:
+  // user/assistant/tool cards for those frames already came from /history, so
+  // rendering them again would duplicate the conversation. It only rebuilds
+  // panel state (diffs, terminal executions, review changes, cache bar).
+  //
+  // It must NOT advance the shared lastEventSeq: frames that also arrived over
+  // the live stream while hydrating are flushed afterwards by
+  // handleWorkspaceEvent, which renders their timeline content exactly as it
+  // would without replay — demoting them here would drop in-flight text that
+  // the base flow keeps. A local cursor only dedupes within this window.
+  function applyReplayFrames(frames) {
+    if (!Array.isArray(frames)) return;
+    var cursor = lastEventSeq;
+    var lastDiff = null;
+    frames.forEach(function (raw) {
+      var payload;
+      try { payload = typeof raw === "string" ? JSON.parse(raw) : raw; } catch (_) { return; }
+      if (!payload || payload.v !== 1 || !Number.isSafeInteger(payload.seq) || payload.seq < 1) return;
+      if (eventTaskID && payload.task_id !== eventTaskID) return;
+      if (!eventTaskID && typeof payload.task_id === "string") eventTaskID = payload.task_id;
+      if (payload.seq <= cursor) return;
+      cursor = payload.seq;
+      if (!canonicalEventTypes[payload.type]) return;
+      var data;
+      try { data = typeof payload.data === "string" ? JSON.parse(payload.data || "{}") : payload.data; } catch (_) { return; }
+      if (!data || typeof data !== "object") return;
+      if (data.kind === "turn_started") {
+        workflow.tools = Object.create(null);
+        workflow.diffs = Object.create(null);
+        return;
+      }
+      if (payload.type === "tool_start" || payload.type === "tool_result") {
+        var tool = data.tool;
+        if (!tool) return;
+        var kind = data.kind === "tool_progress" ? "tool_progress" : payload.type;
+        var key = toolKey(tool, payload.seq);
+        var record = workflow.tools[key];
+        if (!record) {
+          record = { args: "", output: "", err: "", truncated: false, progress: "", fileDiff: null, terminal: false, name: "" };
+          workflow.tools[key] = record;
+        }
+        if (tool.name) {
+          record.name = String(tool.name);
+          record.terminal = record.terminal || tool.name === "bash" || tool.name === "shell" || !!tool.execution;
+        }
+        if (tool.args) record.args = String(tool.args);
+        if (tool.fileDiff) {
+          record.fileDiff = tool.fileDiff;
+          workflow.diffs[String(tool.fileDiff.path || key)] = tool.fileDiff;
+          lastDiff = tool.fileDiff;
+        }
+        if (tool.execution) record.execution = tool.execution;
+        if (kind === "tool_start") {
+          record.state = "running";
+        } else if (kind === "tool_result") {
+          record.output = String(tool.output || "").slice(0, MAX_RENDER_CHARS);
+          record.err = String(tool.err || "").slice(0, MAX_RENDER_CHARS);
+          record.truncated = !!tool.truncated;
+          record.state = record.err ? "failed" : "done";
+        } else {
+          var chunk = String(tool.output || "");
+          if (record.progress.length < MAX_RENDER_CHARS) record.progress += chunk.slice(0, MAX_RENDER_CHARS - record.progress.length);
+          else if (chunk) record.truncated = true;
+          record.output = record.progress;
+          record.state = "running";
+        }
+        if (record.card) renderTool(record.card, record); // keep an existing history card in sync
+        return;
+      }
+      if (payload.type === "cache_status") { updateCacheView(data); return; }
+      if (payload.type === "task_status" && data.code === "semantix_reuse") updateCacheView(data);
+    });
+    renderDiffList();
+    renderTerminalList();
+    renderReviewList();
+    if (lastDiff) renderContextDiff(lastDiff);
   }
 
   function connectWorkspaceEvents() {
@@ -1400,7 +1523,12 @@
     workspaceEvents.addEventListener("open", function () {
       if (hydrated) return;
       hydrated = true;
-      hydrateHistory();
+      // Fetch the retained window before hydrating /history so replay frames
+      // (which only rebuild panels, never timeline cards) land between the
+      // /history render and the buffered-live flush, deduplicating by seq.
+      loadWorkspaceReplay().then(function (frames) {
+        return hydrateHistory(frames);
+      });
     });
     workspaceEvents.addEventListener("error", function () {
       if (!hydrated) hydrateHistory();
@@ -1529,9 +1657,12 @@
       meta.textContent = (s.turns ? s.turns + " 轮" : "") + (updated ? " · " + updated : "");
 
       var stateKey = sessionStatus(s);
+      // Forward-compatible guard: an unknown status must degrade to the
+      // neutral empty pill instead of throwing on TASK_PILLS[stateKey].
+      var pillStyle = TASK_PILLS[stateKey] || TASK_PILLS.empty;
       var pill = document.createElement("span");
-      pill.className = "ws-state-pill " + TASK_PILLS[stateKey][1];
-      pill.textContent = TASK_PILLS[stateKey][0];
+      pill.className = "ws-state-pill " + pillStyle[1];
+      pill.textContent = pillStyle[0];
 
       row.appendChild(dot);
       row.appendChild(title);

--- a/harness/serve/workspace_test.go
+++ b/harness/serve/workspace_test.go
@@ -465,3 +465,48 @@ func TestServeWorkspaceDesignTokens(t *testing.T) {
 		}
 	}
 }
+
+// TestServeWorkspacePanelRecoveryContract pins the epic #403 core-usability
+// fixes in the workspace shell:
+//   - the /sessions "recovered" status renders a pill instead of crashing the
+//     task list (TASK_PILLS key + defensive fallback);
+//   - the composer running latch is re-synced from /status when a turn ends or
+//     aborts instead of staying disabled forever;
+//   - a JSON replay window (/workspace/replay) rebuilds the Diff/Terminal/
+//     Review panels after a refresh without duplicating timeline cards.
+func TestServeWorkspacePanelRecoveryContract(t *testing.T) {
+	js := string(workspaceShellJS)
+	for _, want := range []string{
+		`recovered: ["待恢复", "ws-state-recovered"]`,
+		`TASK_PILLS[stateKey] || TASK_PILLS.empty`,
+		`function refreshRunningState`,
+		`refreshRunningState(); // #403: turn finished`,
+		`refreshRunningState(); // #403: turn aborted`,
+		`"/workspace/replay"`,
+		`function loadWorkspaceReplay`,
+		`function applyReplayFrames`,
+		`must NOT advance the shared lastEventSeq`,
+		`if (record.card) renderTool(record.card, record);`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("workspace shell.js missing %q", want)
+		}
+	}
+	// Replay must stay a panel-only projection: timeline user/assistant/tool
+	// cards are owned by /history + live frames, so applyReplayFrames may never
+	// create timeline cards (it only feeds workflow state into the context
+	// panels). The function is bounded by the next function declaration.
+	replayBody := strings.Split(strings.Split(js, "function applyReplayFrames")[1], "function connectWorkspaceEvents")[0]
+	for _, forbidden := range []string{`makeEvent(`, `el.timeline`, `addOptimisticUserMessage`} {
+		if strings.Contains(replayBody, forbidden) {
+			t.Errorf("applyReplayFrames must not render timeline cards, found %q", forbidden)
+		}
+	}
+
+	css := string(workspaceLayoutCSS)
+	for _, want := range []string{".ws-state-recovered", "var(--sx-orange-dim)", "var(--sx-orange-border)"} {
+		if !strings.Contains(css, want) {
+			t.Errorf("workspace layout.css missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
三个问题都来自 workspace GUI（harness/serve/workspace），修复后 epic #403 「创建/恢复/切换任务 + 实时面板」核心循环可用：

- Bug：一轮 turn 结束后 composer 永久禁用、cancel 常驻。sessionRunning 只在 refreshTasks 里赋值、turn_done/error 从不复位；新增 refreshRunningState() 从 /status 重新同步 running 状态（带乱序防护）并刷新当前行 pill。
- Bug：/sessions 对中断会话返回 status:"recovered"，TASK_PILLS 缺该键导致 renderTasks 抛 TypeError 整列崩溃；补「待恢复」pill + 未知状态防御回退。
- 缺口：Diff/终端/Review/缓存面板只投影实时帧，刷新/重连即丢。新增 GET /workspace/replay 返回 broadcaster 保留窗口（≤256 帧，与 SSE 同一 WebEnvelope/同序），前端 /history 渲染后以 panel-only 方式重建面板： 不新建 timeline 卡片（避免与 /history 重复）、不推进共享 lastEventSeq （缓冲中的 live 帧仍完整走原渲染路径，不丢进行中的文本）。

服务端改动最小且不改变 CLI 语义；新增契约/端点测试，go test ./harness/... 全部通过。

## Summary

<!-- Explain what this pull request changes and why. -->

## Scope

<!-- List the affected packages, commands, integrations, documentation, or site areas. -->

## Validation

<!-- List the exact checks you ran and their results. -->

- [ ] `go vet ./...`
- [ ] `go test ./... -race`
- [ ] `git diff --check`
- [ ] Additional checks are documented below, or are not applicable.

## Compatibility and data impact

<!-- Describe changes to CLI behavior, configuration, event contracts, stored slices, indexes, or supported platforms. Write "None" when there is no impact. -->

## Security and privacy

<!-- Describe changes to trust boundaries, persisted data, sanitization, scopes, retention, external requests, or side effects. Write "None" when there is no impact. -->

## Evidence

<!-- Add sanitized logs, benchmark results, screenshots, or before/after examples when relevant. -->

## Related issues

<!-- Use "Closes #123" or link the relevant issue. -->

## Checklist

- [ ] The change is focused and does not include unrelated work.
- [ ] Tests or documentation cover the changed behavior.
- [ ] User-facing behavior and examples are updated where needed.
- [ ] No credentials, private source code, personal data, or sensitive local paths are included.
- [ ] Wire-contract changes are additive and synchronized with `docs/events.md`.
