### PR TITLE
fix(memory): reject stale L2 slices and attribute outcomes

### DIFF
--- a/cmd/semantix/extract.go
+++ b/cmd/semantix/extract.go
@@ -25,6 +25,7 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 	project := flags.String("project", "", "project slug")
 	taskType := flags.String("task-type", "", "task type metadata")
 	language := flags.String("language", "", "language metadata")
+	baseCommit := flags.String("base-commit", "", "repository revision visible when the session ran")
 	fingerprintPaths := flags.String("fingerprint", "", "comma-separated relative paths to fingerprint (sha256) into each slice's Deps")
 	l3Safe := flags.Bool("l3-safe", false, "mark dependency-free Result slices as explicitly L3-reusable (opt-in; ignored when --fingerprint is set)")
 	embedder := flags.String("embedder", "hash", "embedder for stored slices: hash (default, zero-dependency) | model (remote OpenAI-compatible API; see SEMANTIX_EMBED_* env)")
@@ -60,6 +61,7 @@ func runExtract(args []string, stdout, stderr io.Writer, deps dependencies) erro
 		TaskType:      *taskType,
 		Language:      *language,
 		ProjectSlug:   *project,
+		BaseCommit:    strings.TrimSpace(*baseCommit),
 		Origin:        slice.OriginUserCurated, // Issue #279: explicit user action
 	}
 	if *fingerprintPaths != "" {

--- a/cmd/semantix/main_test.go
+++ b/cmd/semantix/main_test.go
@@ -120,6 +120,7 @@ func TestExtractStoresSlicesInSelectedScope(t *testing.T) {
 	code := run([]string{
 		"extract", "--input", input, "--scope", "user", "--db", dbPath,
 		"--session", "session-1", "--project", "semantix", "--language", "zh-CN",
+		"--base-commit", "abc123",
 	}, &stdout, &stderr, deps)
 	if code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
@@ -127,7 +128,7 @@ func TestExtractStoresSlicesInSelectedScope(t *testing.T) {
 	if openedPath != dbPath {
 		t.Fatalf("opened path = %q, want %q", openedPath, dbPath)
 	}
-	if extractor.meta.SourceSession != "session-1" || extractor.meta.ProjectSlug != "semantix" || extractor.meta.Language != "zh-CN" {
+	if extractor.meta.SourceSession != "session-1" || extractor.meta.ProjectSlug != "semantix" || extractor.meta.Language != "zh-CN" || extractor.meta.BaseCommit != "abc123" {
 		t.Fatalf("extractor meta = %#v", extractor.meta)
 	}
 	for _, id := range []string{"one", "two"} {

--- a/harness/boot/boot.go
+++ b/harness/boot/boot.go
@@ -297,15 +297,16 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	// the sink unchanged (zero overhead on the hot path); a broken kernel
 	// degrades fail-open, never blocking the main loop.
 	semantixBridge := semantix.NewBridge(semantix.Config{
-		Enabled:     cfg.Semantix.Enabled && !opts.Ablation.Off(ablation.Kernel),
-		Binary:      cfg.Semantix.Binary,
-		Inject:      cfg.Semantix.Inject,
-		Mode:        cfg.Semantix.Mode,
-		Budget:      cfg.Semantix.Budget,
-		SessionsDir: cfg.Semantix.SessionsDir,
-		ProjectDir:  cfg.Semantix.ProjectDir,
-		CostMissUSD: cfg.Semantix.CostInputPriceUSD,
-		CostHitUSD:  cfg.Semantix.CostCachePriceUSD,
+		Enabled:      cfg.Semantix.Enabled && !opts.Ablation.Off(ablation.Kernel),
+		Binary:       cfg.Semantix.Binary,
+		Inject:       cfg.Semantix.Inject,
+		Mode:         cfg.Semantix.Mode,
+		Budget:       cfg.Semantix.Budget,
+		SessionsDir:  cfg.Semantix.SessionsDir,
+		ProjectDir:   cfg.Semantix.ProjectDir,
+		WorkspaceDir: cfg.Semantix.WorkspaceDir,
+		CostMissUSD:  cfg.Semantix.CostInputPriceUSD,
+		CostHitUSD:   cfg.Semantix.CostCachePriceUSD,
 	})
 	sink = semantixBridge.Sink(sink)
 	defer semantixBridge.Close()

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -973,6 +973,9 @@ type SemantixConfig struct {
 	// directory to share a slice library across workspaces (e.g. benchmark
 	// arms measuring cross-session reuse).
 	ProjectDir string `toml:"project_dir"`
+	// WorkspaceDir is the live repository used for commit and dependency
+	// freshness checks. It may differ from ProjectDir when stores are shared.
+	WorkspaceDir string `toml:"workspace_dir"`
 	// CostInputPriceUSD / CostCachePriceUSD override the usage cost model
 	// prices (USD per 1M tokens at cache miss / hit) used by the reuse panel
 	// savings delta. Zero keeps the kernel defaults — mirror semantix.toml

--- a/harness/config/render.go
+++ b/harness/config/render.go
@@ -543,6 +543,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	if c.Semantix.ProjectDir != "" {
 		fmt.Fprintf(&b, "project_dir = %q   # shared slice library root (<dir>/.semantix/...)\n", c.Semantix.ProjectDir)
 	}
+	if c.Semantix.WorkspaceDir != "" {
+		fmt.Fprintf(&b, "workspace_dir = %q # live repository root for freshness checks\n", c.Semantix.WorkspaceDir)
+	}
 	if c.Semantix.CostInputPriceUSD != 0 {
 		fmt.Fprintf(&b, "cost_input_price_usd = %s\n", formatFloat(c.Semantix.CostInputPriceUSD))
 	}

--- a/harness/event/event.go
+++ b/harness/event/event.go
@@ -573,6 +573,7 @@ type RetrievalCandidate struct {
 	Type          string  `json:"type,omitempty"`
 	SourceSession string  `json:"sourceSession,omitempty"`
 	Project       string  `json:"project,omitempty"`
+	BaseCommit    string  `json:"baseCommit,omitempty"`
 	Origin        string  `json:"origin,omitempty"`
 	Verified      string  `json:"verified,omitempty"`
 	Score         float64 `json:"score,omitempty"`

--- a/harness/eventwire/wire.go
+++ b/harness/eventwire/wire.go
@@ -84,6 +84,7 @@ type RetrievalCandidate struct {
 	Type          string  `json:"type,omitempty"`
 	SourceSession string  `json:"sourceSession,omitempty"`
 	Project       string  `json:"project,omitempty"`
+	BaseCommit    string  `json:"baseCommit,omitempty"`
 	Origin        string  `json:"origin,omitempty"`
 	Verified      string  `json:"verified,omitempty"`
 	Score         float64 `json:"score,omitempty"`
@@ -323,7 +324,7 @@ func toWireRetrieval(in *event.RetrievalDiagnostics) *RetrievalDiagnostics {
 	}
 	for _, c := range in.Candidates {
 		out.Candidates = append(out.Candidates, RetrievalCandidate{
-			ID: c.ID, Type: c.Type, SourceSession: c.SourceSession, Project: c.Project,
+			ID: c.ID, Type: c.Type, SourceSession: c.SourceSession, Project: c.Project, BaseCommit: c.BaseCommit,
 			Origin: c.Origin, Verified: c.Verified, Score: c.Score, Coverage: c.Coverage,
 			Zone: c.Zone, Admitted: c.Admitted, Reason: c.Reason,
 		})

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -55,6 +55,9 @@ type Config struct {
 	// log resolve against (kernel CLI semantics: <dir>/.semantix/...).
 	// Empty uses the process working directory.
 	ProjectDir string
+	// WorkspaceDir is the live repository used for commit/dependency checks.
+	// Empty falls back to ProjectDir for normal non-benchmark runs.
+	WorkspaceDir string
 	// CostMissUSD / CostHitUSD are the usage cost model prices (USD per 1M
 	// tokens at cache miss / hit) for the reuse panel savings delta.
 	// Zero keeps the kernel defaults (usage.DefaultCost*PerMTok).
@@ -273,12 +276,15 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		return InjectResult{}
 	}
 	z := zone.Default()
+	workspaceDir := b.workspaceDir()
 	inj, err := (&inject.Injector{
 		Index:                idx,
 		Scope:                slice.Project,
 		K:                    5,
 		Budget:               budget,
 		AllowedTypes:         strictAllowedTypes,
+		RootDir:              workspaceDir,
+		CurrentCommit:        readGitHead(workspaceDir),
 		LibrarySize:          len(projectSlices),
 		MinLibrarySize:       strictMinLibrarySize,
 		SourceSessionsByType: sourceSessionCounts(projectSlices),
@@ -337,7 +343,7 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 }
 
 func (b *Bridge) retrievalDiagnostics(query string, retrievalQuery RetrievalQuery, library []*slice.Slice, hits []slice.Hit, inj *inject.Injection) *event.RetrievalDiagnostics {
-	projectDir := b.projectDir()
+	projectDir := b.workspaceDir()
 	d := &event.RetrievalDiagnostics{
 		Mode: string(b.mode), LibrarySize: len(library), Repo: filepath.Base(filepath.Clean(projectDir)),
 		BaseCommit: readGitHead(projectDir), QueryBefore: summarizeQuery(query), QueryAfter: summarizeQuery(retrievalQuery.Text),
@@ -362,6 +368,7 @@ func (b *Bridge) retrievalDiagnostics(query string, retrievalQuery RetrievalQuer
 			candidate.Type = sl.Type.String()
 			candidate.SourceSession = sl.Meta.SourceSession
 			candidate.Project = sl.Meta.ProjectSlug
+			candidate.BaseCommit = sl.Meta.BaseCommit
 			candidate.Origin = string(sl.Meta.Origin)
 			if sl.Type == slice.Result {
 				candidate.Verified = string(sl.Meta.EffectiveResultStatus())
@@ -665,6 +672,13 @@ func (b *Bridge) projectDir() string {
 		return "."
 	}
 	return wd
+}
+
+func (b *Bridge) workspaceDir() string {
+	if strings.TrimSpace(b.cfg.WorkspaceDir) != "" {
+		return b.cfg.WorkspaceDir
+	}
+	return b.projectDir()
 }
 
 // usagePath is the kernel usage log the reuse panel savings delta reads.

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -498,7 +498,22 @@ func (b *Bridge) recordInjection(ids []string, bytes int) {
 // every injected slice that was active when the harness loop guard fired. IDs
 // are canonicalized so one fuse increments each slice exactly once.
 func (b *Bridge) RecordInjectionReject(ids []string, reason string) {
+	b.recordInjectionOutcome(ids, "harmful", reason, true)
+}
+
+// RecordInjectionOutcome persists an evaluator/guard observation for each
+// injected slice. Unsupported outcomes are ignored rather than inventing a
+// category; callers must supply useful, neutral, or harmful.
+func (b *Bridge) RecordInjectionOutcome(ids []string, outcome, reason string) {
+	b.recordInjectionOutcome(ids, outcome, reason, false)
+}
+
+func (b *Bridge) recordInjectionOutcome(ids []string, outcome, reason string, legacyReject bool) {
 	if b == nil || !b.Enabled() || len(ids) == 0 {
+		return
+	}
+	outcome = strings.ToLower(strings.TrimSpace(outcome))
+	if outcome != "useful" && outcome != "neutral" && outcome != "harmful" {
 		return
 	}
 	ids = append([]string(nil), ids...)
@@ -520,7 +535,17 @@ func (b *Bridge) RecordInjectionReject(ids []string, reason string) {
 	if store, err := slice.NewFileStore(filepath.Join(b.projectDir(), ".semantix", "project.db")); err == nil {
 		deltas := make(map[string]slice.SliceStats, len(unique))
 		for _, id := range unique {
-			deltas[id] = slice.SliceStats{Rejected: 1, LastUsed: now.Unix()}
+			delta := slice.SliceStats{LastUsed: now.Unix()}
+			switch outcome {
+			case "useful":
+				delta.Useful = 1
+			case "neutral":
+				delta.Neutral = 1
+			case "harmful":
+				delta.Harmful = 1
+				delta.Rejected = 1
+			}
+			deltas[id] = delta
 		}
 		_ = slice.ApplyStats(store, deltas)
 		closeSliceStore(store)
@@ -529,9 +554,15 @@ func (b *Bridge) RecordInjectionReject(ids []string, reason string) {
 	session := b.label
 	b.mu.Unlock()
 	for _, id := range unique {
-		data, err := json.Marshal(kernelevent.SliceRejectPayload{SliceID: id, Reason: reason})
+		data, err := json.Marshal(kernelevent.SliceOutcomePayload{SliceID: id, Outcome: outcome, Reason: reason})
 		if err == nil {
-			b.events.Emit(kernelevent.Event{Kind: kernelevent.SliceReject, SessionID: session, At: now, Data: data})
+			b.events.Emit(kernelevent.Event{Kind: kernelevent.SliceOutcome, SessionID: session, At: now, Data: data})
+		}
+		if legacyReject {
+			data, err = json.Marshal(kernelevent.SliceRejectPayload{SliceID: id, Reason: reason})
+			if err == nil {
+				b.events.Emit(kernelevent.Event{Kind: kernelevent.SliceReject, SessionID: session, At: now, Data: data})
+			}
 		}
 	}
 }

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -108,7 +108,14 @@ func TestFormatUSD(t *testing.T) {
 // Returns the project dir (pass as Config.ProjectDir).
 func writeKernelDir(t *testing.T, slicesIn []*slice.Slice, usageLines []string) string {
 	t.Helper()
+	const fixtureCommit = "1111111111111111111111111111111111111111"
 	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte(fixtureCommit+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	kernelDir := filepath.Join(dir, ".semantix")
 	if err := os.MkdirAll(kernelDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -118,6 +125,9 @@ func writeKernelDir(t *testing.T, slicesIn []*slice.Slice, usageLines []string) 
 		t.Fatal(err)
 	}
 	for _, s := range slicesIn {
+		if s.Meta.BaseCommit == "" {
+			s.Meta.BaseCommit = fixtureCommit
+		}
 		if err := store.Put(s); err != nil {
 			t.Fatal(err)
 		}

--- a/harness/semantix/reuse_test.go
+++ b/harness/semantix/reuse_test.go
@@ -313,8 +313,42 @@ func TestBridgeRecordInjectionRejectUpdatesSlicesAndEmitsEvents(t *testing.T) {
 	}
 	defer closeSliceStore(store)
 	got, err := store.Get("ctx-strong")
-	if err != nil || got.Stats.Rejected != 1 {
+	if err != nil || got.Stats.Rejected != 1 || got.Stats.Harmful != 1 {
 		t.Fatalf("slice after reject = %+v, %v", got, err)
+	}
+}
+
+func TestBridgeRecordInjectionOutcomeAttributesUsefulAndNeutral(t *testing.T) {
+	dir := writeKernelDir(t, admissionFixtureSlices(), nil)
+	b := NewBridge(Config{Enabled: true, Mode: "strict", ProjectDir: dir})
+	defer b.Close()
+	var outcomes []kernelevent.SliceOutcomePayload
+	unsub := b.Events().Subscribe(func(e kernelevent.Event) {
+		if e.Kind == kernelevent.SliceOutcome {
+			var payload kernelevent.SliceOutcomePayload
+			if json.Unmarshal(e.Data, &payload) == nil {
+				outcomes = append(outcomes, payload)
+			}
+		}
+	})
+	defer unsub()
+
+	b.RecordInjectionOutcome([]string{"ctx-strong", "ctx-strong"}, "useful", "resolved_fewer_steps")
+	b.RecordInjectionOutcome([]string{"ctx-runner"}, "neutral", "no_measurable_delta")
+	b.RecordInjectionOutcome([]string{"ctx-runner"}, "unsupported", "ignored")
+
+	store, err := slice.NewFileStore(filepath.Join(dir, ".semantix", "project.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeSliceStore(store)
+	useful, _ := store.Get("ctx-strong")
+	neutral, _ := store.Get("ctx-runner")
+	if useful.Stats.Useful != 1 || neutral.Stats.Neutral != 1 {
+		t.Fatalf("outcome stats useful=%+v neutral=%+v", useful.Stats, neutral.Stats)
+	}
+	if len(outcomes) != 2 || outcomes[0].Outcome != "useful" || outcomes[0].Reason != "resolved_fewer_steps" {
+		t.Fatalf("outcome events = %+v", outcomes)
 	}
 }
 

--- a/kernel/event/event.go
+++ b/kernel/event/event.go
@@ -40,6 +40,8 @@ const (
 	EvolutionTick
 	// ResourceCatalog reports the harness resource inventory.
 	ResourceCatalog
+	// SliceOutcome attributes an observed post-injection outcome and reason.
+	SliceOutcome
 
 	// KindCount is the sentinel for validation and tests.
 	KindCount
@@ -112,6 +114,13 @@ type SliceInjectPayload struct {
 // SliceRejectPayload reports injection pollution.
 type SliceRejectPayload struct {
 	SliceID string `json:"slice_id"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// SliceOutcomePayload reports a useful, neutral, or harmful injection outcome.
+type SliceOutcomePayload struct {
+	SliceID string `json:"slice_id"`
+	Outcome string `json:"outcome"`
 	Reason  string `json:"reason,omitempty"`
 }
 

--- a/kernel/event/event_test.go
+++ b/kernel/event/event_test.go
@@ -33,6 +33,7 @@ func TestRoundTripAllKinds(t *testing.T) {
 			Models: []ResourceModel{{ID: "flash-model", Tier: "flash", InputPrice: 0.1, OutputPrice: 0.2}},
 			Budget: ResourceBudget{LimitUSD: 1, SpentUSD: 0.25, Window: "session"},
 		}},
+		{SliceOutcome, SliceOutcomePayload{SliceID: "s1", Outcome: "useful", Reason: "resolved_fewer_steps"}},
 	}
 	for _, c := range cases {
 		data, err := json.Marshal(c.data)
@@ -63,8 +64,8 @@ func TestRoundTripAllKinds(t *testing.T) {
 }
 
 func TestResourceCatalogAppendedAfterEvolutionTick(t *testing.T) {
-	if ResourceCatalog != EvolutionTick+1 || KindCount != ResourceCatalog+1 {
-		t.Fatalf("event kinds must be append-only: evolution=%d catalog=%d count=%d", EvolutionTick, ResourceCatalog, KindCount)
+	if ResourceCatalog != EvolutionTick+1 || SliceOutcome != ResourceCatalog+1 || KindCount != SliceOutcome+1 {
+		t.Fatalf("event kinds must be append-only: evolution=%d catalog=%d outcome=%d count=%d", EvolutionTick, ResourceCatalog, SliceOutcome, KindCount)
 	}
 	// A wire event written before ResourceCatalog existed must retain its kind.
 	old, err := FromJSON([]byte(`{"kind":11,"session_id":"old","at":"2026-08-07T12:00:00Z"}`))

--- a/kernel/inject/freshness_test.go
+++ b/kernel/inject/freshness_test.go
@@ -1,0 +1,77 @@
+package inject
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"semantix/kernel/fingerprint"
+	"semantix/kernel/slice"
+)
+
+func freshnessDecision(t *testing.T, in *Injector, sl *slice.Slice) CandidateDecision {
+	t.Helper()
+	out, err := in.BuildHits("cache repair", []slice.Hit{{Slice: sl, Score: 2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Decisions) != 1 {
+		t.Fatalf("decisions = %+v", out.Decisions)
+	}
+	return out.Decisions[0]
+}
+
+func TestStrictFreshnessAdmission(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "pkg", "cache.go")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("package cache\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deps, err := fingerprint.Capture(root, []string{"pkg/cache.go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := &Injector{
+		Budget: 4096, AllowedTypes: map[slice.SliceType]bool{slice.Context: true},
+		RootDir: root, CurrentCommit: "current",
+	}
+	cases := []struct {
+		name string
+		meta slice.SliceMeta
+		want string
+	}{
+		{"missing provenance", slice.SliceMeta{}, "commit_unknown"},
+		{"same commit", slice.SliceMeta{BaseCommit: "current"}, "admitted"},
+		{"mismatch without dependencies", slice.SliceMeta{BaseCommit: "old"}, "stale_commit"},
+		{"mismatch with matching dependency", slice.SliceMeta{BaseCommit: "old", Deps: deps}, "admitted"},
+		{"missing dependency", slice.SliceMeta{BaseCommit: "old", Deps: fingerprint.Deps{"pkg/missing.go": "abc"}}, "path_missing"},
+		{"unsafe dependency", slice.SliceMeta{BaseCommit: "old", Deps: fingerprint.Deps{"../outside": "abc"}}, "dependency_path_invalid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sl := &slice.Slice{ID: tc.name, Type: slice.Context, Scope: slice.Project, Content: []byte("cache repair"), Meta: tc.meta}
+			if got := freshnessDecision(t, in, sl).Reason; got != tc.want {
+				t.Fatalf("reason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	if err := os.WriteFile(path, []byte("package cache\n// changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed := &slice.Slice{ID: "changed", Type: slice.Context, Scope: slice.Project, Content: []byte("cache repair"), Meta: slice.SliceMeta{BaseCommit: "old", Deps: deps}}
+	if got := freshnessDecision(t, in, changed).Reason; got != "dependency_changed" {
+		t.Fatalf("changed dependency reason = %q", got)
+	}
+}
+
+func TestStrictFreshnessRejectsUnknownCurrentCommit(t *testing.T) {
+	in := &Injector{Budget: 4096, AllowedTypes: map[slice.SliceType]bool{slice.Context: true}, RootDir: t.TempDir()}
+	sl := &slice.Slice{ID: "ctx", Type: slice.Context, Scope: slice.Project, Content: []byte("cache repair"), Meta: slice.SliceMeta{BaseCommit: "old"}}
+	if got := freshnessDecision(t, in, sl).Reason; got != "current_commit_unknown" {
+		t.Fatalf("reason = %q", got)
+	}
+}

--- a/kernel/inject/inject.go
+++ b/kernel/inject/inject.go
@@ -16,11 +16,14 @@ package inject
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
 
 	"semantix/kernel/bm25"
+	"semantix/kernel/fingerprint"
 	"semantix/kernel/sanitize"
 	"semantix/kernel/slice"
 	"semantix/kernel/zone"
@@ -84,6 +87,10 @@ type Injector struct {
 	// AllowedTypes, when non-nil, is a fail-closed injection allowlist. Search
 	// results outside it remain in Decisions for shadow analysis.
 	AllowedTypes map[slice.SliceType]bool
+	// RootDir and CurrentCommit enable strict source-freshness admission.
+	// Callers that leave both empty retain the generic injector behavior.
+	RootDir       string
+	CurrentCommit string
 	// LibrarySize and MinLibrarySize gate immature Project libraries.
 	LibrarySize    int
 	MinLibrarySize int
@@ -141,7 +148,9 @@ type Injection struct {
 // slice. Reason is a stable enum: admitted, below_min_score, zone_grey,
 // zone_miss, sanitized_empty, origin_below_floor, budget, nil_slice,
 // type_not_allowed, library_too_small, type_sources_too_few,
-// runner_up_missing, top_margin_low, or coverage_low.
+// runner_up_missing, top_margin_low, coverage_low, current_commit_unknown,
+// commit_unknown, stale_commit, path_missing, dependency_path_invalid, or
+// dependency_changed.
 type CandidateDecision struct {
 	ID       string
 	Score    float64
@@ -179,8 +188,12 @@ func (in *Injector) BuildHits(query string, hits []slice.Hit) (*Injection, error
 		budget = DefaultBudget
 	}
 	eligibleScores := make([]float64, 0, len(hits))
+	freshnessReasons := make(map[*slice.Slice]string, len(hits))
 	for _, h := range hits {
-		if h.Slice != nil && in.admissionTypeEligible(h.Slice) {
+		if h.Slice != nil {
+			freshnessReasons[h.Slice] = in.freshnessReason(h.Slice)
+		}
+		if h.Slice != nil && in.admissionTypeEligible(h.Slice) && freshnessReasons[h.Slice] == "" {
 			eligibleScores = append(eligibleScores, h.Score)
 		}
 	}
@@ -227,6 +240,12 @@ func (in *Injector) BuildHits(query string, hits []slice.Hit) (*Injection, error
 		}
 		if in.AllowedTypes != nil && h.Slice.Type == slice.Result && h.Slice.Meta.EffectiveResultStatus() != slice.ResultStatusVerified {
 			d.Reason = "result_probation"
+			decisions = append(decisions, d)
+			dropped++
+			continue
+		}
+		if reason := freshnessReasons[h.Slice]; reason != "" {
+			d.Reason = reason
 			decisions = append(decisions, d)
 			dropped++
 			continue
@@ -386,8 +405,8 @@ func formatSliceItem(sl *slice.Slice, score float64, content string, grey bool) 
 		verified = string(sl.Meta.EffectiveResultStatus())
 	}
 	provenance := fmt.Sprintf(
-		"type=%s project=%q source=%q origin=%s verified=%s score=%.4f created_at=%d\n",
-		sl.Type.String(), sl.Meta.ProjectSlug, sl.Meta.SourceSession, sl.Meta.Origin, verified, score, sl.CreatedAt,
+		"type=%s project=%q source=%q commit=%q origin=%s verified=%s score=%.4f created_at=%d\n",
+		sl.Type.String(), sl.Meta.ProjectSlug, sl.Meta.SourceSession, sl.Meta.BaseCommit, sl.Meta.Origin, verified, score, sl.CreatedAt,
 	)
 	return header + provenance + content + "\n"
 }
@@ -401,4 +420,46 @@ func (in *Injector) admissionTypeEligible(sl *slice.Slice) bool {
 		return false
 	}
 	return in.AllowedTypes == nil || sl.Type != slice.Result || sl.Meta.EffectiveResultStatus() == slice.ResultStatusVerified
+}
+
+func (in *Injector) freshnessReason(sl *slice.Slice) string {
+	if sl == nil || (in.RootDir == "" && in.CurrentCommit == "") {
+		return ""
+	}
+	if in.CurrentCommit == "" {
+		return "current_commit_unknown"
+	}
+	if sl.Meta.BaseCommit == "" {
+		return "commit_unknown"
+	}
+	if sl.Meta.BaseCommit != in.CurrentCommit && len(sl.Meta.Deps) == 0 {
+		return "stale_commit"
+	}
+	if len(sl.Meta.Deps) == 0 {
+		return ""
+	}
+
+	paths := make([]string, 0, len(sl.Meta.Deps))
+	for path := range sl.Meta.Deps {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		if !filepath.IsLocal(path) {
+			return "dependency_path_invalid"
+		}
+		fullPath := filepath.Join(in.RootDir, path)
+		info, err := os.Lstat(fullPath)
+		if os.IsNotExist(err) {
+			return "path_missing"
+		}
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return "dependency_path_invalid"
+		}
+	}
+	changed, err := fingerprint.Verify(in.RootDir, sl.Meta.Deps)
+	if err != nil || len(changed) > 0 {
+		return "dependency_changed"
+	}
+	return ""
 }

--- a/kernel/inject/inject.go
+++ b/kernel/inject/inject.go
@@ -444,20 +444,38 @@ func (in *Injector) freshnessReason(sl *slice.Slice) string {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
+	root, err := filepath.Abs(in.RootDir)
+	if err != nil {
+		return "dependency_path_invalid"
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return "dependency_path_invalid"
+	}
 	for _, path := range paths {
 		if !filepath.IsLocal(path) {
 			return "dependency_path_invalid"
 		}
-		fullPath := filepath.Join(in.RootDir, path)
-		info, err := os.Lstat(fullPath)
-		if os.IsNotExist(err) {
-			return "path_missing"
-		}
-		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-			return "dependency_path_invalid"
+		parts := strings.Split(filepath.Clean(filepath.FromSlash(path)), string(filepath.Separator))
+		current := root
+		for i, part := range parts {
+			current = filepath.Join(current, part)
+			info, err := os.Lstat(current)
+			if os.IsNotExist(err) {
+				return "path_missing"
+			}
+			if err != nil || info.Mode()&os.ModeSymlink != 0 {
+				return "dependency_path_invalid"
+			}
+			if i < len(parts)-1 && !info.IsDir() {
+				return "dependency_path_invalid"
+			}
+			if i == len(parts)-1 && !info.Mode().IsRegular() {
+				return "dependency_path_invalid"
+			}
 		}
 	}
-	changed, err := fingerprint.Verify(in.RootDir, sl.Meta.Deps)
+	changed, err := fingerprint.Verify(root, sl.Meta.Deps)
 	if err != nil || len(changed) > 0 {
 		return "dependency_changed"
 	}

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -145,6 +145,8 @@ type SliceMeta struct {
 	TaskType      string
 	Language      string
 	ProjectSlug   string
+	// BaseCommit is the repository revision visible when the source session ran.
+	BaseCommit string `json:"base_commit,omitempty"`
 	// Origin is the provenance/trust tag (Issue #279): writing channels
 	// stamp it, injection and the L3 gate check its integrity level.
 	// Empty means unlabelled (legacy) — treated as the lowest level

--- a/kernel/slice/slice.go
+++ b/kernel/slice/slice.go
@@ -107,6 +107,9 @@ type SliceStats struct {
 	Misses       uint64
 	Injected     uint64
 	Rejected     uint64
+	Useful       uint64
+	Neutral      uint64
+	Harmful      uint64
 	UserFeedback float64 // +1 keep / -1 reject / 0 none
 	// LastUsed is the unix-seconds time this slice last served a hit or an
 	// injection. 0 = never used (or legacy line without the field). Unlike
@@ -133,6 +136,9 @@ func mergeStats(cur *SliceStats, delta SliceStats) {
 	cur.Misses += delta.Misses
 	cur.Injected += delta.Injected
 	cur.Rejected += delta.Rejected
+	cur.Useful += delta.Useful
+	cur.Neutral += delta.Neutral
+	cur.Harmful += delta.Harmful
 	cur.UserFeedback += delta.UserFeedback
 	if delta.LastUsed > cur.LastUsed {
 		cur.LastUsed = delta.LastUsed

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -161,6 +161,23 @@ A 不读取 seed；断点续跑通过 `.seed-source.json` 识别已经完成的�
 未知历史与冻结语料混在一起。发布实验结果时应同时保存 seed 生成命令、输入 session
 列表和 repo 顺序。
 
+矩阵启动前先执行 fail-closed 预检；它逐 repo 检查 store 是否存在、library 是否达到
+strict 的最小规模、同类型来源 session 是否达到门槛，以及可注入切片是否携带
+`base_commit`。退出码 `0` 才进入真实评测，退出码 `3` 表示 seed 尚未就绪：
+
+```bash
+python3 validate_memory_seed.py \
+  --seed-dir state/issue447-frozen-seed \
+  --dataset data/swebench_verified.jsonl \
+  --ids subsets/verified-50-s20260824.txt \
+  --json-out results/issue447-seed-validation.json
+```
+
+runner 从 session mirror 的文件参数中提取仍位于 workspace 内的普通文件，并在 extraction
+时写入 SHA-256 dependency fingerprint 与当前 `base_commit`。strict retrieval 在提交不同
+且没有依赖证明、依赖缺失/越界/变化或 provenance 缺失时拒绝该切片；共享 `project_dir`
+不再被误当作实例的 git workspace。
+
 需要历史策略对照时，显式传入 `--legacy-semantix-bin`；该 binary 应固定构建自
 `cb5e9cc`（repo 隔离已合并、strict 仍为旧全类型策略），不能用 harness
 `--ablate all` 代替。矩阵 manifest 保存每个 run 的完整

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -86,6 +86,12 @@ def mirror_fingerprint_paths(mirror: Path, workspace: Path) -> list[str]:
             for child in value:
                 visit(child, key)
             return
+        if isinstance(value, str) and key in {"args", "arguments"}:
+            try:
+                visit(json.loads(value))
+            except json.JSONDecodeError:
+                pass
+            return
         if not isinstance(value, str) or key not in {
                 "path", "paths", "file", "files", "file_path", "filepath", "filename"}:
             return

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -72,6 +72,44 @@ def repo_store_key(inst: dict) -> str:
     return repo_identity(inst).replace("/", "__", 1)
 
 
+def mirror_fingerprint_paths(mirror: Path, workspace: Path) -> list[str]:
+    """Return existing regular workspace files named by tool-call arguments."""
+    workspace = workspace.resolve()
+    found: set[str] = set()
+
+    def visit(value, key: str = "") -> None:
+        if isinstance(value, dict):
+            for child_key, child in value.items():
+                visit(child, str(child_key).lower())
+            return
+        if isinstance(value, list):
+            for child in value:
+                visit(child, key)
+            return
+        if not isinstance(value, str) or key not in {
+                "path", "paths", "file", "files", "file_path", "filepath", "filename"}:
+            return
+        candidate = Path(value)
+        if not candidate.is_absolute():
+            candidate = workspace / candidate
+        try:
+            if candidate.is_symlink():
+                return
+            resolved = candidate.resolve(strict=True)
+            relative = resolved.relative_to(workspace)
+        except (OSError, ValueError):
+            return
+        if resolved.is_file():
+            found.add(relative.as_posix())
+
+    for line in mirror.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            visit(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return sorted(found)
+
+
 class CountProxy:
     """Per-instance metering proxy (count_proxy.py) for harnesses whose own
     telemetry is unreliable. Records provider-reported usage to a ledger."""
@@ -283,8 +321,10 @@ class SemantixAdapter(Adapter):
     def kernel_dir_for(self, inst: dict) -> Path:
         return self.kernel_root / repo_store_key(inst)
 
-    def _write_home(self, home: Path, sessions_dir: Path, kernel_dir: Path | None) -> None:
+    def _write_home(self, home: Path, sessions_dir: Path, kernel_dir: Path | None,
+                    workspace_dir: Path | None = None) -> None:
         home.mkdir(parents=True, exist_ok=True)
+        workspace_dir = workspace_dir or Path.cwd()
         # Provider keys resolve ONLY from Semantix's global .env (never the
         # process environment) — see ProviderEntry.APIKey in harness/config.
         env_file = home / ".env"
@@ -307,6 +347,7 @@ inject       = true
 mode         = "{self.args.semantix_retrieval_mode}"
 budget       = 4096
 project_dir  = "{kernel_dir}"
+workspace_dir = "{workspace_dir}"
 sessions_dir = "{sessions_dir}"
 '''
         (home / "config.toml").write_text(
@@ -338,7 +379,7 @@ context_window = 128000
         sessions_dir = home / "kernel-sessions"
         repo = repo_identity(inst) if self.memory_on else ""
         kernel_dir = self.kernel_dir_for(inst) if self.memory_on else None
-        self._write_home(home, sessions_dir, kernel_dir)
+        self._write_home(home, sessions_dir, kernel_dir, ws)
         env = clean_env()
         env.update({
             "SEMANTIX_HOME": str(home),
@@ -387,11 +428,13 @@ context_window = 128000
             raw["semantix_repo"] = repo
             raw["semantix_project_dir"] = str(kernel_dir)
             raw["extract"] = self._extract_slices(
-                sessions_dir, inst["instance_id"], kernel_dir, repo)
+                sessions_dir, inst["instance_id"], kernel_dir, repo, ws,
+                inst.get("base_commit", ""))
         return exit_code, raw, err
 
     def _extract_slices(self, sessions_dir: Path, instance_id: str,
-                        kernel_dir: Path, repo: str) -> dict:
+                        kernel_dir: Path, repo: str, workspace: Path,
+                        base_commit: str) -> dict:
         """Close the memory loop: distill this instance's session mirrors into
         the repo-isolated slice library so later same-repo instances can retrieve them. The
         agent never extracts on its own (extraction is `semantix extract` /
@@ -403,15 +446,22 @@ context_window = 128000
         out = {"mirrors": len(mirrors), "runs": []}
         db = kernel_dir / ".semantix" / "project.db"
         for mirror in mirrors:
+            fingerprints = mirror_fingerprint_paths(mirror, workspace)
             ecmd = [self.kernel_bin, "extract",
                     "--input", str(mirror),
                     "--scope", "project",
                     "--project-db", str(db),
                     "--session", instance_id,
                     "--project", repo]
+            if base_commit:
+                ecmd += ["--base-commit", base_commit]
+            if fingerprints:
+                ecmd += ["--fingerprint", ",".join(fingerprints)]
             try:
-                ep = subprocess.run(ecmd, capture_output=True, text=True, timeout=120)
+                ep = subprocess.run(ecmd, capture_output=True, text=True, timeout=120,
+                                    cwd=workspace)
                 out["runs"].append({"mirror": mirror.name, "exit": ep.returncode,
+                                    "fingerprints": fingerprints,
                                     "out": (ep.stdout or ep.stderr).strip()[-300:]})
             except Exception as exc:  # extraction is best-effort, never fails the instance
                 out["runs"].append({"mirror": mirror.name, "error": str(exc)[:200]})

--- a/scripts/swebench/test_repo_isolation.py
+++ b/scripts/swebench/test_repo_isolation.py
@@ -173,9 +173,12 @@ class RepoStoreTests(unittest.TestCase):
             self.assertEqual(flask_dir.name, "pallets__flask")
 
             home = root / "home"
-            adapter._write_home(home, root / "sessions", django_dir)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            adapter._write_home(home, root / "sessions", django_dir, workspace)
             config = (home / "config.toml").read_text()
             self.assertIn(f'project_dir  = "{django_dir}"', config)
+            self.assertIn(f'workspace_dir = "{workspace}"', config)
             self.assertNotIn(str(flask_dir), config)
 
     def test_extraction_uses_same_repo_store_and_real_project_identity(self):
@@ -184,16 +187,25 @@ class RepoStoreTests(unittest.TestCase):
             adapter = self.adapter(root)
             sessions = root / "sessions"
             sessions.mkdir()
-            (sessions / "turn.jsonl").write_text("{}\n")
+            workspace = root / "workspace"
+            source = workspace / "pkg" / "cache.py"
+            source.parent.mkdir(parents=True)
+            source.write_text("value = 1\n", encoding="utf-8")
+            (sessions / "turn.jsonl").write_text(
+                '{"role":"assistant","tool_calls":[{"id":"1","name":"read_file",'
+                '"arguments":{"path":"pkg/cache.py"}}]}\n', encoding="utf-8")
             kernel_dir = adapter.kernel_dir_for(inst("d", "django/django"))
             completed = SimpleNamespace(returncode=0, stdout="stored=1", stderr="")
             with mock.patch("run_bench.subprocess.run", return_value=completed) as run:
-                result = adapter._extract_slices(sessions, "d", kernel_dir, "django/django")
+                result = adapter._extract_slices(
+                    sessions, "d", kernel_dir, "django/django", workspace, "abc123")
             self.assertEqual(result["mirrors"], 1)
             command = run.call_args.args[0]
             self.assertEqual(command[command.index("--project") + 1], "django/django")
             self.assertEqual(Path(command[command.index("--project-db") + 1]),
                              kernel_dir / ".semantix" / "project.db")
+            self.assertEqual(command[command.index("--base-commit") + 1], "abc123")
+            self.assertEqual(command[command.index("--fingerprint") + 1], "pkg/cache.py")
 
 
 if __name__ == "__main__":

--- a/scripts/swebench/test_repo_isolation.py
+++ b/scripts/swebench/test_repo_isolation.py
@@ -193,7 +193,7 @@ class RepoStoreTests(unittest.TestCase):
             source.write_text("value = 1\n", encoding="utf-8")
             (sessions / "turn.jsonl").write_text(
                 '{"role":"assistant","tool_calls":[{"id":"1","name":"read_file",'
-                '"arguments":{"path":"pkg/cache.py"}}]}\n', encoding="utf-8")
+                '"arguments":"{\\"path\\":\\"pkg/cache.py\\"}"}]}\n', encoding="utf-8")
             kernel_dir = adapter.kernel_dir_for(inst("d", "django/django"))
             completed = SimpleNamespace(returncode=0, stdout="stored=1", stderr="")
             with mock.patch("run_bench.subprocess.run", return_value=completed) as run:

--- a/scripts/swebench/test_validate_memory_seed.py
+++ b/scripts/swebench/test_validate_memory_seed.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import tempfile
 import unittest
 from pathlib import Path
@@ -15,7 +16,9 @@ class ValidateMemorySeedTest(unittest.TestCase):
         db = root / "seed" / "org__repo" / ".semantix" / "project.db"
         db.parent.mkdir(parents=True)
         db.write_text("")
-        rows = [{"j": 1, "bsize": 0, "bmtime": 0, "bsha": ""}]
+        stat = db.stat()
+        rows = [{"j": 1, "bsize": stat.st_size, "bmtime": stat.st_mtime_ns,
+                 "bsha": hashlib.sha256(db.read_bytes()).hexdigest()}]
         for index in range(5):
             meta = {"SourceSession": f"s{index % 2}"}
             if with_commit:
@@ -45,6 +48,14 @@ class ValidateMemorySeedTest(unittest.TestCase):
         self.assertFalse(report["ok"])
         self.assertIn("org/repo:commit_unknown", report["errors"])
         self.assertIn("other/repo:missing_store", report["errors"])
+
+    def test_rejects_journal_bound_to_another_base_generation(self):
+        with tempfile.TemporaryDirectory() as td:
+            seed, dataset, ids = self.fixture(Path(td))
+            db = seed / "org__repo" / ".semantix" / "project.db"
+            db.write_text("{}\n")
+            report = validator.validate(seed, dataset, ids)
+        self.assertIn("org/repo:store_invalid", report["errors"])
 
 
 if __name__ == "__main__":

--- a/scripts/swebench/test_validate_memory_seed.py
+++ b/scripts/swebench/test_validate_memory_seed.py
@@ -1,0 +1,51 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import validate_memory_seed as validator
+
+
+class ValidateMemorySeedTest(unittest.TestCase):
+    def fixture(self, root: Path, with_commit: bool = True):
+        dataset = root / "dataset.jsonl"
+        dataset.write_text(json.dumps({"instance_id": "i1", "repo": "Org/Repo"}) + "\n")
+        ids = root / "ids.txt"
+        ids.write_text("i1\n")
+        db = root / "seed" / "org__repo" / ".semantix" / "project.db"
+        db.parent.mkdir(parents=True)
+        db.write_text("")
+        rows = [{"j": 1, "bsize": 0, "bmtime": 0, "bsha": ""}]
+        for index in range(5):
+            meta = {"SourceSession": f"s{index % 2}"}
+            if with_commit:
+                meta["base_commit"] = "abc123"
+            rows.append({"op": "put", "s": {
+                "ID": f"slice-{index}", "Type": 1, "Scope": 1,
+                "Content": "eA==", "Meta": meta,
+            }})
+        Path(str(db) + ".journal").write_text(
+            "".join(json.dumps(row) + "\n" for row in rows))
+        return root / "seed", dataset, ids
+
+    def test_accepts_repo_with_minimum_library_sessions_and_commits(self):
+        with tempfile.TemporaryDirectory() as td:
+            report = validator.validate(*self.fixture(Path(td)))
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["summary"]["ready_repos"], 1)
+
+    def test_reports_missing_commit_and_missing_repo_store(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            seed, dataset, ids = self.fixture(root, with_commit=False)
+            with dataset.open("a") as handle:
+                handle.write(json.dumps({"instance_id": "i2", "repo": "Other/Repo"}) + "\n")
+            ids.write_text("i1\ni2\n")
+            report = validator.validate(seed, dataset, ids)
+        self.assertFalse(report["ok"])
+        self.assertIn("org/repo:commit_unknown", report["errors"])
+        self.assertIn("other/repo:missing_store", report["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/swebench/validate_memory_seed.py
+++ b/scripts/swebench/validate_memory_seed.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fail-closed preflight for a frozen repo-isolated Semantix memory seed."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+INJECTABLE_TYPES = {"context", "memory", "result"}
+TYPE_NAMES = {0: "prompt", 1: "context", 2: "tool_pattern", 3: "result", 4: "memory"}
+
+
+def read_jsonl(path: Path):
+    if not path.exists():
+        return
+    for number, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{number}: malformed JSON: {exc.msg}") from exc
+
+
+def load_store(path: Path) -> dict[str, dict]:
+    entries: dict[str, dict] = {}
+    for row in read_jsonl(path) or ():
+        if row.get("ID"):
+            entries[row["ID"]] = row
+    for row in read_jsonl(Path(str(path) + ".journal")) or ():
+        op = row.get("op")
+        if op == "put" and isinstance(row.get("s"), dict) and row["s"].get("ID"):
+            entries[row["s"]["ID"]] = row["s"]
+        elif op == "del":
+            entries.pop(row.get("id"), None)
+    return entries
+
+
+def expected_repos(dataset: Path, ids_path: Path) -> dict[str, list[str]]:
+    ids = {line.strip() for line in ids_path.read_text(encoding="utf-8").splitlines()
+           if line.strip() and not line.lstrip().startswith("#")}
+    repos: dict[str, list[str]] = defaultdict(list)
+    seen: set[str] = set()
+    for row in read_jsonl(dataset) or ():
+        instance_id = row.get("instance_id")
+        if instance_id not in ids:
+            continue
+        repo = row.get("repo")
+        if not isinstance(repo, str) or repo.count("/") != 1:
+            raise ValueError(f"{instance_id}: invalid repo identity {repo!r}")
+        repos[repo.lower()].append(instance_id)
+        seen.add(instance_id)
+    missing = sorted(ids - seen)
+    if missing:
+        raise ValueError(f"IDs absent from dataset: {', '.join(missing)}")
+    return dict(sorted(repos.items()))
+
+
+def type_name(row: dict) -> str:
+    value = row.get("Type")
+    return TYPE_NAMES.get(value, str(value).lower()) if isinstance(value, int) else str(value).lower()
+
+
+def meta_value(row: dict, snake: str, go_name: str):
+    meta = row.get("Meta") or {}
+    return meta.get(snake, meta.get(go_name, ""))
+
+
+def validate(seed_dir: Path, dataset: Path, ids_path: Path,
+             min_library: int = 5, min_source_sessions: int = 2) -> dict:
+    repos = expected_repos(dataset, ids_path)
+    report = {"ok": True, "seed_dir": str(seed_dir), "repos": {}, "errors": []}
+    for repo, instance_ids in repos.items():
+        key = repo.replace("/", "__", 1)
+        db = seed_dir / key / ".semantix" / "project.db"
+        entries = load_store(db) if db.exists() else {}
+        sessions_by_type: dict[str, set[str]] = defaultdict(set)
+        injectable: list[dict] = []
+        missing_commit: list[str] = []
+        verified_results = 0
+        for row in entries.values():
+            kind = type_name(row)
+            if kind not in INJECTABLE_TYPES:
+                continue
+            status = meta_value(row, "result_status", "ResultStatus")
+            if kind == "result" and str(status).lower() != "verified":
+                continue
+            if kind == "result":
+                verified_results += 1
+            injectable.append(row)
+            session = meta_value(row, "source_session", "SourceSession")
+            if session:
+                sessions_by_type[kind].add(str(session))
+            if not meta_value(row, "base_commit", "BaseCommit"):
+                missing_commit.append(str(row.get("ID", "<unknown>")))
+
+        eligible_types = sorted(kind for kind, sessions in sessions_by_type.items()
+                                if len(sessions) >= min_source_sessions)
+        errors: list[str] = []
+        if not db.exists():
+            errors.append("missing_store")
+        if len(entries) < min_library:
+            errors.append("library_too_small")
+        if not eligible_types:
+            errors.append("type_sources_too_few")
+        if missing_commit:
+            errors.append("commit_unknown")
+        repo_report = {
+            "instances": len(instance_ids), "store": str(db), "slices": len(entries),
+            "injectable": len(injectable), "verified_results": verified_results,
+            "source_sessions_by_type": {k: len(v) for k, v in sorted(sessions_by_type.items())},
+            "eligible_types": eligible_types, "missing_base_commit": sorted(missing_commit),
+            "errors": errors,
+        }
+        report["repos"][repo] = repo_report
+        report["errors"].extend(f"{repo}:{error}" for error in errors)
+    report["ok"] = not report["errors"]
+    report["summary"] = {
+        "repos": len(repos),
+        "ready_repos": sum(not item["errors"] for item in report["repos"].values()),
+        "instances": sum(len(items) for items in repos.values()),
+    }
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed-dir", type=Path, required=True)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--ids", type=Path, required=True)
+    parser.add_argument("--min-library", type=int, default=5)
+    parser.add_argument("--min-source-sessions", type=int, default=2)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+    report = validate(args.seed_dir, args.dataset, args.ids,
+                      args.min_library, args.min_source_sessions)
+    rendered = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if report["ok"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/swebench/validate_memory_seed.py
+++ b/scripts/swebench/validate_memory_seed.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from collections import defaultdict
 from pathlib import Path
@@ -30,7 +31,17 @@ def load_store(path: Path) -> dict[str, dict]:
     for row in read_jsonl(path) or ():
         if row.get("ID"):
             entries[row["ID"]] = row
-    for row in read_jsonl(Path(str(path) + ".journal")) or ():
+    journal = Path(str(path) + ".journal")
+    journal_rows = list(read_jsonl(journal) or ())
+    if journal_rows:
+        header = journal_rows.pop(0)
+        stat = path.stat()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if (header.get("j") != 1 or header.get("bsize") != stat.st_size
+                or header.get("bmtime") != stat.st_mtime_ns
+                or header.get("bsha") != digest):
+            raise ValueError(f"{journal}: journal header does not match base store")
+    for row in journal_rows:
         op = row.get("op")
         if op == "put" and isinstance(row.get("s"), dict) and row["s"].get("ID"):
             entries[row["s"]["ID"]] = row["s"]
@@ -76,7 +87,12 @@ def validate(seed_dir: Path, dataset: Path, ids_path: Path,
     for repo, instance_ids in repos.items():
         key = repo.replace("/", "__", 1)
         db = seed_dir / key / ".semantix" / "project.db"
-        entries = load_store(db) if db.exists() else {}
+        store_error = ""
+        try:
+            entries = load_store(db) if db.exists() else {}
+        except ValueError as exc:
+            entries = {}
+            store_error = str(exc)
         sessions_by_type: dict[str, set[str]] = defaultdict(set)
         injectable: list[dict] = []
         missing_commit: list[str] = []
@@ -102,6 +118,8 @@ def validate(seed_dir: Path, dataset: Path, ids_path: Path,
         errors: list[str] = []
         if not db.exists():
             errors.append("missing_store")
+        elif store_error:
+            errors.append("store_invalid")
         if len(entries) < min_library:
             errors.append("library_too_small")
         if not eligible_types:
@@ -113,7 +131,7 @@ def validate(seed_dir: Path, dataset: Path, ids_path: Path,
             "injectable": len(injectable), "verified_results": verified_results,
             "source_sessions_by_type": {k: len(v) for k, v in sorted(sessions_by_type.items())},
             "eligible_types": eligible_types, "missing_base_commit": sorted(missing_commit),
-            "errors": errors,
+            "store_error": store_error, "errors": errors,
         }
         report["repos"][repo] = repo_report
         report["errors"].extend(f"{repo}:{error}" for error in errors)


### PR DESCRIPTION
## 问题
Issue #447 的 strict L2 只判断相关度/覆盖率/来源数量，没有证明命中的切片仍适用于当前 checkout。共享 benchmark store 还会被误当成 git workspace，因此旧提交、缺失依赖或已变化依赖的内容可能被注入，形成意图漂移和重复执行。

## 本 PR（非真实 provider 部分）
1. **提交与依赖新鲜度**
   - `SliceMeta.BaseCommit` 记录 extraction 时看到的提交。
   - strict admission 增加稳定 reason：`current_commit_unknown`、`commit_unknown`、`stale_commit`、`path_missing`、`dependency_path_invalid`、`dependency_changed`。
   - 同提交可直接使用；跨提交必须由全部依赖 SHA-256 未变化证明；依赖路径逐组件拒绝符号链接、越界及非普通文件。
   - top-margin 只在通过新鲜度门槛的候选上计算。
2. **workspace/store 解耦**
   - 新增 `[semantix].workspace_dir`，git commit 和依赖检查针对 live checkout；`project_dir` 继续只承载共享 slice store。
   - retrieval diagnostics 同时记录当前和候选 `baseCommit`。
3. **runner 自动采集 provenance**
   - session mirror 的 tool-call 文件参数会规范化为 workspace 相对普通文件。
   - extraction 自动写 `--base-commit` 与 `--fingerprint`，且在 workspace cwd 执行。
4. **负迁移归因**
   - 新增 `SliceOutcome(useful|neutral|harmful, reason)` 事件与 per-slice 统计。
   - loop guard 继续发兼容的 `SliceReject`，同时记录 `harmful + rejected`。
5. **frozen seed 预检**
   - `validate_memory_seed.py` 按冻结 IDs 检查每个 repo 的 store、journal generation、最小库规模、同类型来源 session 和 `base_commit`。
   - 缺口以 repo + reason 输出 JSON，并用退出码 3 阻止带病 seed 进入矩阵。

## 本地验证
- `go test ./kernel/inject` ✅
- `go test ./kernel/event ./harness/semantix` ✅
- `go test ./harness/eventwire` ✅
- targeted `harness/config` ✅
- compiled `kernel/slice` test binary: PASS ✅
- `python -m unittest discover -p 'test_*.py'` in `scripts/swebench`: **26 tests OK** ✅
- baseline regression test fails to compile due missing freshness fields; modified branch passes all strict freshness cases。

Windows broad `go test -p 1 ./...` additionally encountered two repository/environment-existing classes: `cmd/semantix` global dispatch-state assertion and Windows symlink creation privilege in `harness/autoresearch`; changed-package tests above pass。

## 真实测试边界
真实 DeepSeek/OpenAI SWE-bench A/B/C 矩阵由外部测试执行。合入后应先运行 seed validator；旧 Django-only seed 缺少新的 `base_commit`，需要按当前 runner 重建，不应直接作为完成证据。

Issue #447 remains open until the external A/B/C acceptance thresholds pass.