### PR TITLE
swebench: enforce issue #326 evaluation protocols and leakage audit

### DIFF
--- a/docs/reports/issue-326-evaluation-infrastructure.md
+++ b/docs/reports/issue-326-evaluation-infrastructure.md
@@ -1,0 +1,50 @@
+# Issue #326 — authoritative evaluation infrastructure
+
+Status: infrastructure complete; full three-seed SWE-bench Verified rollout remains a separately funded execution step.
+
+## Protocol boundary
+
+The runner exposes two mutually exclusive protocols and records the selection in
+`run_config.json` and every Semantix cost record:
+
+| Track | Runner flag | State semantics | Publication rule |
+| --- | --- | --- | --- |
+| A — capability | `--protocol standard` (default) | fresh checkout and an isolated, empty kernel store for every instance | leaderboard-comparable after official SWE-bench scoring |
+| B — reuse economics | `--protocol grouped` | frozen input order, serialized within each repository, repository-isolated store retained across instances | non-standard; report separately from Track A |
+
+`--semantix-memory on|off` selects the paired `full` / `no-kernel` arms. The
+harness ablation registry also includes `kernel`, but benchmark memory comparisons
+use the explicit runner flag so store lifecycle is unambiguous. A frozen seed store
+is rejected under the standard protocol.
+
+## Reproducible artifacts
+
+Each run produces:
+
+- `predictions.jsonl`: patches in official SWE-bench prediction format;
+- `cost.jsonl`: per-instance provider usage, USD cost, wall time, errors, empty
+  patches, kernel counters, protocol, and native metrics;
+- `run_config.json`: CLI protocol parameters plus the runner commit SHA;
+- `audit/<instance>.txt`: an opt-in, mode-0600 verbatim record of strict-mode L2 blocks assembled for
+  memory-enabled Semantix runs.
+
+The legacy `preds.jsonl` and `metrics.jsonl` aliases remain for existing tooling.
+Scoring continues to delegate pass/fail exclusively to
+`swebench.harness.run_evaluation`; no project code implements a correctness judge.
+
+## Leakage gate
+
+`scan_injection_leaks.py` compares every audited block against the official dataset
+row for that instance. It exits non-zero for an exact gold patch, a `FAIL_TO_PASS`
+identifier, an unknown audit file, or a missing expected audit file. The JSON report
+is suitable for publishing beside Track B results. Audit files can contain retrieved
+task context and must be handled as sensitive experiment artifacts.
+
+## Evidence and remaining execution
+
+Unit tests cover protocol isolation/grouping, config round-trip, private audit-file
+creation, complete multi-block append behavior, and fail-closed leakage scanning.
+The existing 50-instance single-seed report remains historical evidence only; it
+does not satisfy #326's `n >= 3` publication rule. A release claim still requires
+the predeclared model, sample, three or more seeds, official Docker evaluation,
+confidence intervals, and the Track A/Track B reports generated from those runs.

--- a/harness/boot/boot.go
+++ b/harness/boot/boot.go
@@ -297,16 +297,17 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	// the sink unchanged (zero overhead on the hot path); a broken kernel
 	// degrades fail-open, never blocking the main loop.
 	semantixBridge := semantix.NewBridge(semantix.Config{
-		Enabled:      cfg.Semantix.Enabled && !opts.Ablation.Off(ablation.Kernel),
-		Binary:       cfg.Semantix.Binary,
-		Inject:       cfg.Semantix.Inject,
-		Mode:         cfg.Semantix.Mode,
-		Budget:       cfg.Semantix.Budget,
-		SessionsDir:  cfg.Semantix.SessionsDir,
-		ProjectDir:   cfg.Semantix.ProjectDir,
-		WorkspaceDir: cfg.Semantix.WorkspaceDir,
-		CostMissUSD:  cfg.Semantix.CostInputPriceUSD,
-		CostHitUSD:   cfg.Semantix.CostCachePriceUSD,
+		Enabled:         cfg.Semantix.Enabled && !opts.Ablation.Off(ablation.Kernel),
+		Binary:          cfg.Semantix.Binary,
+		Inject:          cfg.Semantix.Inject,
+		Mode:            cfg.Semantix.Mode,
+		Budget:          cfg.Semantix.Budget,
+		SessionsDir:     cfg.Semantix.SessionsDir,
+		InjectAuditPath: cfg.Semantix.InjectAuditPath,
+		ProjectDir:      cfg.Semantix.ProjectDir,
+		WorkspaceDir:    cfg.Semantix.WorkspaceDir,
+		CostMissUSD:     cfg.Semantix.CostInputPriceUSD,
+		CostHitUSD:      cfg.Semantix.CostCachePriceUSD,
 	})
 	sink = semantixBridge.Sink(sink)
 	defer semantixBridge.Close()

--- a/harness/config/config.go
+++ b/harness/config/config.go
@@ -967,6 +967,10 @@ type SemantixConfig struct {
 	// SessionsDir is where the session JSONL mirror is written; empty uses
 	// <controller session dir>/sessions.
 	SessionsDir string `toml:"sessions_dir"`
+	// InjectAuditPath optionally records every provider-visible L2 injection
+	// block verbatim. It is intended for benchmark leakage audits; normal runs
+	// leave it empty so retrieved context is not duplicated on disk.
+	InjectAuditPath string `toml:"inject_audit_path"`
 	// ProjectDir is the kernel project directory the slice store and usage
 	// log resolve against (kernel CLI semantics: <dir>/.semantix/...). Empty
 	// uses the process working directory. Point several agent runs at one

--- a/harness/config/render.go
+++ b/harness/config/render.go
@@ -540,6 +540,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	if c.Semantix.SessionsDir != "" {
 		fmt.Fprintf(&b, "sessions_dir = %q\n", c.Semantix.SessionsDir)
 	}
+	if c.Semantix.InjectAuditPath != "" {
+		fmt.Fprintf(&b, "inject_audit_path = %q # opt-in verbatim L2 block audit\n", c.Semantix.InjectAuditPath)
+	}
 	if c.Semantix.ProjectDir != "" {
 		fmt.Fprintf(&b, "project_dir = %q   # shared slice library root (<dir>/.semantix/...)\n", c.Semantix.ProjectDir)
 	}

--- a/harness/config/render_test.go
+++ b/harness/config/render_test.go
@@ -211,6 +211,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Desktop.UpdateChannel = "preview"
 	orig.Desktop.Telemetry = boolPtr(false)
 	orig.Semantix.Mode = "shadow"
+	orig.Semantix.InjectAuditPath = "/tmp/semantix-inject-audit.txt"
 	orig.Notifications.Enabled = true
 	orig.Notifications.TurnDone = true
 	orig.Notifications.ApprovalRequest = true
@@ -332,6 +333,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Semantix.Mode != "shadow" {
 		t.Errorf("semantix.mode = %q, want shadow", got.Semantix.Mode)
+	}
+	if got.Semantix.InjectAuditPath != orig.Semantix.InjectAuditPath {
+		t.Errorf("semantix.inject_audit_path = %q, want %q", got.Semantix.InjectAuditPath, orig.Semantix.InjectAuditPath)
 	}
 	if got.Language != "zh" {
 		t.Errorf("language = %q, want zh", got.Language)

--- a/harness/semantix/bridge.go
+++ b/harness/semantix/bridge.go
@@ -51,6 +51,9 @@ type Config struct {
 	// SessionsDir is where the session JSONL mirror is written; empty uses
 	// <controller session dir>/sessions.
 	SessionsDir string
+	// InjectAuditPath optionally receives each provider-visible L2 block in
+	// full. This is opt-in because the file contains retrieved task context.
+	InjectAuditPath string
 	// ProjectDir is the kernel project directory the slice store and usage
 	// log resolve against (kernel CLI semantics: <dir>/.semantix/...).
 	// Empty uses the process working directory.
@@ -84,6 +87,7 @@ type Bridge struct {
 	lastSavings float64
 	evolution   *EvolutionLoop
 	statsWG     sync.WaitGroup
+	auditMu     sync.Mutex
 	closing     bool
 }
 
@@ -328,6 +332,7 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 		}
 	}
 	sort.Strings(targets)
+	b.auditInjection(inj.Text)
 	b.recordInjection(targets, inj.Bytes)
 	diagnostics.Injected = true
 	diagnostics.Bytes = inj.Bytes
@@ -340,6 +345,28 @@ func (b *Bridge) injectResult(ctx context.Context, query string, budget int) Inj
 	}
 	b.emitKernelCacheDetailed(op, "L2", targets, inj.Bytes, "", diagnostics)
 	return InjectResult{Text: inj.Text, Targets: targets, Diagnostics: diagnostics}
+}
+
+func (b *Bridge) auditInjection(block string) {
+	path := strings.TrimSpace(b.cfg.InjectAuditPath)
+	if path == "" || block == "" {
+		return
+	}
+	b.auditMu.Lock()
+	defer b.auditMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err == nil && info.Size() > 0 {
+		_, _ = f.WriteString("\n\n--- semantix injection ---\n\n")
+	}
+	_, _ = f.WriteString(strings.TrimRight(block, "\n") + "\n")
 }
 
 func (b *Bridge) retrievalDiagnostics(query string, retrievalQuery RetrievalQuery, library []*slice.Slice, hits []slice.Hit, inj *inject.Injection) *event.RetrievalDiagnostics {

--- a/harness/semantix/inject_audit_test.go
+++ b/harness/semantix/inject_audit_test.go
@@ -1,0 +1,38 @@
+package semantix
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAuditInjectionIsOptInAndAppendsCompleteBlocks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit", "instance.txt")
+	b := NewBridge(Config{InjectAuditPath: path})
+
+	b.auditInjection("[semantix-reuse]\nfirst\n[/semantix-reuse]")
+	b.auditInjection("[semantix-reuse]\nsecond\n[/semantix-reuse]\n")
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(raw)
+	for _, want := range []string{"first", "second", "--- semantix injection ---"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("audit missing %q:\n%s", want, got)
+		}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("audit mode = %v; want 0600", info.Mode().Perm())
+	}
+
+	withoutAudit := NewBridge(Config{})
+	withoutAudit.auditInjection("secret")
+}

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -43,7 +43,7 @@ cd scripts/swebench
 python3 -c "from pathlib import Path; from common import fetch_dataset; fetch_dataset(Path('data/swebench_verified.jsonl'))"
 
 # 1) 生成 patch（四个 harness 各一轮；--sample 50 --seed 固定可复现子集）
-python3 run_bench.py --harness semantix    --model deepseek-v4-flash --dataset data/swebench_verified.jsonl --sample 50 --workers 4
+python3 run_bench.py --harness semantix    --model deepseek-v4-flash --dataset data/swebench_verified.jsonl --sample 50 --workers 4 --protocol standard
 python3 run_bench.py --harness dsh         --model deepseek-v4-flash --dataset data/swebench_verified.jsonl --sample 50 --workers 4
 python3 run_bench.py --harness claude-code --model deepseek-v4-flash --dataset data/swebench_verified.jsonl --sample 50 --workers 4
 python3 run_bench.py --harness codex       --model deepseek-v4-flash --dataset data/swebench_verified.jsonl --sample 50 --workers 4 \
@@ -65,19 +65,47 @@ python3 run_bench.py --harness semantix --model deepseek-v4-flash \
   --semantix-bin ../../bin/semantix-agent --semantix-kernel-bin ../../bin/semantix
 ```
 
-### semantix 记忆内核臂（`--semantix-memory`，默认 on）
+每轮同时生成 issue #326 约定的公开产物 `predictions.jsonl` + `cost.jsonl`；
+为兼容已有官方评测与报告脚本，也保留等价的 `preds.jsonl` + `metrics.jsonl`。
+`run_config.json` 固化完整 CLI 参数和 runner commit SHA。
+
+### 双协议与 semantix 记忆内核臂
+
+`--protocol standard`（默认）为 Track A：每个 instance 使用独立、空白的 kernel
+store，保持 SWE-bench 标准 fresh-checkout / 无跨任务历史语义。`--protocol grouped`
+为 Track B：按 repo 分组，组内严格按冻结顺序串行，并跨同 repo instance 保留
+store；这是**非 SWE-bench 标准协议**，其结果不得与 leaderboard 数字混报。
+
+`--semantix-memory` 默认 on：
 
 `--semantix-memory on`（默认）把记忆内核真正接入基准：config 写入 `[semantix]`
 enabled/inject；**每实例独立 `SEMANTIX_HOME`**（并发归属无竞态），所有实例的
-`project_dir` 指向**真实 repo 独立切片库**
-（`semantix-home/kernel/<owner>__<repo>/`）；每实例结束后 runner 跑
-`semantix extract` 把该会话蒸馏进库，后续同 repo 实例即可检索注入（跨实例
-记忆闭环，需 `go build -o bin/semantix ./cmd/semantix`）。`off` 为消融孪生臂
-（内核关闭，等价旧行为）。记忆对照请用这对臂，**不要用 `--ablate`**（它只关
+`project_dir` 指向协议决定的隔离切片库：standard 使用
+`semantix-home/kernel/instances/<instance>`，grouped 使用
+`semantix-home/kernel/<owner>__<repo>`。每实例结束后 runner 跑
+`semantix extract` 把该会话蒸馏进库；只有 grouped 的后续同 repo instance
+会检索到这份历史（需 `go build -o bin/semantix ./cmd/semantix`）。`off` 为消融
+孪生臂，runner 同时传入 kernel ablation，使 agent metrics 的 arm 稳定记录为
+`no-kernel`；on 的对照名为 `full`。记忆对照请用这对臂，**不要手工用
+`--ablate` 代替**（该参数还可关闭其他 harness 模块，但不定义 store 生命周期）。判读字段（metrics `raw`）：
 harness 侧模块，不触碰内核）。判读字段（metrics `raw`）：
 `semantix_inject_turns` / `semantix_inject_bytes` / `semantix_reuse_hits` /
 `semantix_fuse_turns` / `semantix_rejected_slices` / `raw.extract`（每实例入库量）。
 设计与根因：`docs/specs/swebench-memory-arm.md`。
+
+Track B 会把 strict 模式下组装用于注入的 L2 块逐实例完整写到
+`results/<run_id>/audit/<instance>.txt`（0600 权限）。跑完必须执行泄漏扫描；
+只要出现 gold patch、`FAIL_TO_PASS` 测试名或未知 instance 文件，命令就以 1 退出：
+
+```bash
+python3 scan_injection_leaks.py \
+  --audit-dir results/<run_id>/audit \
+  --dataset data/swebench_verified.jsonl \
+  --ids subsets/verified-50-s20260824.txt \
+  --json-out results/<run_id>/injection-leak-report.json
+```
+
+审计文件含检索到的任务上下文，只应用于评测取证并按敏感实验产物保管。
 
 #### 调用来源归因字段
 

--- a/scripts/swebench/common.py
+++ b/scripts/swebench/common.py
@@ -4,8 +4,10 @@ One benchmark run = one harness × one model × one instance subset. Every
 adapter produces the same two artifacts so score / tokens / cache hit rate /
 wall time are comparable across harnesses:
 
-  results/<run_id>/preds.jsonl    SWE-bench prediction format
-  results/<run_id>/metrics.jsonl  one normalized metrics record per instance
+  results/<run_id>/predictions.jsonl  SWE-bench prediction format
+  results/<run_id>/cost.jsonl         one normalized cost/usage record per instance
+
+Legacy aliases (preds.jsonl and metrics.jsonl) are emitted for existing tools.
 
 The normalized record is deliberately small; each harness's native metrics
 payload is preserved verbatim under "raw" for audit.

--- a/scripts/swebench/evaluate.py
+++ b/scripts/swebench/evaluate.py
@@ -29,7 +29,9 @@ def main() -> None:
     args = ap.parse_args()
 
     run_dir = Path(args.run_dir).resolve()
-    preds = run_dir / "preds.jsonl"
+    preds = run_dir / "predictions.jsonl"
+    if not preds.exists():
+        preds = run_dir / "preds.jsonl"  # pre-issue-326 run compatibility
     if not preds.exists():
         sys.exit(f"no predictions at {preds}")
     with open(preds) as f:

--- a/scripts/swebench/memory_matrix.py
+++ b/scripts/swebench/memory_matrix.py
@@ -75,6 +75,7 @@ def build_runs(args: argparse.Namespace) -> list[MatrixRun]:
                 "--max-turns", str(args.max_turns),
                 "--preset", args.preset,
                 "--semantix-memory", memory,
+                "--protocol", "grouped",
                 "--semantix-retrieval-mode", retrieval,
                 "--semantix-bin", agent_bin,
                 "--semantix-kernel-bin", args.semantix_kernel_bin,

--- a/scripts/swebench/report.py
+++ b/scripts/swebench/report.py
@@ -4,7 +4,7 @@
 Usage:
   python report.py --runs results/run-a results/run-b ... [--format md|json]
 
-Each run directory needs metrics.jsonl (from run_bench.py); the resolve rate
+Each run directory needs cost.jsonl (or legacy metrics.jsonl) from run_bench.py; the resolve rate
 column fills in when an official report json (evaluate.py output) is present,
 and shows "n/a" otherwise.
 """
@@ -43,7 +43,9 @@ def sum_count_maps(metrics: list[dict], key: str) -> dict[str, int]:
 
 def load_run(run_dir: Path) -> dict:
     metrics = []
-    mpath = run_dir / "metrics.jsonl"
+    mpath = run_dir / "cost.jsonl"
+    if not mpath.exists():
+        mpath = run_dir / "metrics.jsonl"
     if mpath.exists():
         with open(mpath) as f:
             metrics = [json.loads(l) for l in f if l.strip()]

--- a/scripts/swebench/run_bench.py
+++ b/scripts/swebench/run_bench.py
@@ -255,6 +255,21 @@ def semantix_bench_provider(model: str) -> str:
     return "deepseek-pro" if model.endswith("-pro") else "deepseek-flash"
 
 
+def semantix_ablation_spec(spec: str, memory_on: bool) -> str:
+    """Return the agent ablation spec, labeling the off arm no-kernel."""
+    spec = spec.strip()
+    if memory_on:
+        return "" if spec.lower() == "none" else spec
+    if not spec or spec.lower() == "none":
+        return "kernel"
+    if spec.lower() == "all":
+        return spec
+    modules = [field.strip().lower() for field in re.split(r"[ ,]+", spec) if field.strip()]
+    if "kernel" not in modules:
+        spec += ",kernel"
+    return spec
+
+
 class SemantixAdapter(Adapter):
     name = "semantix"
 
@@ -317,7 +332,7 @@ class SemantixAdapter(Adapter):
         )
 
     def execution_batches(self, instances: list[dict]) -> list[list[dict]]:
-        if not self.memory_on:
+        if not self.memory_on or getattr(self.args, "protocol", "grouped") == "standard":
             return super().execution_batches(instances)
         by_repo: dict[str, list[dict]] = {}
         for inst in instances:
@@ -325,10 +340,13 @@ class SemantixAdapter(Adapter):
         return list(by_repo.values())
 
     def kernel_dir_for(self, inst: dict) -> Path:
+        if getattr(self.args, "protocol", "grouped") == "standard":
+            return self.kernel_root / "instances" / inst["instance_id"]
         return self.kernel_root / repo_store_key(inst)
 
     def _write_home(self, home: Path, sessions_dir: Path, kernel_dir: Path | None,
-                    workspace_dir: Path | None = None) -> None:
+                    workspace_dir: Path | None = None,
+                    inject_audit_path: Path | None = None) -> None:
         home.mkdir(parents=True, exist_ok=True)
         workspace_dir = workspace_dir or Path.cwd()
         # Provider keys resolve ONLY from Semantix's global .env (never the
@@ -355,6 +373,7 @@ budget       = 4096
 project_dir  = "{kernel_dir}"
 workspace_dir = "{workspace_dir}"
 sessions_dir = "{sessions_dir}"
+inject_audit_path = "{inject_audit_path or ''}"
 '''
         (home / "config.toml").write_text(
             f'''default_model = "{provider_selector}"
@@ -385,7 +404,12 @@ context_window = 128000
         sessions_dir = home / "kernel-sessions"
         repo = repo_identity(inst) if self.memory_on else ""
         kernel_dir = self.kernel_dir_for(inst) if self.memory_on else None
-        self._write_home(home, sessions_dir, kernel_dir, ws)
+        inject_audit_path = self.run_dir / "audit" / f"{inst['instance_id']}.txt"
+        if self.memory_on:
+            inject_audit_path.parent.mkdir(parents=True, exist_ok=True)
+            inject_audit_path.touch(exist_ok=True)
+            inject_audit_path.chmod(0o600)
+        self._write_home(home, sessions_dir, kernel_dir, ws, inject_audit_path)
         env = clean_env()
         env.update({
             "SEMANTIX_HOME": str(home),
@@ -401,8 +425,9 @@ context_window = 128000
             "--metrics", str(mfile),
             "--model", semantix_bench_provider(self.args.model),
         ]
-        if self.args.ablate:
-            cmd += ["--ablate", self.args.ablate]
+        ablate = semantix_ablation_spec(self.args.ablate, self.memory_on)
+        if ablate:
+            cmd += ["--ablate", ablate]
         stdout_text = ""
         stderr_text = ""
         try:
@@ -433,6 +458,8 @@ context_window = 128000
         if self.memory_on:
             raw["semantix_repo"] = repo
             raw["semantix_project_dir"] = str(kernel_dir)
+            raw["semantix_protocol"] = getattr(self.args, "protocol", "grouped")
+            raw["semantix_inject_audit"] = str(inject_audit_path)
             raw["extract"] = self._extract_slices(
                 sessions_dir, inst["instance_id"], kernel_dir, repo, ws,
                 inst.get("base_commit", ""))
@@ -927,7 +954,9 @@ def process_instance(adapter: Adapter, args, run_dir: Path, prices: dict, inst: 
                            m.output_tokens)
     model_name = f"{adapter.name}+{args.model}"
     write_prediction(run_dir / "preds.jsonl", iid, model_name, patch)
+    write_prediction(run_dir / "predictions.jsonl", iid, model_name, patch)
     append_jsonl(run_dir / "metrics.jsonl", m.to_json())
+    append_jsonl(run_dir / "cost.jsonl", m.to_json())
     rate = m.cache_hit_rate
     print(f"[{iid}] exit={exit_code} wall={m.wall_ms / 1000:.0f}s "
           f"in={m.input_tokens} out={m.output_tokens} "
@@ -970,6 +999,9 @@ def main() -> None:
     ap.add_argument("--semantix-memory", default="on", choices=("on", "off"),
                     help="semantix memory-kernel arm: on = [semantix] enabled+inject, shared slice "
                     "library across instances, per-instance extract; off = kernel disabled (ablation twin)")
+    ap.add_argument("--protocol", default="standard", choices=("standard", "grouped"),
+                    help="standard isolates every instance store (leaderboard-comparable); grouped "
+                    "orders by repo and preserves that repo's store across instances (non-standard Track B)")
     ap.add_argument("--semantix-retrieval-mode", default="strict",
                     choices=("off", "shadow", "strict"),
                     help="L2 retrieval mode when --semantix-memory=on; shadow records the same "
@@ -991,8 +1023,12 @@ def main() -> None:
     args = ap.parse_args()
     resolve_cli_paths(args)
 
+    if args.harness == "semantix" and args.protocol == "standard" and args.semantix_seed_dir:
+        ap.error("--semantix-seed-dir requires --protocol grouped; standard runs must start without reusable history")
+
     if not args.run_id:
-        args.run_id = f"{args.harness}.{args.model.replace('/', '-')}.{args.seed}"
+        protocol_part = f".{args.protocol}" if args.harness == "semantix" else ""
+        args.run_id = f"{args.harness}.{args.model.replace('/', '-')}{protocol_part}.{args.seed}"
     run_dir = Path(args.results_dir) / args.run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     args.state_path = Path(args.state_dir) / args.run_id
@@ -1016,7 +1052,15 @@ def main() -> None:
     batches = adapter.execution_batches(todo)
     prices = load_prices(args.prices or None)
 
-    (run_dir / "run_config.json").write_text(json.dumps(vars(args), indent=2, default=str))
+    run_config = dict(vars(args))
+    try:
+        run_config["runner_commit"] = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=HERE.parent.parent,
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        run_config["runner_commit"] = "unknown"
+    (run_dir / "run_config.json").write_text(json.dumps(run_config, indent=2, default=str))
 
     if args.workers <= 1:
         for batch in batches:
@@ -1030,7 +1074,7 @@ def main() -> None:
                 if exc:
                     print(f"worker error: {exc!r}", file=sys.stderr, flush=True)
 
-    print(f"done: predictions at {preds_path}", flush=True)
+    print(f"done: predictions at {run_dir / 'predictions.jsonl'}; costs at {run_dir / 'cost.jsonl'}", flush=True)
 
 
 if __name__ == "__main__":

--- a/scripts/swebench/scan_injection_leaks.py
+++ b/scripts/swebench/scan_injection_leaks.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Fail when grouped-protocol L2 audit blocks contain SWE-bench answers.
+
+The scanner deliberately uses only official dataset fields. It does not judge
+whether a patch is correct: exact gold-patch text and FAIL_TO_PASS identifiers
+are treated as prohibited benchmark leakage and reported for review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_tests(value: object) -> list[str]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            value = [value]
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def load_dataset(path: Path) -> dict[str, dict]:
+    rows: dict[str, dict] = {}
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            rows[row["instance_id"]] = row
+    return rows
+
+
+def scan(audit_dir: Path, dataset: dict[str, dict], expected_ids: list[str] | None = None) -> dict:
+    findings: list[dict] = []
+    files = sorted(audit_dir.glob("*.txt")) if audit_dir.exists() else []
+    found_ids = {path.stem for path in files}
+    for instance_id in expected_ids or []:
+        if instance_id not in found_ids:
+            findings.append({
+                "instance_id": instance_id,
+                "kind": "missing_audit",
+                "value": instance_id,
+            })
+    for path in files:
+        instance_id = path.stem
+        row = dataset.get(instance_id)
+        if row is None:
+            findings.append({
+                "instance_id": instance_id,
+                "kind": "unknown_instance",
+                "value": instance_id,
+            })
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        gold_patch = row.get("patch") or row.get("gold_patch") or ""
+        if isinstance(gold_patch, str) and gold_patch.strip() and gold_patch.strip() in text:
+            findings.append({
+                "instance_id": instance_id,
+                "kind": "gold_patch",
+                "value": "exact gold patch",
+            })
+        for test_name in parse_tests(row.get("FAIL_TO_PASS", row.get("fail_to_pass", []))):
+            if test_name in text:
+                findings.append({
+                    "instance_id": instance_id,
+                    "kind": "fail_to_pass",
+                    "value": test_name,
+                })
+    return {
+        "schema": 1,
+        "audit_dir": str(audit_dir),
+        "files_scanned": len(files),
+        "findings": findings,
+        "passed": not findings,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--audit-dir", required=True)
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--ids", help="selected instance ids; missing audit files fail closed")
+    parser.add_argument("--json-out", help="write the machine-readable report here")
+    args = parser.parse_args()
+
+    expected_ids = None
+    if args.ids:
+        expected_ids = [
+            line.strip() for line in Path(args.ids).read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+    report = scan(Path(args.audit_dir), load_dataset(Path(args.dataset)), expected_ids)
+    payload = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    if args.json_out:
+        output = Path(args.json_out)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(payload, encoding="utf-8")
+    print(payload, end="")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/swebench/test_repo_isolation.py
+++ b/scripts/swebench/test_repo_isolation.py
@@ -7,7 +7,13 @@ from unittest import mock
 
 import common
 import run_bench
-from run_bench import Adapter, SemantixAdapter, process_batch, repo_store_key
+from run_bench import (
+    Adapter,
+    SemantixAdapter,
+    process_batch,
+    repo_store_key,
+    semantix_ablation_spec,
+)
 
 
 def inst(iid: str, repo: str) -> dict:
@@ -28,6 +34,34 @@ class RepoIdentityTests(unittest.TestCase):
 
 
 class RepoSchedulingTests(unittest.TestCase):
+    def test_memory_off_arm_is_named_no_kernel(self):
+        self.assertEqual(semantix_ablation_spec("", False), "kernel")
+        self.assertEqual(semantix_ablation_spec("planner", False), "planner,kernel")
+        self.assertEqual(semantix_ablation_spec("kernel", False), "kernel")
+        self.assertEqual(semantix_ablation_spec("all", False), "all")
+        self.assertEqual(semantix_ablation_spec("planner", True), "planner")
+
+    def test_standard_protocol_isolates_every_instance(self):
+        adapter = SemantixAdapter(SimpleNamespace(protocol="standard"), Path("run"))
+        adapter.memory_on = True
+        adapter.kernel_root = Path("/state/kernel")
+        chosen = [inst("django-1", "django/django"), inst("django-2", "django/django")]
+
+        self.assertEqual(adapter.execution_batches(chosen), [[chosen[0]], [chosen[1]]])
+        self.assertNotEqual(adapter.kernel_dir_for(chosen[0]), adapter.kernel_dir_for(chosen[1]))
+
+    def test_grouped_protocol_shares_only_within_repo(self):
+        adapter = SemantixAdapter(SimpleNamespace(protocol="grouped"), Path("run"))
+        adapter.memory_on = True
+        adapter.kernel_root = Path("/state/kernel")
+        first = inst("django-1", "django/django")
+        second = inst("django-2", "django/django")
+        other = inst("flask-1", "pallets/flask")
+
+        self.assertEqual(adapter.execution_batches([first, other, second]), [[first, second], [other]])
+        self.assertEqual(adapter.kernel_dir_for(first), adapter.kernel_dir_for(second))
+        self.assertNotEqual(adapter.kernel_dir_for(first), adapter.kernel_dir_for(other))
+
     def test_memory_on_groups_by_repo_and_preserves_selected_order(self):
         adapter = SemantixAdapter(SimpleNamespace(), Path("run"))
         adapter.memory_on = True

--- a/scripts/swebench/test_scan_injection_leaks.py
+++ b/scripts/swebench/test_scan_injection_leaks.py
@@ -1,0 +1,51 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import scan_injection_leaks as scanner
+
+
+class InjectionLeakScannerTests(unittest.TestCase):
+    def test_clean_and_leaking_blocks(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            audit = root / "audit"
+            audit.mkdir()
+            dataset = {
+                "org__repo-1": {
+                    "instance_id": "org__repo-1",
+                    "patch": "diff --git a/x b/x\n+gold answer",
+                    "FAIL_TO_PASS": json.dumps(["tests/test_x.py::test_bug"]),
+                }
+            }
+
+            (audit / "org__repo-1.txt").write_text("use the public API\n", encoding="utf-8")
+            report = scanner.scan(audit, dataset)
+            self.assertTrue(report["passed"])
+            self.assertEqual(report["files_scanned"], 1)
+
+            (audit / "org__repo-1.txt").write_text(
+                "tests/test_x.py::test_bug\n", encoding="utf-8"
+            )
+            report = scanner.scan(audit, dataset)
+            self.assertFalse(report["passed"])
+            self.assertEqual(report["findings"][0]["kind"], "fail_to_pass")
+
+    def test_unknown_audit_file_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            audit = Path(td)
+            (audit / "unknown.txt").write_text("anything", encoding="utf-8")
+            report = scanner.scan(audit, {})
+            self.assertFalse(report["passed"])
+            self.assertEqual(report["findings"][0]["kind"], "unknown_instance")
+
+    def test_expected_instance_without_audit_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            report = scanner.scan(Path(td), {"expected": {}}, ["expected"])
+            self.assertFalse(report["passed"])
+            self.assertEqual(report["findings"][0]["kind"], "missing_audit")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an explicit `--protocol standard|grouped` boundary to the SWE-bench runner
- isolate every kernel store in standard Track A and preserve repo-scoped history only in non-standard grouped Track B
- label `--semantix-memory off` runs as `no-kernel` through the real harness ablation path
- emit the public `predictions.jsonl` and `cost.jsonl` artifacts while keeping legacy aliases
- record runner commit and protocol details for reproducibility
- add opt-in, mode-0600 full L2 injection-block audit files and a fail-closed gold-patch / FAIL_TO_PASS leakage scanner
- make the existing memory matrix select grouped mode explicitly and document the publication boundary

## Why

Current `main` already contains the kernel ablation module, SWE-bench adapters, official Docker scoring wrapper, cost reporting, and historical 50-instance results. The remaining issue #326 contracts were not enforceable: standard and grouped state lifecycles were implicit, memory-off still reported the `full` arm, and Track B had no full injection audit or leakage gate.

This PR closes those infrastructure gaps. It does not invent or claim the separately funded full 500-instance, three-seed rollout; the acceptance report calls that remaining execution out explicitly.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./harness/semantix`
- `python3 -m unittest discover -s scripts/swebench -p 'test_*.py'` (33 tests)
- Python syntax compilation for all changed SWE-bench scripts
- `git diff --check`

## Security and data handling

Injection auditing is opt-in and disabled for normal runs. Benchmark audit files are created with mode 0600 and documented as sensitive experiment artifacts because they contain retrieved task context.

Addresses #326.
