### PR TITLE
fix(site): clarify full agent installation

### DIFF
--- a/site/scripts/copy-code.test.mjs
+++ b/site/scripts/copy-code.test.mjs
@@ -8,5 +8,9 @@ test("every compact code box exposes a copy control", () => {
   const copyButtons = home.match(/aria-label="复制代码"/g) ?? [];
 
   assert.equal(copyButtons.length, 10);
-  assert.ok(home.includes("$ go install semantix/cmd/semantix"));
+  assert.ok(
+    home.includes(
+      "$ curl -fsSL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/scripts/install.sh | sh",
+    ),
+  );
 });

--- a/site/src/components/BrandIntroOverlay.tsx
+++ b/site/src/components/BrandIntroOverlay.tsx
@@ -231,11 +231,11 @@ export default function BrandIntroOverlay() {
               <div className="relative">
                 <h2 className="font-semibold">CLI</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  extract / search 切片提取与 BM25 检索
+                  Coding Agent + 跨会话记忆内核
                 </p>
                 <CopyCode
                   className="mt-3"
-                  code="go build -o semantix ./cmd/semantix"
+                  code="curl -fsSL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/scripts/install.sh | sh"
                   prompt
                   singleLine
                 />

--- a/site/src/components/CopyCode.tsx
+++ b/site/src/components/CopyCode.tsx
@@ -89,7 +89,7 @@ export default function CopyCode({
       <pre
         className={`min-w-0 flex-1 p-3 font-mono leading-5 ${
           singleLine
-            ? "whitespace-pre-wrap break-words text-[11px] sm:whitespace-nowrap"
+            ? "overflow-hidden text-ellipsis whitespace-nowrap text-[11px]"
             : "whitespace-pre-wrap break-words text-xs"
         } ${
           isDark
@@ -105,7 +105,6 @@ export default function CopyCode({
         type="button"
         onClick={handleCopy}
         aria-label={`${label}代码`}
-        title={label}
         className={`flex w-11 shrink-0 items-center justify-center border-l transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent active:translate-y-px ${
           isDark
             ? "border-white/10 bg-[oklch(0.25_0.008_260)] text-slate-300 hover:bg-[oklch(0.29_0.01_260)] hover:text-emerald-300"

--- a/site/src/components/Install.tsx
+++ b/site/src/components/Install.tsx
@@ -5,30 +5,30 @@ import CopyCode from "@/components/CopyCode";
 const steps = [
   {
     number: "01",
-    title: "克隆仓库",
-    titleEn: "Clone",
-    desc: "把 semantix 拉到本地，并进入仓库目录。",
-    code: "git clone https://github.com/Gnosil/semantix.git && cd semantix",
-    href: "https://github.com/Gnosil/semantix",
+    title: "安装完整 Agent",
+    titleEn: "Install",
+    desc: "一行安装交互式 Agent 与记忆内核，无需安装 Go。",
+    code: "curl -fsSL https://raw.githubusercontent.com/Gnosil/semantix/main/agent-skill/scripts/install.sh | sh",
+    href: "https://github.com/Gnosil/semantix/releases/latest",
     external: true,
-    linkLabel: "仓库 →",
+    linkLabel: "发布包 ↗",
   },
   {
     number: "02",
-    title: "安装 CLI",
-    titleEn: "Install",
-    desc: "使用 Go 1.26+ 安装完整的 Semantix 内核 CLI。",
-    code: "go install semantix/cmd/semantix",
+    title: "进入项目",
+    titleEn: "Open project",
+    desc: "进入你的项目文件夹；该目录将成为 Agent 的工作区。",
+    code: "cd ~/your-project",
     href: "https://github.com/Gnosil/semantix/blob/main/docs/QUICKSTART.md",
     external: true,
-    linkLabel: "构建步骤 ↗",
+    linkLabel: "快速上手 ↗",
   },
   {
     number: "03",
-    title: "提取并检索",
-    titleEn: "Extract & Search",
-    desc: "先从会话中提取切片，再运行 BM25 检索。",
-    code: './semantix extract --input s.jsonl --scope project\n./semantix search --query "fix failing test" --retriever bm25',
+    title: "开始对话",
+    titleEn: "Start",
+    desc: "运行 Semantix；首次启动会引导你配置模型与 API key。",
+    code: "semantix",
     href: "/docs/guide",
     external: false,
     linkLabel: "深度文档 →",
@@ -73,6 +73,7 @@ export default function Install() {
                   className="mt-7 !rounded-none border-[#101313]/12"
                   code={step.code}
                   prompt
+                  singleLine
                   tone="dark"
                 />
                 <div className="mt-auto pt-8 text-sm font-semibold text-[#101313]">


### PR DESCRIPTION
## Summary
- update the landing-page intro to describe the complete interactive Agent and memory kernel
- replace the old clone/build instructions with the actual one-line installer, project entry, and Agent launch flow
- keep long single-line commands readable with truncation while preserving copy behavior

## Validation
- inspected the exact localhost:3010/#start preview
- npm run lint
- npm run typecheck
- npm run build -- --webpack
- git diff --check