### PR TITLE
fix(cli): reset mouse before TUI shutdown

### DIFF
--- a/harness/cli/chat_tui.go
+++ b/harness/cli/chat_tui.go
@@ -2009,7 +2009,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.ctrl.Snapshot()
 			m.followSessionLease()
 		}
-		return m, tea.Sequence(tea.Raw(resetMouseTracking), tea.Quit)
+		return m, tea.Quit
 
 	case modelSwitchMsg:
 		m.modelSwitchPending = false

--- a/harness/cli/chat_tui.go
+++ b/harness/cli/chat_tui.go
@@ -2009,7 +2009,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.ctrl.Snapshot()
 			m.followSessionLease()
 		}
-		return m, tea.Quit
+		return m, tea.Sequence(tea.Raw(resetMouseTracking), tea.Quit)
 
 	case modelSwitchMsg:
 		m.modelSwitchPending = false
@@ -3589,7 +3589,7 @@ func (m chatTUI) View() tea.View {
 		v := tea.NewView(m.themeSweep.render())
 		if !m.nativeScrollback {
 			v.AltScreen = true
-			if m.mouseCaptureOff {
+			if m.shuttingDown || m.mouseCaptureOff {
 				v.MouseMode = tea.MouseModeNone
 			} else {
 				v.MouseMode = tea.MouseModeCellMotion
@@ -3724,7 +3724,7 @@ func (m chatTUI) View() tea.View {
 	}
 	v := tea.NewView(mainArea + "\n" + strings.Join(parts, "\n"))
 	v.AltScreen = true
-	if m.mouseCaptureOff {
+	if m.shuttingDown || m.mouseCaptureOff {
 		// Release the mouse to the terminal: native click-drag selection and
 		// right-click context menu work again, at the cost of the in-app
 		// scrollbar, wheel-scroll, and drag-select while it's off.

--- a/harness/cli/chat_tui_test.go
+++ b/harness/cli/chat_tui_test.go
@@ -2389,8 +2389,12 @@ func TestMouseReenableIsSuppressedAfterShutdownStarts(t *testing.T) {
 func TestShutdownMessageMakesMouseLifecycleIrreversible(t *testing.T) {
 	m := newTestChatTUI()
 	next, cmd := m.Update(tuiShutdownMsg{})
-	if !next.(chatTUI).shuttingDown {
+	nextTUI := next.(chatTUI)
+	if !nextTUI.shuttingDown {
 		t.Fatal("shutdown must mark TUI")
+	}
+	if got := nextTUI.View().MouseMode; got != tea.MouseModeNone {
+		t.Fatalf("MouseMode during shutdown = %v, want MouseModeNone", got)
 	}
 	if cmd == nil {
 		t.Fatal("shutdown must request quit")

--- a/harness/cli/chat_tui_test.go
+++ b/harness/cli/chat_tui_test.go
@@ -2387,7 +2387,10 @@ func TestMouseReenableIsSuppressedAfterShutdownStarts(t *testing.T) {
 }
 
 func TestShutdownMessageMakesMouseLifecycleIrreversible(t *testing.T) {
-	m := newTestChatTUI()
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 60)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
+	m = m0.(chatTUI)
 	next, cmd := m.Update(tuiShutdownMsg{})
 	nextTUI := next.(chatTUI)
 	if !nextTUI.shuttingDown {


### PR DESCRIPTION
## Summary

- force every shutdown frame to request `MouseModeNone`, including the theme-sweep view
- extend the shutdown lifecycle regression test to assert mouse capture is disabled
- preserve the existing `tea.QuitMsg` shutdown contract

## Why

The existing #348 fallback writes the reset after `Program.Run` returns and suppresses delayed mouse re-enable commands once shutdown begins. However, the final `View()` still requested `MouseModeCellMotion`, leaving the renderer's last frame in mouse-capture mode until outer cleanup completed.

Making `shuttingDown` override mouse capture causes Bubble Tea's final render to disable mouse reporting before it returns control to the parent shell. The outer `runTUIProgram` reset remains as an idempotent second guard.

## Verification

- `gofmt -w harness/cli/chat_tui.go harness/cli/chat_tui_test.go`
- `git diff --check`
- repository CI (`go test ./... -race`, website checks)

Fixes #479